### PR TITLE
Add directory workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ spaces.
 | `kwt prune`      | Clean up stale Git worktree metadata      |
 | `kwt sync`       | Publish and inspect multi-machine status  |
 | `kwt tmux`       | Manage standalone tmux sessions           |
+| `kwt workspace`  | Manage directory workspaces               |
 | `kwt config`     | Read and write config values              |
 | `kwt completion` | Generate shell completion and integration |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ stable command surface.
 | `kwt prune`      | Clean up stale Git worktree metadata.                  |
 | `kwt sync`       | Publish and inspect multi-machine sync state.          |
 | `kwt tmux`       | Manage standalone tmux sessions.                       |
+| `kwt workspace`  | Manage directory workspaces.                           |
 | `kwt config`     | Read and write config values.                          |
 | `kwt completion` | Generate shell completion and integration.             |
 

--- a/docs/superpowers/plans/2026-07-06-directory-workspaces.md
+++ b/docs/superpowers/plans/2026-07-06-directory-workspaces.md
@@ -1,0 +1,1439 @@
+# Directory Workspaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let kwt register plain directories as tmux workspaces, open them with layouts, and surface them in the TUI dashboard.
+
+**Architecture:** A `[[workspaces]]` registry in global config, a `kwt workspace` CLI group, a third `dashboard.Row` flavor (`Workspace`), and a `kwt-workspace-dir-{name}-{hash8(path)}` tmux session namespace. Liveness and attach match sessions by the trailing path hash so renames re-attach instead of orphaning.
+
+**Tech Stack:** Go, cobra, viper, tmux, testify. Spec: `docs/superpowers/specs/2026-07-06-directory-workspaces-design.md`.
+
+## Global Constraints
+
+- Work in worktree `/Users/wesm/.config/superpowers/worktrees/kwt/feature-directory-workspaces` on branch `feature/directory-workspaces`.
+- Run `go test ./<package>` after each task; `golangci-lint run` must report 0 issues before each commit (pre-push hook enforces `make lint`, `golangci-lint fmt -d`, `oxfmt --check` on markdown).
+- `workspaces` is machine-level config: excluded from repo-local `.kwt.toml` merge, never published in fleet manifests.
+- Never auto-register the user's home directory.
+- Errors: fail fast with the offending value (except never echo credentials — not applicable here). Unknown `remove` names list registered names.
+- Commit messages: imperative mood, ≤72-char subject, no `--amend`, end body with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: models.Workspace and config plumbing
+
+**Files:**
+
+- Modify: `pkg/models/models.go` (add `Workspace` type; add `Workspaces` field to `Config` next to `Projects`)
+- Modify: `internal/config/config.go` (`expandConfigPaths`, `mergeLocalConfig` skip list)
+- Test: `internal/config/config_test.go`
+
+**Interfaces:**
+
+- Produces: `models.Workspace{Name string; Path string}`; `models.Config.Workspaces []models.Workspace`. Later tasks read `cfg.Workspaces` with expanded, symlink-resolved paths.
+
+- [ ] **Step 1: Write failing tests** — append to `internal/config/config_test.go`:
+
+```go
+func TestLoadExpandsWorkspacePaths(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	viper.SetConfigType("toml")
+	viper.Set("workspaces", []map[string]any{{"name": "notes", "path": "~/notes"}})
+
+	cfg, err := Load()
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Workspaces, 1)
+	assert.Equal(t, "notes", cfg.Workspaces[0].Name)
+	assert.Equal(t, dir, cfg.Workspaces[0].Path)
+}
+```
+
+Add a subtest to `TestMergeLocalConfig` (same file, mirrors `IgnoresFleetSettings`):
+
+```go
+	t.Run("IgnoresWorkspaces", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+
+		tmpDir := t.TempDir()
+		localConfig := []byte(`
+[[workspaces]]
+name = "evil"
+path = "/tmp/evil"
+`)
+		if err := os.WriteFile(filepath.Join(tmpDir, ".kwt.toml"), localConfig, 0644); err != nil {
+			t.Fatalf("Failed to create local config: %v", err)
+		}
+		changeDir(t, tmpDir)
+
+		viper.SetConfigType("toml")
+
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
+			t.Fatalf("mergeLocalConfig() error = %v", err)
+		}
+		if viper.IsSet("workspaces") {
+			t.Errorf("workspaces must not be settable from local config")
+		}
+	})
+```
+
+Note: `TestLoadExpandsWorkspacePaths` needs `require`/`assert` imports; the file already imports them if other tests use them — check the import block and add `"github.com/stretchr/testify/assert"` / `"github.com/stretchr/testify/require"` if absent.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run "TestLoadExpandsWorkspacePaths|TestMergeLocalConfig/IgnoresWorkspaces" -v`
+Expected: FAIL (`cfg.Workspaces` undefined → compile error is the failure mode for the first test).
+
+- [ ] **Step 3: Implement** — in `pkg/models/models.go`, after the `Project` struct:
+
+```go
+// Workspace records a plain directory kwt can open as a tmux workspace,
+// independent of any git worktree.
+type Workspace struct {
+	Name string `mapstructure:"name" toml:"name"` // Unique display name
+	Path string `mapstructure:"path" toml:"path"` // Directory root
+}
+```
+
+In the `Config` struct, after the `Projects` field:
+
+```go
+	Workspaces         []Workspace         `mapstructure:"workspaces" toml:"workspaces"` // Registered directory workspaces
+```
+
+In `internal/config/config.go` `expandConfigPaths`, after the `cfg.Projects` loop:
+
+```go
+	for i := range cfg.Workspaces {
+		path := cfg.Workspaces[i].Path
+		if path == "" {
+			continue
+		}
+		expandedPath, err = utils.ExpandPath(path)
+		if err != nil {
+			return fmt.Errorf("failed to expand workspace path: %w", err)
+		}
+		if resolved, err := filepath.EvalSymlinks(expandedPath); err == nil {
+			expandedPath = resolved
+		}
+		cfg.Workspaces[i].Path = expandedPath
+	}
+```
+
+In `mergeLocalConfig`'s key switch, extend the `projects` case:
+
+```go
+		case key == "projects" || key == "workspaces":
+			continue
+```
+
+(Replace the existing `case key == "projects":` line; keep the comment style of the surrounding code.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -v -run "TestLoadExpandsWorkspacePaths|TestMergeLocalConfig"`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/models/models.go internal/config/config.go internal/config/config_test.go
+git commit -m "Add workspace registry to config model"
+```
+
+---
+
+### Task 2: RegisterWorkspace and UnregisterWorkspace
+
+**Files:**
+
+- Create: `internal/config/workspace.go`
+- Test: `internal/config/workspace_test.go`
+
+**Interfaces:**
+
+- Consumes: `models.Workspace` from Task 1; existing unexported helpers `getConfigDir`, `configName`, `configType`, `normalizeProjectPath` in package `config`.
+- Produces: `config.RegisterWorkspace(workspace models.Workspace) (models.Workspace, error)` (returns the normalized entry actually stored) and `config.UnregisterWorkspace(name string) error`. Errors: missing/non-dir path → `workspace path <path> is not a directory`; duplicate name for different path → `workspace name %q is already registered for <path>; choose another with --name`; unregister unknown name → `no workspace named %q; registered: a, b, c` (or `no workspaces registered`).
+
+- [ ] **Step 1: Write failing tests** — create `internal/config/workspace_test.go`:
+
+```go
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func workspaceTestEnv(t *testing.T) string {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	return configHome
+}
+
+func registeredWorkspaces(t *testing.T) []models.Workspace {
+	t.Helper()
+	globalViper := viper.New()
+	globalViper.SetConfigFile(filepath.Join(getConfigDir(), configName+"."+configType))
+	globalViper.SetConfigType(configType)
+	require.NoError(t, globalViper.ReadInConfig())
+	var workspaces []models.Workspace
+	require.NoError(t, globalViper.UnmarshalKey("workspaces", &workspaces))
+	return workspaces
+}
+
+func TestRegisterWorkspaceDefaultsNameAndPersists(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	stored, err := RegisterWorkspace(models.Workspace{Path: dir})
+
+	require.NoError(t, err)
+	assert.Equal(t, "notes", stored.Name)
+	workspaces := registeredWorkspaces(t)
+	require.Len(t, workspaces, 1)
+	assert.Equal(t, "notes", workspaces[0].Name)
+}
+
+func TestRegisterWorkspaceRejectsMissingPath(t *testing.T) {
+	workspaceTestEnv(t)
+
+	_, err := RegisterWorkspace(models.Workspace{Path: filepath.Join(t.TempDir(), "absent")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestRegisterWorkspaceUpdatesNameForSamePath(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	_, err := RegisterWorkspace(models.Workspace{Name: "old", Path: dir})
+	require.NoError(t, err)
+
+	_, err = RegisterWorkspace(models.Workspace{Name: "new", Path: dir})
+
+	require.NoError(t, err)
+	workspaces := registeredWorkspaces(t)
+	require.Len(t, workspaces, 1)
+	assert.Equal(t, "new", workspaces[0].Name)
+}
+
+func TestRegisterWorkspaceRejectsDuplicateNameForDifferentPath(t *testing.T) {
+	workspaceTestEnv(t)
+	base := t.TempDir()
+	first := filepath.Join(base, "a")
+	second := filepath.Join(base, "b")
+	require.NoError(t, os.MkdirAll(first, 0o755))
+	require.NoError(t, os.MkdirAll(second, 0o755))
+	_, err := RegisterWorkspace(models.Workspace{Name: "notes", Path: first})
+	require.NoError(t, err)
+
+	_, err = RegisterWorkspace(models.Workspace{Name: "notes", Path: second})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name")
+}
+
+func TestUnregisterWorkspace(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	_, err := RegisterWorkspace(models.Workspace{Path: dir})
+	require.NoError(t, err)
+
+	require.NoError(t, UnregisterWorkspace("notes"))
+	assert.Empty(t, registeredWorkspaces(t))
+
+	err = UnregisterWorkspace("notes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspace")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run "TestRegisterWorkspace|TestUnregisterWorkspace" -v`
+Expected: FAIL to compile (`RegisterWorkspace` undefined).
+
+- [ ] **Step 3: Implement** — create `internal/config/workspace.go`:
+
+```go
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/viper"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+// RegisterWorkspace records a directory workspace in the global config.
+// The path is expanded and resolved; an empty name defaults to the directory
+// base name. Re-registering an existing path updates its name; registering an
+// existing name for a different path is an error.
+func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
+	path, err := normalizeProjectPath(workspace.Path)
+	if err != nil {
+		return models.Workspace{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return models.Workspace{}, fmt.Errorf("workspace path %s is not a directory", workspace.Path)
+	}
+	workspace.Path = path
+	if strings.TrimSpace(workspace.Name) == "" {
+		workspace.Name = filepath.Base(path)
+	}
+	workspace.Name = strings.TrimSpace(workspace.Name)
+
+	workspaces, globalViper, err := readGlobalWorkspaces()
+	if err != nil {
+		return models.Workspace{}, err
+	}
+
+	updated := false
+	for i := range workspaces {
+		if workspaces[i].Path == workspace.Path {
+			workspaces[i] = workspace
+			updated = true
+			continue
+		}
+		if strings.EqualFold(workspaces[i].Name, workspace.Name) {
+			return models.Workspace{}, fmt.Errorf(
+				"workspace name %q is already registered for %s; choose another with --name",
+				workspace.Name, workspaces[i].Path,
+			)
+		}
+	}
+	if !updated {
+		workspaces = append(workspaces, workspace)
+	}
+	if err := writeGlobalWorkspaces(globalViper, workspaces); err != nil {
+		return models.Workspace{}, err
+	}
+	return workspace, nil
+}
+
+// UnregisterWorkspace removes a directory workspace from the global config by
+// name. The directory itself is never touched.
+func UnregisterWorkspace(name string) error {
+	name = strings.TrimSpace(name)
+	workspaces, globalViper, err := readGlobalWorkspaces()
+	if err != nil {
+		return err
+	}
+
+	kept := workspaces[:0]
+	removed := false
+	for _, workspace := range workspaces {
+		if strings.EqualFold(workspace.Name, name) {
+			removed = true
+			continue
+		}
+		kept = append(kept, workspace)
+	}
+	if !removed {
+		if len(workspaces) == 0 {
+			return fmt.Errorf("no workspace named %q; no workspaces registered", name)
+		}
+		names := make([]string, 0, len(workspaces))
+		for _, workspace := range workspaces {
+			names = append(names, workspace.Name)
+		}
+		sort.Strings(names)
+		return fmt.Errorf("no workspace named %q; registered: %s", name, strings.Join(names, ", "))
+	}
+	return writeGlobalWorkspaces(globalViper, kept)
+}
+
+func readGlobalWorkspaces() ([]models.Workspace, *viper.Viper, error) {
+	configDir := getConfigDir()
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return nil, nil, fmt.Errorf("failed to create config directory: %w", err)
+	}
+	globalViper := viper.New()
+	globalViper.SetConfigName(configName)
+	globalViper.SetConfigType(configType)
+	globalViper.AddConfigPath(configDir)
+	if err := globalViper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, nil, fmt.Errorf("failed to read config: %w", err)
+		}
+	}
+	var workspaces []models.Workspace
+	if err := globalViper.UnmarshalKey("workspaces", &workspaces); err != nil {
+		return nil, nil, fmt.Errorf("failed to read workspaces: %w", err)
+	}
+	return workspaces, globalViper, nil
+}
+
+func writeGlobalWorkspaces(globalViper *viper.Viper, workspaces []models.Workspace) error {
+	globalViper.Set("workspaces", workspaces)
+	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	if err := globalViper.WriteConfigAs(configPath); err != nil {
+		return err
+	}
+	viper.Set("workspaces", workspaces)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -run "TestRegisterWorkspace|TestUnregisterWorkspace" -v`
+Expected: PASS (5 tests). Also run `go test ./internal/config/` to confirm no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/workspace.go internal/config/workspace_test.go
+git commit -m "Add workspace register and unregister helpers"
+```
+
+---
+
+### Task 3: Directory workspace session naming and hash matching
+
+**Files:**
+
+- Modify: `internal/tmux/session.go`
+- Test: `internal/tmux/session_test.go` (append; create if the file does not exist)
+
+**Interfaces:**
+
+- Consumes: `template.ShortHash(input string) string` (8-hex-char hash), unexported `sanitizeTmuxName`.
+- Produces: `tmux.DirWorkspaceSessionName(name, path string) string` returning `kwt-workspace-dir-{sanitized name}-{hash8(path)}`; `tmux.MatchDirWorkspaceSession(sessions []string, path string) (string, bool)` returning the live session whose name has prefix `kwt-workspace-dir-` and suffix `-{hash8(path)}`.
+
+- [ ] **Step 1: Write failing tests** — append to `internal/tmux/session_test.go`:
+
+```go
+func TestDirWorkspaceSessionName(t *testing.T) {
+	name := DirWorkspaceSessionName("my notes", "/Users/me/notes")
+
+	assert.True(t, strings.HasPrefix(name, "kwt-workspace-dir-my-notes-"), name)
+	assert.Regexp(t, `^kwt-workspace-dir-my-notes-[0-9a-f]{8}$`, name)
+	assert.Equal(t, name, DirWorkspaceSessionName("my notes", "/Users/me/notes"),
+		"session names must be deterministic")
+	assert.NotEqual(t, name, DirWorkspaceSessionName("my notes", "/Users/me/other"),
+		"different paths must not collide")
+}
+
+func TestMatchDirWorkspaceSessionMatchesByPathHash(t *testing.T) {
+	current := DirWorkspaceSessionName("new-name", "/Users/me/notes")
+	old := DirWorkspaceSessionName("old-name", "/Users/me/notes")
+	sessions := []string{"kwt-workspace-foo-12345678", old, "unrelated"}
+
+	got, ok := MatchDirWorkspaceSession(sessions, "/Users/me/notes")
+
+	require.True(t, ok)
+	assert.Equal(t, old, got, "renamed workspaces must re-attach to the live old-name session")
+	assert.NotEqual(t, current, got)
+
+	_, ok = MatchDirWorkspaceSession([]string{"kwt-workspace-foo-12345678"}, "/Users/me/notes")
+	assert.False(t, ok)
+}
+```
+
+(Check the file's imports: needs `strings`, `testing`, testify `assert`/`require`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tmux/ -run "TestDirWorkspaceSessionName|TestMatchDirWorkspaceSession" -v`
+Expected: FAIL to compile (`DirWorkspaceSessionName` undefined).
+
+- [ ] **Step 3: Implement** — append to `internal/tmux/session.go`:
+
+```go
+const dirWorkspaceSessionPrefix = "kwt-workspace-dir-"
+
+// DirWorkspaceSessionName returns a stable, tmux-safe session name for a
+// directory workspace: kwt-workspace-dir-{name}-{hash}. The hash is computed
+// over the workspace path so renames keep a recognizable suffix and distinct
+// directories never collide.
+func DirWorkspaceSessionName(name, path string) string {
+	raw := fmt.Sprintf("%s%s-%s", dirWorkspaceSessionPrefix, name, template.ShortHash(path))
+	return sanitizeTmuxName(raw)
+}
+
+// MatchDirWorkspaceSession finds the live directory-workspace session for
+// path, matching by prefix and trailing path hash rather than the full name
+// so a renamed workspace still finds its running session.
+func MatchDirWorkspaceSession(sessions []string, path string) (string, bool) {
+	suffix := "-" + template.ShortHash(path)
+	for _, session := range sessions {
+		if strings.HasPrefix(session, dirWorkspaceSessionPrefix) && strings.HasSuffix(session, suffix) {
+			return session, true
+		}
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tmux/ -v -run "TestDirWorkspaceSessionName|TestMatchDirWorkspaceSession"`
+Expected: PASS. Also `go test ./internal/tmux/` for regressions (the existing `workspaceSessionRe` parsing test must still pass — `kwt-workspace-dir-...-{hash8}` matches it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tmux/session.go internal/tmux/session_test.go
+git commit -m "Add directory workspace session naming and matching"
+```
+
+---
+
+### Task 4: kwt workspace CLI (add, list, remove)
+
+**Files:**
+
+- Create: `internal/cmd/workspace.go`
+- Test: `internal/cmd/workspace_test.go`
+
+**Interfaces:**
+
+- Consumes: `config.RegisterWorkspace`, `config.UnregisterWorkspace` (Task 2); `tmux.DirWorkspaceSessionName`, `tmux.MatchDirWorkspaceSession` (Task 3); `config.Load`; `tmux.NewTmuxCommand("").ListSessions()`.
+- Produces: `kwt workspace add [path] [--name X]`, `kwt workspace list`, `kwt workspace remove <name>`. Package-level function vars `registerWorkspace`, `unregisterWorkspace`, `loadWorkspaceConfig`, `listWorkspaceSessions` for test stubbing (follow the `loadFleetConfig` pattern in `internal/cmd/fleet.go`).
+
+- [ ] **Step 1: Write failing tests** — create `internal/cmd/workspace_test.go`:
+
+```go
+package cmd
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func changeDir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func resetWorkspaceCommandDeps(t *testing.T) {
+	t.Helper()
+	origRegister := registerWorkspace
+	origUnregister := unregisterWorkspace
+	origLoad := loadWorkspaceConfig
+	origSessions := listWorkspaceSessions
+	t.Cleanup(func() {
+		registerWorkspace = origRegister
+		unregisterWorkspace = origUnregister
+		loadWorkspaceConfig = origLoad
+		listWorkspaceSessions = origSessions
+	})
+}
+
+func TestWorkspaceAddRegistersCwdByDefault(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	dir := t.TempDir()
+	changeDir(t, dir)
+	var got models.Workspace
+	registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		got = workspace
+		workspace.Name = "resolved"
+		return workspace, nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceAdd(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, dir, got.Path)
+	assert.Empty(t, got.Name)
+	assert.Contains(t, stdout.String(), "resolved")
+}
+
+func TestWorkspaceAddUsesArgsAndNameFlag(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	var got models.Workspace
+	registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		got = workspace
+		return workspace, nil
+	}
+
+	cmd, _, _ := fleetTestCommand()
+	workspaceAddName = "scratch"
+	t.Cleanup(func() { workspaceAddName = "" })
+	err := runWorkspaceAdd(cmd, []string{"/tmp/somewhere"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/somewhere", got.Path)
+	assert.Equal(t, "scratch", got.Name)
+}
+
+func TestWorkspaceListShowsLiveState(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{
+			{Name: "notes", Path: "/Users/me/notes"},
+			{Name: "scratch", Path: "/Users/me/scratch"},
+		}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{tmuxDirSessionNameForTest("notes", "/Users/me/notes")}, nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceList(cmd, nil)
+
+	require.NoError(t, err)
+	out := stdout.String()
+	assert.Contains(t, out, "notes")
+	assert.Contains(t, out, "live")
+	assert.Contains(t, out, "scratch")
+	assert.Contains(t, out, "stopped")
+}
+
+func TestWorkspaceRemoveReportsLiveSession(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{tmuxDirSessionNameForTest("notes", "/Users/me/notes")}, nil
+	}
+	unregisterWorkspace = func(name string) error {
+		assert.Equal(t, "notes", name)
+		return nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceRemove(cmd, []string{"notes"})
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "still running")
+}
+
+func TestWorkspaceRemovePropagatesUnknownNameError(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) { return &models.Config{}, nil }
+	listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+	unregisterWorkspace = func(name string) error {
+		return errors.New(`no workspace named "nope"; no workspaces registered`)
+	}
+
+	cmd, _, _ := fleetTestCommand()
+	err := runWorkspaceRemove(cmd, []string{"nope"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspace named")
+}
+```
+
+Add this helper at the bottom:
+
+```go
+func tmuxDirSessionNameForTest(name, path string) string {
+	return tmux.DirWorkspaceSessionName(name, path)
+}
+```
+
+(`fleetTestCommand` already exists in `internal/cmd/fleet_test.go` — reuse it, do not redefine. `changeDir` exists only in `internal/config`, not this package, hence the copy above.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmd/ -run TestWorkspace -v`
+Expected: FAIL to compile (`runWorkspaceAdd` undefined).
+
+- [ ] **Step 3: Implement** — create `internal/cmd/workspace.go`:
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/table"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+var (
+	workspaceAddName string
+
+	registerWorkspace     = config.RegisterWorkspace
+	unregisterWorkspace   = config.UnregisterWorkspace
+	loadWorkspaceConfig   = config.Load
+	listWorkspaceSessions = func() ([]string, error) {
+		return tmux.NewTmuxCommand("").ListSessions()
+	}
+)
+
+var workspaceCmd = &cobra.Command{
+	Use:   "workspace",
+	Short: "Manage directory workspaces not bound to a git worktree",
+}
+
+var workspaceAddCmd = &cobra.Command{
+	Use:   "add [path]",
+	Short: "Register a directory as a workspace",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runWorkspaceAdd,
+}
+
+var workspaceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered directory workspaces",
+	Args:  cobra.NoArgs,
+	RunE:  runWorkspaceList,
+}
+
+var workspaceRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Unregister a directory workspace (never deletes the directory)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWorkspaceRemove,
+}
+
+func init() {
+	workspaceAddCmd.Flags().StringVar(&workspaceAddName, "name", "", "workspace name (defaults to the directory base name)")
+	workspaceCmd.AddCommand(workspaceAddCmd, workspaceListCmd, workspaceRemoveCmd)
+	rootCmd.AddCommand(workspaceCmd)
+}
+
+func runWorkspaceAdd(cmd *cobra.Command, args []string) error {
+	path := ""
+	if len(args) == 1 {
+		path = args[0]
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to resolve current directory: %w", err)
+		}
+		path = cwd
+	}
+	stored, err := registerWorkspace(models.Workspace{Name: workspaceAddName, Path: path})
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "registered workspace %s at %s\n", stored.Name, stored.Path)
+	return nil
+}
+
+func runWorkspaceList(cmd *cobra.Command, args []string) error {
+	cfg, err := loadWorkspaceConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if len(cfg.Workspaces) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no workspaces registered")
+		return nil
+	}
+	sessions, err := listWorkspaceSessions()
+	if err != nil {
+		sessions = nil
+	}
+	t := table.New().SetOutput(cmd.OutOrStdout()).Headers("NAME", "PATH", "SESSION")
+	for _, workspace := range cfg.Workspaces {
+		state := "stopped"
+		if _, ok := tmux.MatchDirWorkspaceSession(sessions, workspace.Path); ok {
+			state = "live"
+		}
+		t.Row(workspace.Name, workspace.Path, state)
+	}
+	return t.Println()
+}
+
+func runWorkspaceRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	cfg, cfgErr := loadWorkspaceConfig()
+	livePath := ""
+	if cfgErr == nil {
+		for _, workspace := range cfg.Workspaces {
+			if workspace.Name == name {
+				livePath = workspace.Path
+			}
+		}
+	}
+	if err := unregisterWorkspace(name); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unregistered workspace %s\n", name)
+	if livePath != "" {
+		sessions, err := listWorkspaceSessions()
+		if err == nil {
+			if session, ok := tmux.MatchDirWorkspaceSession(sessions, livePath); ok {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+					"its tmux session %s is still running; kill it with: tmux kill-session -t %s\n",
+					session, session)
+			}
+		}
+	}
+	return nil
+}
+```
+
+(The `table.New().SetOutput(w).Headers(...)` / `t.Row(...)` / `t.Println()` chain matches `internal/fleet/render.go` `RenderStatusTable` — same builder.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmd/ -run TestWorkspace -v`
+Expected: PASS (5 tests). Then `go build ./...` and `kwt workspace --help` via `go run ./cmd/kwt workspace --help` to eyeball command wiring.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmd/workspace.go internal/cmd/workspace_test.go
+git commit -m "Add kwt workspace add, list, and remove commands"
+```
+
+---
+
+### Task 5: Workspace rows in the TUI backend + auto-registration
+
+**Files:**
+
+- Modify: `internal/tui/backend.go` (add `WorkspaceInfo`, `Row.Workspace` field)
+- Modify: `internal/cmd/tui_backend.go` (`List` appends workspace rows; auto-register non-git launch dir; `registerWorkspace` hook field on `tuiBackend`)
+- Test: `internal/cmd/tui_test.go`
+
+**Interfaces:**
+
+- Consumes: `cfg.Workspaces` (Task 1), `config.RegisterWorkspace` (Task 2), `tmux.DirWorkspaceSessionName`/`MatchDirWorkspaceSession` (Task 3).
+- Produces: `dashboard.WorkspaceInfo{Name, Path string}`; `Row.Workspace *WorkspaceInfo` (mutually exclusive with `Entry` and `Fleet`); `tuiBackend.registerWorkspace func(models.Workspace) (models.Workspace, error)` hook. Workspace rows carry `SessionName` (live session name if matched by hash, else `DirWorkspaceSessionName`) and `SessionLive`.
+
+- [ ] **Step 1: Write failing tests** — append to `internal/cmd/tui_test.go`:
+
+```go
+func TestTUIBackendListIncludesWorkspaceRows(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &models.Config{
+		Worktree:   models.WorktreeConfig{BaseDir: "/global"},
+		Workspaces: []models.Workspace{{Name: "notes", Path: dir}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	liveSession := tmux.DirWorkspaceSessionName("old-name", dir)
+	backend.listSessions = func() ([]string, error) { return []string{liveSession}, nil }
+
+	rows, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].Workspace)
+	assert.Equal(t, "notes", rows[0].Workspace.Name)
+	assert.Equal(t, dir, rows[0].Workspace.Path)
+	assert.True(t, rows[0].SessionLive,
+		"liveness must match by path hash even under an old session name")
+	assert.Equal(t, liveSession, rows[0].SessionName,
+		"attach must target the live session, not the freshly computed name")
+	assert.Nil(t, rows[0].Entry)
+	assert.Nil(t, rows[0].Fleet)
+}
+
+func TestTUIBackendAutoRegistersNonGitLaunchDir(t *testing.T) {
+	launchDir := t.TempDir()
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	backend := newTUIBackendWithLaunchDir(cfg, launchDir)
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	var registered []models.Workspace
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		registered = append(registered, workspace)
+		return workspace, nil
+	}
+
+	_, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, registered, 1)
+	assert.Equal(t, launchDir, registered[0].Path)
+}
+
+func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	backend := newTUIBackendWithLaunchDir(cfg, home)
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		t.Fatalf("home directory must never be auto-registered, got %v", workspace)
+		return workspace, nil
+	}
+
+	_, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmd/ -run "TestTUIBackendListIncludesWorkspaceRows|TestTUIBackendAutoRegisters|TestTUIBackendNeverAutoRegisters" -v`
+Expected: FAIL to compile (`rows[0].Workspace`, `backend.registerWorkspace` undefined).
+
+- [ ] **Step 3: Implement.** In `internal/tui/backend.go`, add to `Row` after `Fleet`:
+
+```go
+	Workspace   *WorkspaceInfo
+```
+
+and below `FleetInfo`:
+
+```go
+// WorkspaceInfo is the TUI-facing view of one registered directory workspace.
+type WorkspaceInfo struct {
+	Name string
+	Path string
+}
+```
+
+In `internal/cmd/tui_backend.go`:
+
+1. Add a field to `tuiBackend`: `registerWorkspace func(models.Workspace) (models.Workspace, error)` and set it in `newTUIBackendWithLaunchDir`: `registerWorkspace: config.RegisterWorkspace,`.
+2. In `List`, after `b.registerLaunchProject(launchEntries)` add `b.registerLaunchWorkspace(launchEntries)`, and after the worktree-row loop (before `mergeFleetRows`) append workspace rows:
+
+```go
+	rows = append(rows, b.workspaceRows(sessions)...)
+```
+
+Note: `List` currently discards the raw `sessions` slice after building `liveSessions`; keep the `sessions` variable in scope for this call.
+
+3. Add the two methods:
+
+```go
+func (b *tuiBackend) workspaceRows(sessions []string) []dashboard.Row {
+	if b.cfg == nil || len(b.cfg.Workspaces) == 0 {
+		return nil
+	}
+	rows := make([]dashboard.Row, 0, len(b.cfg.Workspaces))
+	for _, workspace := range b.cfg.Workspaces {
+		sessionName := tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path)
+		sessionLive := false
+		// Match by path hash so a renamed workspace still finds (and later
+		// attaches to) its live session created under the old name.
+		if live, ok := tmux.MatchDirWorkspaceSession(sessions, workspace.Path); ok {
+			sessionName = live
+			sessionLive = true
+		}
+		rows = append(rows, dashboard.Row{
+			Workspace:   &dashboard.WorkspaceInfo{Name: workspace.Name, Path: workspace.Path},
+			SessionName: sessionName,
+			SessionLive: sessionLive,
+		})
+	}
+	return rows
+}
+
+// registerLaunchWorkspace records a non-git launch directory as a workspace,
+// best-effort, mirroring launch-repo project registration. The home directory
+// is never auto-registered: running kwt from ~ is common and would create a
+// junk entry.
+func (b *tuiBackend) registerLaunchWorkspace(launchEntries []*discovery.GlobalWorktreeEntry) {
+	if b.registerWorkspace == nil || b.launchDir == "" || len(launchEntries) > 0 {
+		return
+	}
+	if home, err := os.UserHomeDir(); err == nil && samePath(home, b.launchDir) {
+		return
+	}
+	stored, err := b.registerWorkspace(models.Workspace{Path: b.launchDir})
+	if err != nil {
+		return
+	}
+	b.cfg.Workspaces = upsertWorkspace(b.cfg.Workspaces, stored)
+}
+
+func upsertWorkspace(workspaces []models.Workspace, workspace models.Workspace) []models.Workspace {
+	for i := range workspaces {
+		if samePath(workspaces[i].Path, workspace.Path) {
+			workspaces[i] = workspace
+			return workspaces
+		}
+	}
+	return append(workspaces, workspace)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmd/ -run "TestTUIBackend" -v`
+Expected: new tests PASS; all pre-existing `TestTUIBackend*` tests still PASS. They stub `registerProject` but not `registerWorkspace`, so update the existing helper at `internal/cmd/tui_test.go:1824`:
+
+```go
+func stubTUIProjectRegistration(backend *tuiBackend) {
+	backend.registerProject = func(models.Project) error { return nil }
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		return workspace, nil
+	}
+}
+```
+
+(Existing tests pass launch dirs like `/repos/other` with non-empty launch entries or empty launch dirs, so none of them hit auto-registration; the stub is defense against nil-func panics only.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/backend.go internal/cmd/tui_backend.go internal/cmd/tui_test.go
+git commit -m "Surface directory workspaces as TUI rows"
+```
+
+---
+
+### Task 6: Backend actions for workspace rows
+
+**Files:**
+
+- Modify: `internal/cmd/tui_backend.go` (`attachWorkspace`, `sessionName`, `resolveLayout`), `internal/cmd/tui.go` (`rowPathForHandoff`)
+- Modify: `internal/tui/backend.go` (add `UnregisterWorkspace(row Row) error` to the `Backend` interface)
+- Modify: `internal/cmd/tui_backend.go` (implement `UnregisterWorkspace`; add `unregisterWorkspace` hook field)
+- Test: `internal/cmd/tui_test.go`
+
+**Interfaces:**
+
+- Consumes: `Row.Workspace` (Task 5), `config.UnregisterWorkspace` (Task 2), `config.LoadRepoLayoutDefault(dir, interactive)` (existing).
+- Produces: workspace rows are openable/attachable/killable through the existing `OpenInTmux`/`AttachOutsideTmux`/`KillSession`; `Backend.UnregisterWorkspace(row Row) error`; `rowPathForHandoff` returns `Workspace.Path` for workspace rows.
+
+- [ ] **Step 1: Write failing tests** — append to `internal/cmd/tui_test.go`:
+
+```go
+func TestTUIBackendSessionNameAndHandoffPathForWorkspaceRow(t *testing.T) {
+	row := dashboard.Row{
+		Workspace:   &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+		SessionName: tmux.DirWorkspaceSessionName("notes", "/Users/me/notes"),
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+
+	name, err := backend.sessionName(row)
+
+	require.NoError(t, err)
+	assert.Equal(t, row.SessionName, name)
+	assert.Equal(t, "/Users/me/notes", rowPathForHandoff(row))
+}
+
+func TestTUIBackendUnregisterWorkspace(t *testing.T) {
+	cfg := &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	var removed []string
+	backend.unregisterWorkspace = func(name string) error {
+		removed = append(removed, name)
+		return nil
+	}
+
+	err := backend.UnregisterWorkspace(dashboard.Row{
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"notes"}, removed)
+	assert.Empty(t, cfg.Workspaces, "unregister must also drop the in-memory entry")
+
+	err = backend.UnregisterWorkspace(dashboard.Row{})
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cmd/ -run "TestTUIBackendSessionNameAndHandoffPathForWorkspaceRow|TestTUIBackendUnregisterWorkspace" -v`
+Expected: FAIL to compile (`backend.unregisterWorkspace`, `UnregisterWorkspace` undefined). Note `sessionName` currently errors on nil `Entry`, so the first test fails even once it compiles.
+
+- [ ] **Step 3: Implement.**
+
+In `internal/cmd/tui.go` `rowPathForHandoff`, add before the `Entry` check:
+
+```go
+	if row.Workspace != nil {
+		return row.Workspace.Path
+	}
+```
+
+In `internal/cmd/tui_backend.go`:
+
+1. `sessionName`: add before the nil-Entry error:
+
+```go
+	if row.Workspace != nil {
+		return tmux.DirWorkspaceSessionName(row.Workspace.Name, row.Workspace.Path), nil
+	}
+```
+
+(the `row.SessionName != ""` fast path above already returns the hash-matched live name when the row came from `List`).
+
+2. `attachWorkspace`: replace the leading guard
+
+```go
+	if row.Entry == nil {
+		return fmt.Errorf("no worktree selected")
+	}
+```
+
+with
+
+```go
+	if row.Entry == nil && row.Workspace == nil {
+		return fmt.Errorf("no worktree selected")
+	}
+```
+
+and replace `row.Entry.Path` in the `EnsureAndAttach` call with `rowPaneRoot(row)`; add:
+
+```go
+func rowPaneRoot(row dashboard.Row) string {
+	if row.Workspace != nil {
+		return row.Workspace.Path
+	}
+	if row.Entry != nil {
+		return row.Entry.Path
+	}
+	return ""
+}
+```
+
+3. `resolveLayout`: in the `layoutName == ""` branch, resolve the default-layout directory from the workspace when present:
+
+```go
+		var layoutRoot string
+		if row.Workspace != nil {
+			layoutRoot = row.Workspace.Path
+		} else {
+			layoutRoot, err = b.repositoryRootForRow(row)
+			if err != nil {
+				return models.Layout{}, err
+			}
+		}
+		var targetDefault string
+		targetDefault, err = config.LoadRepoLayoutDefault(layoutRoot, interactive)
+```
+
+(rename the existing `repoRoot` variable accordingly).
+
+4. Add the hook field to `tuiBackend`: `unregisterWorkspace func(name string) error`, defaulted in `newTUIBackendWithLaunchDir` to `config.UnregisterWorkspace`. Implement the interface method:
+
+```go
+func (b *tuiBackend) UnregisterWorkspace(row dashboard.Row) error {
+	if row.Workspace == nil {
+		return fmt.Errorf("no workspace selected")
+	}
+	if err := b.unregisterWorkspace(row.Workspace.Name); err != nil {
+		return err
+	}
+	if b.cfg != nil {
+		kept := b.cfg.Workspaces[:0]
+		for _, workspace := range b.cfg.Workspaces {
+			if !samePath(workspace.Path, row.Workspace.Path) {
+				kept = append(kept, workspace)
+			}
+		}
+		b.cfg.Workspaces = kept
+	}
+	return nil
+}
+```
+
+5. In `internal/tui/backend.go`, add to the `Backend` interface after `RemoveWorktree`:
+
+```go
+	UnregisterWorkspace(row Row) error
+```
+
+6. Update `fakeBackend` in `internal/tui/model_test.go`:
+
+```go
+func (b *fakeBackend) UnregisterWorkspace(row Row) error {
+	b.unregistered = append(b.unregistered, row)
+	return nil
+}
+```
+
+and add `unregistered []Row` to the `fakeBackend` struct.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cmd/ ./internal/tui/ -v -run "TestTUIBackendSessionNameAndHandoffPathForWorkspaceRow|TestTUIBackendUnregisterWorkspace"` then the full `go test ./internal/cmd/ ./internal/tui/`.
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/backend.go internal/tui/model_test.go internal/cmd/tui_backend.go internal/cmd/tui.go internal/cmd/tui_test.go
+git commit -m "Route workspace rows through backend session actions"
+```
+
+---
+
+### Task 7: TUI rendering and action guards for workspace rows
+
+**Files:**
+
+- Modify: `internal/tui/list.go` (`rowRepoName`, `rowBranch`, `rowPath`, `formatMachines`, `formatRowSync`, `formatRowChanges`/CHANGES + HEADS + ACTIVITY formatters, `formatWorkspace`, filter haystack)
+- Modify: `internal/tui/model.go` (`openSelected`, `shellSelected`, `startKill`, `startDelete` + confirm flow, `startNewBranch`, `syncSelected`)
+- Test: `internal/tui/list_test.go`, `internal/tui/model_test.go`
+
+**Interfaces:**
+
+- Consumes: `Row.Workspace` (Task 5), `Backend.UnregisterWorkspace` (Task 6).
+- Produces: workspace rows render as REPO=name, BRANCH=tilde-abbreviated path, MACHINES=`local`, CHANGES=`-`, HEADS=`-`, ACTIVITY=`-`, WORKSPACE=live/offline; `confirmUnregister` confirm kind; git actions on workspace rows show status-line messages.
+
+- [ ] **Step 1: Write failing tests.** In `internal/tui/list_test.go`:
+
+```go
+func TestWorkspaceRowRendering(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	row := Row{
+		Workspace:   &WorkspaceInfo{Name: "notes", Path: filepath.Join(home, "notes")},
+		SessionLive: true,
+	}
+
+	assert.Equal(t, "notes", rowRepoName(row))
+	assert.Equal(t, "~/notes", rowBranch(row))
+	assert.Equal(t, filepath.Join(home, "notes"), rowPath(row))
+	assert.Equal(t, "local", formatMachines(row))
+	assert.Equal(t, "live", formatWorkspace(row))
+}
+```
+
+(Tilde abbreviation comes from the existing `utils.TildePath` at `internal/utils/utils.go:97` — no new helper needed.)
+
+In `internal/tui/model_test.go`:
+
+```go
+func TestWorkspaceRowActions(t *testing.T) {
+	row := Row{
+		Workspace:   &WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+		SessionName: "kwt-workspace-dir-notes-12345678",
+		SessionLive: true,
+	}
+	backend := &fakeBackend{}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{row}})
+
+	// Open: workspace rows hand off to attach outside tmux.
+	next, _ := model.openSelected()
+	assert.Equal(t, HandoffAttach, next.Handoff().Kind)
+
+	// New branch: gated with a message.
+	next, _ = model.startNewBranch()
+	assert.Contains(t, next.message, "not a git worktree")
+
+	// Sync: already gated by the row.Fleet == nil branch.
+	next, _ = model.syncSelected(row)
+	assert.Contains(t, next.message, "nothing to sync")
+
+	// Kill: allowed for live sessions.
+	next, _ = model.startKill()
+	assert.Equal(t, confirmKill, next.confirm.kind)
+
+	// Delete key: offers unregister, never worktree removal.
+	next, _ = model.startDelete()
+	require.Equal(t, confirmUnregister, next.confirm.kind)
+	assert.Contains(t, next.confirm.text, "unregister")
+
+	// Confirming with y calls Backend.UnregisterWorkspace and refreshes.
+	_, cmd := updateModel(t, next, press("y"))
+	require.NotNil(t, cmd)
+	msg := cmd()
+	done, ok := msg.(actionDoneMsg)
+	require.True(t, ok)
+	assert.True(t, done.refresh)
+	require.Len(t, backend.unregistered, 1)
+	assert.Equal(t, "notes", backend.unregistered[0].Workspace.Name)
+}
+```
+
+(`press` and `updateModel` are existing helpers in `model_test.go`; the `y` press routes through `handleConfirmKey` at `internal/tui/model.go:471`, which is where Step 3 adds the `confirmUnregister` case.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tui/ -run "TestWorkspaceRow" -v`
+Expected: FAIL (rendering falls through to empty strings; `confirmUnregister` undefined → compile error first).
+
+- [ ] **Step 3: Implement.** In `internal/tui/list.go`:
+
+1. `rowRepoName`: first branch:
+
+```go
+	if row.Workspace != nil {
+		return row.Workspace.Name
+	}
+```
+
+2. `rowBranch`: first branch (add `go.kenn.io/kwt/internal/utils` to imports):
+
+```go
+	if row.Workspace != nil {
+		return utils.TildePath(row.Workspace.Path)
+	}
+```
+
+3. `rowPath`: first branch:
+
+```go
+	if row.Workspace != nil {
+		return row.Workspace.Path
+	}
+```
+
+4. `formatMachines`: workspace rows have `row.Fleet == nil`, which already returns `"local"` — verify, don't change.
+5. CHANGES/HEADS/ACTIVITY formatters: locate the three formatter functions used by the table builder near `internal/tui/list.go:487` and add a leading `if row.Workspace != nil { return "-" }` to each (CHANGES, HEADS/sync, ACTIVITY). For `formatRowSync` specifically the guard must come before the `"local only"` fallback.
+6. `formatWorkspace`: no change needed (`SessionLive` drives live/offline; the `Entry == nil && Fleet != nil` remote branch doesn't hit workspace rows) — verify with the rendering test.
+7. Filter haystack: `filterRows`/`rowFleetHaystack` build search text from `rowRepoName`, `rowBranch`, `rowPath` — with the branches above, name and path are already included; verify by reading `filterRows` and add `row.Workspace.Name`/`Path` explicitly only if it composes differently.
+
+In `internal/tui/model.go`:
+
+1. Add `confirmUnregister` to the confirm-kind const block after `confirmKill`.
+2. `openSelected`: change the guard to
+
+```go
+	if row.Entry == nil && row.Workspace == nil {
+```
+
+(keep the fleet materialize hint inside). 3. `shellSelected`: same guard change. 4. `startKill`: change `if row.Entry == nil` to `if row.Entry == nil && row.Workspace == nil`. 5. `startNewBranch`: add after the existing selection:
+
+```go
+	if row.Workspace != nil {
+		m.message = "not a git worktree"
+		return m, nil
+	}
+```
+
+6. `syncSelected`: already returns "nothing to sync for this row" when `row.Fleet == nil` — verify covers workspace rows; no change expected.
+7. `startDelete`: add before the nil-Entry guard:
+
+```go
+	if row.Workspace != nil {
+		m.confirm = confirmState{
+			kind: confirmUnregister,
+			row:  row,
+			text: fmt.Sprintf("unregister workspace %s? (directory is kept) [y/N]", row.Workspace.Name),
+		}
+		return m, nil
+	}
+```
+
+8. In `handleConfirmKey` (`internal/tui/model.go:471`), add a case to the `switch kind` block alongside `confirmDelete`/`confirmKill`:
+
+```go
+	case confirmUnregister:
+		return m, m.unregisterWorkspaceCmd(row)
+```
+
+and the command, modeled on `removeWorktreeCmd`:
+
+```go
+func (m Model) unregisterWorkspaceCmd(row Row) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.backend.UnregisterWorkspace(row); err != nil {
+			return actionDoneMsg{err: err}
+		}
+		return actionDoneMsg{message: "workspace unregistered", refresh: true}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/tui/ -v -run TestWorkspaceRow`, then full `go test ./internal/tui/ ./internal/cmd/`.
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/list.go internal/tui/model.go internal/tui/list_test.go internal/tui/model_test.go
+git commit -m "Render and gate workspace rows in the dashboard"
+```
+
+---
+
+### Task 8: End-to-end check, lint, docs touch-up
+
+**Files:**
+
+- Modify: `docs/reference/` or `README.md` only if a command list enumerates subcommands (check `rg -n "kwt tmux|kwt sync" README.md docs/` and mirror the style for `kwt workspace`)
+- Test: whole tree
+
+- [ ] **Step 1: Full verification**
+
+Run:
+
+```bash
+go build ./... && go test ./... && go vet ./... && golangci-lint run
+```
+
+Expected: all pass, `0 issues`.
+
+- [ ] **Step 2: Manual smoke test** (real tmux required; skip pane assertions if no tmux on PATH):
+
+```bash
+go build -o /tmp/kwt-dw ./cmd/kwt
+mkdir -p /tmp/kwt-demo-notes
+KWT_HOME=$(mktemp -d) /tmp/kwt-dw workspace add /tmp/kwt-demo-notes --name demo-notes
+KWT_HOME=<same dir> /tmp/kwt-dw workspace list      # expect demo-notes ... stopped
+KWT_HOME=<same dir> /tmp/kwt-dw workspace remove demo-notes
+```
+
+Expected: registered → listed stopped → unregistered; `remove` of a second, unknown name errors listing nothing registered.
+
+- [ ] **Step 3: Docs** — if README/docs enumerate command groups, add one line for `kwt workspace` following the existing style. Do not write new doc pages.
+
+- [ ] **Step 4: Commit** (only if docs changed; otherwise skip)
+
+```bash
+git add README.md docs/
+git commit -m "Document kwt workspace command group"
+```

--- a/docs/superpowers/specs/2026-07-06-directory-workspaces-design.md
+++ b/docs/superpowers/specs/2026-07-06-directory-workspaces-design.md
@@ -1,0 +1,117 @@
+# Directory Workspaces
+
+**Date:** 2026-07-06
+**Status:** Approved
+**Base branch:** `feature/fleet-sync` (depends on the fleet-era TUI row model)
+
+## Problem
+
+kwt can only create and surface tmux workspaces bound to a git worktree. There
+is no way to register a plain directory (notes, scratch space, a non-git
+project) as a workspace, open it with a layout, and see it in the dashboard.
+
+## Decision summary
+
+Directory workspaces become a first-class registry entry and a third TUI row
+flavor. They are anchored to a directory, persist in global config when their
+session is not running, and stay local-only (never published to the sync hub).
+
+Rejected alternatives: modeling directories as fake projects/worktrees (plants
+non-git lies in a git-centric data model that fleet identity logic depends
+on), and live-session discovery without a registry (rows vanish when sessions
+die; nothing to "open").
+
+## Data model and config
+
+- New global-config section:
+
+  ```toml
+  [[workspaces]]
+  name = "notes"
+  path = "/Users/me/notes"
+  ```
+
+- `models.Workspace{Name, Path string}`; `models.Config.Workspaces []Workspace`
+  (`mapstructure:"workspaces"`). Paths are expanded and symlink-resolved on
+  load like project paths.
+- `config.RegisterWorkspace(workspace models.Workspace) error`, mirroring
+  `RegisterProject`:
+  - Expand and resolve `Path`; error if it does not exist or is not a
+    directory (fail fast with the offending path in the message).
+  - Default `Name` to `filepath.Base(path)` when empty.
+  - Dedupe by resolved path: re-registering an existing path updates its name.
+  - Reject a duplicate name registered for a different path; the error
+    suggests `--name`.
+- `mergeLocalConfig` skips the `workspaces` key, same as `projects` and
+  `fleet.*`: the registry is machine-level and repo-local `.kwt.toml` must not
+  alter it.
+- Fleet manifests do not include workspaces. No hub, client, or state changes.
+
+## CLI
+
+New `kwt workspace` command group:
+
+- `kwt workspace add [path] [--name X]` — path defaults to the current
+  directory. Registers only; does not open a session.
+- `kwt workspace list` — table of name, path, and session state
+  (live/stopped).
+- `kwt workspace remove <name>` — unregisters. Never touches the directory.
+  A live session is left running and the command says so. Unknown names error
+  and list the registered names.
+
+Auto-register on open: when the TUI launches from a directory that is not
+inside a git repository, register it as a workspace best-effort (silently,
+mirroring launch-repo project registration), except when the directory is the
+user's home directory, which is never auto-registered.
+
+## TUI
+
+- `dashboard.Row` gains a third flavor: `Workspace *WorkspaceInfo` with
+  `Name`, `Path`, plus the existing `SessionName`/`SessionLive` fields on the
+  row. `Workspace` is mutually exclusive with `Entry` and `Fleet` (which can
+  appear together on merged worktree rows).
+- The backend appends one row per registered workspace after worktree and
+  fleet rows, computing session liveness from the same `listSessions` map.
+- Rendering: workspace name in the project column, tilde-abbreviated path in
+  the ref column, `local` in the machines column, session liveness in the
+  status column.
+- Actions on workspace rows:
+  - Open in tmux, attach outside tmux, kill session, and layout selection
+    work exactly as for worktree rows.
+  - Git-specific actions (new branch, sync/materialize, worktree remove) are
+    gated off with a status-line message.
+  - The remove keybinding unregisters the workspace after the standard
+    confirm prompt.
+- Name and path join the filter/search haystack.
+
+## Sessions and layouts
+
+- Session name: `kwt-workspace-dir-{name}-{hash8(path)}` via a new
+  `tmux.DirWorkspaceSessionName(name, path string) string`. The hash is over
+  the resolved path (collision resistance); the name passes through the
+  existing tmux sanitizer. The result still matches the existing
+  `kwt-workspace-*` session-parsing regex.
+- Opening uses the existing `tmux.WorkspaceRunner.EnsureAndAttach` with the
+  workspace directory as the pane root and the same layout presets.
+- Per-directory layout defaults reuse the trust-gated
+  `config.LoadRepoLayoutDefault(dir, interactive)` mechanism unchanged.
+
+## Error handling
+
+- `add`: missing/non-directory path, and duplicate-name errors as above.
+- `remove`: unknown name lists registered names.
+- TUI: gated actions produce a short status-line message, not an error state.
+- Auto-registration failures are silent (best-effort), matching project
+  auto-registration.
+
+## Testing
+
+- Config: register/dedupe by path, name-collision error, missing-path error,
+  name defaulting, `workspaces` excluded from local-config merge.
+- tmux: `DirWorkspaceSessionName` determinism, sanitization, regex
+  compatibility.
+- Backend: `List` returns workspace rows with correct liveness; home-dir
+  guard on auto-registration; non-git launch dir auto-registers.
+- TUI: rendering of workspace rows, action gating messages, unregister flow
+  with confirmation.
+- CLI: `add`/`list`/`remove` happy paths and each error path.

--- a/docs/superpowers/specs/2026-07-06-directory-workspaces-design.md
+++ b/docs/superpowers/specs/2026-07-06-directory-workspaces-design.md
@@ -31,9 +31,11 @@ die; nothing to "open").
   path = "/Users/me/notes"
   ```
 
-- `models.Workspace{Name, Path string}`; `models.Config.Workspaces []Workspace`
-  (`mapstructure:"workspaces"`). Paths are expanded and symlink-resolved on
-  load like project paths.
+- `models.Workspace{Name, Path string}` with both tag families on every field
+  (`mapstructure:"name" toml:"name"`, `mapstructure:"path" toml:"path"`),
+  matching existing persisted structs; `models.Config.Workspaces []Workspace`
+  (`mapstructure:"workspaces" toml:"workspaces"`). Paths are expanded and
+  symlink-resolved on load like project paths.
 - `config.RegisterWorkspace(workspace models.Workspace) error`, mirroring
   `RegisterProject`:
   - Expand and resolve `Path`; error if it does not exist or is not a
@@ -72,12 +74,24 @@ user's home directory, which is never auto-registered.
   appear together on merged worktree rows).
 - The backend appends one row per registered workspace after worktree and
   fleet rows, computing session liveness from the same `listSessions` map.
-- Rendering: workspace name in the project column, tilde-abbreviated path in
-  the ref column, `local` in the machines column, session liveness in the
-  status column.
+- Rendering, using the dashboard's actual columns (REPO, BRANCH, MACHINES,
+  CHANGES, HEADS, ACTIVITY, WORKSPACE): workspace name under REPO,
+  tilde-abbreviated path under BRANCH, `local` under MACHINES, `-` under
+  CHANGES and HEADS, `-` under ACTIVITY, and session liveness under WORKSPACE
+  through the existing `formatWorkspace` path.
+- Row-path, session, and layout helpers must branch on `Workspace`, not only
+  `Entry`. Today every action path treats `row.Entry == nil` as
+  non-actionable — the model's open/attach/kill guards and the backend's
+  `attachWorkspace`, `sessionName`, and `rowPathForHandoff` all reject nil
+  entries, and `resolveLayout` resolves the repo root via
+  `repositoryRootForRow`. Each of these gains a workspace branch: the session
+  name comes from `DirWorkspaceSessionName`, the pane root and handoff path
+  are `Workspace.Path`, and the per-directory layout default is loaded from
+  `Workspace.Path` instead of a repo root.
 - Actions on workspace rows:
   - Open in tmux, attach outside tmux, kill session, and layout selection
-    work exactly as for worktree rows.
+    work exactly as for worktree rows once the guards above branch on
+    `Workspace`.
   - Git-specific actions (new branch, sync/materialize, worktree remove) are
     gated off with a status-line message.
   - The remove keybinding unregisters the workspace after the standard
@@ -91,6 +105,12 @@ user's home directory, which is never auto-registered.
   the resolved path (collision resistance); the name passes through the
   existing tmux sanitizer. The result still matches the existing
   `kwt-workspace-*` session-parsing regex.
+- Rename semantics: liveness detection and attach match live sessions by the
+  `kwt-workspace-dir-` prefix plus the trailing path hash, not the full
+  session name. Renaming a registered workspace therefore re-attaches to the
+  existing live session (under its old tmux name) rather than orphaning it;
+  the dashboard shows the new name immediately, and the tmux session adopts
+  the new name the next time it is created from scratch.
 - Opening uses the existing `tmux.WorkspaceRunner.EnsureAndAttach` with the
   workspace directory as the pane root and the same layout presets.
 - Per-directory layout defaults reuse the trust-gated
@@ -109,7 +129,8 @@ user's home directory, which is never auto-registered.
 - Config: register/dedupe by path, name-collision error, missing-path error,
   name defaulting, `workspaces` excluded from local-config merge.
 - tmux: `DirWorkspaceSessionName` determinism, sanitization, regex
-  compatibility.
+  compatibility, and hash-suffix matching so a renamed workspace still
+  detects and attaches to its live old-name session.
 - Backend: `List` returns workspace rows with correct liveness; home-dir
   guard on auto-registration; non-git launch dir auto-registers.
 - TUI: rendering of workspace rows, action gating messages, unregister flow

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -69,6 +69,9 @@ func executeTUIHandoff(backend *tuiBackend, handoff dashboard.Handoff) error {
 }
 
 func rowPathForHandoff(row dashboard.Row) string {
+	if row.Workspace != nil {
+		return row.Workspace.Path
+	}
 	if row.Entry != nil {
 		return row.Entry.Path
 	}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
@@ -44,7 +45,8 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 
 	backend := newTUIBackend(cfg)
-	model := dashboard.NewModel(backend, cfg.Worktree.BaseDir)
+	model := dashboard.NewModel(backend, cfg.Worktree.BaseDir).
+		WithInitialAnchor(launchAnchorPath(backend.launchDir))
 	final, err := tea.NewProgram(model).Run()
 	if err != nil {
 		return err
@@ -66,6 +68,19 @@ func executeTUIHandoff(backend *tuiBackend, handoff dashboard.Handoff) error {
 	default:
 		return nil
 	}
+}
+
+// launchAnchorPath resolves symlinks in the launch directory so the initial
+// anchor string matches registered workspace paths, which are stored
+// symlink-resolved.
+func launchAnchorPath(launchDir string) string {
+	if launchDir == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(launchDir); err == nil {
+		return resolved
+	}
+	return launchDir
 }
 
 func rowPathForHandoff(row dashboard.Row) string {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -36,6 +36,7 @@ type tuiBackend struct {
 	listSessions             func() ([]string, error)
 	registerProject          func(models.Project) error
 	registerWorkspace        func(models.Workspace) (models.Workspace, error)
+	unregisterWorkspace      func(name string) error
 	readFleetState           func(context.Context, *models.Config) (fleet.FleetState, error)
 	now                      func() time.Time
 }
@@ -58,6 +59,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		listSessions:             tmuxCmd.ListSessions,
 		registerProject:          config.RegisterProject,
 		registerWorkspace:        config.RegisterWorkspace,
+		unregisterWorkspace:      config.UnregisterWorkspace,
 		readFleetState:           readTUIFleetState,
 		now:                      time.Now,
 	}
@@ -1164,7 +1166,7 @@ func (b *tuiBackend) InsideTmux() bool {
 }
 
 func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, layoutName string, insideTmux bool, interactive bool) error {
-	if row.Entry == nil {
+	if row.Entry == nil && row.Workspace == nil {
 		return fmt.Errorf("no worktree selected")
 	}
 	sessionName, err := b.sessionName(row)
@@ -1175,7 +1177,17 @@ func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, lay
 	if err != nil {
 		return err
 	}
-	return tmux.NewWorkspaceRunner(b.tmux).EnsureAndAttach(ctx, sessionName, row.Entry.Path, layout, insideTmux)
+	return tmux.NewWorkspaceRunner(b.tmux).EnsureAndAttach(ctx, sessionName, rowPaneRoot(row), layout, insideTmux)
+}
+
+func rowPaneRoot(row dashboard.Row) string {
+	if row.Workspace != nil {
+		return row.Workspace.Path
+	}
+	if row.Entry != nil {
+		return row.Entry.Path
+	}
+	return ""
 }
 
 func (b *tuiBackend) resolveLayout(row dashboard.Row, layoutName string, interactive bool) (models.Layout, error) {
@@ -1184,13 +1196,17 @@ func (b *tuiBackend) resolveLayout(row dashboard.Row, layoutName string, interac
 	if layoutName != "" {
 		layout, err = tmux.ResolveLayout(b.cfg.Layouts, layoutName, false, "", nil)
 	} else {
-		var repoRoot string
-		repoRoot, err = b.repositoryRootForRow(row)
-		if err != nil {
-			return models.Layout{}, err
+		var layoutRoot string
+		if row.Workspace != nil {
+			layoutRoot = row.Workspace.Path
+		} else {
+			layoutRoot, err = b.repositoryRootForRow(row)
+			if err != nil {
+				return models.Layout{}, err
+			}
 		}
 		var targetDefault string
-		targetDefault, err = config.LoadRepoLayoutDefault(repoRoot, interactive)
+		targetDefault, err = config.LoadRepoLayoutDefault(layoutRoot, interactive)
 		if err != nil {
 			return models.Layout{}, err
 		}
@@ -1206,10 +1222,32 @@ func (b *tuiBackend) sessionName(row dashboard.Row) (string, error) {
 	if row.SessionName != "" {
 		return row.SessionName, nil
 	}
+	if row.Workspace != nil {
+		return tmux.DirWorkspaceSessionName(row.Workspace.Name, row.Workspace.Path), nil
+	}
 	if row.Entry == nil || row.Entry.RepositoryInfo == nil {
 		return "", fmt.Errorf("could not resolve repository info for %s", rowPathForHandoff(row))
 	}
 	return tmux.WorkspaceSessionName(row.Entry.RepositoryInfo, row.Entry.Branch, row.Entry.Path), nil
+}
+
+func (b *tuiBackend) UnregisterWorkspace(row dashboard.Row) error {
+	if row.Workspace == nil {
+		return fmt.Errorf("no workspace selected")
+	}
+	if err := b.unregisterWorkspace(row.Workspace.Name); err != nil {
+		return err
+	}
+	if b.cfg != nil {
+		kept := b.cfg.Workspaces[:0]
+		for _, workspace := range b.cfg.Workspaces {
+			if !samePath(workspace.Path, row.Workspace.Path) {
+				kept = append(kept, workspace)
+			}
+		}
+		b.cfg.Workspaces = kept
+	}
+	return nil
 }
 
 func unknownStatusForEntry(entry *discovery.GlobalWorktreeEntry) *models.WorktreeStatus {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -26,19 +26,20 @@ import (
 )
 
 type tuiBackend struct {
-	cfg                      *models.Config
-	tmux                     *tmux.TmuxCommand
-	launchDir                string
-	discoverGlobalWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverProjectWorktrees func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverLaunchWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	collectStatuses          func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
-	listSessions             func() ([]string, error)
-	registerProject          func(models.Project) error
-	registerWorkspace        func(models.Workspace) (models.Workspace, error)
-	unregisterWorkspace      func(name string) error
-	readFleetState           func(context.Context, *models.Config) (fleet.FleetState, error)
-	now                      func() time.Time
+	cfg                       *models.Config
+	tmux                      *tmux.TmuxCommand
+	launchDir                 string
+	launchWorkspaceRegistered bool
+	discoverGlobalWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverProjectWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverLaunchWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
+	listSessions              func() ([]string, error)
+	registerProject           func(models.Project) error
+	registerWorkspace         func(models.Workspace) (models.Workspace, error)
+	unregisterWorkspace       func(name string) error
+	readFleetState            func(context.Context, *models.Config) (fleet.FleetState, error)
+	now                       func() time.Time
 }
 
 func newTUIBackend(cfg *models.Config) *tuiBackend {
@@ -284,12 +285,25 @@ func (b *tuiBackend) workspaceRows(sessions []string) []dashboard.Row {
 // registerLaunchWorkspace records a non-git launch directory as a workspace,
 // best-effort, mirroring launch-repo project registration. The home directory
 // is never auto-registered: running kwt from ~ is common and would create a
-// junk entry.
+// junk entry. Registration is attempted at most once per backend lifetime, so
+// a later refresh never re-registers a workspace the user just unregistered
+// in the TUI, and the global config is not rewritten on every List call.
 func (b *tuiBackend) registerLaunchWorkspace(launchEntries []*discovery.GlobalWorktreeEntry) {
+	if b.launchWorkspaceRegistered {
+		return
+	}
+	b.launchWorkspaceRegistered = true
+
 	if b.registerWorkspace == nil || b.launchDir == "" || len(launchEntries) > 0 {
 		return
 	}
 	if home, err := os.UserHomeDir(); err == nil && samePath(home, b.launchDir) {
+		return
+	}
+	if launchDirAlreadyRegistered(b.cfg, b.launchDir) {
+		// Preserve a custom name set via `kwt workspace add --name`: the
+		// same-path branch of config.RegisterWorkspace would otherwise
+		// overwrite it with the directory's defaulted base name.
 		return
 	}
 	stored, err := b.registerWorkspace(models.Workspace{Path: b.launchDir})
@@ -297,6 +311,18 @@ func (b *tuiBackend) registerLaunchWorkspace(launchEntries []*discovery.GlobalWo
 		return
 	}
 	b.cfg.Workspaces = upsertWorkspace(b.cfg.Workspaces, stored)
+}
+
+func launchDirAlreadyRegistered(cfg *models.Config, launchDir string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, workspace := range cfg.Workspaces {
+		if samePath(workspace.Path, launchDir) {
+			return true
+		}
+	}
+	return false
 }
 
 func upsertWorkspace(workspaces []models.Workspace, workspace models.Workspace) []models.Workspace {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -35,6 +35,7 @@ type tuiBackend struct {
 	collectStatuses          func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
 	listSessions             func() ([]string, error)
 	registerProject          func(models.Project) error
+	registerWorkspace        func(models.Workspace) (models.Workspace, error)
 	readFleetState           func(context.Context, *models.Config) (fleet.FleetState, error)
 	now                      func() time.Time
 }
@@ -56,6 +57,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		collectStatuses:          collectTUIStatuses,
 		listSessions:             tmuxCmd.ListSessions,
 		registerProject:          config.RegisterProject,
+		registerWorkspace:        config.RegisterWorkspace,
 		readFleetState:           readTUIFleetState,
 		now:                      time.Now,
 	}
@@ -74,6 +76,7 @@ func (b *tuiBackend) List(ctx context.Context) ([]dashboard.Row, []string, error
 		return nil, nil, fmt.Errorf("failed to discover launch repository worktrees: %w", err)
 	}
 	b.registerLaunchProject(launchEntries)
+	b.registerLaunchWorkspace(launchEntries)
 	entries = mergeTUIEntries(entries, launchEntries)
 
 	statusByPath, err := b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
@@ -98,6 +101,7 @@ func (b *tuiBackend) List(ctx context.Context) ([]dashboard.Row, []string, error
 		}
 		rows = append(rows, buildTUIRow(entry, st, liveSessions))
 	}
+	rows = append(rows, b.workspaceRows(sessions)...)
 	rows, warnings := b.mergeFleetRows(ctx, rows)
 	return rows, warnings, nil
 }
@@ -250,6 +254,57 @@ func (b *tuiBackend) registerLaunchProject(entries []*discovery.GlobalWorktreeEn
 		return
 	}
 	b.upsertProject(project)
+}
+
+func (b *tuiBackend) workspaceRows(sessions []string) []dashboard.Row {
+	if b.cfg == nil || len(b.cfg.Workspaces) == 0 {
+		return nil
+	}
+	rows := make([]dashboard.Row, 0, len(b.cfg.Workspaces))
+	for _, workspace := range b.cfg.Workspaces {
+		sessionName := tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path)
+		sessionLive := false
+		// Match by path hash so a renamed workspace still finds (and later
+		// attaches to) its live session created under the old name.
+		if live, ok := tmux.MatchDirWorkspaceSession(sessions, workspace.Path); ok {
+			sessionName = live
+			sessionLive = true
+		}
+		rows = append(rows, dashboard.Row{
+			Workspace:   &dashboard.WorkspaceInfo{Name: workspace.Name, Path: workspace.Path},
+			SessionName: sessionName,
+			SessionLive: sessionLive,
+		})
+	}
+	return rows
+}
+
+// registerLaunchWorkspace records a non-git launch directory as a workspace,
+// best-effort, mirroring launch-repo project registration. The home directory
+// is never auto-registered: running kwt from ~ is common and would create a
+// junk entry.
+func (b *tuiBackend) registerLaunchWorkspace(launchEntries []*discovery.GlobalWorktreeEntry) {
+	if b.registerWorkspace == nil || b.launchDir == "" || len(launchEntries) > 0 {
+		return
+	}
+	if home, err := os.UserHomeDir(); err == nil && samePath(home, b.launchDir) {
+		return
+	}
+	stored, err := b.registerWorkspace(models.Workspace{Path: b.launchDir})
+	if err != nil {
+		return
+	}
+	b.cfg.Workspaces = upsertWorkspace(b.cfg.Workspaces, stored)
+}
+
+func upsertWorkspace(workspaces []models.Workspace, workspace models.Workspace) []models.Workspace {
+	for i := range workspaces {
+		if samePath(workspaces[i].Path, workspace.Path) {
+			workspaces[i] = workspace
+			return workspaces
+		}
+	}
+	return append(workspaces, workspace)
 }
 
 func (b *tuiBackend) projectByPath(projectPath string) (models.Project, bool) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/fleet"
 	"go.kenn.io/kwt/internal/tmux"
@@ -1956,16 +1959,106 @@ func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
 
 func TestTUIBackendSessionNameAndHandoffPathForWorkspaceRow(t *testing.T) {
 	row := dashboard.Row{
-		Workspace:   &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
-		SessionName: tmux.DirWorkspaceSessionName("notes", "/Users/me/notes"),
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
 	}
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 
 	name, err := backend.sessionName(row)
 
 	require.NoError(t, err)
-	assert.Equal(t, row.SessionName, name)
+	assert.Equal(t, tmux.DirWorkspaceSessionName("notes", "/Users/me/notes"), name,
+		"an unset SessionName must fall back to the workspace branch")
 	assert.Equal(t, "/Users/me/notes", rowPathForHandoff(row))
+
+	row.SessionName = "live-session-name"
+	name, err = backend.sessionName(row)
+
+	require.NoError(t, err)
+	assert.Equal(t, "live-session-name", name,
+		"a non-empty SessionName must win over the workspace branch")
+}
+
+func TestRowPaneRoot(t *testing.T) {
+	assert.Equal(t, "/Users/me/notes", rowPaneRoot(dashboard.Row{
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+	}), "a workspace row must use the workspace path")
+
+	assert.Equal(t, "/repos/service", rowPaneRoot(dashboard.Row{
+		Entry: &discovery.GlobalWorktreeEntry{Path: "/repos/service"},
+	}), "an entry row must use the entry path")
+
+	assert.Equal(t, "", rowPaneRoot(dashboard.Row{}),
+		"an empty row must fall back to an empty pane root")
+}
+
+func TestTUIBackendAttachWorkspaceGuardRejectsEmptyRow(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+
+	err := backend.attachWorkspace(context.Background(), dashboard.Row{}, "", false, false)
+
+	require.Error(t, err)
+	assert.Equal(t, "no worktree selected", err.Error())
+}
+
+// TestTUIBackendAttachWorkspacePassesGuardForWorkspaceRow exercises the
+// relaxed guard in attachWorkspace: a workspace-only row (row.Entry == nil)
+// must get past it. There is no seam to stub the tmux runner that
+// attachWorkspace constructs internally, so this test relies on an empty
+// layouts config to force a layout-resolution error before EnsureAndAttach
+// is ever reached; that keeps the test from touching real tmux while still
+// proving the row cleared the guard.
+func TestTUIBackendAttachWorkspacePassesGuardForWorkspaceRow(t *testing.T) {
+	row := dashboard.Row{
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: t.TempDir()},
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+
+	err := backend.attachWorkspace(context.Background(), row, "", false, false)
+
+	require.Error(t, err)
+	assert.NotEqual(t, "no worktree selected", err.Error(),
+		"a workspace row must clear the entry/workspace guard")
+}
+
+// TestTUIBackendResolveLayoutUsesWorkspacePathForDefault covers resolveLayout's
+// workspace branch: for a workspace row, the repo-local layout default must be
+// read from row.Workspace.Path, not from repositoryRootForRow (which requires
+// row.Entry and would error for a workspace-only row).
+func TestTUIBackendResolveLayoutUsesWorkspacePathForDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	workspaceDir := t.TempDir()
+	localTOML := []byte("[layouts]\ndefault = \"focus\"\n")
+	localConfigPath := filepath.Join(workspaceDir, ".kwt.toml")
+	require.NoError(t, os.WriteFile(localConfigPath, localTOML, 0o644))
+
+	absPath, err := filepath.EvalSymlinks(localConfigPath)
+	require.NoError(t, err)
+	sum := sha256.Sum256(localTOML)
+	trustStorePath := filepath.Join(home, ".config", "kwt", "trusted_configs.json")
+	store, err := config.LoadTrustStore(trustStorePath)
+	require.NoError(t, err)
+	require.NoError(t, store.Add(absPath, hex.EncodeToString(sum[:])))
+
+	cfg := &models.Config{
+		Layouts: models.LayoutsConfig{
+			Default: "quad",
+			Presets: []models.Layout{
+				{Name: "quad", Arrange: "tiled", Panes: []string{"shell"}},
+				{Name: "focus", Arrange: "main-vertical", Panes: []string{"shell"}},
+			},
+		},
+	}
+	row := dashboard.Row{Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: workspaceDir}}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+
+	layout, err := backend.resolveLayout(row, "", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "focus", layout.Name,
+		"the workspace directory's .kwt.toml default must win over the global default")
 }
 
 func TestTUIBackendUnregisterWorkspace(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/fleet"
+	"go.kenn.io/kwt/internal/tmux"
 	dashboard "go.kenn.io/kwt/internal/tui"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/pkg/models"
@@ -1823,6 +1824,9 @@ func runTUITestGitOutput(t *testing.T, dir string, args ...string) string {
 
 func stubTUIProjectRegistration(backend *tuiBackend) {
 	backend.registerProject = func(models.Project) error { return nil }
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		return workspace, nil
+	}
 }
 
 func TestTUIBackendListReturnsHubWarnings(t *testing.T) {
@@ -1856,4 +1860,96 @@ func TestTUIBackendListReturnsHubWarnings(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, warnings, 1)
 	assert.Equal(t, `multiple machines are publishing as host ID "same" (host same)`, warnings[0])
+}
+
+func TestTUIBackendListIncludesWorkspaceRows(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &models.Config{
+		Worktree:   models.WorktreeConfig{BaseDir: "/global"},
+		Workspaces: []models.Workspace{{Name: "notes", Path: dir}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	liveSession := tmux.DirWorkspaceSessionName("old-name", dir)
+	backend.listSessions = func() ([]string, error) { return []string{liveSession}, nil }
+
+	rows, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].Workspace)
+	assert.Equal(t, "notes", rows[0].Workspace.Name)
+	assert.Equal(t, dir, rows[0].Workspace.Path)
+	assert.True(t, rows[0].SessionLive,
+		"liveness must match by path hash even under an old session name")
+	assert.Equal(t, liveSession, rows[0].SessionName,
+		"attach must target the live session, not the freshly computed name")
+	assert.Nil(t, rows[0].Entry)
+	assert.Nil(t, rows[0].Fleet)
+}
+
+func TestTUIBackendAutoRegistersNonGitLaunchDir(t *testing.T) {
+	launchDir := t.TempDir()
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	backend := newTUIBackendWithLaunchDir(cfg, launchDir)
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	var registered []models.Workspace
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		registered = append(registered, workspace)
+		return workspace, nil
+	}
+
+	_, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, registered, 1)
+	assert.Equal(t, launchDir, registered[0].Path)
+}
+
+func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	backend := newTUIBackendWithLaunchDir(cfg, home)
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		t.Fatalf("home directory must never be auto-registered, got %v", workspace)
+		return workspace, nil
+	}
+
+	_, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
 }

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1930,6 +1930,116 @@ func TestTUIBackendAutoRegistersNonGitLaunchDir(t *testing.T) {
 	assert.Equal(t, launchDir, registered[0].Path)
 }
 
+func TestTUIBackendSkipsAutoRegisterWhenAlreadyRegisteredWithCustomName(t *testing.T) {
+	launchDir := t.TempDir()
+	cfg := &models.Config{
+		Worktree:   models.WorktreeConfig{BaseDir: "/global"},
+		Workspaces: []models.Workspace{{Name: "mynotes", Path: launchDir}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, launchDir)
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	called := false
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		called = true
+		return workspace, nil
+	}
+
+	_, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	assert.False(t, called, "an already-registered launch dir must not be re-registered")
+	require.Len(t, cfg.Workspaces, 1)
+	assert.Equal(t, "mynotes", cfg.Workspaces[0].Name,
+		"a custom workspace name must survive the auto-registration refresh")
+}
+
+func TestTUIBackendAutoRegistersLaunchWorkspaceOnlyOnce(t *testing.T) {
+	launchDir := t.TempDir()
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	backend := newTUIBackendWithLaunchDir(cfg, launchDir)
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	registrations := 0
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		registrations++
+		return workspace, nil
+	}
+	backend.unregisterWorkspace = func(name string) error { return nil }
+
+	_, _, err := backend.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, registrations)
+
+	require.NoError(t, backend.UnregisterWorkspace(dashboard.Row{
+		Workspace: &dashboard.WorkspaceInfo{Name: filepath.Base(launchDir), Path: launchDir},
+	}))
+	assert.Empty(t, cfg.Workspaces, "unregister must drop the in-memory entry")
+
+	_, _, err = backend.List(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, registrations,
+		"a second refresh must not re-register the launch workspace after it was unregistered")
+	assert.Empty(t, cfg.Workspaces,
+		"the unregistered launch workspace must not reappear on the next refresh")
+}
+
+func TestTUIBackendNeverRegistersWorkspaceForGitLaunchDir(t *testing.T) {
+	launchDir := "/repos/other"
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	backend := newTUIBackendWithLaunchDir(cfg, launchDir)
+	stubTUIProjectRegistration(backend)
+	launchEntry := &discovery.GlobalWorktreeEntry{
+		RepositoryInfo: &url.RepositoryInfo{Host: "github.com", Owner: "example", Repository: "other"},
+		Branch:         "main",
+		Path:           launchDir,
+		IsMain:         true,
+	}
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return []*discovery.GlobalWorktreeEntry{launchEntry}, nil
+	}
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		t.Fatalf("a git launch directory must never be registered as a workspace, got %v", workspace)
+		return workspace, nil
+	}
+
+	_, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Workspaces)
+}
+
 func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -2028,6 +2138,7 @@ func TestTUIBackendResolveLayoutUsesWorkspacePathForDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("KWT_HOME", filepath.Join(home, ".config", "kwt"))
 
 	workspaceDir := t.TempDir()
 	localTOML := []byte("[layouts]\ndefault = \"focus\"\n")

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2043,6 +2043,7 @@ func TestTUIBackendNeverRegistersWorkspaceForGitLaunchDir(t *testing.T) {
 func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads USERPROFILE on Windows
 	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
 	backend := newTUIBackendWithLaunchDir(cfg, home)
 	stubTUIProjectRegistration(backend)

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1953,3 +1953,38 @@ func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestTUIBackendSessionNameAndHandoffPathForWorkspaceRow(t *testing.T) {
+	row := dashboard.Row{
+		Workspace:   &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+		SessionName: tmux.DirWorkspaceSessionName("notes", "/Users/me/notes"),
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+
+	name, err := backend.sessionName(row)
+
+	require.NoError(t, err)
+	assert.Equal(t, row.SessionName, name)
+	assert.Equal(t, "/Users/me/notes", rowPathForHandoff(row))
+}
+
+func TestTUIBackendUnregisterWorkspace(t *testing.T) {
+	cfg := &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	var removed []string
+	backend.unregisterWorkspace = func(name string) error {
+		removed = append(removed, name)
+		return nil
+	}
+
+	err := backend.UnregisterWorkspace(dashboard.Row{
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"notes"}, removed)
+	assert.Empty(t, cfg.Workspaces, "unregister must also drop the in-memory entry")
+
+	err = backend.UnregisterWorkspace(dashboard.Row{})
+	require.Error(t, err)
+}

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
@@ -103,7 +104,7 @@ func runWorkspaceRemove(cmd *cobra.Command, args []string) error {
 	livePath := ""
 	if cfgErr == nil {
 		for _, workspace := range cfg.Workspaces {
-			if workspace.Name == name {
+			if strings.EqualFold(workspace.Name, name) {
 				livePath = workspace.Path
 			}
 		}

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -26,6 +26,10 @@ var (
 var workspaceCmd = &cobra.Command{
 	Use:   "workspace",
 	Short: "Manage directory workspaces not bound to a git worktree",
+	// Isolation: workspace commands manage machine-level state in the global
+	// config and must not merge the caller's cwd .kwt.toml. Overriding the
+	// root PersistentPreRunE with a no-op keeps the global config pristine.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 }
 
 var workspaceAddCmd = &cobra.Command{
@@ -85,7 +89,7 @@ func runWorkspaceList(cmd *cobra.Command, args []string) error {
 	}
 	sessions, err := listWorkspaceSessions()
 	if err != nil {
-		sessions = nil
+		return fmt.Errorf("failed to list tmux sessions: %w", err)
 	}
 	t := table.New().SetOutput(cmd.OutOrStdout()).Headers("NAME", "PATH", "SESSION")
 	for _, workspace := range cfg.Workspaces {
@@ -115,12 +119,12 @@ func runWorkspaceRemove(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unregistered workspace %s\n", name)
 	if livePath != "" {
 		sessions, err := listWorkspaceSessions()
-		if err == nil {
-			if session, ok := tmux.MatchDirWorkspaceSession(sessions, livePath); ok {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-					"its tmux session %s is still running; kill it with: tmux kill-session -t %s\n",
-					session, session)
-			}
+		if err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not check for a live session: %v\n", err)
+		} else if session, ok := tmux.MatchDirWorkspaceSession(sessions, livePath); ok {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"its tmux session %s is still running; kill it with: tmux kill-session -t %s\n",
+				session, session)
 		}
 	}
 	return nil

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/table"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+var (
+	workspaceAddName string
+
+	registerWorkspace     = config.RegisterWorkspace
+	unregisterWorkspace   = config.UnregisterWorkspace
+	loadWorkspaceConfig   = config.Load
+	listWorkspaceSessions = func() ([]string, error) {
+		return tmux.NewTmuxCommand("").ListSessions()
+	}
+)
+
+var workspaceCmd = &cobra.Command{
+	Use:   "workspace",
+	Short: "Manage directory workspaces not bound to a git worktree",
+}
+
+var workspaceAddCmd = &cobra.Command{
+	Use:   "add [path]",
+	Short: "Register a directory as a workspace",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runWorkspaceAdd,
+}
+
+var workspaceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered directory workspaces",
+	Args:  cobra.NoArgs,
+	RunE:  runWorkspaceList,
+}
+
+var workspaceRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Unregister a directory workspace (never deletes the directory)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWorkspaceRemove,
+}
+
+func init() {
+	workspaceAddCmd.Flags().StringVar(&workspaceAddName, "name", "", "workspace name (defaults to the directory base name)")
+	workspaceCmd.AddCommand(workspaceAddCmd, workspaceListCmd, workspaceRemoveCmd)
+	rootCmd.AddCommand(workspaceCmd)
+}
+
+func runWorkspaceAdd(cmd *cobra.Command, args []string) error {
+	path := ""
+	if len(args) == 1 {
+		path = args[0]
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to resolve current directory: %w", err)
+		}
+		path = cwd
+	}
+	stored, err := registerWorkspace(models.Workspace{Name: workspaceAddName, Path: path})
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "registered workspace %s at %s\n", stored.Name, stored.Path)
+	return nil
+}
+
+func runWorkspaceList(cmd *cobra.Command, args []string) error {
+	cfg, err := loadWorkspaceConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if len(cfg.Workspaces) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no workspaces registered")
+		return nil
+	}
+	sessions, err := listWorkspaceSessions()
+	if err != nil {
+		sessions = nil
+	}
+	t := table.New().SetOutput(cmd.OutOrStdout()).Headers("NAME", "PATH", "SESSION")
+	for _, workspace := range cfg.Workspaces {
+		state := "stopped"
+		if _, ok := tmux.MatchDirWorkspaceSession(sessions, workspace.Path); ok {
+			state = "live"
+		}
+		t.Row(workspace.Name, workspace.Path, state)
+	}
+	return t.Println()
+}
+
+func runWorkspaceRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	cfg, cfgErr := loadWorkspaceConfig()
+	livePath := ""
+	if cfgErr == nil {
+		for _, workspace := range cfg.Workspaces {
+			if workspace.Name == name {
+				livePath = workspace.Path
+			}
+		}
+	}
+	if err := unregisterWorkspace(name); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unregistered workspace %s\n", name)
+	if livePath != "" {
+		sessions, err := listWorkspaceSessions()
+		if err == nil {
+			if session, ok := tmux.MatchDirWorkspaceSession(sessions, livePath); ok {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+					"its tmux session %s is still running; kill it with: tmux kill-session -t %s\n",
+					session, session)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func changeDir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func resetWorkspaceCommandDeps(t *testing.T) {
+	t.Helper()
+	origRegister := registerWorkspace
+	origUnregister := unregisterWorkspace
+	origLoad := loadWorkspaceConfig
+	origSessions := listWorkspaceSessions
+	t.Cleanup(func() {
+		registerWorkspace = origRegister
+		unregisterWorkspace = origUnregister
+		loadWorkspaceConfig = origLoad
+		listWorkspaceSessions = origSessions
+	})
+}
+
+func TestWorkspaceAddRegistersCwdByDefault(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	dir := t.TempDir()
+	changeDir(t, dir)
+	var got models.Workspace
+	registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		got = workspace
+		workspace.Name = "resolved"
+		return workspace, nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceAdd(cmd, nil)
+
+	require.NoError(t, err)
+	// Normalize paths to handle macOS symlink differences (/var vs /private/var)
+	expectedPath, _ := filepath.EvalSymlinks(dir)
+	gotPath, _ := filepath.EvalSymlinks(got.Path)
+	assert.Equal(t, expectedPath, gotPath)
+	assert.Empty(t, got.Name)
+	assert.Contains(t, stdout.String(), "resolved")
+}
+
+func TestWorkspaceAddUsesArgsAndNameFlag(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	var got models.Workspace
+	registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		got = workspace
+		return workspace, nil
+	}
+
+	cmd, _, _ := fleetTestCommand()
+	workspaceAddName = "scratch"
+	t.Cleanup(func() { workspaceAddName = "" })
+	err := runWorkspaceAdd(cmd, []string{"/tmp/somewhere"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/somewhere", got.Path)
+	assert.Equal(t, "scratch", got.Name)
+}
+
+func TestWorkspaceListShowsLiveState(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{
+			{Name: "notes", Path: "/Users/me/notes"},
+			{Name: "scratch", Path: "/Users/me/scratch"},
+		}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{tmuxDirSessionNameForTest("notes", "/Users/me/notes")}, nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceList(cmd, nil)
+
+	require.NoError(t, err)
+	out := stdout.String()
+	assert.Contains(t, out, "notes")
+	assert.Contains(t, out, "live")
+	assert.Contains(t, out, "scratch")
+	assert.Contains(t, out, "stopped")
+}
+
+func TestWorkspaceRemoveReportsLiveSession(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{tmuxDirSessionNameForTest("notes", "/Users/me/notes")}, nil
+	}
+	unregisterWorkspace = func(name string) error {
+		assert.Equal(t, "notes", name)
+		return nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceRemove(cmd, []string{"notes"})
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "still running")
+}
+
+func TestWorkspaceRemovePropagatesUnknownNameError(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) { return &models.Config{}, nil }
+	listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+	unregisterWorkspace = func(name string) error {
+		return errors.New(`no workspace named "nope"; no workspaces registered`)
+	}
+
+	cmd, _, _ := fleetTestCommand()
+	err := runWorkspaceRemove(cmd, []string{"nope"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspace named")
+}
+
+func tmuxDirSessionNameForTest(name, path string) string {
+	return tmux.DirWorkspaceSessionName(name, path)
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -156,3 +156,53 @@ func TestWorkspaceRemoveReportsLiveSessionCaseInsensitive(t *testing.T) {
 func tmuxDirSessionNameForTest(name, path string) string {
 	return tmux.DirWorkspaceSessionName(name, path)
 }
+
+// TestWorkspaceCmdIsolatesFromCwdConfig guards the config-isolation invariant:
+// workspaceCmd overrides the root PersistentPreRunE (which merges the
+// caller's cwd .kwt.toml) with a no-op, since workspace commands manage
+// machine-level global state. If the override is removed, workspace
+// subcommands fall back to root's cwd merge -- this test fails because the
+// field goes nil.
+func TestWorkspaceCmdIsolatesFromCwdConfig(t *testing.T) {
+	require.NotNil(t, workspaceCmd.PersistentPreRunE,
+		"workspace must define its own PersistentPreRunE to bypass root's cwd merge")
+	require.NoError(t, workspaceCmd.PersistentPreRunE(workspaceCmd, nil),
+		"workspace's PersistentPreRunE must be a no-op that never errors")
+}
+
+func TestWorkspaceListPropagatesSessionError(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return nil, errors.New("tmux: no such file or directory")
+	}
+
+	cmd, _, _ := fleetTestCommand()
+	err := runWorkspaceList(cmd, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list tmux sessions")
+}
+
+func TestWorkspaceRemoveWarnsOnSessionCheckError(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return nil, errors.New("tmux: no such file or directory")
+	}
+	unregisterWorkspace = func(name string) error {
+		assert.Equal(t, "notes", name)
+		return nil
+	}
+
+	cmd, stdout, stderr := fleetTestCommand()
+	err := runWorkspaceRemove(cmd, []string{"notes"})
+
+	require.NoError(t, err, "the session check is advisory; it must not fail the remove")
+	assert.Contains(t, stdout.String(), "unregistered workspace notes")
+	assert.Contains(t, stderr.String(), "warning: could not check for a live session")
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -133,6 +133,26 @@ func TestWorkspaceRemovePropagatesUnknownNameError(t *testing.T) {
 	assert.Contains(t, err.Error(), "no workspace named")
 }
 
+func TestWorkspaceRemoveReportsLiveSessionCaseInsensitive(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: []models.Workspace{{Name: "Notes", Path: "/Users/me/notes"}}}, nil
+	}
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{tmuxDirSessionNameForTest("Notes", "/Users/me/notes")}, nil
+	}
+	unregisterWorkspace = func(name string) error {
+		assert.Equal(t, "notes", name)
+		return nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	err := runWorkspaceRemove(cmd, []string{"notes"})
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "still running")
+}
+
 func tmuxDirSessionNameForTest(name, path string) string {
 	return tmux.DirWorkspaceSessionName(name, path)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,7 +148,7 @@ func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive boo
 		switch {
 		case key == "repository_settings":
 			mergeRepositorySettings(localViper)
-		case key == "projects":
+		case key == "projects" || key == "workspaces":
 			continue
 		case key == "fleet" || strings.HasPrefix(key, "fleet."):
 			// Sync settings decide where bearer tokens are read from and
@@ -520,6 +520,20 @@ func expandConfigPaths(cfg *models.Config) error {
 			expandedPath = resolved
 		}
 		cfg.Projects[i].Path = expandedPath
+	}
+	for i := range cfg.Workspaces {
+		path := cfg.Workspaces[i].Path
+		if path == "" {
+			continue
+		}
+		expandedPath, err = utils.ExpandPath(path)
+		if err != nil {
+			return fmt.Errorf("failed to expand workspace path: %w", err)
+		}
+		if resolved, err := filepath.EvalSymlinks(expandedPath); err == nil {
+			expandedPath = resolved
+		}
+		cfg.Workspaces[i].Path = expandedPath
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,7 +148,7 @@ func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive boo
 		switch {
 		case key == "repository_settings":
 			mergeRepositorySettings(localViper)
-		case key == "projects" || key == "workspaces":
+		case key == "projects" || key == "workspaces" || strings.HasPrefix(key, "workspaces."):
 			continue
 		case key == "fleet" || strings.HasPrefix(key, "fleet."):
 			// Sync settings decide where bearer tokens are read from and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -539,6 +539,34 @@ path = "/tmp/evil"
 		}
 	})
 
+	t.Run("IgnoresWorkspacesTable", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+
+		tmpDir := t.TempDir()
+		localConfig := []byte(`
+[workspaces]
+name = "evil"
+path = "/tmp/evil"
+`)
+		if err := os.WriteFile(filepath.Join(tmpDir, ".kwt.toml"), localConfig, 0644); err != nil {
+			t.Fatalf("Failed to create local config: %v", err)
+		}
+		changeDir(t, tmpDir)
+
+		viper.SetConfigType("toml")
+
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
+			t.Fatalf("mergeLocalConfig() error = %v", err)
+		}
+		if viper.IsSet("workspaces.name") {
+			t.Errorf("workspaces.name must not be settable from local config")
+		}
+		if viper.IsSet("workspaces") {
+			t.Errorf("workspaces must not be settable from local config")
+		}
+	})
+
 	t.Run("PartialOverride", func(t *testing.T) {
 		viper.Reset()
 		t.Cleanup(func() { viper.Reset() })

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -514,6 +514,31 @@ preview = false
 		}
 	})
 
+	t.Run("IgnoresWorkspaces", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+
+		tmpDir := t.TempDir()
+		localConfig := []byte(`
+[[workspaces]]
+name = "evil"
+path = "/tmp/evil"
+`)
+		if err := os.WriteFile(filepath.Join(tmpDir, ".kwt.toml"), localConfig, 0644); err != nil {
+			t.Fatalf("Failed to create local config: %v", err)
+		}
+		changeDir(t, tmpDir)
+
+		viper.SetConfigType("toml")
+
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
+			t.Fatalf("mergeLocalConfig() error = %v", err)
+		}
+		if viper.IsSet("workspaces") {
+			t.Errorf("workspaces must not be settable from local config")
+		}
+	})
+
 	t.Run("PartialOverride", func(t *testing.T) {
 		viper.Reset()
 		t.Cleanup(func() { viper.Reset() })
@@ -1528,4 +1553,27 @@ func TestLoadRepoLayoutDefaultTrustedReturnsDefault(t *testing.T) {
 	got, err := LoadRepoLayoutDefault(repo, false)
 	require.NoError(t, err)
 	assert.Equal(t, "focus", got)
+}
+
+func TestLoadExpandsWorkspacePaths(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	home := t.TempDir()
+	// Resolve symlinks for consistent paths on macOS where /var -> /private/var
+	home, err := filepath.EvalSymlinks(home)
+	require.NoError(t, err)
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	viper.SetConfigType("toml")
+	viper.Set("workspaces", []map[string]any{{"name": "notes", "path": "~/notes"}})
+
+	cfg, err := Load()
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Workspaces, 1)
+	assert.Equal(t, "notes", cfg.Workspaces[0].Name)
+	assert.Equal(t, dir, cfg.Workspaces[0].Path)
 }

--- a/internal/config/workspace.go
+++ b/internal/config/workspace.go
@@ -40,7 +40,7 @@ func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
 
 	updated := false
 	for i := range workspaces {
-		if workspaces[i].Path == workspace.Path {
+		if sameProjectPath(workspaces[i].Path, workspace.Path) {
 			workspaces[i] = workspace
 			updated = true
 			continue

--- a/internal/config/workspace.go
+++ b/internal/config/workspace.go
@@ -21,7 +21,10 @@ func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
 		return models.Workspace{}, err
 	}
 	info, err := os.Stat(path)
-	if err != nil || !info.IsDir() {
+	if err != nil {
+		return models.Workspace{}, fmt.Errorf("workspace path %s: %w", workspace.Path, err)
+	}
+	if !info.IsDir() {
 		return models.Workspace{}, fmt.Errorf("workspace path %s is not a directory", workspace.Path)
 	}
 	workspace.Path = path

--- a/internal/config/workspace.go
+++ b/internal/config/workspace.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/viper"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+// RegisterWorkspace records a directory workspace in the global config.
+// The path is expanded and resolved; an empty name defaults to the directory
+// base name. Re-registering an existing path updates its name; registering an
+// existing name for a different path is an error.
+func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
+	path, err := normalizeProjectPath(workspace.Path)
+	if err != nil {
+		return models.Workspace{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return models.Workspace{}, fmt.Errorf("workspace path %s is not a directory", workspace.Path)
+	}
+	workspace.Path = path
+	if strings.TrimSpace(workspace.Name) == "" {
+		workspace.Name = filepath.Base(path)
+	}
+	workspace.Name = strings.TrimSpace(workspace.Name)
+
+	workspaces, globalViper, err := readGlobalWorkspaces()
+	if err != nil {
+		return models.Workspace{}, err
+	}
+
+	updated := false
+	for i := range workspaces {
+		if workspaces[i].Path == workspace.Path {
+			workspaces[i] = workspace
+			updated = true
+			continue
+		}
+		if strings.EqualFold(workspaces[i].Name, workspace.Name) {
+			return models.Workspace{}, fmt.Errorf(
+				"workspace name %q is already registered for %s; choose another with --name",
+				workspace.Name, workspaces[i].Path,
+			)
+		}
+	}
+	if !updated {
+		workspaces = append(workspaces, workspace)
+	}
+	if err := writeGlobalWorkspaces(globalViper, workspaces); err != nil {
+		return models.Workspace{}, err
+	}
+	return workspace, nil
+}
+
+// UnregisterWorkspace removes a directory workspace from the global config by
+// name. The directory itself is never touched.
+func UnregisterWorkspace(name string) error {
+	name = strings.TrimSpace(name)
+	workspaces, globalViper, err := readGlobalWorkspaces()
+	if err != nil {
+		return err
+	}
+
+	kept := workspaces[:0]
+	removed := false
+	for _, workspace := range workspaces {
+		if strings.EqualFold(workspace.Name, name) {
+			removed = true
+			continue
+		}
+		kept = append(kept, workspace)
+	}
+	if !removed {
+		if len(workspaces) == 0 {
+			return fmt.Errorf("no workspace named %q; no workspaces registered", name)
+		}
+		names := make([]string, 0, len(workspaces))
+		for _, workspace := range workspaces {
+			names = append(names, workspace.Name)
+		}
+		sort.Strings(names)
+		return fmt.Errorf("no workspace named %q; registered: %s", name, strings.Join(names, ", "))
+	}
+	return writeGlobalWorkspaces(globalViper, kept)
+}
+
+func readGlobalWorkspaces() ([]models.Workspace, *viper.Viper, error) {
+	configDir := getConfigDir()
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return nil, nil, fmt.Errorf("failed to create config directory: %w", err)
+	}
+	globalViper := viper.New()
+	globalViper.SetConfigName(configName)
+	globalViper.SetConfigType(configType)
+	globalViper.AddConfigPath(configDir)
+	if err := globalViper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, nil, fmt.Errorf("failed to read config: %w", err)
+		}
+	}
+	var workspaces []models.Workspace
+	if err := globalViper.UnmarshalKey("workspaces", &workspaces); err != nil {
+		return nil, nil, fmt.Errorf("failed to read workspaces: %w", err)
+	}
+	return workspaces, globalViper, nil
+}
+
+func writeGlobalWorkspaces(globalViper *viper.Viper, workspaces []models.Workspace) error {
+	globalViper.Set("workspaces", workspaces)
+	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	if err := globalViper.WriteConfigAs(configPath); err != nil {
+		return err
+	}
+	viper.Set("workspaces", workspaces)
+	return nil
+}

--- a/internal/config/workspace_test.go
+++ b/internal/config/workspace_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func workspaceTestEnv(t *testing.T) string {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	return configHome
+}
+
+func registeredWorkspaces(t *testing.T) []models.Workspace {
+	t.Helper()
+	globalViper := viper.New()
+	globalViper.SetConfigFile(filepath.Join(getConfigDir(), configName+"."+configType))
+	globalViper.SetConfigType(configType)
+	require.NoError(t, globalViper.ReadInConfig())
+	var workspaces []models.Workspace
+	require.NoError(t, globalViper.UnmarshalKey("workspaces", &workspaces))
+	return workspaces
+}
+
+func TestRegisterWorkspaceDefaultsNameAndPersists(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	stored, err := RegisterWorkspace(models.Workspace{Path: dir})
+
+	require.NoError(t, err)
+	assert.Equal(t, "notes", stored.Name)
+	workspaces := registeredWorkspaces(t)
+	require.Len(t, workspaces, 1)
+	assert.Equal(t, "notes", workspaces[0].Name)
+}
+
+func TestRegisterWorkspaceRejectsMissingPath(t *testing.T) {
+	workspaceTestEnv(t)
+
+	_, err := RegisterWorkspace(models.Workspace{Path: filepath.Join(t.TempDir(), "absent")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestRegisterWorkspaceUpdatesNameForSamePath(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	_, err := RegisterWorkspace(models.Workspace{Name: "old", Path: dir})
+	require.NoError(t, err)
+
+	_, err = RegisterWorkspace(models.Workspace{Name: "new", Path: dir})
+
+	require.NoError(t, err)
+	workspaces := registeredWorkspaces(t)
+	require.Len(t, workspaces, 1)
+	assert.Equal(t, "new", workspaces[0].Name)
+}
+
+func TestRegisterWorkspaceRejectsDuplicateNameForDifferentPath(t *testing.T) {
+	workspaceTestEnv(t)
+	base := t.TempDir()
+	first := filepath.Join(base, "a")
+	second := filepath.Join(base, "b")
+	require.NoError(t, os.MkdirAll(first, 0o755))
+	require.NoError(t, os.MkdirAll(second, 0o755))
+	_, err := RegisterWorkspace(models.Workspace{Name: "notes", Path: first})
+	require.NoError(t, err)
+
+	_, err = RegisterWorkspace(models.Workspace{Name: "notes", Path: second})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name")
+}
+
+func TestUnregisterWorkspace(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	_, err := RegisterWorkspace(models.Workspace{Path: dir})
+	require.NoError(t, err)
+
+	require.NoError(t, UnregisterWorkspace("notes"))
+	assert.Empty(t, registeredWorkspaces(t))
+
+	err = UnregisterWorkspace("notes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspace")
+}

--- a/internal/config/workspace_test.go
+++ b/internal/config/workspace_test.go
@@ -112,6 +112,32 @@ func TestRegisterWorkspaceRejectsDuplicateNameForDifferentPath(t *testing.T) {
 	assert.Contains(t, err.Error(), "--name")
 }
 
+// TestRegisterWorkspaceDedupesUnexpandedStoredPath guards against a stored
+// workspace path like "~/notes" (unexpanded, e.g. hand-edited into the
+// config, or written before path normalization existed) failing to dedupe
+// against the same directory registered later via its resolved absolute
+// path. Without normalizing the comparison, this would either duplicate the
+// entry or reject the re-registration as a name collision.
+func TestRegisterWorkspaceDedupesUnexpandedStoredPath(t *testing.T) {
+	configHome := workspaceTestEnv(t)
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	notesDir := filepath.Join(tempHome, "notes")
+	require.NoError(t, os.MkdirAll(notesDir, 0o755))
+
+	configPath := filepath.Join(configHome, configName+"."+configType)
+	unexpanded := "[[workspaces]]\nname = \"old\"\npath = \"~/notes\"\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(unexpanded), 0o644))
+
+	stored, err := RegisterWorkspace(models.Workspace{Name: "new", Path: notesDir})
+
+	require.NoError(t, err)
+	assert.Equal(t, "new", stored.Name)
+	workspaces := registeredWorkspaces(t)
+	require.Len(t, workspaces, 1, "resolved path must dedupe against the unexpanded stored path")
+	assert.Equal(t, "new", workspaces[0].Name)
+}
+
 func TestUnregisterWorkspace(t *testing.T) {
 	workspaceTestEnv(t)
 	dir := filepath.Join(t.TempDir(), "notes")

--- a/internal/config/workspace_test.go
+++ b/internal/config/workspace_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +52,33 @@ func TestRegisterWorkspaceRejectsMissingPath(t *testing.T) {
 	_, err := RegisterWorkspace(models.Workspace{Path: filepath.Join(t.TempDir(), "absent")})
 
 	require.Error(t, err)
+	assert.True(t, os.IsNotExist(errors.Unwrap(err)),
+		"a missing path must wrap the underlying stat error, not report it as a non-directory")
+}
+
+func TestRegisterWorkspaceRejectsFile(t *testing.T) {
+	workspaceTestEnv(t)
+	file := filepath.Join(t.TempDir(), "notes.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+
+	_, err := RegisterWorkspace(models.Workspace{Path: file})
+
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestRegisterWorkspaceWrapsStatErrorWhenParentIsFile(t *testing.T) {
+	workspaceTestEnv(t)
+	file := filepath.Join(t.TempDir(), "notes.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+
+	_, err := RegisterWorkspace(models.Workspace{Path: filepath.Join(file, "child")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace path")
+	assert.NotContains(t, err.Error(), "is not a directory",
+		"a stat failure must report the underlying error, not the not-a-directory message")
+	assert.Error(t, errors.Unwrap(err), "the stat error must be wrapped for errors.Is/As")
 }
 
 func TestRegisterWorkspaceUpdatesNameForSamePath(t *testing.T) {

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -62,3 +62,27 @@ func sanitizeTmuxName(s string) string {
 		".", "-", ":", "-", "/", "-", " ", "-", "\t", "-",
 	).Replace(s)
 }
+
+const dirWorkspaceSessionPrefix = "kwt-workspace-dir-"
+
+// DirWorkspaceSessionName returns a stable, tmux-safe session name for a
+// directory workspace: kwt-workspace-dir-{name}-{hash}. The hash is computed
+// over the workspace path so renames keep a recognizable suffix and distinct
+// directories never collide.
+func DirWorkspaceSessionName(name, path string) string {
+	raw := fmt.Sprintf("%s%s-%s", dirWorkspaceSessionPrefix, name, template.ShortHash(path))
+	return sanitizeTmuxName(raw)
+}
+
+// MatchDirWorkspaceSession finds the live directory-workspace session for
+// path, matching by prefix and trailing path hash rather than the full name
+// so a renamed workspace still finds its running session.
+func MatchDirWorkspaceSession(sessions []string, path string) (string, bool) {
+	suffix := "-" + template.ShortHash(path)
+	for _, session := range sessions {
+		if strings.HasPrefix(session, dirWorkspaceSessionPrefix) && strings.HasSuffix(session, suffix) {
+			return session, true
+		}
+	}
+	return "", false
+}

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/url"
 )
 
@@ -76,4 +77,30 @@ func TestWorkspaceSessionName(t *testing.T) {
 	detached1 := WorkspaceSessionName(info, "HEAD", "/home/u/worktrees/github.com/wesm/kwt/wt1")
 	detached2 := WorkspaceSessionName(info, "HEAD", "/home/u/worktrees/github.com/wesm/kwt/wt2")
 	assert.NotEqual(t, detached1, detached2)
+}
+
+func TestDirWorkspaceSessionName(t *testing.T) {
+	name := DirWorkspaceSessionName("my notes", "/Users/me/notes")
+
+	assert.True(t, strings.HasPrefix(name, "kwt-workspace-dir-my-notes-"), name)
+	assert.Regexp(t, `^kwt-workspace-dir-my-notes-[0-9a-f]{8}$`, name)
+	assert.Equal(t, name, DirWorkspaceSessionName("my notes", "/Users/me/notes"),
+		"session names must be deterministic")
+	assert.NotEqual(t, name, DirWorkspaceSessionName("my notes", "/Users/me/other"),
+		"different paths must not collide")
+}
+
+func TestMatchDirWorkspaceSessionMatchesByPathHash(t *testing.T) {
+	current := DirWorkspaceSessionName("new-name", "/Users/me/notes")
+	old := DirWorkspaceSessionName("old-name", "/Users/me/notes")
+	sessions := []string{"kwt-workspace-foo-12345678", old, "unrelated"}
+
+	got, ok := MatchDirWorkspaceSession(sessions, "/Users/me/notes")
+
+	require.True(t, ok)
+	assert.Equal(t, old, got, "renamed workspaces must re-attach to the live old-name session")
+	assert.NotEqual(t, current, got)
+
+	_, ok = MatchDirWorkspaceSession([]string{"kwt-workspace-foo-12345678"}, "/Users/me/notes")
+	assert.False(t, ok)
 }

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -64,6 +64,7 @@ type Backend interface {
 	CreateWorktree(ctx context.Context, row Row, branch string) (string, error)
 	MaterializeWorktree(ctx context.Context, row Row) (string, error)
 	RemoveWorktree(ctx context.Context, row Row, force bool) error
+	UnregisterWorkspace(row Row) error
 	KillSession(row Row) error
 	OpenInTmux(ctx context.Context, row Row, layoutName string) error
 	LayoutNames() []string

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -25,8 +25,15 @@ type Row struct {
 	Entry       *discovery.GlobalWorktreeEntry
 	Status      *models.WorktreeStatus
 	Fleet       *FleetInfo
+	Workspace   *WorkspaceInfo
 	SessionName string
 	SessionLive bool
+}
+
+// WorkspaceInfo is the TUI-facing view of one registered directory workspace.
+type WorkspaceInfo struct {
+	Name string
+	Path string
 }
 
 // FleetInfo is the TUI-facing summary of one multi-machine sync row.

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -11,12 +11,16 @@ import (
 	"time"
 
 	"github.com/mattn/go-runewidth"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
 var timeNow = time.Now
 
 func rowRepoName(row Row) string {
+	if row.Workspace != nil {
+		return row.Workspace.Name
+	}
 	if row.Entry != nil && row.Entry.RepositoryInfo != nil && row.Entry.RepositoryInfo.Repository != "" {
 		return row.Entry.RepositoryInfo.Repository
 	}
@@ -41,6 +45,9 @@ func rowRepoName(row Row) string {
 }
 
 func rowBranch(row Row) string {
+	if row.Workspace != nil {
+		return utils.TildePath(row.Workspace.Path)
+	}
 	if row.Entry != nil {
 		return row.Entry.Branch
 	}
@@ -57,6 +64,9 @@ func rowBranch(row Row) string {
 }
 
 func rowPath(row Row) string {
+	if row.Workspace != nil {
+		return row.Workspace.Path
+	}
 	if row.Entry != nil {
 		return row.Entry.Path
 	}
@@ -254,6 +264,9 @@ func formatPushPullStatus(status *models.WorktreeStatus) (string, bool) {
 }
 
 func formatRowChanges(row Row) string {
+	if row.Workspace != nil {
+		return "-"
+	}
 	if rowHasUncommittedChanges(row) {
 		return formatChanges(row.Status)
 	}
@@ -331,6 +344,9 @@ func compactFleetDirtySummary(summary string) string {
 }
 
 func formatRowSync(row Row) string {
+	if row.Workspace != nil {
+		return "-"
+	}
 	if row.Fleet != nil {
 		if !row.Fleet.Local {
 			return "remote only"
@@ -396,6 +412,9 @@ func rowHasOtherHosts(row Row) bool {
 }
 
 func formatRowActivity(row Row, now time.Time) string {
+	if row.Workspace != nil {
+		return "-"
+	}
 	if row.Status != nil {
 		return formatActivityAt(row.Status.LastActivity, now)
 	}

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -34,6 +36,20 @@ func TestRowRepoNameFallsBackToPathBase(t *testing.T) {
 
 	assert.Equal(t, "no-info", rowRepoName(row))
 	assert.Equal(t, "no-info:main", rowLabel(row))
+}
+
+func TestWorkspaceRowRendering(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	row := Row{
+		Workspace:   &WorkspaceInfo{Name: "notes", Path: filepath.Join(home, "notes")},
+		SessionLive: true,
+	}
+
+	assert.Equal(t, "notes", rowRepoName(row))
+	assert.Equal(t, "~/notes", rowBranch(row))
+	assert.Equal(t, filepath.Join(home, "notes"), rowPath(row))
+	assert.Equal(t, "local", formatMachines(row))
+	assert.Equal(t, "live", formatWorkspace(row))
 }
 
 func TestSortRowsByRepoThenBranch(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -29,6 +29,7 @@ const (
 	confirmNone confirmKind = iota
 	confirmDelete
 	confirmKill
+	confirmUnregister
 )
 
 type confirmState struct {
@@ -487,6 +488,8 @@ func (m Model) handleConfirmKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		return m, m.removeWorktreeCmd(row, force)
 	case confirmKill:
 		return m, m.killSessionCmd(row)
+	case confirmUnregister:
+		return m, m.unregisterWorkspaceCmd(row)
 	default:
 		return m, nil
 	}
@@ -494,7 +497,7 @@ func (m Model) handleConfirmKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 func (m Model) openSelected() (Model, tea.Cmd) {
 	row := m.selectedRow()
-	if row.Entry == nil {
+	if row.Entry == nil && row.Workspace == nil {
 		if row.Fleet != nil && row.Fleet.CanMaterialize {
 			m.message = "press s to sync this worktree"
 			return m, nil
@@ -511,7 +514,7 @@ func (m Model) openSelected() (Model, tea.Cmd) {
 
 func (m Model) shellSelected() (Model, tea.Cmd) {
 	row := m.selectedRow()
-	if row.Entry == nil {
+	if row.Entry == nil && row.Workspace == nil {
 		m.message = "sync this worktree before opening a shell"
 		return m, nil
 	}
@@ -546,6 +549,10 @@ func (m Model) cycleLayout() (Model, tea.Cmd) {
 
 func (m Model) startNewBranch() (Model, tea.Cmd) {
 	row := m.selectedRow()
+	if row.Workspace != nil {
+		m.message = "not a git worktree"
+		return m, nil
+	}
 	if row.Entry == nil {
 		m.message = "no worktree selected"
 		return m, nil
@@ -627,6 +634,14 @@ func (m Model) cursorAfterProjectChange(selectedPath string) int {
 
 func (m Model) startDelete() (Model, tea.Cmd) {
 	row := m.selectedRow()
+	if row.Workspace != nil {
+		m.confirm = confirmState{
+			kind: confirmUnregister,
+			row:  row,
+			text: fmt.Sprintf("unregister workspace %s? (directory is kept) [y/N]", row.Workspace.Name),
+		}
+		return m, nil
+	}
 	if row.Entry == nil {
 		m.message = "no worktree selected"
 		return m, nil
@@ -671,7 +686,7 @@ func rowHasUncommittedChanges(row Row) bool {
 
 func (m Model) startKill() (Model, tea.Cmd) {
 	row := m.selectedRow()
-	if row.Entry == nil {
+	if row.Entry == nil && row.Workspace == nil {
 		m.message = "no worktree selected"
 		return m, nil
 	}
@@ -728,6 +743,15 @@ func (m Model) removeWorktreeCmd(row Row, force bool) tea.Cmd {
 			return actionDoneMsg{err: err}
 		}
 		return actionDoneMsg{message: fmt.Sprintf("removed %s", rowLabel(row)), refresh: true}
+	}
+}
+
+func (m Model) unregisterWorkspaceCmd(row Row) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.backend.UnregisterWorkspace(row); err != nil {
+			return actionDoneMsg{err: err}
+		}
+		return actionDoneMsg{message: "workspace unregistered", refresh: true}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -99,6 +99,14 @@ func NewModel(backend Backend, baseDir string) Model {
 	}
 }
 
+// WithInitialAnchor pre-selects the row whose path matches path on the first
+// rows load — typically the launch directory's workspace row, which the
+// activity-descending sort would otherwise bury at the bottom of the list.
+func (m Model) WithInitialAnchor(path string) Model {
+	m.anchorPath = path
+	return m
+}
+
 func (m Model) Init() tea.Cmd {
 	return m.fetchRowsCmd()
 }
@@ -195,6 +203,15 @@ func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 			m.anchorPath = ""
 		} else if m.pendingRefresh {
 			m.cursor = anchorCursorByPath(oldRows, oldCursor, newRows)
+		} else if !hadRows {
+			// An initial anchor that matches nothing keeps the first-load
+			// behavior of selecting the current worktree.
+			m.anchorPath = ""
+			if index, ok := currentRowIndex(newRows); ok {
+				m.cursor = index
+			} else {
+				m.cursor = anchorCursorByPath(oldRows, oldCursor, newRows)
+			}
 		} else {
 			m.cursor = 0
 			m.anchorPath = ""

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -933,3 +933,36 @@ func TestModelPathAnchorsCursorAfterRefresh(t *testing.T) {
 	assert.Equal(t, "/w/kwt/feature", rowPath(model.selectedRow()))
 	assert.Equal(t, 1, model.cursor)
 }
+
+func TestInitialAnchorSelectsLaunchWorkspaceRow(t *testing.T) {
+	active := testRow("kwt", "main", "/w/kwt/main")
+	active.Status.LastActivity = time.Now()
+	workspace := Row{Workspace: &WorkspaceInfo{Name: "code", Path: "/Users/me/code"}}
+	model := NewModel(&fakeBackend{}, "/worktrees").WithInitialAnchor("/Users/me/code")
+
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{active, workspace}})
+
+	require.NotNil(t, model.selectedRow().Workspace,
+		"first load must select the launch directory's workspace row despite activity sorting")
+	assert.Equal(t, "/Users/me/code", model.selectedRow().Workspace.Path)
+
+	// The anchor is consumed: a refresh keeps the cursor by path instead of
+	// snapping back, and moving afterwards works normally.
+	model, _ = updateModel(t, model, press("g"))
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{active, workspace}})
+	require.NotNil(t, model.selectedRow().Entry, "anchor must not re-apply on later refreshes")
+}
+
+func TestInitialAnchorMissFallsBackToCurrentRow(t *testing.T) {
+	other := testRow("kwt", "main", "/w/kwt/main")
+	other.Status.LastActivity = time.Now()
+	current := testRow("kata", "feature", "/w/kata/feature")
+	current.Status.IsCurrent = true
+	model := NewModel(&fakeBackend{}, "/worktrees").WithInitialAnchor("/nowhere/unmatched")
+
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{other, current}})
+
+	require.NotNil(t, model.selectedRow().Entry)
+	assert.Equal(t, "/w/kata/feature", model.selectedRow().Entry.Path,
+		"an unmatched initial anchor must fall back to the current worktree row")
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -32,6 +32,7 @@ type fakeBackend struct {
 	removeForces    []bool
 	killCalls       []string
 	openCalls       []string
+	unregistered    []Row
 }
 
 func (b *fakeBackend) List(ctx context.Context) ([]Row, []string, error) {
@@ -65,6 +66,11 @@ func (b *fakeBackend) KillSession(row Row) error {
 func (b *fakeBackend) OpenInTmux(ctx context.Context, row Row, layoutName string) error {
 	b.openCalls = append(b.openCalls, rowPath(row)+":"+layoutName)
 	return b.openErr
+}
+
+func (b *fakeBackend) UnregisterWorkspace(row Row) error {
+	b.unregistered = append(b.unregistered, row)
+	return nil
 }
 
 func (b *fakeBackend) LayoutNames() []string { return append([]string(nil), b.layoutNames...) }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -111,6 +111,48 @@ func viewContent(model Model) string {
 	return model.View().Content
 }
 
+func TestWorkspaceRowActions(t *testing.T) {
+	row := Row{
+		Workspace:   &WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+		SessionName: "kwt-workspace-dir-notes-12345678",
+		SessionLive: true,
+	}
+	backend := &fakeBackend{}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{row}})
+
+	// Open: workspace rows hand off to attach outside tmux.
+	next, _ := model.openSelected()
+	assert.Equal(t, HandoffAttach, next.Handoff().Kind)
+
+	// New branch: gated with a message.
+	next, _ = model.startNewBranch()
+	assert.Contains(t, next.message, "not a git worktree")
+
+	// Sync: already gated by the row.Fleet == nil branch.
+	next, _ = model.syncSelected(row)
+	assert.Contains(t, next.message, "nothing to sync")
+
+	// Kill: allowed for live sessions.
+	next, _ = model.startKill()
+	assert.Equal(t, confirmKill, next.confirm.kind)
+
+	// Delete key: offers unregister, never worktree removal.
+	next, _ = model.startDelete()
+	require.Equal(t, confirmUnregister, next.confirm.kind)
+	assert.Contains(t, next.confirm.text, "unregister")
+
+	// Confirming with y calls Backend.UnregisterWorkspace and refreshes.
+	_, cmd := updateModel(t, next, press("y"))
+	require.NotNil(t, cmd)
+	msg := cmd()
+	done, ok := msg.(actionDoneMsg)
+	require.True(t, ok)
+	assert.True(t, done.refresh)
+	require.Len(t, backend.unregistered, 1)
+	assert.Equal(t, "notes", backend.unregistered[0].Workspace.Name)
+}
+
 func TestModelRowsMessageSortsRendersAndUsesAltScreen(t *testing.T) {
 	model := NewModel(&fakeBackend{}, "/worktrees")
 	model, _ = updateModel(t, model, rowsMsg{rows: []Row{

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -43,6 +43,7 @@ type Config struct {
 	Naming             NamingConfig        `mapstructure:"naming"`              // Naming and template configuration
 	Agents             map[string]string   `mapstructure:"agents"`              // Named agent invocation commands for layouts
 	Projects           []Project           `mapstructure:"projects"`            // Known repositories for cross-project discovery
+	Workspaces         []Workspace         `mapstructure:"workspaces" toml:"workspaces"` // Registered directory workspaces
 	RepositorySettings []RepositorySetting `mapstructure:"repository_settings"` // Per-repository setup/copy overrides
 	Layouts            LayoutsConfig       `mapstructure:"layouts"`             // Named tmux workspace layout library
 }
@@ -92,6 +93,13 @@ type Project struct {
 	Name        string `mapstructure:"name" toml:"name"`                 // Human-friendly display name
 	Path        string `mapstructure:"path" toml:"path"`                 // Main repository root path
 	LastTouched string `mapstructure:"last_touched" toml:"last_touched"` // RFC3339 UTC timestamp
+}
+
+// Workspace records a plain directory kwt can open as a tmux workspace,
+// independent of any git worktree.
+type Workspace struct {
+	Name string `mapstructure:"name" toml:"name"` // Unique display name
+	Path string `mapstructure:"path" toml:"path"` // Directory root
 }
 
 // WorktreeConfig contains worktree-specific configuration options.

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -35,17 +35,17 @@ type CdConfig struct {
 
 // Config represents the application configuration.
 type Config struct {
-	Worktree           WorktreeConfig      `mapstructure:"worktree"`            // Worktree-related configuration
-	Fleet              FleetConfig         `mapstructure:"fleet" toml:"fleet"`  // Multi-machine sync configuration
-	Cd                 CdConfig            `mapstructure:"cd"`                  // Cd command configuration
-	Finder             FinderConfig        `mapstructure:"finder"`              // Fuzzy finder configuration
-	UI                 UIConfig            `mapstructure:"ui"`                  // UI-related configuration
-	Naming             NamingConfig        `mapstructure:"naming"`              // Naming and template configuration
-	Agents             map[string]string   `mapstructure:"agents"`              // Named agent invocation commands for layouts
-	Projects           []Project           `mapstructure:"projects"`            // Known repositories for cross-project discovery
+	Worktree           WorktreeConfig      `mapstructure:"worktree"`                     // Worktree-related configuration
+	Fleet              FleetConfig         `mapstructure:"fleet" toml:"fleet"`           // Multi-machine sync configuration
+	Cd                 CdConfig            `mapstructure:"cd"`                           // Cd command configuration
+	Finder             FinderConfig        `mapstructure:"finder"`                       // Fuzzy finder configuration
+	UI                 UIConfig            `mapstructure:"ui"`                           // UI-related configuration
+	Naming             NamingConfig        `mapstructure:"naming"`                       // Naming and template configuration
+	Agents             map[string]string   `mapstructure:"agents"`                       // Named agent invocation commands for layouts
+	Projects           []Project           `mapstructure:"projects"`                     // Known repositories for cross-project discovery
 	Workspaces         []Workspace         `mapstructure:"workspaces" toml:"workspaces"` // Registered directory workspaces
-	RepositorySettings []RepositorySetting `mapstructure:"repository_settings"` // Per-repository setup/copy overrides
-	Layouts            LayoutsConfig       `mapstructure:"layouts"`             // Named tmux workspace layout library
+	RepositorySettings []RepositorySetting `mapstructure:"repository_settings"`          // Per-repository setup/copy overrides
+	Layouts            LayoutsConfig       `mapstructure:"layouts"`                      // Named tmux workspace layout library
 }
 
 // FleetConfig contains optional multi-machine sync configuration.


### PR DESCRIPTION
Adds directory workspaces: plain directories (notes, scratch space, non-git projects) registered as tmux workspaces, opened with layouts, and shown in the TUI dashboard.

## What's in this PR

- **Config**: a `[[workspaces]]` section in global config (`models.Workspace{Name, Path}`). Paths are expanded and symlink-resolved on load. The `workspaces` key is machine-level only — repo-local `.kwt.toml` cannot set it, and workspaces are never published to the sync hub.
- **Registry**: `config.RegisterWorkspace` (name defaults to the directory base name, dedupes by resolved path, rejects duplicate names for different paths) and `config.UnregisterWorkspace` (unknown names list what is registered).
- **CLI**: `kwt workspace add [path] [--name X]`, `kwt workspace list` (name, path, live/stopped), `kwt workspace remove <name>`. Remove never touches the directory; if its session is live, the command says so and prints the kill command.
- **Sessions**: names follow `kwt-workspace-dir-{name}-{hash8(path)}`. Liveness and attach match by the trailing path hash, so renaming a workspace re-attaches to its existing live session instead of orphaning it.
- **TUI**: workspace rows render as a third row flavor (name under REPO, tilde path under BRANCH, `local` under MACHINES, `-` for the git columns, live/offline under WORKSPACE). Open, attach, and kill work like worktree rows; git actions (new branch, sync, worktree delete) are gated with a status-line message; the delete key unregisters after a confirm that notes the directory is kept. Name and path join the filter haystack.
- **Auto-registration**: launching the TUI from a non-git directory registers it best-effort, at most once per session, skipping already-registered paths (custom names survive) and never the home directory.
- **Layouts**: per-directory defaults reuse the trust-gated `.kwt.toml` layout mechanism, keyed off the workspace directory.

Design spec: `docs/superpowers/specs/2026-07-06-directory-workspaces-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-06-directory-workspaces.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)