### PR TITLE
Document directory workspaces across the docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dist/
 # Claude Code
 .claude/todos/
 .superpowers/
+.vercel
+.env*

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -16,31 +16,34 @@ go build -o kwt ./cmd/kwt
 
 ## Open the dashboard
 
-From any Git repository:
+From any directory:
 
 ```sh
 kwt
 ```
 
 Bare `kwt` opens the full-screen dashboard when stdin and stdout are interactive.
-Use `kwt tui` when you want the explicit command form.
+Use `kwt tui` when you want the explicit command form. Launching from a Git
+repository registers it as a project; launching from a plain directory registers
+it as a [directory workspace](../workflows/directory-workspaces.md) and
+pre-selects its row, so `enter` opens a tmux session right there.
 
 Useful keys:
 
-| Key     | Action                                               |
-| ------- | ---------------------------------------------------- |
-| `enter` | Attach to the selected workspace.                    |
-| `n`     | Create a worktree in the active project perspective. |
-| `P`     | Switch the active project perspective.               |
-| `p`     | Filter visible projects by name.                     |
-| `/`     | Search rows within the active perspective/filter.    |
-| `L`     | Select a workspace layout.                           |
-| `d`     | Delete the selected worktree.                        |
-| `K`     | Kill the selected live tmux workspace.               |
-| `s`     | Sync a remote-only branch row locally.               |
-| `c`     | Open a shell in the selected worktree.               |
-| `r`     | Refresh.                                             |
-| `?`     | Toggle help.                                         |
+| Key     | Action                                                  |
+| ------- | ------------------------------------------------------- |
+| `enter` | Attach to the selected workspace.                       |
+| `n`     | Create a worktree in the active project perspective.    |
+| `P`     | Switch the active project perspective.                  |
+| `p`     | Filter visible projects by name.                        |
+| `/`     | Search rows within the active perspective/filter.       |
+| `L`     | Select a workspace layout.                              |
+| `d`     | Delete the selected worktree or unregister a workspace. |
+| `K`     | Kill the selected live tmux workspace.                  |
+| `s`     | Sync a remote-only branch row locally.                  |
+| `c`     | Open a shell in the selected worktree.                  |
+| `r`     | Refresh.                                                |
+| `?`     | Toggle help.                                            |
 
 ## Create a worktree
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,8 @@ kwt
 
 Run `kwt` from a repository to open the dashboard. The dashboard registers that
 repository, shows worktrees from known projects, and attaches to a tmux workspace
-for the selected branch.
+for the selected branch. Plain directories work too: launching from a non-Git
+directory registers it as a directory workspace with its own tmux session.
 
 ## What kwt optimizes for
 
@@ -45,6 +46,8 @@ kwt remove feature/machine-view
 
 See the [quickstart](get-started/quickstart.md), [CLI reference](reference/cli.md),
 and [configuration reference](reference/configuration.md) for the maintained
-surface. [Multi-machine sync](multi-machine-sync.md) covers trusted multi-host
-worktree visibility, and the [design notes](design/index.md) preserve the
-decisions behind the cross-project TUI and synchronization architecture.
+surface. [Directory workspaces](workflows/directory-workspaces.md) covers tmux
+sessions for non-Git directories, [multi-machine sync](multi-machine-sync.md)
+covers trusted multi-host worktree visibility, and the
+[design notes](design/index.md) preserve the decisions behind the cross-project
+TUI and synchronization architecture.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,8 @@ kwt open parser
 kwt status
 kwt sync status
 kwt exec fix/parser-race -- go test ./internal/parser
+kwt workspace add ~/notes
+kwt workspace list
 kwt config get layouts.default
 kwt config set --local layouts.default stack
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -59,6 +59,23 @@ path = "~/code/kwt"
 last_touched = "2026-07-04T12:00:00Z"
 ```
 
+## Directory workspaces
+
+Plain directories registered as tmux workspaces, independent of any Git
+worktree:
+
+```toml
+[[workspaces]]
+name = "notes"
+path = "~/notes"
+```
+
+Paths are expanded and symlink-resolved on load. Entries are machine-level
+configuration: repository-local `.kwt.toml` files cannot set them, and they are
+never published over multi-machine sync. Manage entries with
+`kwt workspace add|list|remove` rather than editing the file; see
+[Directory workspaces](../workflows/directory-workspaces.md) for the workflow.
+
 ## Repository setup
 
 Optional repository settings can copy files or run commands when new worktrees

--- a/docs/workflows/directory-workspaces.md
+++ b/docs/workflows/directory-workspaces.md
@@ -1,0 +1,55 @@
+# Directory Workspaces
+
+Not everything is a Git worktree. kwt can register plain directories — notes,
+scratch space, non-Git projects — as workspaces, open them in tmux with your
+configured layouts, and show them in the dashboard next to worktrees.
+
+## Register a directory
+
+```sh
+kwt workspace add ~/notes
+kwt workspace add ~/scratch/protos --name protos
+kwt workspace list
+kwt workspace remove protos
+```
+
+Names default to the directory base name and must be unique. Re-adding the same
+directory updates its name. `remove` only unregisters: it never deletes the
+directory, and a live tmux session is left running with a hint on how to kill
+it.
+
+## Open from the dashboard
+
+Launching `kwt` from a directory that is not inside a Git repository registers
+that directory automatically and pre-selects its row, so `enter` immediately
+creates and attaches its tmux session. The home directory is never
+auto-registered.
+
+Workspace rows show the workspace name under REPO, the path under BRANCH, and
+session liveness under WORKSPACE; Git-specific columns show `-`. Rows match `/`
+search by name and path. `K` kills a live session, and `d` unregisters the
+workspace after confirmation. Git actions such as `n` (new branch) and `s`
+(sync) do not apply and say so in the status line.
+
+## Sessions and layouts
+
+Workspace sessions are named `kwt-workspace-dir-{name}-{hash}`, where the hash
+covers the directory path. Renaming a workspace re-attaches to its existing
+live session instead of orphaning it; the session adopts the new name the next
+time it is created from scratch.
+
+Layouts behave exactly as for worktrees, including the trust-gated
+per-directory default in the directory's `.kwt.toml`:
+
+```toml
+[layouts]
+default = "stack"
+```
+
+## Scope
+
+The registry is machine-level configuration. Repository-local `.kwt.toml`
+files cannot add workspaces, and workspaces are never published over
+[multi-machine sync](../multi-machine-sync.md). See the
+[configuration reference](../reference/configuration.md#directory-workspaces)
+for the `[[workspaces]]` format.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -20,6 +20,7 @@ nav = [
   ] },
   { "Workflows" = [
     { "Agent workspaces" = "workflows/agent-workspaces.md" },
+    { "Directory workspaces" = "workflows/directory-workspaces.md" },
   ] },
   { "Multi-machine sync" = [
     { "Overview" = "multi-machine-sync.md" },


### PR DESCRIPTION
Brings the docs site up to date with the directory-workspaces feature (#9), which previously had only a one-line entry in the CLI command table.

- New **Workflows → Directory workspaces** page: registering directories, dashboard behavior (auto-register on non-Git launch, pre-selected row, action gating), session naming and rename re-attach semantics, per-directory layout defaults, and the machine-level scope (no repo-local injection, never synced).
- **Configuration reference**: `[[workspaces]]` section with format and scope notes.
- **CLI reference**: `kwt workspace` examples.
- **Quickstart**: dashboard section now covers launching from any directory; the `d` key row mentions workspace unregistration.
- **Overview**: mentions directory workspaces and links the new page.
- Nav updated in `zensical.toml`.

Site builds clean with `make docs-build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)