### PR TITLE
Add Discord link to docs top nav

### DIFF
--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -1,0 +1,70 @@
+{# Zensical header with the kwt Discord invite folded into the top nav. #}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer" aria-label="{{ lang.t('nav') }}">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "search" in config.plugins %}
+      {% set search = config.plugins["search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search" aria-label="{{ lang.t('search') }}">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    <a href="https://discord.gg/fDnmxB8Wkq" title="Join Discord" class="md-header__button md-icon kwt-discord-link" aria-label="Join Discord" target="_blank" rel="noopener noreferrer">
+      {% include ".icons/fontawesome/brands/discord.svg" %}
+    </a>
+    <div class="md-header__source">
+      {% if config.repo_url %}
+        {% include "partials/source.html" %}
+      {% endif %}
+    </div>
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,8 @@
+.kwt-discord-link {
+  color: var(--md-primary-bg-color);
+}
+
+.kwt-discord-link:hover,
+.kwt-discord-link:focus-visible {
+  color: var(--md-accent-fg-color);
+}

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -9,6 +9,7 @@ site_dir = "site"
 repo_url = "https://github.com/kenn-io/kwt"
 repo_name = "kenn-io/kwt"
 edit_uri = "edit/main/docs/"
+extra_css = ["stylesheets/extra.css"]
 nav = [
   { "Start" = [
     { "Overview" = "index.md" },
@@ -37,6 +38,7 @@ nav = [
 
 [project.theme]
 variant = "modern"
+custom_dir = "overrides"
 features = [
   "navigation.instant",
   "navigation.instant.progress",


### PR DESCRIPTION
## Summary
- Adds a Discord invite icon to the docs site header, next to search and the GitHub repo link
- Matches the pattern used in roborev's docs (`overrides/partials/header.html` + `stylesheets/extra.css`)
- Links to https://discord.gg/fDnmxB8Wkq

🤖 Generated with [Claude Code](https://claude.com/claude-code)