### PR TITLE
Initialize kata issue tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist/
 .superpowers/
 .vercel
 .env*
+.kata.local.toml

--- a/.kata.toml
+++ b/.kata.toml
@@ -1,0 +1,4 @@
+version = 1
+
+[project]
+name = "kwt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - Prefer the repo's commands for verification: `make test`, `make build`, and focused `go test ./path` runs while iterating.
 
 <!-- BEGIN KATA (managed by `kata init --with-agents`) -->
+
 ## kata issue tracker
 
 This project uses [kata](https://github.com/kenn-io/kata) as its shared issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,18 @@
 - Documentation should move with behavior changes when practical: CLI flags, config keys, workflows, and user-facing contracts should be updated with the code.
 - Keep changes focused. Do not refactor unrelated code or rewrite user changes while completing a task.
 - Prefer the repo's commands for verification: `make test`, `make build`, and focused `go test ./path` runs while iterating.
+
+<!-- BEGIN KATA (managed by `kata init --with-agents`) -->
+## kata issue tracker
+
+This project uses [kata](https://github.com/kenn-io/kata) as its shared issue
+ledger. Run `kata quickstart` at the start of each session for the full agent
+contract. The short version:
+
+- Search before creating: `kata search "<keywords>" --agent`.
+- Prefer updating existing issues over duplicates (`kata comment`, `kata label add`, `kata edit`).
+- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.
+- Close only verified work: `kata close <ref> --done --message "<scope + verification>" --commit <sha>`.
+- If work is incomplete, label `needs-review` and comment what remains rather than closing.
+- Never `kata delete` or `kata purge` without explicit user authorization.
+<!-- END KATA -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ make install        # Build and install kwt
 4. **Delete anything the agent can infer** from your code
 
 <!-- BEGIN KATA (managed by `kata init --with-agents`) -->
+
 ## kata issue tracker
 
 This project uses [kata](https://github.com/kenn-io/kata) as its shared issue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,18 @@ make install        # Build and install kwt
 2. **CRITICAL: Keep total under 20-30 lines** - move detailed docs to separate files and reference them
 3. **Update commands immediately** when workflows change
 4. **Delete anything the agent can infer** from your code
+
+<!-- BEGIN KATA (managed by `kata init --with-agents`) -->
+## kata issue tracker
+
+This project uses [kata](https://github.com/kenn-io/kata) as its shared issue
+ledger. Run `kata quickstart` at the start of each session for the full agent
+contract. The short version:
+
+- Search before creating: `kata search "<keywords>" --agent`.
+- Prefer updating existing issues over duplicates (`kata comment`, `kata label add`, `kata edit`).
+- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.
+- Close only verified work: `kata close <ref> --done --message "<scope + verification>" --commit <sha>`.
+- If work is incomplete, label `needs-review` and comment what remains rather than closing.
+- Never `kata delete` or `kata purge` without explicit user authorization.
+<!-- END KATA -->


### PR DESCRIPTION
kwt now uses kata as its shared issue ledger, but the repository did not yet have checked-in project config or a shared agent contract for using it. Without that, future agent sessions would be more likely to duplicate issues, skip the tracker, or close work without the expected evidence.

This adds the kata project config, keeps machine-local kata daemon settings ignored, and embeds the managed kata guidance in both agent instruction files so Codex and Claude sessions follow the same issue-tracker workflow. The branch also includes the minimal Markdown formatting needed for the repository pre-push hook.