### PR TITLE
Delay Renovate updates for 72 hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "enabledManagers": ["gomod"],
+  "minimumReleaseAge": "3 days",
   "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Dependency update pull requests are currently created within hours of a release, leaving little time for upstream regressions or compromised releases to surface. Requiring a three-day release age gives new versions a 72-hour observation window before Renovate proposes them.

This applies consistently to the repository’s enabled Go module updates. Renovate security updates continue to bypass minimum-release-age checks by design.