### PR TITLE
Base new worktrees on the remote default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ kwt remove feature/new-ui
 kwt remove -b feature/new-ui
 ```
 
+When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
+branch. If that remote base is unavailable, it falls back to local `main`, then
+`master`, then the branch checked out in the primary worktree.
+
 ### Dashboard Keys
 
 | Key       | Action                                  |

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -51,6 +51,10 @@ Useful keys:
 kwt add -b feature/new-ui
 ```
 
+When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
+branch. If that remote base is unavailable, it falls back to local `main`, then
+`master`, then the branch checked out in the primary worktree.
+
 By default, `kwt add` creates the worktree and launches a tmux workspace — a
 blank single-pane session unless a [layout](../reference/configuration.md) is
 selected. To create without launching:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,6 +35,10 @@ kwt config get layouts.default
 kwt config set --local layouts.default stack
 ```
 
+When `kwt add -b` creates a branch, it fetches `origin` and starts from its
+default branch. If that remote base is unavailable, it falls back to local
+`main`, then `master`, then the branch checked out in the primary worktree.
+
 ## Exit behavior
 
 Commands intended to launch the dashboard or attach to tmux require an

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -34,7 +34,11 @@ var addCmd = &cobra.Command{
 	Long: `Create a new worktree for the specified branch.
 
 If no path is provided, it will be generated based on the configuration template.
-Use -i flag to interactively select a branch using fuzzy finder.`,
+Use -i flag to interactively select a branch using fuzzy finder.
+
+When -b creates a branch, kwt fetches origin and starts from its default branch.
+If that remote base is unavailable, it falls back to local main, then master,
+then the branch checked out in the primary worktree.`,
 	Example: `  # Create worktree from existing branch
   kwt add feature/new-ui
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -355,6 +355,52 @@ func TestAddWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("NewBranchFetchesRemoteDefaultOutsideConfiguredRefspec", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		remoteParent := t.TempDir()
+		remotePath := filepath.Join(remoteParent, "origin.git")
+		gitOutput(t, remoteParent, "init", "--bare", "-b", "trunk", remotePath)
+		if err := repo.run("remote", "add", "origin", remotePath); err != nil {
+			t.Fatalf("add origin: %v", err)
+		}
+		if err := repo.run("push", "origin", "main:trunk", "main:other"); err != nil {
+			t.Fatalf("push initial remote branches: %v", err)
+		}
+		if err := repo.run("fetch", "origin"); err != nil {
+			t.Fatalf("fetch initial remote state: %v", err)
+		}
+		staleRemoteHead := gitOutput(t, repo.Path, "rev-parse", "refs/remotes/origin/trunk")
+		if err := repo.run("config", "--unset-all", "remote.origin.fetch"); err != nil {
+			t.Fatalf("clear origin fetch refspec: %v", err)
+		}
+		if err := repo.run("config", "--add", "remote.origin.fetch", "+refs/heads/other:refs/remotes/origin/other"); err != nil {
+			t.Fatalf("set restrictive origin fetch refspec: %v", err)
+		}
+
+		repo.CreateBranch(t, "feature/current")
+		commitTestFile(t, repo.Path, "feature.txt", "feature\n", "Feature commit")
+
+		updaterParent := t.TempDir()
+		updaterPath := filepath.Join(updaterParent, "updater")
+		gitOutput(t, updaterParent, "clone", remotePath, updaterPath)
+		gitOutput(t, updaterPath, "config", "user.name", "Test User")
+		gitOutput(t, updaterPath, "config", "user.email", "test@example.com")
+		commitTestFile(t, updaterPath, "remote.txt", "remote\n", "Advance remote default")
+		gitOutput(t, updaterPath, "push", "origin", "trunk")
+		freshRemoteHead := gitOutput(t, remotePath, "rev-parse", "refs/heads/trunk")
+		if freshRemoteHead == staleRemoteHead {
+			t.Fatal("test setup did not advance the remote default")
+		}
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		if err := New(repo.Path).AddWorktree(worktreePath, "new-from-default", true); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+		if got := gitOutput(t, worktreePath, "rev-parse", "HEAD"); got != freshRemoteHead {
+			t.Fatalf("new worktree HEAD = %s, want fetched remote default %s", got, freshRemoteHead)
+		}
+	})
+
 	t.Run("NewBranchFromLocalMain", func(t *testing.T) {
 		repo := NewTestRepository(t)
 		want := gitOutput(t, repo.Path, "rev-parse", "main")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -107,6 +107,26 @@ func (r *TestRepository) getCurrentBranch() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\nOutput: %s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func commitTestFile(t *testing.T, dir, name, contents, message string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	gitOutput(t, dir, "add", name)
+	gitOutput(t, dir, "commit", "-m", message)
+}
+
 func TestNew(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)
@@ -223,6 +243,45 @@ func TestAddWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("ExistingBranchDoesNotFetch", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		remoteParent := t.TempDir()
+		remotePath := filepath.Join(remoteParent, "origin.git")
+		gitOutput(t, remoteParent, "init", "--bare", "-b", "trunk", remotePath)
+		if err := repo.run("remote", "add", "origin", remotePath); err != nil {
+			t.Fatalf("add origin: %v", err)
+		}
+		if err := repo.run("push", "origin", "main:trunk"); err != nil {
+			t.Fatalf("push initial remote default: %v", err)
+		}
+		if err := repo.run("fetch", "origin"); err != nil {
+			t.Fatalf("fetch initial remote state: %v", err)
+		}
+		staleRemoteHead := gitOutput(t, repo.Path, "rev-parse", "refs/remotes/origin/trunk")
+		if err := repo.run("branch", "existing-branch"); err != nil {
+			t.Fatalf("create existing branch: %v", err)
+		}
+
+		updaterParent := t.TempDir()
+		updaterPath := filepath.Join(updaterParent, "updater")
+		gitOutput(t, updaterParent, "clone", remotePath, updaterPath)
+		gitOutput(t, updaterPath, "config", "user.name", "Test User")
+		gitOutput(t, updaterPath, "config", "user.email", "test@example.com")
+		commitTestFile(t, updaterPath, "remote.txt", "remote\n", "Advance remote default")
+		gitOutput(t, updaterPath, "push", "origin", "trunk")
+		if remoteHead := gitOutput(t, remotePath, "rev-parse", "refs/heads/trunk"); remoteHead == staleRemoteHead {
+			t.Fatal("test setup did not advance the remote default")
+		}
+
+		worktreePath := filepath.Join(t.TempDir(), "existing-wt")
+		if err := New(repo.Path).AddWorktree(worktreePath, "existing-branch", false); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+		if got := gitOutput(t, repo.Path, "rev-parse", "refs/remotes/origin/trunk"); got != staleRemoteHead {
+			t.Fatalf("existing-branch creation fetched origin: tracking ref = %s, want stale %s", got, staleRemoteHead)
+		}
+	})
+
 	t.Run("NewBranch", func(t *testing.T) {
 		// Add worktree with new branch
 		worktreePath := filepath.Join(t.TempDir(), "new-wt")
@@ -258,6 +317,136 @@ func TestAddWorktree(t *testing.T) {
 		}
 		if !found {
 			t.Error("New branch worktree not found")
+		}
+	})
+
+	t.Run("NewBranchFromRemoteDefault", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		remoteParent := t.TempDir()
+		remotePath := filepath.Join(remoteParent, "origin.git")
+		gitOutput(t, remoteParent, "init", "--bare", "-b", "trunk", remotePath)
+		if err := repo.run("remote", "add", "origin", remotePath); err != nil {
+			t.Fatalf("add origin: %v", err)
+		}
+		if err := repo.run("push", "origin", "main:trunk"); err != nil {
+			t.Fatalf("push initial remote default: %v", err)
+		}
+
+		repo.CreateBranch(t, "feature/current")
+		commitTestFile(t, repo.Path, "feature.txt", "feature\n", "Feature commit")
+
+		updaterParent := t.TempDir()
+		updaterPath := filepath.Join(updaterParent, "updater")
+		gitOutput(t, updaterParent, "clone", remotePath, updaterPath)
+		gitOutput(t, updaterPath, "config", "user.name", "Test User")
+		gitOutput(t, updaterPath, "config", "user.email", "test@example.com")
+		commitTestFile(t, updaterPath, "remote.txt", "remote\n", "Advance remote default")
+		gitOutput(t, updaterPath, "push", "origin", "trunk")
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		if err := New(repo.Path).AddWorktree(worktreePath, "new-from-default", true); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+
+		got := gitOutput(t, worktreePath, "rev-parse", "HEAD")
+		want := gitOutput(t, remotePath, "rev-parse", "refs/heads/trunk")
+		if got != want {
+			t.Fatalf("new worktree HEAD = %s, want fetched remote default %s", got, want)
+		}
+	})
+
+	t.Run("NewBranchFromLocalMain", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		want := gitOutput(t, repo.Path, "rev-parse", "main")
+		repo.CreateBranch(t, "feature/current")
+		commitTestFile(t, repo.Path, "feature.txt", "feature\n", "Feature commit")
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		if err := New(repo.Path).AddWorktree(worktreePath, "new-from-main", true); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+		if got := gitOutput(t, worktreePath, "rev-parse", "HEAD"); got != want {
+			t.Fatalf("new worktree HEAD = %s, want local main %s", got, want)
+		}
+	})
+
+	t.Run("NewBranchPrefersLocalMainOverMaster", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		want := gitOutput(t, repo.Path, "rev-parse", "main")
+		repo.CreateBranch(t, "master")
+		commitTestFile(t, repo.Path, "master.txt", "master\n", "Advance master")
+		repo.CreateBranch(t, "feature/current")
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		if err := New(repo.Path).AddWorktree(worktreePath, "new-from-main", true); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+		if got := gitOutput(t, worktreePath, "rev-parse", "HEAD"); got != want {
+			t.Fatalf("new worktree HEAD = %s, want preferred local main %s", got, want)
+		}
+	})
+
+	t.Run("NewBranchFromLocalMaster", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		if err := repo.run("branch", "-m", "master"); err != nil {
+			t.Fatalf("rename main to master: %v", err)
+		}
+		want := gitOutput(t, repo.Path, "rev-parse", "master")
+		repo.CreateBranch(t, "feature/current")
+		commitTestFile(t, repo.Path, "feature.txt", "feature\n", "Feature commit")
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		if err := New(repo.Path).AddWorktree(worktreePath, "new-from-master", true); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+		if got := gitOutput(t, worktreePath, "rev-parse", "HEAD"); got != want {
+			t.Fatalf("new worktree HEAD = %s, want local master %s", got, want)
+		}
+	})
+
+	t.Run("NewBranchFromPrimaryWorktree", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		if err := repo.run("branch", "-m", "trunk"); err != nil {
+			t.Fatalf("rename main to trunk: %v", err)
+		}
+		want := gitOutput(t, repo.Path, "rev-parse", "trunk")
+		if err := repo.run("branch", "feature/current"); err != nil {
+			t.Fatalf("create feature branch: %v", err)
+		}
+		featurePath := filepath.Join(t.TempDir(), "feature-wt")
+		if err := repo.run("worktree", "add", featurePath, "feature/current"); err != nil {
+			t.Fatalf("create feature worktree: %v", err)
+		}
+		commitTestFile(t, featurePath, "feature.txt", "feature\n", "Feature commit")
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		if err := New(featurePath).AddWorktree(worktreePath, "new-from-primary", true); err != nil {
+			t.Fatalf("AddWorktree() error = %v", err)
+		}
+		if got := gitOutput(t, worktreePath, "rev-parse", "HEAD"); got != want {
+			t.Fatalf("new worktree HEAD = %s, want primary worktree branch %s", got, want)
+		}
+	})
+
+	t.Run("NewBranchFailsWithoutDefaultBase", func(t *testing.T) {
+		repo := NewTestRepository(t)
+		if err := repo.run("branch", "-m", "trunk"); err != nil {
+			t.Fatalf("rename main to trunk: %v", err)
+		}
+		if err := repo.run("checkout", "--detach"); err != nil {
+			t.Fatalf("detach primary worktree: %v", err)
+		}
+
+		worktreePath := filepath.Join(t.TempDir(), "new-wt")
+		err := New(repo.Path).AddWorktree(worktreePath, "new-without-base", true)
+		if err == nil {
+			t.Fatal("AddWorktree() error = nil, want base resolution error")
+		}
+		if !strings.Contains(err.Error(), "no local main, master, or primary worktree branch") {
+			t.Fatalf("AddWorktree() error = %q, want local fallback details", err)
+		}
+		if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
+			t.Fatalf("worktree path created despite resolution failure: stat error = %v", statErr)
 		}
 	})
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -342,6 +343,26 @@ func TestAddWorktree(t *testing.T) {
 		gitOutput(t, updaterPath, "config", "user.email", "test@example.com")
 		commitTestFile(t, updaterPath, "remote.txt", "remote\n", "Advance remote default")
 		gitOutput(t, updaterPath, "push", "origin", "trunk")
+
+		if runtime.GOOS != "windows" {
+			realGit, err := exec.LookPath("git")
+			if err != nil {
+				t.Fatalf("find git executable: %v", err)
+			}
+			wrapperDir := t.TempDir()
+			wrapperPath := filepath.Join(wrapperDir, "git")
+			wrapper := `#!/bin/sh
+if [ "$1" = "ls-remote" ] && [ "$2" = "--symref" ]; then
+	exit 129
+fi
+exec "$REAL_GIT" "$@"
+`
+			if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+				t.Fatalf("write git compatibility wrapper: %v", err)
+			}
+			t.Setenv("REAL_GIT", realGit)
+			t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		}
 
 		worktreePath := filepath.Join(t.TempDir(), "new-wt")
 		if err := New(repo.Path).AddWorktree(worktreePath, "new-from-default", true); err != nil {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -148,11 +148,12 @@ func (g *Git) remoteDefaultWorktreeBase() (string, error) {
 		return "", fmt.Errorf("origin did not advertise a default branch")
 	}
 
-	if _, err := g.run("fetch", "origin"); err != nil {
-		return "", fmt.Errorf("fetch origin: %w", err)
+	ref := "refs/remotes/origin/" + branch
+	refspec := "+refs/heads/" + branch + ":" + ref
+	if _, err := g.run("fetch", "origin", refspec); err != nil {
+		return "", fmt.Errorf("fetch origin default branch: %w", err)
 	}
 
-	ref := "refs/remotes/origin/" + branch
 	if !g.refExists(ref) {
 		return "", fmt.Errorf("fetched origin default ref %s does not exist", ref)
 	}

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -84,7 +84,11 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 	args := []string{"worktree", "add"}
 
 	if createBranch {
-		args = append(args, "-b", branch, path)
+		base, err := g.defaultWorktreeBase()
+		if err != nil {
+			return err
+		}
+		args = append(args, "-b", branch, path, base)
 	} else {
 		args = append(args, path, branch)
 	}
@@ -94,6 +98,70 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 	}
 
 	return nil
+}
+
+func (g *Git) defaultWorktreeBase() (string, error) {
+	remoteBase, remoteErr := g.remoteDefaultWorktreeBase()
+	if remoteErr == nil {
+		return remoteBase, nil
+	}
+
+	for _, branch := range []string{"main", "master"} {
+		ref := "refs/heads/" + branch
+		if g.refExists(ref) {
+			return ref, nil
+		}
+	}
+
+	root, rootErr := g.getMainRepoRoot()
+	if rootErr == nil {
+		output, branchErr := g.run("-C", root, "symbolic-ref", "--quiet", "--short", "HEAD")
+		if branchErr == nil {
+			ref := "refs/heads/" + strings.TrimSpace(output)
+			if g.refExists(ref) {
+				return ref, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf(
+		"could not resolve default worktree base: remote default unavailable (%v); no local main, master, or primary worktree branch",
+		remoteErr,
+	)
+}
+
+func (g *Git) remoteDefaultWorktreeBase() (string, error) {
+	output, err := g.run("ls-remote", "--symref", "origin", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("discover origin default branch: %w", err)
+	}
+
+	var branch string
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" {
+			branch = strings.TrimPrefix(fields[1], "refs/heads/")
+			break
+		}
+	}
+	if branch == "" {
+		return "", fmt.Errorf("origin did not advertise a default branch")
+	}
+
+	if _, err := g.run("fetch", "origin"); err != nil {
+		return "", fmt.Errorf("fetch origin: %w", err)
+	}
+
+	ref := "refs/remotes/origin/" + branch
+	if !g.refExists(ref) {
+		return "", fmt.Errorf("fetched origin default ref %s does not exist", ref)
+	}
+	return ref, nil
+}
+
+func (g *Git) refExists(ref string) bool {
+	_, err := g.run("show-ref", "--verify", "--quiet", ref)
+	return err == nil
 }
 
 // AddWorktreeFromBase creates a new worktree with a branch from a specific base branch.

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -131,31 +131,13 @@ func (g *Git) defaultWorktreeBase() (string, error) {
 }
 
 func (g *Git) remoteDefaultWorktreeBase() (string, error) {
-	output, err := g.run("ls-remote", "--symref", "origin", "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("discover origin default branch: %w", err)
-	}
-
-	var branch string
-	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" {
-			branch = strings.TrimPrefix(fields[1], "refs/heads/")
-			break
-		}
-	}
-	if branch == "" {
-		return "", fmt.Errorf("origin did not advertise a default branch")
-	}
-
-	ref := "refs/remotes/origin/" + branch
-	refspec := "+refs/heads/" + branch + ":" + ref
-	if _, err := g.run("fetch", "origin", refspec); err != nil {
+	const ref = "refs/kwt/origin/default"
+	if _, err := g.run("fetch", "origin", "+HEAD:"+ref); err != nil {
 		return "", fmt.Errorf("fetch origin default branch: %w", err)
 	}
 
 	if !g.refExists(ref) {
-		return "", fmt.Errorf("fetched origin default ref %s does not exist", ref)
+		return "", fmt.Errorf("fetched origin default ref does not exist")
 	}
 	return ref, nil
 }


### PR DESCRIPTION
Creating a worktree from within a feature branch currently makes the new branch inherit that feature HEAD. That silently stacks otherwise independent work and makes the result depend on the invocation location.

New-branch creation now fetches the advertised `origin` `HEAD` directly into a kwt-owned ref, keeping the selected commit fresh even with restrictive clone fetch refspecs and preserving the documented Git 2.5+ minimum. If the remote base is unavailable, `kwt` falls back to local `main`, then `master`, then the primary worktree branch. Existing-branch creation remains network-free.

The user-visible consequence is that `kwt add -b` normally fetches before creating a branch; remote-less and offline repositories continue through the deterministic local fallback order.
