### PR TITLE
Harden manifest and tmux regression coverage

### DIFF
--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/ui"
+	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -136,6 +138,14 @@ func TestEnrichManifestFields(t *testing.T) {
 		// Verify it contains the expected path structure (github.com/example/demo)
 		if worktrees[0].Repository != "github.com/example/demo" {
 			t.Errorf("expected Repository to be 'github.com/example/demo', got %q", worktrees[0].Repository)
+		}
+		info, err := worktree.RepositoryInfoFromGit(g)
+		if err != nil {
+			t.Fatalf("resolve repository info: %v", err)
+		}
+		wantSession := tmux.WorkspaceSessionName(info, worktrees[0].Branch, worktrees[0].Path)
+		if worktrees[0].SessionName != wantSession {
+			t.Errorf("expected SessionName %q, got %q", wantSession, worktrees[0].SessionName)
 		}
 	})
 

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,6 +70,34 @@ func TestRunProjectsJSONEmitsRegistry(t *testing.T) {
 		got[0].Path != "/home/wesm/code/kwt" || got[0].LastTouched != "2026-07-16T00:00:00Z" {
 		t.Errorf("unexpected project: %+v", got[0])
 	}
+}
+
+func TestRunProjectsRendersTable(t *testing.T) {
+	withProjectsConfig(t, []models.Project{{
+		Repository:  "github.com/wesm/kwt",
+		Name:        "kwt",
+		Path:        "/home/wesm/code/kwt",
+		LastTouched: "2026-07-16T00:00:00Z",
+	}})
+
+	out := runProjectsForTest(t, false)
+
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "REPOSITORY")
+	assert.Contains(t, out, "github.com/wesm/kwt")
+	assert.Contains(t, out, "/home/wesm/code/kwt")
+}
+
+func TestRunProjectsReturnsConfigLoadError(t *testing.T) {
+	origLoad := loadProjectsConfig
+	t.Cleanup(func() { loadProjectsConfig = origLoad })
+	loadProjectsConfig = func() (*models.Config, error) {
+		return nil, errors.New("config unavailable")
+	}
+
+	err := runProjects(projectsCmd, nil)
+
+	require.EqualError(t, err, "failed to load config: config unavailable")
 }
 
 // TestRunProjectsJSONCanonicalizesLegacyAbsolutePathIdentity pins the fix for

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -41,6 +41,7 @@ type tuiBackend struct {
 	discoverLaunchWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
 	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
 	listSessions              func() ([]string, error)
+	ensureAndAttach           func(context.Context, string, string, models.Layout, bool) error
 	registerProject           func(models.Project) error
 	registerWorkspace         func(models.Workspace) (models.Workspace, error)
 	unregisterWorkspace       func(name string) error
@@ -69,6 +70,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
 		collectStatuses:          collectTUIStatuses,
 		listSessions:             tmuxCmd.ListSessions,
+		ensureAndAttach:          tmux.NewWorkspaceRunner(tmuxCmd).EnsureAndAttach,
 		registerProject:          config.RegisterProject,
 		registerWorkspace:        config.RegisterWorkspace,
 		unregisterWorkspace:      config.UnregisterWorkspace,
@@ -1247,7 +1249,7 @@ func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, lay
 	if err != nil {
 		return err
 	}
-	return tmux.NewWorkspaceRunner(b.tmux).EnsureAndAttach(
+	return b.ensureAndAttach(
 		ctx, sessionName, rowPaneRoot(row), layout, insideTmux,
 	)
 }

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -2361,24 +2362,57 @@ func TestTUIBackendAttachWorkspaceGuardRejectsEmptyRow(t *testing.T) {
 	assert.Equal(t, "no worktree selected", err.Error())
 }
 
-// TestTUIBackendAttachWorkspacePassesGuardForWorkspaceRow exercises the
-// relaxed guard in attachWorkspace: a workspace-only row (row.Entry == nil)
-// must get past it. There is no seam to stub the tmux runner that
-// attachWorkspace constructs internally, so this test relies on an empty
-// layouts config to force a layout-resolution error before EnsureAndAttach
-// is ever reached; that keeps the test from touching real tmux while still
-// proving the row cleared the guard.
-func TestTUIBackendAttachWorkspacePassesGuardForWorkspaceRow(t *testing.T) {
+// TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner keeps the command
+// layer on a stubbed runner boundary. In particular, this must never create a
+// detached session on the user's default tmux server merely because a unit
+// test needs to prove a workspace-only row clears the selection guard.
+func TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner(t *testing.T) {
 	row := dashboard.Row{
 		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: t.TempDir()},
 	}
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	before := defaultTmuxSessions(t)
 
-	err := backend.attachWorkspace(context.Background(), row, "", false, false)
+	var gotSession, gotRoot string
+	var gotLayout models.Layout
+	var gotInsideTmux bool
+	backend.ensureAndAttach = func(
+		ctx context.Context,
+		session, root string,
+		layout models.Layout,
+		insideTmux bool,
+	) error {
+		gotSession, gotRoot = session, root
+		gotLayout, gotInsideTmux = layout, insideTmux
+		return nil
+	}
 
-	require.Error(t, err)
-	assert.NotEqual(t, "no worktree selected", err.Error(),
-		"a workspace row must clear the entry/workspace guard")
+	err := backend.attachWorkspace(context.Background(), row, tmux.BlankLayoutName, false, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, tmux.DirWorkspaceSessionName("notes", row.Workspace.Path), gotSession)
+	assert.Equal(t, row.Workspace.Path, gotRoot)
+	assert.Equal(t, tmux.BlankLayout(), gotLayout)
+	assert.False(t, gotInsideTmux)
+	assert.Equal(t, before, defaultTmuxSessions(t),
+		"the stubbed command-layer test must not add default-server tmux sessions")
+}
+
+func defaultTmuxSessions(t *testing.T) []string {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return nil
+	}
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return nil // No default server is equivalent to an empty session list.
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	sort.Strings(lines)
+	return lines
 }
 
 // TestTUIBackendResolveLayoutUsesWorkspacePathForDefault covers resolveLayout's

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -225,17 +225,10 @@ func ConvertToWorktreeModels(entries []*GlobalWorktreeEntry, showRepoName bool) 
 	worktrees := make([]models.Worktree, 0, len(entries))
 
 	for _, entry := range entries {
-		branch := entry.Branch
+		wt := entry.Model()
 		if showRepoName && entry.RepositoryInfo != nil {
 			// Use repository name from parsed URL info
-			branch = fmt.Sprintf("%s:%s", entry.RepositoryInfo.Repository, entry.Branch)
-		}
-
-		wt := models.Worktree{
-			Branch:     branch,
-			Path:       entry.Path,
-			CommitHash: entry.CommitHash,
-			IsMain:     entry.IsMain,
+			wt.Branch = fmt.Sprintf("%s:%s", entry.RepositoryInfo.Repository, entry.Branch)
 		}
 		worktrees = append(worktrees, wt)
 	}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -402,6 +402,7 @@ func TestConvertToWorktreeModels_BasicConversion(t *testing.T) {
 
 func TestConvertToWorktreeModels_WithRepoName(t *testing.T) {
 	repoInfo, _ := url.ParseRepositoryURL("https://github.com/testuser/testrepo.git")
+	createdAt := time.Date(2026, 7, 17, 12, 30, 0, 0, time.UTC)
 	entries := []*GlobalWorktreeEntry{
 		{
 			RepositoryInfo: repoInfo,
@@ -409,6 +410,7 @@ func TestConvertToWorktreeModels_WithRepoName(t *testing.T) {
 			Path:           "/path/to/feature",
 			CommitHash:     "abc123",
 			IsMain:         false,
+			CreatedAt:      createdAt,
 		},
 	}
 
@@ -421,6 +423,16 @@ func TestConvertToWorktreeModels_WithRepoName(t *testing.T) {
 	expected := "testrepo:feature"
 	if worktrees[0].Branch != expected {
 		t.Errorf("Expected branch '%s', got '%s'", expected, worktrees[0].Branch)
+	}
+	if worktrees[0].Repository != repoInfo.FullPath {
+		t.Errorf("Repository = %q, want %q", worktrees[0].Repository, repoInfo.FullPath)
+	}
+	if !worktrees[0].CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", worktrees[0].CreatedAt, createdAt)
+	}
+	wantSession := tmux.WorkspaceSessionName(repoInfo, entries[0].Branch, entries[0].Path)
+	if worktrees[0].SessionName != wantSession {
+		t.Errorf("SessionName = %q, want %q", worktrees[0].SessionName, wantSession)
 	}
 }
 

--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -297,6 +297,12 @@ func (f *Finder) generateWorktreePreview(wt models.Worktree, maxLines int) strin
 		fmt.Sprintf("Commit: %s", truncateHash(wt.CommitHash)),
 		fmt.Sprintf("Created: %s", wt.CreatedAt.Format("2006-01-02 15:04")),
 	}
+	if wt.Repository != "" {
+		preview = append(preview, fmt.Sprintf("Repository: %s", wt.Repository))
+	}
+	if wt.SessionName != "" {
+		preview = append(preview, fmt.Sprintf("Session: %s", wt.SessionName))
+	}
 
 	if wt.IsMain {
 		preview = append(preview, "Type: Main worktree")

--- a/internal/finder/finder_test.go
+++ b/internal/finder/finder_test.go
@@ -360,11 +360,13 @@ func TestGenerateSessionPreview_MaxLines(t *testing.T) {
 
 func TestGenerateWorktreePreview_WithoutGit(t *testing.T) {
 	wt := models.Worktree{
-		Branch:     "feature-branch",
-		Path:       "/home/user/project/feature",
-		CommitHash: "abc1234567890def",
-		CreatedAt:  time.Date(2023, 6, 15, 10, 30, 0, 0, time.UTC),
-		IsMain:     false,
+		Branch:      "feature-branch",
+		Path:        "/home/user/project/feature",
+		CommitHash:  "abc1234567890def",
+		CreatedAt:   time.Date(2023, 6, 15, 10, 30, 0, 0, time.UTC),
+		IsMain:      false,
+		Repository:  "github.com/example/project",
+		SessionName: "kwt-workspace-example",
 	}
 
 	finder := &Finder{git: nil} // No git instance
@@ -375,6 +377,8 @@ func TestGenerateWorktreePreview_WithoutGit(t *testing.T) {
 		"Path: /home/user/project/feature",
 		"Commit: abc12345",
 		"Created: 2023-06-15 10:30",
+		"Repository: github.com/example/project",
+		"Session: kwt-workspace-example",
 		"Type: Additional worktree",
 	}
 

--- a/internal/tmux/bootstrap_integration_test.go
+++ b/internal/tmux/bootstrap_integration_test.go
@@ -38,7 +38,13 @@ func TestStripEnvMasksGlobalEnvForSessionOnly(t *testing.T) {
 	const canary2Name = "STARSHIP_SHELL"
 	const canary2Value = "zsh"
 
-	t.Cleanup(func() { killPrivateTmuxServer(socket) })
+	var socketPath string
+	t.Cleanup(func() {
+		killPrivateTmuxServer(socket)
+		if socketPath != "" {
+			_ = os.Remove(socketPath)
+		}
+	})
 
 	worktreeDir := t.TempDir()
 	// The server inherits this environment at start time, so the canaries
@@ -51,6 +57,11 @@ func TestStripEnvMasksGlobalEnvForSessionOnly(t *testing.T) {
 	if _, err := runTmuxSocket(t, socket, serverEnv, createCmd...); err != nil {
 		t.Fatalf("tmux %v: %v", createCmd, err)
 	}
+	socketPathOut, err := runTmuxSocket(t, socket, nil, "display-message", "-p", "#{socket_path}")
+	if err != nil {
+		t.Fatalf("resolve private tmux socket path: %v", err)
+	}
+	socketPath = strings.TrimSpace(socketPathOut)
 
 	bootCmd := BuildSessionBootstrapCommand(session, []string{canaryName, canary2Name})
 	if _, err := runTmuxSocket(t, socket, nil, bootCmd...); err != nil {
@@ -71,8 +82,14 @@ func TestStripEnvMasksGlobalEnvForSessionOnly(t *testing.T) {
 	}
 
 	killPrivateTmuxServer(socket)
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove private tmux socket %q: %v", socketPath, err)
+	}
 	if out, err := runTmuxSocket(t, socket, nil, "list-sessions"); err == nil {
 		t.Errorf("expected private tmux server %q to be gone after kill-server, got: %s", socket, out)
+	}
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Errorf("private tmux socket %q remains after test: %v", socketPath, err)
 	}
 }
 


### PR DESCRIPTION
## Why

A command-layer unit test was crossing into the real default tmux server. Repeated test runs created detached shell sessions that survived their temporary workspace directories, polluting developer machines and making the test boundary unsafe. The manifest follow-up review also found metadata drift between worktree selection and JSON surfaces, plus uncovered output branches where regressions could pass unnoticed.

## Approach

The TUI backend now exposes an injectable workspace-runner boundary, allowing the workspace-row test to verify routing and assert the default server is unchanged without creating a session. Finder conversion reuses the manifest model so repository, creation time, and session identity stay consistent, and previews expose those identity fields. Adjacent list/projects coverage now pins the local session name, table rendering, and configuration failure behavior. The real-tmux integration test also removes its private socket after shutting down its server.

This does not change a JSON schema; it keeps existing surfaces aligned and prevents tests from leaving machine-level residue.

## Validation

- make test
- make build