### PR TITLE
Allow PR imports to establish workspace sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ kwt status
 kwt pr list --project github.com/acme/widget --json
 kwt pr import 17 --project github.com/acme/widget --json
 
+# Import and establish the canonical tmux workspace for another client
+kwt pr import 17 --project github.com/acme/widget \
+  --start-session --json
+
 # Use a worktree path in scripts
 cd "$(kwt get feature/new-ui)"
 kwt exec feature/new-ui -- npm test

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,8 @@ kwt add -b fix/parser-race
 kwt open parser
 kwt status
 kwt pr list --project github.com/acme/widget --json
-kwt pr import 17 --project github.com/acme/widget --json
+kwt pr import 17 --project github.com/acme/widget \
+  --start-session --json
 kwt sync status
 kwt exec fix/parser-race -- go test ./internal/parser
 kwt workspace add ~/notes
@@ -70,6 +71,9 @@ for pull-request clients. kwt owns provider calls, ref handling, branch and
 workspace naming, normal worktree creation and setup, push configuration,
 provenance, and tmux session naming. See [Pull-request
 automation](pull-requests.md) for the JSON and exit-status contract.
+`pr import --start-session` additionally establishes that canonical session
+without attaching, for clients that provide their own ordinary tmux
+presentation.
 
 ### Repository identity fallback
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -135,14 +135,14 @@ explicit, documented exception, so they cannot silently drift apart:
   `EDITOR`/`VISUAL` out of every pane's shell even though the server process
   itself now keeps them.
 
-The full list: exact names `__CFBundleIdentifier`, `EDITOR`, `OLDPWD`,
-`PROMPT`, `PROMPT_COMMAND`, `PWD`, `RPROMPT`, `SHLVL`,
-`TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VISUAL`, `WINDOWID`, `_`; and
-prefixes `ALACRITTY_`, `CONDA_`, `FZF_`, `ITERM`, `KITTY_`, `KWT_`, `NVM_`,
-`PYENV_`, `STARSHIP_`, `VIRTUAL_ENV`, `WEZTERM_`, `WT_`, `VSCODE_`. PR
-workspace bootstrap additionally removes the exact variable named by
-`fleet.token_env`, both from tmux subprocesses and from the session
-environment. `EDITOR` and
+The full list: exact names `__CFBundleIdentifier`, `EDITOR`,
+`KWT_GITHUB_TOKEN`, `OLDPWD`, `PROMPT`, `PROMPT_COMMAND`, `PWD`, `RPROMPT`,
+`SHLVL`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VISUAL`, `WINDOWID`, `_`; and
+prefixes `ALACRITTY_`, `CONDA_`, `FZF_`, `ITERM`, `KITTY_`, `NVM_`, `PYENV_`,
+`STARSHIP_`, `VIRTUAL_ENV`, `WEZTERM_`, `WT_`, `VSCODE_`. Operational kwt
+variables such as `KWT_HOME` are preserved. PR workspace bootstrap additionally
+removes the exact variable named by `fleet.token_env`, both from tmux
+subprocesses and from the session environment. `EDITOR` and
 `VISUAL` are excluded from exec-time sanitization only, per above; every
 other name in this list is treated identically by both mechanisms.
 
@@ -178,6 +178,13 @@ already running, it re-applies the safe bootstrap subset (`default-command`
 plus the remove-markers — never construction or pane commands), so a session
 another tool created bare converges on consistent behavior for windows opened
 after that attach.
+
+PR imports use a stricter reuse boundary. `pr import --start-session` records
+the canonical workspace path when it creates the session and reuses only a
+same-named session with that exact marker. It rejects a shared server or
+existing session whose environment contains the provider or configured fleet
+credential, because a process inside the imported workspace can access the
+shared tmux socket and session masking does not remove the server's copy.
 
 The repair path deliberately does not rewrite panes in an externally created
 session that is already running; it only makes future windows consistent. In a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -138,8 +138,11 @@ explicit, documented exception, so they cannot silently drift apart:
 The full list: exact names `__CFBundleIdentifier`, `EDITOR`, `OLDPWD`,
 `PROMPT`, `PROMPT_COMMAND`, `PWD`, `RPROMPT`, `SHLVL`,
 `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VISUAL`, `WINDOWID`, `_`; and
-prefixes `ALACRITTY_`, `CONDA_`, `FZF_`, `ITERM`, `KITTY_`, `NVM_`, `PYENV_`,
-`STARSHIP_`, `VIRTUAL_ENV`, `WEZTERM_`, `WT_`, `VSCODE_`. `EDITOR` and
+prefixes `ALACRITTY_`, `CONDA_`, `FZF_`, `ITERM`, `KITTY_`, `KWT_`, `NVM_`,
+`PYENV_`, `STARSHIP_`, `VIRTUAL_ENV`, `WEZTERM_`, `WT_`, `VSCODE_`. PR
+workspace bootstrap additionally removes the exact variable named by
+`fleet.token_env`, both from tmux subprocesses and from the session
+environment. `EDITOR` and
 `VISUAL` are excluded from exec-time sanitization only, per above; every
 other name in this list is treated identically by both mechanisms.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,7 +73,8 @@ provenance, and tmux session naming. See [Pull-request
 automation](pull-requests.md) for the JSON and exit-status contract.
 `pr import --start-session` additionally establishes that canonical session
 without attaching, for clients that provide their own ordinary tmux
-presentation.
+presentation. Its workspace record includes `tmux_socket_name`; attach with
+`tmux -L <tmux_socket_name> attach-session -t <session_name>`.
 
 ### Repository identity fallback
 
@@ -180,11 +181,12 @@ another tool created bare converges on consistent behavior for windows opened
 after that attach.
 
 PR imports use a stricter reuse boundary. `pr import --start-session` records
-the canonical workspace path when it creates the session and reuses only a
-same-named session with that exact marker. It rejects a shared server or
-existing session whose environment contains the provider or configured fleet
-credential, because a process inside the imported workspace can access the
-shared tmux socket and session masking does not remove the server's copy.
+the canonical workspace path when it creates the session on a deterministic,
+workspace-specific socket and reuses only a same-named session with that exact
+marker. The isolated server starts without the provider or configured fleet
+credential. The protected session also masks those names and removes them
+from `update-environment`, preventing a later client attach from restoring
+them.
 
 The repair path deliberately does not rewrite panes in an externally created
 session that is already running; it only makes future windows consistent. In a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,10 +49,13 @@ default branch. If that remote base is unavailable, it falls back to local
 `--json` emits an array of objects with `path`, `branch`, `commit_hash`, `is_main`,
 `created_at` (worktree directory mtime), `repository` (the `host/owner/name`
 slug, or a `local/<path>` fallback for a repository without a usable remote —
-see below), and `session_name` (the tmux workspace session name kwt attaches to). To
+see below), and `session_name` (the tmux workspace session name kwt attaches to).
+An imported pull-request worktree additionally includes `tmux_socket_name` for
+its protected workspace-specific server. To
 converge on the same session, prefer an attach-only command — `tmux
-attach-session -t <session_name>` (or `switch-client -t` from inside tmux) — so
-you never create the session bare. See [Attaching from other
+attach-session -t <session_name>` on the normal server, or `tmux -L
+<tmux_socket_name> attach-session -t <session_name>` when that field is
+present — so you never create the session bare. See [Attaching from other
 tools](#attaching-from-other-tools) before using `new-session`.
 `created_at` is populated in both local and `-g` mode.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,6 +57,8 @@ attach-session -t <session_name>` on the normal server, or `kwt pr attach
 <path>` when `tmux_socket_name` is present — so you never create the session
 bare or bypass its protected attach policy. See [Attaching from other
 tools](#attaching-from-other-tools) before using `new-session`.
+`kwt open` and dashboard open actions refuse protected pull-request imports
+and direct the user through `kwt pr attach`.
 `created_at` is populated in both local and `-g` mode.
 
 ## `kwt projects`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -53,9 +53,9 @@ see below), and `session_name` (the tmux workspace session name kwt attaches to)
 An imported pull-request worktree additionally includes `tmux_socket_name` for
 its protected workspace-specific server. To
 converge on the same session, prefer an attach-only command — `tmux
-attach-session -t <session_name>` on the normal server, or `tmux -L
-<tmux_socket_name> attach-session -t <session_name>` when that field is
-present — so you never create the session bare. See [Attaching from other
+attach-session -t <session_name>` on the normal server, or `kwt pr attach
+<path>` when `tmux_socket_name` is present — so you never create the session
+bare or bypass its protected attach policy. See [Attaching from other
 tools](#attaching-from-other-tools) before using `new-session`.
 `created_at` is populated in both local and `-g` mode.
 
@@ -77,7 +77,8 @@ automation](pull-requests.md) for the JSON and exit-status contract.
 `pr import --start-session` additionally establishes that canonical session
 without attaching, for clients that provide their own ordinary tmux
 presentation. Its workspace record includes `tmux_socket_name`; attach with
-`tmux -L <tmux_socket_name> attach-session -t <session_name>`.
+`kwt pr attach <workspace.path>`, which verifies the persisted identity and
+uses `attach-session -E`.
 
 ### Repository identity fallback
 
@@ -187,9 +188,10 @@ PR imports use a stricter reuse boundary. `pr import --start-session` records
 the canonical workspace path when it creates the session on a deterministic,
 workspace-specific socket and reuses only a same-named session with that exact
 marker. The isolated server starts without the provider or configured fleet
-credential. The protected session also masks those names and removes them
-from `update-environment`, preventing a later client attach from restoring
-them.
+credential. The protected session also masks those names and filters them from
+`update-environment`. Clients must use `kwt pr attach <workspace.path>`;
+because tmux options are mutable, that command repairs the policy and enforces
+`attach-session -E` rather than trusting the current option value.
 
 The repair path deliberately does not rewrite panes in an externally created
 session that is already running; it only makes future windows consistent. In a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,8 +79,9 @@ automation](pull-requests.md) for the JSON and exit-status contract.
 `pr import --start-session` additionally establishes that canonical session
 without attaching, for clients that provide their own ordinary tmux
 presentation. Its workspace record includes `tmux_socket_name`; attach with
-`kwt pr attach <workspace.path>`, which verifies the persisted identity and
-uses `attach-session -E`.
+`kwt pr attach <workspace.path>`, which verifies the persisted identity,
+creates or repairs the protected session when needed, and uses
+`attach-session -E`.
 
 ### Repository identity fallback
 
@@ -192,8 +193,9 @@ workspace-specific socket and reuses only a same-named session with that exact
 marker. The isolated server starts without the provider or configured fleet
 credential. The protected session also masks those names and filters them from
 `update-environment`. Clients must use `kwt pr attach <workspace.path>`;
-because tmux options are mutable, that command repairs the policy and enforces
-`attach-session -E` rather than trusting the current option value.
+because tmux options are mutable, that command creates or repairs the
+configured protected session and enforces `attach-session -E` rather than
+trusting the current option value.
 
 The repair path deliberately does not rewrite panes in an externally created
 session that is already running; it only makes future windows consistent. In a

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -32,11 +32,13 @@ kwt pr attach <workspace.path>
 ```
 
 The attach command resolves the persisted workspace identity, verifies the
-isolated server and session, repairs the protected environment policy, and
-executes `attach-session -E` so tmux cannot import client environment
-variables. It is idempotent for an already imported worktree or a
-verified session that kwt created for the same workspace. Session setup
-failures return a non-retryable `workspace_creation_failed` error.
+recorded project clone and exact live worktree identity, verifies the isolated
+server and session, repairs the protected environment policy, and executes
+`attach-session -E` so tmux cannot import client environment variables. A
+deleted project, reused path, or branch, repository, or session-name mismatch
+fails closed. It is idempotent for an already imported worktree or a verified
+session that kwt created for the same workspace. Session setup failures return
+a non-retryable `workspace_creation_failed` error.
 
 Kwt runs each protected PR workspace on a deterministic, workspace-specific
 tmux socket rather than the user's ordinary tmux server. Before invoking that
@@ -52,6 +54,11 @@ Kwt reuses an existing session on that isolated socket only when the session
 carries the matching workspace marker and both its server and session
 environments are credential-free. A rejected protected session must be
 removed before retrying.
+
+`kwt list --json` reads the same provenance store before it labels worktrees
+with `tmux_socket_name`. If that store cannot be read or decoded, listing fails
+instead of emitting an imported workspace without its safety-critical socket
+identity.
 
 `--project` accepts a repository identity from `kwt projects --json`, a
 registered project name, or its absolute canonical main-repository path.

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -40,8 +40,30 @@ fails closed. Prunable entries and paths without a live Git worktree are not
 accepted. The registered project's canonical identity remains authoritative
 when its checkout's origin points to a fork, matching kwt's other inventory
 surfaces. It is idempotent for an already imported worktree or a verified
-session that kwt created for the same workspace. Session setup failures return
-a non-retryable `workspace_creation_failed` error.
+session that kwt created for the same workspace. Kwt validates layout and
+agent configuration before import mutation. If runtime session establishment
+fails after the import becomes durable, the command still exits successfully
+and returns the imported workspace with an explicit
+`session_start_error`:
+
+```json
+{
+  "status": "created",
+  "workspace": {
+    "path": "/worktrees/pr-17",
+    "session_name": "kwt-workspace-pr-17"
+  },
+  "session_start_error": {
+    "code": "workspace_creation_failed",
+    "message": "failed to start imported workspace session",
+    "retryable": false
+  }
+}
+```
+
+Clients must retain or refresh the imported workspace when this field is
+present and present the session failure separately. Retrying the same import
+converges on `already_imported` and retries session establishment.
 
 Kwt runs each protected PR workspace on a deterministic, workspace-specific
 tmux socket rather than the user's ordinary tmux server. Before invoking that
@@ -342,8 +364,10 @@ returns a conflict rather than replacing the original clone's provenance. KWT
 does not push during this check or rewrite Git remotes and routing that the
 local user changed after import.
 
-If an import fails after creating a workspace, kwt rolls it back even when the
-request context was canceled. Request cancellation, including `SIGINT` and
+If the import transaction fails after creating a workspace, kwt rolls it back
+even when the request context was canceled. Session establishment happens
+after that transaction and therefore uses the partial-success contract above
+rather than claiming rollback. Request cancellation, including `SIGINT` and
 `SIGTERM`, terminates checkout; cleanup then runs without the canceled context.
 Worktree creation retains an ownership reservation through late rollback and
 removes only the original directory identity, a clean worktree, and the
@@ -376,7 +400,7 @@ and return a stable nonzero status. For example:
 | 6    | `inaccessible_head`             | The fork or source branch is unavailable. |
 | 7    | `naming_conflict`               | The generated branch or workspace is occupied. |
 | 8    | `network_failure`               | A retryable provider or Git network failure. |
-| 9    | `workspace_creation_failed`     | Worktree creation, setup, push config, persistence, or protected session startup failed. |
+| 9    | `workspace_creation_failed`     | Worktree creation, setup, push config, persistence, or session-configuration preflight failed. |
 | 10   | `malformed_provider_response`   | GitHub returned an invalid success response. |
 | 11   | `import_conflict`               | Concurrent state or the selected head SHA changed. |
 | 12   | `unsupported_git_version`        | Git is too old for isolated per-worktree push configuration. |

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -32,11 +32,14 @@ kwt pr attach <workspace.path>
 ```
 
 The attach command resolves the persisted workspace identity, verifies the
-recorded project clone and exact live worktree identity, verifies the isolated
-server and session, repairs the protected environment policy, and executes
-`attach-session -E` so tmux cannot import client environment variables. A
-parent tmux client identity is removed before attachment, so the command also
-works when invoked from a pane connected to another tmux server. A
+recorded project clone and exact live worktree identity, validates the current
+layout configuration, and creates or repairs the session on its isolated
+server before executing `attach-session -E` so tmux cannot import client
+environment variables. This makes the command converge imports created without
+`--start-session`, imports whose startup failed, and sessions that disappeared
+after import. A parent tmux client identity is removed before attachment, so
+the command also works when invoked from a pane connected to another tmux
+server. A
 deleted project, reused path, or branch, repository, or session-name mismatch
 fails closed. Prunable entries and paths without a live Git worktree are not
 accepted. The registered project's canonical identity remains authoritative
@@ -69,8 +72,9 @@ imported workspace with an explicit
 ```
 
 Clients must retain or refresh the imported workspace when this field is
-present and present the session failure separately. Retrying the same import
-converges on `already_imported` and retries session establishment.
+present and present the session failure separately. `kwt pr attach
+<workspace.path>` retries session establishment directly; repeating the import
+also converges on `already_imported`.
 
 Kwt runs each protected PR workspace on a deterministic, workspace-specific
 tmux socket rather than the user's ordinary tmux server. Before invoking that

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -25,19 +25,28 @@ kwt pr import 17 --project github.com/acme/widget \
 `--start-session` creates or repairs the `session_name` returned by the import
 using kwt's configured default layout and workspace bootstrap, then leaves it
 detached for the caller. The response also includes `tmux_socket_name`; clients
-must attach with `tmux -L <tmux_socket_name> attach-session -t
-<session_name>`. It is idempotent for an already imported worktree or a
+must attach through kwt's protected path:
+
+```sh
+kwt pr attach <workspace.path>
+```
+
+The attach command resolves the persisted workspace identity, verifies the
+isolated server and session, repairs the protected environment policy, and
+executes `attach-session -E` so tmux cannot import client environment
+variables. It is idempotent for an already imported worktree or a
 verified session that kwt created for the same workspace. Session setup
 failures return a non-retryable `workspace_creation_failed` error.
 
 Kwt runs each protected PR workspace on a deterministic, workspace-specific
 tmux socket rather than the user's ordinary tmux server. Before invoking that
-server, kwt removes `KWT_GITHUB_TOKEN` and the variable named by
-`fleet.token_env` from the subprocess environment. It installs matching
-session remove-markers before any imported-workspace shell starts and removes
-those names from the session's effective `update-environment` option so later
-client attachment cannot restore them. Operational state such as `KWT_HOME`
-remains available inside the workspace.
+server, kwt removes `KWT_GITHUB_TOKEN`, `KWT_FLEET_TOKEN`, and the variable
+named by `fleet.token_env` from the subprocess environment. It installs
+matching session remove-markers before any imported-workspace shell starts.
+Because tmux options are mutable by processes with socket access, filtering
+`update-environment` is defense in depth; the protected attach command always
+passes `-E` and never relies on that option for enforcement. Operational state
+such as `KWT_HOME` remains available inside the workspace.
 
 Kwt reuses an existing session on that isolated socket only when the session
 carries the matching workspace marker and both its server and session

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -36,7 +36,10 @@ recorded project clone and exact live worktree identity, verifies the isolated
 server and session, repairs the protected environment policy, and executes
 `attach-session -E` so tmux cannot import client environment variables. A
 deleted project, reused path, or branch, repository, or session-name mismatch
-fails closed. It is idempotent for an already imported worktree or a verified
+fails closed. Prunable entries and paths without a live Git worktree are not
+accepted. The registered project's canonical identity remains authoritative
+when its checkout's origin points to a fork, matching kwt's other inventory
+surfaces. It is idempotent for an already imported worktree or a verified
 session that kwt created for the same workspace. Session setup failures return
 a non-retryable `workspace_creation_failed` error.
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -25,15 +25,21 @@ kwt pr import 17 --project github.com/acme/widget \
 `--start-session` creates or repairs the `session_name` returned by the import
 using kwt's configured default layout and workspace bootstrap, then leaves it
 detached for the caller. It is idempotent for an already imported worktree or
-an existing session. If session setup fails, the command returns a
-`workspace_creation_failed` error; retrying the same import safely retries
-session setup.
+a verified session that kwt created for the same workspace. Session setup
+failures return a non-retryable `workspace_creation_failed` error.
 
-Before invoking tmux, kwt removes every `KWT_*` variable and the variable named
-by `fleet.token_env` from the subprocess environment. It installs matching
-session remove-markers as part of bootstrap, including names discovered in an
-already-running tmux server or session, so provider and fleet credentials are
-not inherited by imported workspace panes.
+Before invoking tmux, kwt removes `KWT_GITHUB_TOKEN` and the variable named by
+`fleet.token_env` from the subprocess environment. It installs matching
+session remove-markers before any imported-workspace shell starts. Operational
+state such as `KWT_HOME` remains available inside the workspace.
+
+Session remove-markers are not an isolation boundary for a shared tmux server:
+a pane can reach that server through its tmux socket. Kwt therefore refuses to
+start a PR workspace when the server's global environment still contains
+either credential. It also refuses to reuse an existing same-named session
+unless the session carries the matching kwt workspace marker and its session
+environment is credential-free. The user must remove or rename rejected
+sessions, or remove sensitive variables from the server, before retrying.
 
 `--project` accepts a repository identity from `kwt projects --json`, a
 registered project name, or its absolute canonical main-repository path.
@@ -348,7 +354,7 @@ and return a stable nonzero status. For example:
 | 6    | `inaccessible_head`             | The fork or source branch is unavailable. |
 | 7    | `naming_conflict`               | The generated branch or workspace is occupied. |
 | 8    | `network_failure`               | A retryable provider or Git network failure. |
-| 9    | `workspace_creation_failed`     | Worktree creation, setup, push config, or persistence failed. |
+| 9    | `workspace_creation_failed`     | Worktree creation, setup, push config, persistence, or protected session startup failed. |
 | 10   | `malformed_provider_response`   | GitHub returned an invalid success response. |
 | 11   | `import_conflict`               | Concurrent state or the selected head SHA changed. |
 | 12   | `unsupported_git_version`        | Git is too old for isolated per-worktree push configuration. |

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -24,22 +24,25 @@ kwt pr import 17 --project github.com/acme/widget \
 
 `--start-session` creates or repairs the `session_name` returned by the import
 using kwt's configured default layout and workspace bootstrap, then leaves it
-detached for the caller. It is idempotent for an already imported worktree or
-a verified session that kwt created for the same workspace. Session setup
+detached for the caller. The response also includes `tmux_socket_name`; clients
+must attach with `tmux -L <tmux_socket_name> attach-session -t
+<session_name>`. It is idempotent for an already imported worktree or a
+verified session that kwt created for the same workspace. Session setup
 failures return a non-retryable `workspace_creation_failed` error.
 
-Before invoking tmux, kwt removes `KWT_GITHUB_TOKEN` and the variable named by
+Kwt runs each protected PR workspace on a deterministic, workspace-specific
+tmux socket rather than the user's ordinary tmux server. Before invoking that
+server, kwt removes `KWT_GITHUB_TOKEN` and the variable named by
 `fleet.token_env` from the subprocess environment. It installs matching
-session remove-markers before any imported-workspace shell starts. Operational
-state such as `KWT_HOME` remains available inside the workspace.
+session remove-markers before any imported-workspace shell starts and removes
+those names from the session's effective `update-environment` option so later
+client attachment cannot restore them. Operational state such as `KWT_HOME`
+remains available inside the workspace.
 
-Session remove-markers are not an isolation boundary for a shared tmux server:
-a pane can reach that server through its tmux socket. Kwt therefore refuses to
-start a PR workspace when the server's global environment still contains
-either credential. It also refuses to reuse an existing same-named session
-unless the session carries the matching kwt workspace marker and its session
-environment is credential-free. The user must remove or rename rejected
-sessions, or remove sensitive variables from the server, before retrying.
+Kwt reuses an existing session on that isolated socket only when the session
+carries the matching workspace marker and both its server and session
+environments are credential-free. A rejected protected session must be
+removed before retrying.
 
 `--project` accepts a repository identity from `kwt projects --json`, a
 registered project name, or its absolute canonical main-repository path.

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -29,6 +29,12 @@ an existing session. If session setup fails, the command returns a
 `workspace_creation_failed` error; retrying the same import safely retries
 session setup.
 
+Before invoking tmux, kwt removes every `KWT_*` variable and the variable named
+by `fleet.token_env` from the subprocess environment. It installs matching
+session remove-markers as part of bootstrap, including names discovered in an
+already-running tmux server or session, so provider and fleet credentials are
+not inherited by imported workspace panes.
+
 `--project` accepts a repository identity from `kwt projects --json`, a
 registered project name, or its absolute canonical main-repository path.
 Identity and unique-name matching take precedence over path matching; relative

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -35,6 +35,8 @@ The attach command resolves the persisted workspace identity, verifies the
 recorded project clone and exact live worktree identity, verifies the isolated
 server and session, repairs the protected environment policy, and executes
 `attach-session -E` so tmux cannot import client environment variables. A
+parent tmux client identity is removed before attachment, so the command also
+works when invoked from a pane connected to another tmux server. A
 deleted project, reused path, or branch, repository, or session-name mismatch
 fails closed. Prunable entries and paths without a live Git worktree are not
 accepted. The registered project's canonical identity remains authoritative

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -14,6 +14,21 @@ kwt pr import github:github.com/acme/widget#17 \
   --project github.com/acme/widget --json
 ```
 
+Clients that present their own ordinary tmux client can ask kwt to establish
+the canonical workspace session without attaching kwt's process:
+
+```sh
+kwt pr import 17 --project github.com/acme/widget \
+  --start-session --json
+```
+
+`--start-session` creates or repairs the `session_name` returned by the import
+using kwt's configured default layout and workspace bootstrap, then leaves it
+detached for the caller. It is idempotent for an already imported worktree or
+an existing session. If session setup fails, the command returns a
+`workspace_creation_failed` error; retrying the same import safely retries
+session setup.
+
 `--project` accepts a repository identity from `kwt projects --json`, a
 registered project name, or its absolute canonical main-repository path.
 Identity and unique-name matching take precedence over path matching; relative

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -41,11 +41,16 @@ deleted project, reused path, or branch, repository, or session-name mismatch
 fails closed. Prunable entries and paths without a live Git worktree are not
 accepted. The registered project's canonical identity remains authoritative
 when its checkout's origin points to a fork, matching kwt's other inventory
-surfaces. It is idempotent for an already imported worktree or a verified
-session that kwt created for the same workspace. Kwt validates layout and
-agent configuration before import mutation. If runtime session establishment
-fails after the import becomes durable, the command still exits successfully
-and returns the imported workspace with an explicit
+surfaces. An import created from an unregistered repository remains attachable
+when its live Git identity matches the recorded repository; ambiguous or
+conflicting registrations fail closed. Ordinary `kwt open` and dashboard open
+actions refuse imported workspaces because they use the normal tmux server;
+use `kwt pr attach <workspace.path>` instead. The protected attach path is
+idempotent for an already imported worktree or a verified session that kwt
+created for the same workspace. Kwt validates layout and agent configuration
+before import mutation. If runtime session establishment fails after the
+import becomes durable, the command still exits successfully and returns the
+imported workspace with an explicit
 `session_start_error`:
 
 ```json

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -77,7 +77,12 @@ func runList(cmd *cobra.Command, args []string) error {
 
 			if listJSON {
 				enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-				enrichProtectedSocketIdentity(worktrees)
+				if err := enrichProtectedSocketIdentity(
+					cmd.Context(),
+					worktrees,
+				); err != nil {
+					return err
+				}
 				return ctx.Printer.PrintWorktreesJSON(worktrees)
 			}
 
@@ -114,7 +119,12 @@ func showGlobalWorktrees(ctx *CommandContext) error {
 	}
 
 	if listJSON {
-		enrichProtectedSocketIdentity(worktrees)
+		if err := enrichProtectedSocketIdentity(
+			context.Background(),
+			worktrees,
+		); err != nil {
+			return err
+		}
 		return ctx.Printer.PrintWorktreesJSON(worktrees)
 	}
 
@@ -122,10 +132,13 @@ func showGlobalWorktrees(ctx *CommandContext) error {
 	return nil
 }
 
-func enrichProtectedSocketIdentity(worktrees []models.Worktree) {
+func enrichProtectedSocketIdentity(
+	ctx context.Context,
+	worktrees []models.Worktree,
+) error {
 	records := make(map[string]pullrequest.Provenance)
 	if err := pullrequest.NewFileStore(prStorePath()).View(
-		context.Background(),
+		ctx,
 		func(current map[string]pullrequest.Provenance) error {
 			for key, record := range current {
 				records[key] = record
@@ -133,9 +146,10 @@ func enrichProtectedSocketIdentity(worktrees []models.Worktree) {
 			return nil
 		},
 	); err != nil {
-		return
+		return fmt.Errorf("failed to read pull-request provenance: %w", err)
 	}
 	annotateProtectedSocketIdentity(worktrees, records)
+	return nil
 }
 
 func annotateProtectedSocketIdentity(

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -142,21 +142,47 @@ func annotateProtectedSocketIdentity(
 	worktrees []models.Worktree,
 	records map[string]pullrequest.Provenance,
 ) {
-	socketByPath := make(map[string]string, len(records))
+	type workspaceIdentity struct {
+		path       string
+		branch     string
+		session    string
+		repository string
+	}
+	socketByIdentity := make(map[workspaceIdentity]string, len(records))
 	for _, record := range records {
 		workspace := record.Workspace
-		if workspace.Path == "" || workspace.SessionName == "" {
+		repository := workspace.Repository
+		if repository == "" {
+			repository = record.Project.Identity
+		}
+		if workspace.Path == "" ||
+			workspace.Branch == "" ||
+			workspace.SessionName == "" ||
+			repository == "" {
 			continue
 		}
-		socketByPath[utils.CanonicalPath(workspace.Path)] =
+		key := workspaceIdentity{
+			path:       utils.CanonicalPath(workspace.Path),
+			branch:     workspace.Branch,
+			session:    workspace.SessionName,
+			repository: pullrequest.NormalizeRepositoryIdentity(repository),
+		}
+		socketByIdentity[key] =
 			tmux.ProtectedWorkspaceSocketName(
 				workspace.SessionName,
 				workspace.Path,
 			)
 	}
 	for i := range worktrees {
-		worktrees[i].TmuxSocketName =
-			socketByPath[utils.CanonicalPath(worktrees[i].Path)]
+		key := workspaceIdentity{
+			path:    utils.CanonicalPath(worktrees[i].Path),
+			branch:  worktrees[i].Branch,
+			session: worktrees[i].SessionName,
+			repository: pullrequest.NormalizeRepositoryIdentity(
+				worktrees[i].Repository,
+			),
+		}
+		worktrees[i].TmuxSocketName = socketByIdentity[key]
 	}
 }
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -74,6 +77,7 @@ func runList(cmd *cobra.Command, args []string) error {
 
 			if listJSON {
 				enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
+				enrichProtectedSocketIdentity(worktrees)
 				return ctx.Printer.PrintWorktreesJSON(worktrees)
 			}
 
@@ -110,11 +114,50 @@ func showGlobalWorktrees(ctx *CommandContext) error {
 	}
 
 	if listJSON {
+		enrichProtectedSocketIdentity(worktrees)
 		return ctx.Printer.PrintWorktreesJSON(worktrees)
 	}
 
 	ctx.Printer.PrintWorktrees(worktrees, listVerbose)
 	return nil
+}
+
+func enrichProtectedSocketIdentity(worktrees []models.Worktree) {
+	records := make(map[string]pullrequest.Provenance)
+	if err := pullrequest.NewFileStore(prStorePath()).View(
+		context.Background(),
+		func(current map[string]pullrequest.Provenance) error {
+			for key, record := range current {
+				records[key] = record
+			}
+			return nil
+		},
+	); err != nil {
+		return
+	}
+	annotateProtectedSocketIdentity(worktrees, records)
+}
+
+func annotateProtectedSocketIdentity(
+	worktrees []models.Worktree,
+	records map[string]pullrequest.Provenance,
+) {
+	socketByPath := make(map[string]string, len(records))
+	for _, record := range records {
+		workspace := record.Workspace
+		if workspace.Path == "" || workspace.SessionName == "" {
+			continue
+		}
+		socketByPath[utils.CanonicalPath(workspace.Path)] =
+			tmux.ProtectedWorkspaceSocketName(
+				workspace.SessionName,
+				workspace.Path,
+			)
+	}
+	for i := range worktrees {
+		worktrees[i].TmuxSocketName =
+			socketByPath[utils.CanonicalPath(worktrees[i].Path)]
+	}
 }
 
 // enrichWorktreeIdentity fills the repository slug and session name for each

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
@@ -81,6 +84,24 @@ func TestStaleProvenanceDoesNotLabelReusedWorktreePath(t *testing.T) {
 	for _, worktree := range tests {
 		assert.Empty(t, worktree.TmuxSocketName)
 	}
+}
+
+func TestProtectedSocketEnrichmentReportsUnreadableProvenance(t *testing.T) {
+	kwtHome := t.TempDir()
+	t.Setenv("KWT_HOME", kwtHome)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(kwtHome, "pull-requests.json"),
+		[]byte("{"),
+		0o600,
+	))
+
+	err := enrichProtectedSocketIdentity(
+		context.Background(),
+		[]models.Worktree{{Path: "/worktrees/pr-32"}},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pull-request provenance")
 }
 
 // captureStdout runs fn with os.Stdout redirected to a pipe and returns

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -8,11 +8,35 @@ import (
 	"testing"
 
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/ui"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+func TestImportedWorktreeReceivesProtectedSocketIdentity(t *testing.T) {
+	worktrees := []models.Worktree{{
+		Path:        "/worktrees/pr-32",
+		SessionName: "kwt-workspace-pr-32",
+	}}
+	annotateProtectedSocketIdentity(worktrees, map[string]pullrequest.Provenance{
+		"pr-32": {
+			Workspace: pullrequest.Workspace{
+				Path:        "/worktrees/pr-32",
+				SessionName: "kwt-workspace-pr-32",
+			},
+		},
+	})
+
+	want := tmux.ProtectedWorkspaceSocketName(
+		"kwt-workspace-pr-32",
+		"/worktrees/pr-32",
+	)
+	if worktrees[0].TmuxSocketName != want {
+		t.Fatalf("tmux socket = %q, want %q", worktrees[0].TmuxSocketName, want)
+	}
+}
 
 // captureStdout runs fn with os.Stdout redirected to a pipe and returns
 // everything it wrote. The ui.Printer writes to os.Stdout directly, so this is

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
@@ -18,12 +19,19 @@ import (
 func TestImportedWorktreeReceivesProtectedSocketIdentity(t *testing.T) {
 	worktrees := []models.Worktree{{
 		Path:        "/worktrees/pr-32",
+		Branch:      "pr-32",
+		Repository:  "github.com/acme/widget",
 		SessionName: "kwt-workspace-pr-32",
 	}}
 	annotateProtectedSocketIdentity(worktrees, map[string]pullrequest.Provenance{
 		"pr-32": {
+			Project: pullrequest.Project{
+				Identity: "github.com/acme/widget",
+			},
 			Workspace: pullrequest.Workspace{
 				Path:        "/worktrees/pr-32",
+				Branch:      "pr-32",
+				Repository:  "github.com/acme/widget",
 				SessionName: "kwt-workspace-pr-32",
 			},
 		},
@@ -35,6 +43,43 @@ func TestImportedWorktreeReceivesProtectedSocketIdentity(t *testing.T) {
 	)
 	if worktrees[0].TmuxSocketName != want {
 		t.Fatalf("tmux socket = %q, want %q", worktrees[0].TmuxSocketName, want)
+	}
+}
+
+func TestStaleProvenanceDoesNotLabelReusedWorktreePath(t *testing.T) {
+	record := pullrequest.Provenance{
+		Project: pullrequest.Project{Identity: "github.com/acme/widget"},
+		Workspace: pullrequest.Workspace{
+			Path:        "/worktrees/reused",
+			Branch:      "pr-32",
+			Repository:  "github.com/acme/widget",
+			SessionName: "kwt-workspace-pr-32",
+		},
+	}
+	tests := []models.Worktree{
+		{
+			Path: "/worktrees/reused", Branch: "other",
+			Repository:  "github.com/acme/widget",
+			SessionName: "kwt-workspace-pr-32",
+		},
+		{
+			Path: "/worktrees/reused", Branch: "pr-32",
+			Repository:  "github.com/acme/other",
+			SessionName: "kwt-workspace-pr-32",
+		},
+		{
+			Path: "/worktrees/reused", Branch: "pr-32",
+			Repository:  "github.com/acme/widget",
+			SessionName: "kwt-workspace-other",
+		},
+	}
+
+	annotateProtectedSocketIdentity(tests, map[string]pullrequest.Provenance{
+		"stale": record,
+	})
+
+	for _, worktree := range tests {
+		assert.Empty(t, worktree.TmuxSocketName)
 	}
 }
 

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -74,45 +74,68 @@ func runOpen(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("could not resolve repository info for %s", selected.Path)
 		}
 
-		// Only resolve the target repo's default layout (which requires
-		// finding its root and loading, and possibly trust-prompting for, its
-		// .kwt.toml) when neither flag already determines the layout. This
-		// avoids trust-prompting on, or failing over, a malformed target
-		// config whose default would be ignored anyway.
-		targetDefault := ""
-		if shouldLoadTargetDefault(openLayout, openSelectLayout) {
-			repoRoot, err := git.New(entry.Path).GetMainRepositoryPath()
-			if err != nil {
-				return fmt.Errorf("failed to find repository root: %w", err)
-			}
-			targetDefault, err = config.LoadRepoLayoutDefault(repoRoot, config.StdinInteractive())
-			if err != nil {
-				return err
-			}
-		}
-
-		layout, err := tmux.ResolveLayout(ctx.Config.Layouts, openLayout, openSelectLayout, targetDefault,
+		return openSelectedWorktree(
+			cmd.Context(),
+			ctx,
+			entry,
 			func(ls []models.Layout) (models.Layout, error) {
 				sel, err := finder.SelectLayout(ls)
 				if err != nil {
 					return models.Layout{}, err
 				}
 				return *sel, nil
-			})
-		if err != nil {
-			return err
-		}
-		layout, err = tmux.ResolvePaneCommands(layout, ctx.Config.Agents)
-		if err != nil {
-			return err
-		}
-
-		session := tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path)
-		runner := tmux.NewWorkspaceRunner(tmux.NewTmuxCommand(""))
-		return runner.EnsureAndAttach(
-			context.Background(), session, entry.Path, layout, os.Getenv("TMUX") != "",
+			},
 		)
 	})(cmd, args)
+}
+
+func openSelectedWorktree(
+	commandCtx context.Context,
+	ctx *CommandContext,
+	entry *discovery.GlobalWorktreeEntry,
+	selectLayout func([]models.Layout) (models.Layout, error),
+) error {
+	if err := rejectProtectedWorkspaceOpen(commandCtx, entry.Path); err != nil {
+		return err
+	}
+
+	// Only resolve the target repo's default layout (which requires
+	// finding its root and loading, and possibly trust-prompting for, its
+	// .kwt.toml) when neither flag already determines the layout. This
+	// avoids trust-prompting on, or failing over, a malformed target
+	// config whose default would be ignored anyway.
+	targetDefault := ""
+	if shouldLoadTargetDefault(openLayout, openSelectLayout) {
+		repoRoot, err := git.New(entry.Path).GetMainRepositoryPath()
+		if err != nil {
+			return fmt.Errorf("failed to find repository root: %w", err)
+		}
+		targetDefault, err = config.LoadRepoLayoutDefault(repoRoot, config.StdinInteractive())
+		if err != nil {
+			return err
+		}
+	}
+
+	layout, err := tmux.ResolveLayout(
+		ctx.Config.Layouts,
+		openLayout,
+		openSelectLayout,
+		targetDefault,
+		selectLayout,
+	)
+	if err != nil {
+		return err
+	}
+	layout, err = tmux.ResolvePaneCommands(layout, ctx.Config.Agents)
+	if err != nil {
+		return err
+	}
+
+	session := tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path)
+	runner := tmux.NewWorkspaceRunner(tmux.NewTmuxCommand(""))
+	return runner.EnsureAndAttach(
+		commandCtx, session, entry.Path, layout, os.Getenv("TMUX") != "",
+	)
 }
 
 // shouldLoadTargetDefault reports whether kwt open must consult the target

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 func TestFindEntryByPath(t *testing.T) {
@@ -40,6 +43,37 @@ func TestShouldLoadTargetDefault(t *testing.T) {
 			assert.Equal(t, tc.want, shouldLoadTargetDefault(tc.layoutFlag, tc.selectLayout))
 		})
 	}
+}
+
+func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
+	t *testing.T,
+) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	workspacePath := t.TempDir()
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-32"] = pullrequest.Provenance{
+				Workspace: pullrequest.Workspace{Path: workspacePath},
+			}
+			return nil
+		},
+	))
+
+	err := openSelectedWorktree(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		&discovery.GlobalWorktreeEntry{
+			Path: workspacePath,
+			RepositoryInfo: &url.RepositoryInfo{
+				FullPath: "github.com/acme/widget",
+			},
+		},
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kwt pr attach")
 }
 
 // TestOpenCmdIsolatesFromCwdConfig guards the config-isolation invariant:

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -552,6 +552,10 @@ func defaultAttachPRWorkspaceSession(
 		strings.TrimSpace(workspace.SessionName) == "" {
 		return fmt.Errorf("imported workspace has no tmux identity")
 	}
+	layout, err := preparePRWorkspaceSessionLayout(cfg)
+	if err != nil {
+		return err
+	}
 	stripNames := protectedCredentialNames(cfg)
 	socketName := tmux.ProtectedWorkspaceSocketName(
 		workspace.SessionName,
@@ -565,10 +569,11 @@ func defaultAttachPRWorkspaceSession(
 	return tmux.NewProtectedWorkspaceRunner(
 		tmuxCommand,
 		stripNames,
-	).AttachProtected(
+	).EnsureAndAttachProtected(
 		ctx,
 		workspace.SessionName,
 		workspace.Path,
+		layout,
 	)
 }
 

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/kwt/internal/config"
 	gitadapter "go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/tmux"
 	urlutil "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
@@ -24,14 +25,16 @@ type prService interface {
 }
 
 var (
-	prProject string
-	prState   string
-	prJSON    bool
+	prProject      string
+	prState        string
+	prJSON         bool
+	prStartSession bool
 
-	loadPRConfig          = config.Load
-	loadPRTargetConfig    = config.LoadForTarget
-	newPRService          = defaultNewPRService
-	validatePRProjectRoot = defaultValidatePRProjectRoot
+	loadPRConfig            = config.Load
+	loadPRTargetConfig      = config.LoadForTarget
+	newPRService            = defaultNewPRService
+	validatePRProjectRoot   = defaultValidatePRProjectRoot
+	startPRWorkspaceSession = defaultStartPRWorkspaceSession
 )
 
 var prCmd = &cobra.Command{
@@ -73,6 +76,12 @@ func init() {
 	prCmd.PersistentFlags().StringVar(&prProject, "project", "", "registered project identity, name, or path (defaults to current repository)")
 	prCmd.PersistentFlags().BoolVar(&prJSON, "json", true, "emit the stable JSON automation contract")
 	prListCmd.Flags().StringVar(&prState, "state", "open", "pull-request state: open, closed, or all")
+	prImportCmd.Flags().BoolVar(
+		&prStartSession,
+		"start-session",
+		false,
+		"ensure the imported workspace's tmux session exists without attaching",
+	)
 	prCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return writePRError(cmd, pullrequest.NewError(pullrequest.CodeInvalidSelector, err.Error(), false, nil))
 	})
@@ -87,7 +96,7 @@ func runPRList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	service, err := preparePRService(cmd.Context(), project)
+	service, _, err := preparePRService(cmd.Context(), project)
 	if err != nil {
 		return writePRError(cmd, err)
 	}
@@ -111,13 +120,27 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if _, err := pullrequest.ParseSelector(args[0], project.Identity); err != nil {
 		return writePRError(cmd, err)
 	}
-	service, err := preparePRService(cmd.Context(), project)
+	service, cfg, err := preparePRService(cmd.Context(), project)
 	if err != nil {
 		return writePRError(cmd, err)
 	}
 	result, err := service.Import(cmd.Context(), project, args[0])
 	if err != nil {
 		return writePRError(cmd, err)
+	}
+	if prStartSession {
+		if err := startPRWorkspaceSession(
+			cmd.Context(),
+			result.Workspace,
+			cfg,
+		); err != nil {
+			return writePRError(cmd, pullrequest.NewError(
+				pullrequest.CodeWorkspaceCreation,
+				"failed to start imported workspace session",
+				true,
+				err,
+			))
+		}
 	}
 	return writePRJSON(cmd, result)
 }
@@ -135,17 +158,63 @@ func preparePRProject() (pullrequest.Project, error) {
 	return project, nil
 }
 
-func preparePRService(ctx context.Context, project pullrequest.Project) (prService, error) {
+func preparePRService(
+	ctx context.Context,
+	project pullrequest.Project,
+) (prService, *models.Config, error) {
 	project, err := validatePRProjectRoot(project)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	cfg, err := loadPRTargetConfig(project.Path, false)
 	if err != nil {
-		return nil, pullrequest.NewError(
+		return nil, nil, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation, "failed to load selected project configuration", false, err)
 	}
-	return newPRService(ctx, cfg, project)
+	service, err := newPRService(ctx, cfg, project)
+	if err != nil {
+		return nil, nil, err
+	}
+	return service, cfg, nil
+}
+
+func defaultStartPRWorkspaceSession(
+	ctx context.Context,
+	workspace pullrequest.Workspace,
+	cfg *models.Config,
+) error {
+	if cfg == nil {
+		return fmt.Errorf("kwt configuration is unavailable")
+	}
+	if strings.TrimSpace(workspace.Path) == "" ||
+		strings.TrimSpace(workspace.SessionName) == "" {
+		return fmt.Errorf("imported workspace has no tmux identity")
+	}
+	if err := tmux.ValidateLayouts(cfg.Layouts, cfg.Agents); err != nil {
+		return err
+	}
+	layout, err := tmux.ResolveLayout(
+		cfg.Layouts,
+		"",
+		false,
+		"",
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	layout, err = tmux.ResolvePaneCommands(layout, cfg.Agents)
+	if err != nil {
+		return err
+	}
+	return tmux.NewWorkspaceRunner(
+		tmux.NewTmuxCommand(""),
+	).Ensure(
+		ctx,
+		workspace.SessionName,
+		workspace.Path,
+		layout,
+	)
 }
 
 func defaultNewPRService(ctx context.Context, cfg *models.Config, project pullrequest.Project) (prService, error) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -31,11 +31,12 @@ var (
 	prJSON         bool
 	prStartSession bool
 
-	loadPRConfig            = config.Load
-	loadPRTargetConfig      = config.LoadForTarget
-	newPRService            = defaultNewPRService
-	validatePRProjectRoot   = defaultValidatePRProjectRoot
-	startPRWorkspaceSession = defaultStartPRWorkspaceSession
+	loadPRConfig             = config.Load
+	loadPRTargetConfig       = config.LoadForTarget
+	newPRService             = defaultNewPRService
+	validatePRProjectRoot    = defaultValidatePRProjectRoot
+	startPRWorkspaceSession  = defaultStartPRWorkspaceSession
+	attachPRWorkspaceSession = defaultAttachPRWorkspaceSession
 )
 
 var prCmd = &cobra.Command{
@@ -71,9 +72,16 @@ var prImportCmd = &cobra.Command{
 	RunE:  withGracefulSignals(runPRImport),
 }
 
+var prAttachCmd = &cobra.Command{
+	Use:   "attach <workspace-path>",
+	Short: "Attach to a protected imported workspace session",
+	Args:  prExactArgs(1),
+	RunE:  withGracefulSignals(runPRAttach),
+}
+
 func init() {
 	rootCmd.AddCommand(prCmd)
-	prCmd.AddCommand(prListCmd, prImportCmd)
+	prCmd.AddCommand(prListCmd, prImportCmd, prAttachCmd)
 	prCmd.PersistentFlags().StringVar(&prProject, "project", "", "registered project identity, name, or path (defaults to current repository)")
 	prCmd.PersistentFlags().BoolVar(&prJSON, "json", true, "emit the stable JSON automation contract")
 	prListCmd.Flags().StringVar(&prState, "state", "open", "pull-request state: open, closed, or all")
@@ -149,8 +157,85 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 			))
 		}
 		result.Workspace.TmuxSocketName = socketName
+		result.PullRequest.Workspace = &result.Workspace
 	}
 	return writePRJSON(cmd, result)
+}
+
+func runPRAttach(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return prExactArgs(1)(cmd, args)
+	}
+	record, err := importedWorkspaceProvenance(
+		cmd.Context(),
+		args[0],
+	)
+	if err != nil {
+		return writePRError(cmd, err)
+	}
+	cfg, err := loadPRTargetConfig(record.Project.Path, false)
+	if err != nil {
+		return writePRError(cmd, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			"failed to load imported workspace configuration",
+			false,
+			err,
+		))
+	}
+	if err := attachPRWorkspaceSession(
+		cmd.Context(),
+		record.Workspace,
+		cfg,
+	); err != nil {
+		message := "failed to attach imported workspace session"
+		var safetyError *tmux.SessionSafetyError
+		if errors.As(err, &safetyError) {
+			message = safetyError.Error()
+		}
+		return writePRError(cmd, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			message,
+			false,
+			err,
+		))
+	}
+	return nil
+}
+
+func importedWorkspaceProvenance(
+	ctx context.Context,
+	workspacePath string,
+) (pullrequest.Provenance, error) {
+	path := utils.CanonicalPath(workspacePath)
+	var matches []pullrequest.Provenance
+	err := pullrequest.NewFileStore(prStorePath()).View(
+		ctx,
+		func(records map[string]pullrequest.Provenance) error {
+			for _, record := range records {
+				if utils.CanonicalPath(record.Workspace.Path) == path {
+					matches = append(matches, record)
+				}
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return pullrequest.Provenance{}, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			"failed to read pull-request provenance",
+			false,
+			err,
+		)
+	}
+	if len(matches) != 1 {
+		return pullrequest.Provenance{}, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			"workspace is not a uniquely verified pull-request import",
+			false,
+			nil,
+		)
+	}
+	return matches[0], nil
 }
 
 func preparePRProject() (pullrequest.Project, error) {
@@ -215,7 +300,7 @@ func defaultStartPRWorkspaceSession(
 	if err != nil {
 		return "", err
 	}
-	stripNames := []string{"KWT_GITHUB_TOKEN", cfg.Fleet.TokenEnv}
+	stripNames := protectedCredentialNames(cfg)
 	socketName := tmux.ProtectedWorkspaceSocketName(
 		workspace.SessionName,
 		workspace.Path,
@@ -238,6 +323,56 @@ func defaultStartPRWorkspaceSession(
 		return "", err
 	}
 	return socketName, nil
+}
+
+func defaultAttachPRWorkspaceSession(
+	ctx context.Context,
+	workspace pullrequest.Workspace,
+	cfg *models.Config,
+) error {
+	if cfg == nil {
+		return fmt.Errorf("kwt configuration is unavailable")
+	}
+	if strings.TrimSpace(workspace.Path) == "" ||
+		strings.TrimSpace(workspace.SessionName) == "" {
+		return fmt.Errorf("imported workspace has no tmux identity")
+	}
+	stripNames := protectedCredentialNames(cfg)
+	socketName := tmux.ProtectedWorkspaceSocketName(
+		workspace.SessionName,
+		workspace.Path,
+	)
+	tmuxCommand := tmux.NewTmuxCommandForSocketWithStripNames(
+		"",
+		socketName,
+		stripNames,
+	)
+	return tmux.NewProtectedWorkspaceRunner(
+		tmuxCommand,
+		stripNames,
+	).AttachProtected(
+		ctx,
+		workspace.SessionName,
+		workspace.Path,
+	)
+}
+
+func protectedCredentialNames(cfg *models.Config) []string {
+	names := []string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"}
+	if cfg != nil {
+		names = append(names, cfg.Fleet.TokenEnv)
+	}
+	seen := make(map[string]bool, len(names))
+	protected := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		protected = append(protected, name)
+	}
+	return protected
 }
 
 func defaultNewPRService(ctx context.Context, cfg *models.Config, project pullrequest.Project) (prService, error) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -31,13 +31,14 @@ var (
 	prJSON         bool
 	prStartSession bool
 
-	loadPRConfig             = config.Load
-	loadPRTargetConfig       = config.LoadForTarget
-	newPRService             = defaultNewPRService
-	validatePRProjectRoot    = defaultValidatePRProjectRoot
-	inspectPRProjectClone    = defaultInspectPRProjectClone
-	startPRWorkspaceSession  = defaultStartPRWorkspaceSession
-	attachPRWorkspaceSession = defaultAttachPRWorkspaceSession
+	loadPRConfig                     = config.Load
+	loadPRTargetConfig               = config.LoadForTarget
+	newPRService                     = defaultNewPRService
+	validatePRProjectRoot            = defaultValidatePRProjectRoot
+	inspectPRProjectClone            = defaultInspectPRProjectClone
+	validatePRWorkspaceSessionConfig = defaultValidatePRWorkspaceSessionConfig
+	startPRWorkspaceSession          = defaultStartPRWorkspaceSession
+	attachPRWorkspaceSession         = defaultAttachPRWorkspaceSession
 )
 
 var prCmd = &cobra.Command{
@@ -134,6 +135,16 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
+	if prStartSession {
+		if err := validatePRWorkspaceSessionConfig(cfg); err != nil {
+			return writePRError(cmd, pullrequest.NewError(
+				pullrequest.CodeWorkspaceCreation,
+				"invalid imported workspace session configuration",
+				false,
+				err,
+			))
+		}
+	}
 	result, err := service.Import(cmd.Context(), project, args[0])
 	if err != nil {
 		return writePRError(cmd, err)
@@ -150,12 +161,14 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 			if errors.As(startErr, &safetyError) {
 				message = safetyError.Error()
 			}
-			return writePRError(cmd, pullrequest.NewError(
+			result.SessionStartError = pullrequest.NewError(
 				pullrequest.CodeWorkspaceCreation,
 				message,
 				false,
 				startErr,
-			))
+			)
+			result.PullRequest.Workspace = &result.Workspace
+			return writePRJSON(cmd, result)
 		}
 		result.Workspace.TmuxSocketName = socketName
 		result.PullRequest.Workspace = &result.Workspace
@@ -427,20 +440,7 @@ func defaultStartPRWorkspaceSession(
 		strings.TrimSpace(workspace.SessionName) == "" {
 		return "", fmt.Errorf("imported workspace has no tmux identity")
 	}
-	if err := tmux.ValidateLayouts(cfg.Layouts, cfg.Agents); err != nil {
-		return "", err
-	}
-	layout, err := tmux.ResolveLayout(
-		cfg.Layouts,
-		"",
-		false,
-		"",
-		nil,
-	)
-	if err != nil {
-		return "", err
-	}
-	layout, err = tmux.ResolvePaneCommands(layout, cfg.Agents)
+	layout, err := preparePRWorkspaceSessionLayout(cfg)
 	if err != nil {
 		return "", err
 	}
@@ -467,6 +467,39 @@ func defaultStartPRWorkspaceSession(
 		return "", err
 	}
 	return socketName, nil
+}
+
+func defaultValidatePRWorkspaceSessionConfig(
+	cfg *models.Config,
+) error {
+	if cfg == nil {
+		return fmt.Errorf("kwt configuration is unavailable")
+	}
+	_, err := preparePRWorkspaceSessionLayout(cfg)
+	return err
+}
+
+func preparePRWorkspaceSessionLayout(
+	cfg *models.Config,
+) (models.Layout, error) {
+	if err := tmux.ValidateLayouts(cfg.Layouts, cfg.Agents); err != nil {
+		return models.Layout{}, err
+	}
+	layout, err := tmux.ResolveLayout(
+		cfg.Layouts,
+		"",
+		false,
+		"",
+		nil,
+	)
+	if err != nil {
+		return models.Layout{}, err
+	}
+	layout, err = tmux.ResolvePaneCommands(layout, cfg.Agents)
+	if err != nil {
+		return models.Layout{}, err
+	}
+	return layout, nil
 }
 
 func defaultAttachPRWorkspaceSession(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -274,6 +274,39 @@ func importedWorkspaceProvenance(
 	return record, nil
 }
 
+func rejectProtectedWorkspaceOpen(
+	ctx context.Context,
+	workspacePath string,
+) error {
+	path := utils.CanonicalPath(workspacePath)
+	protected := false
+	err := pullrequest.NewFileStore(prStorePath()).View(
+		ctx,
+		func(records map[string]pullrequest.Provenance) error {
+			for _, record := range records {
+				if utils.CanonicalPath(record.Workspace.Path) == path {
+					protected = true
+					break
+				}
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to verify pull-request protection for workspace: %w",
+			err,
+		)
+	}
+	if protected {
+		return fmt.Errorf(
+			"protected pull-request workspaces must be opened with kwt pr attach %s",
+			workspacePath,
+		)
+	}
+	return nil
+}
+
 func defaultInspectPRProjectClone(
 	ctx context.Context,
 	recorded pullrequest.Project,
@@ -295,18 +328,23 @@ func defaultInspectPRProjectClone(
 	registered := make([]models.Project, 0, 1)
 	for _, candidate := range cfg.Projects {
 		if utils.CanonicalPath(candidate.Path) !=
-			utils.CanonicalPath(recorded.Path) ||
-			!pullrequest.EqualRepositoryIdentity(
-				publishableProjectRepository(candidate),
-				recorded.Identity,
-			) {
+			utils.CanonicalPath(recorded.Path) {
 			continue
 		}
 		registered = append(registered, candidate)
 	}
-	if len(registered) != 1 {
+	if len(registered) > 1 {
 		return pullrequest.Project{}, nil, fmt.Errorf(
 			"recorded project is not uniquely registered",
+		)
+	}
+	if len(registered) == 1 &&
+		!pullrequest.EqualRepositoryIdentity(
+			publishableProjectRepository(registered[0]),
+			recorded.Identity,
+		) {
+		return pullrequest.Project{}, nil, fmt.Errorf(
+			"registered project conflicts with recorded identity",
 		)
 	}
 	g := gitadapter.New(project.Path)

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -272,8 +272,35 @@ func defaultInspectPRProjectClone(
 	if err != nil {
 		return pullrequest.Project{}, nil, err
 	}
+	cfg, err := loadPRConfig()
+	if err != nil {
+		return pullrequest.Project{}, nil, fmt.Errorf(
+			"load registered project inventory: %w",
+			err,
+		)
+	}
+	registered := make([]models.Project, 0, 1)
+	for _, candidate := range cfg.Projects {
+		if utils.CanonicalPath(candidate.Path) !=
+			utils.CanonicalPath(recorded.Path) ||
+			!pullrequest.EqualRepositoryIdentity(
+				publishableProjectRepository(candidate),
+				recorded.Identity,
+			) {
+			continue
+		}
+		registered = append(registered, candidate)
+	}
+	if len(registered) != 1 {
+		return pullrequest.Project{}, nil, fmt.Errorf(
+			"recorded project is not uniquely registered",
+		)
+	}
 	g := gitadapter.New(project.Path)
-	info, err := worktree.RepositoryInfoFromGit(g)
+	info, err := worktree.RepositoryInfoWithProjects(
+		g,
+		registered,
+	)
 	if err != nil {
 		return pullrequest.Project{}, nil, fmt.Errorf(
 			"resolve recorded project repository: %w",
@@ -291,8 +318,19 @@ func defaultInspectPRProjectClone(
 		return pullrequest.Project{}, nil, err
 	}
 	project.Identity = pullrequest.NormalizeRepositoryIdentity(info.FullPath)
+	return project, livePRWorkspaces(info, project, live), nil
+}
+
+func livePRWorkspaces(
+	info *urlutil.RepositoryInfo,
+	project pullrequest.Project,
+	live []models.Worktree,
+) []pullrequest.Workspace {
 	workspaces := make([]pullrequest.Workspace, 0, len(live))
 	for _, candidate := range live {
+		if candidate.Prunable || !liveGitWorktreePath(candidate.Path) {
+			continue
+		}
 		workspaces = append(workspaces, pullrequest.Workspace{
 			Path:       candidate.Path,
 			Branch:     candidate.Branch,
@@ -304,7 +342,16 @@ func defaultInspectPRProjectClone(
 			),
 		})
 	}
-	return project, workspaces, nil
+	return workspaces
+}
+
+func liveGitWorktreePath(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(path, ".git"))
+	return err == nil
 }
 
 func samePRProjectClone(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -134,10 +135,15 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 			result.Workspace,
 			cfg,
 		); err != nil {
+			message := "failed to start imported workspace session"
+			var safetyError *tmux.SessionSafetyError
+			if errors.As(err, &safetyError) {
+				message = safetyError.Error()
+			}
 			return writePRError(cmd, pullrequest.NewError(
 				pullrequest.CodeWorkspaceCreation,
-				"failed to start imported workspace session",
-				true,
+				message,
+				false,
 				err,
 			))
 		}
@@ -207,9 +213,9 @@ func defaultStartPRWorkspaceSession(
 	if err != nil {
 		return err
 	}
-	stripNames := []string{cfg.Fleet.TokenEnv}
+	stripNames := []string{"KWT_GITHUB_TOKEN", cfg.Fleet.TokenEnv}
 	tmuxCommand := tmux.NewTmuxCommandWithStripNames("", stripNames)
-	return tmux.NewWorkspaceRunnerWithStripNames(
+	return tmux.NewProtectedWorkspaceRunner(
 		tmuxCommand,
 		stripNames,
 	).Ensure(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -35,6 +35,7 @@ var (
 	loadPRTargetConfig       = config.LoadForTarget
 	newPRService             = defaultNewPRService
 	validatePRProjectRoot    = defaultValidatePRProjectRoot
+	inspectPRProjectClone    = defaultInspectPRProjectClone
 	startPRWorkspaceSession  = defaultStartPRWorkspaceSession
 	attachPRWorkspaceSession = defaultAttachPRWorkspaceSession
 )
@@ -235,7 +236,103 @@ func importedWorkspaceProvenance(
 			nil,
 		)
 	}
-	return matches[0], nil
+	record := matches[0]
+	liveProject, liveWorkspaces, err := inspectPRProjectClone(
+		ctx,
+		record.Project,
+	)
+	if err != nil {
+		return pullrequest.Provenance{}, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			"failed to verify imported workspace provenance",
+			false,
+			err,
+		)
+	}
+	if !samePRProjectClone(record.Project, liveProject) ||
+		!containsPRWorkspace(liveWorkspaces, record.Workspace) {
+		return pullrequest.Provenance{}, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			"workspace no longer matches its pull-request provenance",
+			false,
+			nil,
+		)
+	}
+	return record, nil
+}
+
+func defaultInspectPRProjectClone(
+	ctx context.Context,
+	recorded pullrequest.Project,
+) (pullrequest.Project, []pullrequest.Workspace, error) {
+	if err := ctx.Err(); err != nil {
+		return pullrequest.Project{}, nil, err
+	}
+	project, err := validatePRProjectRoot(recorded)
+	if err != nil {
+		return pullrequest.Project{}, nil, err
+	}
+	g := gitadapter.New(project.Path)
+	info, err := worktree.RepositoryInfoFromGit(g)
+	if err != nil {
+		return pullrequest.Project{}, nil, fmt.Errorf(
+			"resolve recorded project repository: %w",
+			err,
+		)
+	}
+	live, err := worktree.New(g, nil).List()
+	if err != nil {
+		return pullrequest.Project{}, nil, fmt.Errorf(
+			"list recorded project worktrees: %w",
+			err,
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return pullrequest.Project{}, nil, err
+	}
+	project.Identity = pullrequest.NormalizeRepositoryIdentity(info.FullPath)
+	workspaces := make([]pullrequest.Workspace, 0, len(live))
+	for _, candidate := range live {
+		workspaces = append(workspaces, pullrequest.Workspace{
+			Path:       candidate.Path,
+			Branch:     candidate.Branch,
+			Repository: project.Identity,
+			SessionName: tmux.WorkspaceSessionName(
+				info,
+				candidate.Branch,
+				candidate.Path,
+			),
+		})
+	}
+	return project, workspaces, nil
+}
+
+func samePRProjectClone(
+	left, right pullrequest.Project,
+) bool {
+	return pullrequest.EqualRepositoryIdentity(
+		left.Identity,
+		right.Identity,
+	) && utils.CanonicalPath(left.Path) == utils.CanonicalPath(right.Path)
+}
+
+func containsPRWorkspace(
+	live []pullrequest.Workspace,
+	recorded pullrequest.Workspace,
+) bool {
+	for _, candidate := range live {
+		if utils.CanonicalPath(candidate.Path) ==
+			utils.CanonicalPath(recorded.Path) &&
+			candidate.Branch == recorded.Branch &&
+			pullrequest.EqualRepositoryIdentity(
+				candidate.Repository,
+				recorded.Repository,
+			) &&
+			candidate.SessionName == recorded.SessionName {
+			return true
+		}
+	}
+	return false
 }
 
 func preparePRProject() (pullrequest.Project, error) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -130,23 +130,25 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 		return writePRError(cmd, err)
 	}
 	if prStartSession {
-		if err := startPRWorkspaceSession(
+		socketName, startErr := startPRWorkspaceSession(
 			cmd.Context(),
 			result.Workspace,
 			cfg,
-		); err != nil {
+		)
+		if startErr != nil {
 			message := "failed to start imported workspace session"
 			var safetyError *tmux.SessionSafetyError
-			if errors.As(err, &safetyError) {
+			if errors.As(startErr, &safetyError) {
 				message = safetyError.Error()
 			}
 			return writePRError(cmd, pullrequest.NewError(
 				pullrequest.CodeWorkspaceCreation,
 				message,
 				false,
-				err,
+				startErr,
 			))
 		}
+		result.Workspace.TmuxSocketName = socketName
 	}
 	return writePRJSON(cmd, result)
 }
@@ -188,16 +190,16 @@ func defaultStartPRWorkspaceSession(
 	ctx context.Context,
 	workspace pullrequest.Workspace,
 	cfg *models.Config,
-) error {
+) (string, error) {
 	if cfg == nil {
-		return fmt.Errorf("kwt configuration is unavailable")
+		return "", fmt.Errorf("kwt configuration is unavailable")
 	}
 	if strings.TrimSpace(workspace.Path) == "" ||
 		strings.TrimSpace(workspace.SessionName) == "" {
-		return fmt.Errorf("imported workspace has no tmux identity")
+		return "", fmt.Errorf("imported workspace has no tmux identity")
 	}
 	if err := tmux.ValidateLayouts(cfg.Layouts, cfg.Agents); err != nil {
-		return err
+		return "", err
 	}
 	layout, err := tmux.ResolveLayout(
 		cfg.Layouts,
@@ -207,15 +209,23 @@ func defaultStartPRWorkspaceSession(
 		nil,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 	layout, err = tmux.ResolvePaneCommands(layout, cfg.Agents)
 	if err != nil {
-		return err
+		return "", err
 	}
 	stripNames := []string{"KWT_GITHUB_TOKEN", cfg.Fleet.TokenEnv}
-	tmuxCommand := tmux.NewTmuxCommandWithStripNames("", stripNames)
-	return tmux.NewProtectedWorkspaceRunner(
+	socketName := tmux.ProtectedWorkspaceSocketName(
+		workspace.SessionName,
+		workspace.Path,
+	)
+	tmuxCommand := tmux.NewTmuxCommandForSocketWithStripNames(
+		"",
+		socketName,
+		stripNames,
+	)
+	err = tmux.NewProtectedWorkspaceRunner(
 		tmuxCommand,
 		stripNames,
 	).Ensure(
@@ -224,6 +234,10 @@ func defaultStartPRWorkspaceSession(
 		workspace.Path,
 		layout,
 	)
+	if err != nil {
+		return "", err
+	}
+	return socketName, nil
 }
 
 func defaultNewPRService(ctx context.Context, cfg *models.Config, project pullrequest.Project) (prService, error) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -207,8 +207,11 @@ func defaultStartPRWorkspaceSession(
 	if err != nil {
 		return err
 	}
-	return tmux.NewWorkspaceRunner(
-		tmux.NewTmuxCommand(""),
+	stripNames := []string{cfg.Fleet.TokenEnv}
+	tmuxCommand := tmux.NewTmuxCommandWithStripNames("", stripNames)
+	return tmux.NewWorkspaceRunnerWithStripNames(
+		tmuxCommand,
+		stripNames,
 	).Ensure(
 		ctx,
 		workspace.SessionName,

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -50,6 +50,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldState := prState
 	oldStartSession := prStartSession
 	oldStartWorkspaceSession := startPRWorkspaceSession
+	oldAttachWorkspaceSession := attachPRWorkspaceSession
 	t.Cleanup(func() {
 		loadPRConfig = oldLoad
 		loadPRTargetConfig = oldTargetLoad
@@ -59,6 +60,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		prState = oldState
 		prStartSession = oldStartSession
 		startPRWorkspaceSession = oldStartWorkspaceSession
+		attachPRWorkspaceSession = oldAttachWorkspaceSession
 	})
 	loadPRConfig = func() (*models.Config, error) { return cfg, nil }
 	loadPRTargetConfig = func(string, bool) (*models.Config, error) { return cfg, nil }
@@ -179,6 +181,7 @@ func TestPreparePRServiceRejectsPathOutsideMainRepositoryRootBeforeLoadingConfig
 
 func prTestCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.SetOut(stdout)
@@ -307,6 +310,79 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 	var got pullrequest.ImportResult
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
 	assert.Equal(t, "kwt-pr-0123456789abcdef", got.Workspace.TmuxSocketName)
+	importedWorkspace := tryRequireWorkspace(t, got.PullRequest.Workspace)
+	assert.Equal(
+		t,
+		"kwt-pr-0123456789abcdef",
+		importedWorkspace.TmuxSocketName,
+	)
+}
+
+func tryRequireWorkspace(
+	t *testing.T,
+	workspace *pullrequest.Workspace,
+) pullrequest.Workspace {
+	t.Helper()
+	require.NotNil(t, workspace)
+	return *workspace
+}
+
+func TestProtectedCredentialNamesAlwaysIncludeFleetDefaults(t *testing.T) {
+	for _, configured := range []string{"", "CUSTOM_FLEET_TOKEN"} {
+		names := protectedCredentialNames(&models.Config{
+			Fleet: models.FleetConfig{TokenEnv: configured},
+		})
+		want := []string{
+			"KWT_GITHUB_TOKEN",
+			"KWT_FLEET_TOKEN",
+		}
+		if configured != "" {
+			want = append(want, configured)
+		}
+		assert.ElementsMatch(t, want, names)
+	}
+}
+
+func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	workspace := pullrequest.Workspace{
+		Path:        "/worktrees/pr-32",
+		Branch:      "pr-32",
+		SessionName: "kwt-workspace-pr-32",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-32"] = pullrequest.Provenance{
+				Project: pullrequest.Project{
+					Identity: "github.com/acme/widget",
+					Path:     "/repos/widget",
+				},
+				Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	cfg := testPRConfig()
+	cfg.Fleet.TokenEnv = "CUSTOM_FLEET_TOKEN"
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	var attached bool
+	attachPRWorkspaceSession = func(
+		_ context.Context,
+		got pullrequest.Workspace,
+		gotConfig *models.Config,
+	) error {
+		attached = true
+		assert.Equal(t, workspace, got)
+		assert.Same(t, cfg, gotConfig)
+		return nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRAttach(cmd, []string{workspace.Path})
+
+	require.NoError(t, err)
+	assert.True(t, attached)
 }
 
 func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -492,6 +492,103 @@ func TestInspectPRProjectCloneUsesRegisteredIdentityOverForkOrigin(
 	assert.Equal(t, recorded.Identity, workspaces[0].Repository)
 }
 
+func TestInspectPRProjectCloneUsesLiveIdentityWithoutRegistration(
+	t *testing.T,
+) {
+	repo := newPRInspectionRepo(t)
+	runPRInspectionGit(
+		t,
+		repo,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/acme/widget.git",
+	)
+	recorded := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	oldLoad := loadPRConfig
+	t.Cleanup(func() { loadPRConfig = oldLoad })
+	loadPRConfig = func() (*models.Config, error) {
+		return &models.Config{}, nil
+	}
+
+	project, workspaces, err := defaultInspectPRProjectClone(
+		context.Background(),
+		recorded,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, recorded.Identity, project.Identity)
+	require.NotEmpty(t, workspaces)
+	assert.Equal(t, recorded.Identity, workspaces[0].Repository)
+}
+
+func TestInspectPRProjectCloneRejectsConflictingRegistration(
+	t *testing.T,
+) {
+	repo := newPRInspectionRepo(t)
+	recorded := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	oldLoad := loadPRConfig
+	t.Cleanup(func() { loadPRConfig = oldLoad })
+	loadPRConfig = func() (*models.Config, error) {
+		return &models.Config{Projects: []models.Project{{
+			Repository: "github.com/other/widget",
+			Name:       recorded.Name,
+			Path:       recorded.Path,
+		}}}, nil
+	}
+
+	_, _, err := defaultInspectPRProjectClone(
+		context.Background(),
+		recorded,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with recorded identity")
+}
+
+func TestInspectPRProjectCloneRejectsAmbiguousRegistrations(
+	t *testing.T,
+) {
+	repo := newPRInspectionRepo(t)
+	recorded := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	oldLoad := loadPRConfig
+	t.Cleanup(func() { loadPRConfig = oldLoad })
+	loadPRConfig = func() (*models.Config, error) {
+		return &models.Config{Projects: []models.Project{
+			{
+				Repository: recorded.Identity,
+				Name:       recorded.Name,
+				Path:       recorded.Path,
+			},
+			{
+				Repository: recorded.Identity,
+				Name:       "widget-copy",
+				Path:       recorded.Path,
+			},
+		}}, nil
+	}
+
+	_, _, err := defaultInspectPRProjectClone(
+		context.Background(),
+		recorded,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not uniquely registered")
+}
+
 func TestLivePRWorkspacesExcludePrunableAndMissingPaths(
 	t *testing.T,
 ) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
+	urlutil "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -446,6 +447,107 @@ func TestRunPRAttachRejectsStaleProvenanceAgainstLiveInventory(t *testing.T) {
 
 	assertPRCode(t, err, pullrequest.CodeWorkspaceCreation)
 	assert.False(t, attached)
+}
+
+func TestInspectPRProjectCloneUsesRegisteredIdentityOverForkOrigin(
+	t *testing.T,
+) {
+	repo := newPRInspectionRepo(t)
+	runPRInspectionGit(
+		t,
+		repo,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/contributor/widget.git",
+	)
+	recorded := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	oldLoad := loadPRConfig
+	t.Cleanup(func() { loadPRConfig = oldLoad })
+	loadPRConfig = func() (*models.Config, error) {
+		return &models.Config{Projects: []models.Project{{
+			Repository: recorded.Identity,
+			Name:       recorded.Name,
+			Path:       recorded.Path,
+		}}}, nil
+	}
+
+	project, workspaces, err := defaultInspectPRProjectClone(
+		context.Background(),
+		recorded,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, recorded.Identity, project.Identity)
+	require.NotEmpty(t, workspaces)
+	assert.Equal(t, recorded.Identity, workspaces[0].Repository)
+}
+
+func TestLivePRWorkspacesExcludePrunableAndMissingPaths(
+	t *testing.T,
+) {
+	livePath := t.TempDir()
+	require.NoError(t, os.Mkdir(
+		filepath.Join(livePath, ".git"),
+		0o755,
+	))
+	info, ok := urlutil.CanonicalRepositoryInfo("github.com/acme/widget")
+	require.True(t, ok)
+
+	workspaces := livePRWorkspaces(
+		info,
+		pullrequest.Project{Identity: info.FullPath},
+		[]models.Worktree{
+			{
+				Path:     livePath,
+				Branch:   "prunable",
+				Prunable: true,
+			},
+			{
+				Path:   filepath.Join(t.TempDir(), "missing"),
+				Branch: "missing",
+			},
+			{
+				Path:   livePath,
+				Branch: "live",
+			},
+		},
+	)
+
+	require.Len(t, workspaces, 1)
+	assert.Equal(t, "live", workspaces[0].Branch)
+}
+
+func newPRInspectionRepo(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	runPRInspectionGit(t, "", "init", "-b", "main", repo)
+	runPRInspectionGit(t, repo, "config", "user.name", "Test User")
+	runPRInspectionGit(t, repo, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "README.md"),
+		[]byte("# widget\n"),
+		0o644,
+	))
+	runPRInspectionGit(t, repo, "add", "README.md")
+	runPRInspectionGit(t, repo, "commit", "-m", "Initial commit")
+	return repo
+}
+
+func runPRInspectionGit(
+	t *testing.T,
+	dir string,
+	args ...string,
+) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s", output)
 }
 
 func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -50,6 +50,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldProject := prProject
 	oldState := prState
 	oldStartSession := prStartSession
+	oldValidateSessionConfig := validatePRWorkspaceSessionConfig
 	oldStartWorkspaceSession := startPRWorkspaceSession
 	oldAttachWorkspaceSession := attachPRWorkspaceSession
 	oldInspectProjectClone := inspectPRProjectClone
@@ -61,6 +62,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		prProject = oldProject
 		prState = oldState
 		prStartSession = oldStartSession
+		validatePRWorkspaceSessionConfig = oldValidateSessionConfig
 		startPRWorkspaceSession = oldStartWorkspaceSession
 		attachPRWorkspaceSession = oldAttachWorkspaceSession
 		inspectPRProjectClone = oldInspectProjectClone
@@ -78,6 +80,9 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	prProject = "widget"
 	prState = "open"
 	prStartSession = false
+	validatePRWorkspaceSessionConfig = func(*models.Config) error {
+		return nil
+	}
 }
 
 func TestRunPRImportValidatesSelectorBeforeAuthentication(t *testing.T) {
@@ -550,7 +555,28 @@ func runPRInspectionGit(
 	require.NoError(t, err, "%s", output)
 }
 
-func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {
+func TestRunPRImportPreflightsSessionBeforeMutation(t *testing.T) {
+	service := &fakePRService{}
+	withPRCommandDeps(t, testPRConfig(), service)
+	prStartSession = true
+	validatePRWorkspaceSessionConfig = func(*models.Config) error {
+		return errors.New("invalid layout")
+	}
+	cmd, stdout, _ := prTestCommand()
+
+	err := runPRImport(cmd, []string{"17"})
+
+	assert.Empty(t, service.gotSelector)
+	var typed *pullrequest.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, pullrequest.CodeWorkspaceCreation, typed.Code)
+	var envelope pullrequest.ErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	require.NotNil(t, envelope.Error)
+	assert.Equal(t, pullrequest.CodeWorkspaceCreation, envelope.Error.Code)
+}
+
+func TestRunPRImportReportsDurableImportWithSessionFailure(t *testing.T) {
 	service := &fakePRService{result: pullrequest.ImportResult{
 		Status: pullrequest.ImportCreated,
 		Workspace: pullrequest.Workspace{
@@ -571,13 +597,17 @@ func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {
 
 	err := runPRImport(cmd, []string{"17"})
 
-	var typed *pullrequest.Error
-	require.ErrorAs(t, err, &typed)
-	assert.False(t, typed.Retryable)
-	var envelope pullrequest.ErrorEnvelope
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
-	require.NotNil(t, envelope.Error)
-	assert.False(t, envelope.Error.Retryable)
+	require.NoError(t, err)
+	var result pullrequest.ImportResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.Equal(t, pullrequest.ImportCreated, result.Status)
+	require.NotNil(t, result.SessionStartError)
+	assert.Equal(
+		t,
+		pullrequest.CodeWorkspaceCreation,
+		result.SessionStartError.Code,
+	)
+	assert.False(t, result.SessionStartError.Retryable)
 }
 
 func TestRunPRImportReportsSessionSafetyFailure(t *testing.T) {
@@ -603,13 +633,15 @@ func TestRunPRImportReportsSessionSafetyFailure(t *testing.T) {
 
 	err := runPRImport(cmd, []string{"17"})
 
-	var typed *pullrequest.Error
-	require.ErrorAs(t, err, &typed)
-	assert.Equal(t, "existing tmux session is not verified", typed.Message)
-	var envelope pullrequest.ErrorEnvelope
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
-	require.NotNil(t, envelope.Error)
-	assert.Equal(t, "existing tmux session is not verified", envelope.Error.Message)
+	require.NoError(t, err)
+	var result pullrequest.ImportResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	require.NotNil(t, result.SessionStartError)
+	assert.Equal(
+		t,
+		"existing tmux session is not verified",
+		result.SessionStartError.Message,
+	)
 }
 
 func TestPRCommandWritesTypedJSONErrorAndExitStatus(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -303,6 +304,68 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, started)
+}
+
+func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {
+	service := &fakePRService{result: pullrequest.ImportResult{
+		Status: pullrequest.ImportCreated,
+		Workspace: pullrequest.Workspace{
+			ID: "ws", Path: "/worktrees/ws",
+			SessionName: "kwt-workspace-ws",
+		},
+	}}
+	withPRCommandDeps(t, testPRConfig(), service)
+	prStartSession = true
+	startPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) error {
+		return errors.New("invalid layout")
+	}
+	cmd, stdout, _ := prTestCommand()
+
+	err := runPRImport(cmd, []string{"17"})
+
+	var typed *pullrequest.Error
+	require.ErrorAs(t, err, &typed)
+	assert.False(t, typed.Retryable)
+	var envelope pullrequest.ErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	require.NotNil(t, envelope.Error)
+	assert.False(t, envelope.Error.Retryable)
+}
+
+func TestRunPRImportReportsSessionSafetyFailure(t *testing.T) {
+	service := &fakePRService{result: pullrequest.ImportResult{
+		Status: pullrequest.ImportExisting,
+		Workspace: pullrequest.Workspace{
+			ID: "ws", Path: "/worktrees/ws",
+			SessionName: "kwt-workspace-ws",
+		},
+	}}
+	withPRCommandDeps(t, testPRConfig(), service)
+	prStartSession = true
+	startPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) error {
+		return &tmux.SessionSafetyError{
+			Reason: "existing tmux session is not verified",
+		}
+	}
+	cmd, stdout, _ := prTestCommand()
+
+	err := runPRImport(cmd, []string{"17"})
+
+	var typed *pullrequest.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "existing tmux session is not verified", typed.Message)
+	var envelope pullrequest.ErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	require.NotNil(t, envelope.Error)
+	assert.Equal(t, "existing tmux session is not verified", envelope.Error.Message)
 }
 
 func TestPRCommandWritesTypedJSONErrorAndExitStatus(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -289,13 +289,13 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 		_ context.Context,
 		got pullrequest.Workspace,
 		gotConfig *models.Config,
-	) error {
+	) (string, error) {
 		started = true
 		assert.Equal(t, workspace, got)
 		assert.Same(t, cfg, gotConfig)
-		return nil
+		return "kwt-pr-0123456789abcdef", nil
 	}
-	cmd, _, _ := prTestCommand()
+	cmd, stdout, _ := prTestCommand()
 
 	err := runPRImport(
 		cmd,
@@ -304,6 +304,9 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, started)
+	var got pullrequest.ImportResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Equal(t, "kwt-pr-0123456789abcdef", got.Workspace.TmuxSocketName)
 }
 
 func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {
@@ -320,8 +323,8 @@ func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {
 		context.Context,
 		pullrequest.Workspace,
 		*models.Config,
-	) error {
-		return errors.New("invalid layout")
+	) (string, error) {
+		return "", errors.New("invalid layout")
 	}
 	cmd, stdout, _ := prTestCommand()
 
@@ -350,8 +353,8 @@ func TestRunPRImportReportsSessionSafetyFailure(t *testing.T) {
 		context.Context,
 		pullrequest.Workspace,
 		*models.Config,
-	) error {
-		return &tmux.SessionSafetyError{
+	) (string, error) {
+		return "", &tmux.SessionSafetyError{
 			Reason: "existing tmux session is not verified",
 		}
 	}

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -51,6 +51,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldStartSession := prStartSession
 	oldStartWorkspaceSession := startPRWorkspaceSession
 	oldAttachWorkspaceSession := attachPRWorkspaceSession
+	oldInspectProjectClone := inspectPRProjectClone
 	t.Cleanup(func() {
 		loadPRConfig = oldLoad
 		loadPRTargetConfig = oldTargetLoad
@@ -61,11 +62,18 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		prStartSession = oldStartSession
 		startPRWorkspaceSession = oldStartWorkspaceSession
 		attachPRWorkspaceSession = oldAttachWorkspaceSession
+		inspectPRProjectClone = oldInspectProjectClone
 	})
 	loadPRConfig = func() (*models.Config, error) { return cfg, nil }
 	loadPRTargetConfig = func(string, bool) (*models.Config, error) { return cfg, nil }
 	newPRService = func(context.Context, *models.Config, pullrequest.Project) (prService, error) { return service, nil }
 	validatePRProjectRoot = func(project pullrequest.Project) (pullrequest.Project, error) { return project, nil }
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Project,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return pullrequest.Project{}, nil, nil
+	}
 	prProject = "widget"
 	prState = "open"
 	prStartSession = false
@@ -348,16 +356,18 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	workspace := pullrequest.Workspace{
 		Path:        "/worktrees/pr-32",
 		Branch:      "pr-32",
+		Repository:  "github.com/acme/widget",
 		SessionName: "kwt-workspace-pr-32",
+	}
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Path:     "/repos/widget",
 	}
 	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
 		context.Background(),
 		func(records map[string]pullrequest.Provenance) error {
 			records["pr-32"] = pullrequest.Provenance{
-				Project: pullrequest.Project{
-					Identity: "github.com/acme/widget",
-					Path:     "/repos/widget",
-				},
+				Project:   project,
 				Workspace: workspace,
 			}
 			return nil
@@ -366,6 +376,12 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	cfg := testPRConfig()
 	cfg.Fleet.TokenEnv = "CUSTOM_FLEET_TOKEN"
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Project,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return project, []pullrequest.Workspace{workspace}, nil
+	}
 	var attached bool
 	attachPRWorkspaceSession = func(
 		_ context.Context,
@@ -383,6 +399,53 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, attached)
+}
+
+func TestRunPRAttachRejectsStaleProvenanceAgainstLiveInventory(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	recorded := pullrequest.Workspace{
+		Path:        "/worktrees/reused",
+		Branch:      "pr-32",
+		Repository:  "github.com/acme/widget",
+		SessionName: "kwt-workspace-pr-32",
+	}
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Path:     "/repos/widget",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-32"] = pullrequest.Provenance{
+				Project: project, Workspace: recorded,
+			}
+			return nil
+		},
+	))
+	withPRCommandDeps(t, testPRConfig(), &fakePRService{})
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Project,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		live := recorded
+		live.Branch = "unrelated"
+		return project, []pullrequest.Workspace{live}, nil
+	}
+	attached := false
+	attachPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) error {
+		attached = true
+		return nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRAttach(cmd, []string{recorded.Path})
+
+	assertPRCode(t, err, pullrequest.CodeWorkspaceCreation)
+	assert.False(t, attached)
 }
 
 func TestRunPRImportSessionFailureIsNotRetryable(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -47,6 +47,8 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldValidateRoot := validatePRProjectRoot
 	oldProject := prProject
 	oldState := prState
+	oldStartSession := prStartSession
+	oldStartWorkspaceSession := startPRWorkspaceSession
 	t.Cleanup(func() {
 		loadPRConfig = oldLoad
 		loadPRTargetConfig = oldTargetLoad
@@ -54,6 +56,8 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		validatePRProjectRoot = oldValidateRoot
 		prProject = oldProject
 		prState = oldState
+		prStartSession = oldStartSession
+		startPRWorkspaceSession = oldStartWorkspaceSession
 	})
 	loadPRConfig = func() (*models.Config, error) { return cfg, nil }
 	loadPRTargetConfig = func(string, bool) (*models.Config, error) { return cfg, nil }
@@ -61,6 +65,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	validatePRProjectRoot = func(project pullrequest.Project) (pullrequest.Project, error) { return project, nil }
 	prProject = "widget"
 	prState = "open"
+	prStartSession = false
 }
 
 func TestRunPRImportValidatesSelectorBeforeAuthentication(t *testing.T) {
@@ -136,7 +141,7 @@ func TestPreparePRServiceLoadsSelectedTargetConfiguration(t *testing.T) {
 
 	project, err := preparePRProject()
 	require.NoError(t, err)
-	_, err = preparePRService(context.Background(), project)
+	_, _, err = preparePRService(context.Background(), project)
 
 	require.NoError(t, err)
 	assert.Equal(t, "/repos/widget", loadedPath)
@@ -163,7 +168,7 @@ func TestPreparePRServiceRejectsPathOutsideMainRepositoryRootBeforeLoadingConfig
 		return testPRConfig(), nil
 	}
 
-	_, err := preparePRService(context.Background(), pullrequest.Project{
+	_, _, err := preparePRService(context.Background(), pullrequest.Project{
 		Identity: "github.com/acme/widget", Name: "widget", Path: subdir,
 	})
 
@@ -263,6 +268,41 @@ func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 			assert.Equal(t, "https://github.com/acme/widget/pull/17", service.gotSelector)
 		})
 	}
+}
+
+func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
+	workspace := pullrequest.Workspace{
+		ID: "ws", Path: "/worktrees/ws",
+		SessionName: "kwt-workspace-ws",
+	}
+	service := &fakePRService{result: pullrequest.ImportResult{
+		Status:    pullrequest.ImportCreated,
+		Project:   pullrequest.Project{Identity: "github.com/acme/widget"},
+		Workspace: workspace,
+	}}
+	cfg := testPRConfig()
+	withPRCommandDeps(t, cfg, service)
+	prStartSession = true
+	var started bool
+	startPRWorkspaceSession = func(
+		_ context.Context,
+		got pullrequest.Workspace,
+		gotConfig *models.Config,
+	) error {
+		started = true
+		assert.Equal(t, workspace, got)
+		assert.Same(t, cfg, gotConfig)
+		return nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRImport(
+		cmd,
+		[]string{"https://github.com/acme/widget/pull/17"},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, started)
 }
 
 func TestPRCommandWritesTypedJSONErrorAndExitStatus(t *testing.T) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1241,6 +1241,9 @@ func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, lay
 	if row.Entry == nil && row.Workspace == nil {
 		return fmt.Errorf("no worktree selected")
 	}
+	if err := rejectProtectedWorkspaceOpen(ctx, rowPaneRoot(row)); err != nil {
+		return err
+	}
 	sessionName, err := b.sessionName(row)
 	if err != nil {
 		return err

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/fleet"
+	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
 	dashboard "go.kenn.io/kwt/internal/tui"
 	"go.kenn.io/kwt/internal/url"
@@ -2360,6 +2361,49 @@ func TestTUIBackendAttachWorkspaceGuardRejectsEmptyRow(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, "no worktree selected", err.Error())
+}
+
+func TestTUIBackendRefusesProtectedPullRequestWorkspace(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	workspacePath := t.TempDir()
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-32"] = pullrequest.Provenance{
+				Workspace: pullrequest.Workspace{Path: workspacePath},
+			}
+			return nil
+		},
+	))
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	called := false
+	backend.ensureAndAttach = func(
+		context.Context,
+		string,
+		string,
+		models.Layout,
+		bool,
+	) error {
+		called = true
+		return nil
+	}
+
+	err := backend.attachWorkspace(
+		context.Background(),
+		dashboard.Row{
+			Workspace: &dashboard.WorkspaceInfo{
+				Name: "pr-32",
+				Path: workspacePath,
+			},
+		},
+		tmux.BlankLayoutName,
+		false,
+		false,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kwt pr attach")
+	assert.False(t, called)
 }
 
 // TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner keeps the command

--- a/internal/pullrequest/types.go
+++ b/internal/pullrequest/types.go
@@ -100,6 +100,7 @@ type Workspace struct {
 	Path           string `json:"path"`
 	State          string `json:"state"`
 	SessionName    string `json:"session_name"`
+	TmuxSocketName string `json:"tmux_socket_name,omitempty"`
 	partialCleanup *workspacePartialCleanup
 	// preserveOnImportError means Kit could not prove that cleanup was safe.
 	// Other post-creation failures retain rollback metadata and are cleaned up.

--- a/internal/pullrequest/types.go
+++ b/internal/pullrequest/types.go
@@ -132,10 +132,11 @@ const (
 )
 
 type ImportResult struct {
-	Status      ImportStatus `json:"status"`
-	PullRequest PullRequest  `json:"pull_request"`
-	Project     Project      `json:"project"`
-	Workspace   Workspace    `json:"workspace"`
+	Status            ImportStatus `json:"status"`
+	PullRequest       PullRequest  `json:"pull_request"`
+	Project           Project      `json:"project"`
+	Workspace         Workspace    `json:"workspace"`
+	SessionStartError *Error       `json:"session_start_error,omitempty"`
 }
 
 type ErrorEnvelope struct {

--- a/internal/tmux/bootstrap.go
+++ b/internal/tmux/bootstrap.go
@@ -53,6 +53,7 @@ func FirstPanePlaceholderArgv() []string {
 var canonicalStripExact = map[string]bool{
 	"__CFBundleIdentifier": true,
 	"EDITOR":               true,
+	"KWT_GITHUB_TOKEN":     true,
 	"OLDPWD":               true,
 	"PROMPT":               true,
 	"PROMPT_COMMAND":       true,
@@ -74,7 +75,6 @@ var canonicalStripPrefixes = []string{
 	"FZF_",
 	"ITERM",
 	"KITTY_",
-	"KWT_",
 	"NVM_",
 	"PYENV_",
 	"STARSHIP_",
@@ -176,6 +176,22 @@ func ParseServerEnvNames(output string) []string {
 			if after != "" {
 				names = append(names, after)
 			}
+			continue
+		}
+		if name, _, ok := strings.Cut(line, "="); ok && name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// setServerEnvNames extracts only variables with values from tmux
+// show-environment output. Session removal markers are intentionally ignored.
+func setServerEnvNames(output string) []string {
+	var names []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "-") {
 			continue
 		}
 		if name, _, ok := strings.Cut(line, "="); ok && name != "" {
@@ -289,4 +305,19 @@ func BuildSessionBootstrapCommand(session string, stripNames []string) []string 
 		cmd = append(cmd, ";", "set-environment", "-t", session, "-r", name)
 	}
 	return cmd
+}
+
+const workspacePathOption = "@kwt-workspace-path"
+
+// buildProtectedSessionBootstrapCommand records the workspace identity in the
+// same pre-shell bootstrap transaction as the session environment policy.
+func buildProtectedSessionBootstrapCommand(
+	session, worktreeDir string,
+	stripNames []string,
+) []string {
+	cmd := BuildSessionBootstrapCommand(session, stripNames)
+	return append(
+		cmd,
+		";", "set-option", "-t", session, workspacePathOption, worktreeDir,
+	)
 }

--- a/internal/tmux/bootstrap.go
+++ b/internal/tmux/bootstrap.go
@@ -314,10 +314,15 @@ const workspacePathOption = "@kwt-workspace-path"
 func buildProtectedSessionBootstrapCommand(
 	session, worktreeDir string,
 	stripNames []string,
+	updateEnvironment string,
 ) []string {
 	cmd := BuildSessionBootstrapCommand(session, stripNames)
-	return append(
+	cmd = append(
 		cmd,
 		";", "set-option", "-t", session, workspacePathOption, worktreeDir,
+	)
+	return append(
+		cmd,
+		";", "set-option", "-t", session, "update-environment", updateEnvironment,
 	)
 }

--- a/internal/tmux/bootstrap.go
+++ b/internal/tmux/bootstrap.go
@@ -74,6 +74,7 @@ var canonicalStripPrefixes = []string{
 	"FZF_",
 	"ITERM",
 	"KITTY_",
+	"KWT_",
 	"NVM_",
 	"PYENV_",
 	"STARSHIP_",

--- a/internal/tmux/bootstrap_test.go
+++ b/internal/tmux/bootstrap_test.go
@@ -174,8 +174,8 @@ func TestSanitizedEnvironDropsExactKeys(t *testing.T) {
 // set (canonicalStripPrefixes) exhaustively, one prefix at a time.
 func TestSanitizedEnvironDropsPrefixedKeys(t *testing.T) {
 	prefixes := []string{
-		"ALACRITTY_", "CONDA_", "FZF_", "ITERM", "KITTY_", "NVM_", "PYENV_",
-		"STARSHIP_", "VIRTUAL_ENV", "WEZTERM_", "WT_", "VSCODE_",
+		"ALACRITTY_", "CONDA_", "FZF_", "ITERM", "KITTY_", "KWT_", "NVM_",
+		"PYENV_", "STARSHIP_", "VIRTUAL_ENV", "WEZTERM_", "WT_", "VSCODE_",
 	}
 	for _, prefix := range prefixes {
 		t.Run(prefix, func(t *testing.T) {

--- a/internal/tmux/bootstrap_test.go
+++ b/internal/tmux/bootstrap_test.go
@@ -44,6 +44,7 @@ func TestStripEnvNamesSelectsExactAndPrefix(t *testing.T) {
 func TestStripEnvNamesCoversFullCanonicalSet(t *testing.T) {
 	env := []string{
 		"__CFBundleIdentifier=com.example.Terminal",
+		"KWT_GITHUB_TOKEN=secret",
 		"OLDPWD=/old",
 		"PROMPT=$ ",
 		"PROMPT_COMMAND=update_prompt",
@@ -69,6 +70,7 @@ func TestStripEnvNamesCoversFullCanonicalSet(t *testing.T) {
 
 	want := []string{
 		"__CFBundleIdentifier",
+		"KWT_GITHUB_TOKEN",
 		"OLDPWD",
 		"PROMPT",
 		"PROMPT_COMMAND",
@@ -96,8 +98,8 @@ func TestCanonicalStripExactNamesIsSortedAndComplete(t *testing.T) {
 	got := CanonicalStripExactNames()
 
 	want := []string{
-		"EDITOR", "OLDPWD", "PROMPT", "PROMPT_COMMAND", "PWD", "RPROMPT",
-		"SHLVL", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "VISUAL",
+		"EDITOR", "KWT_GITHUB_TOKEN", "OLDPWD", "PROMPT", "PROMPT_COMMAND",
+		"PWD", "RPROMPT", "SHLVL", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "VISUAL",
 		"WINDOWID", "_", "__CFBundleIdentifier",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -128,6 +130,17 @@ func TestParseServerEnvNamesHandlesSetAndRemovedEntries(t *testing.T) {
 	}
 }
 
+func TestSetServerEnvNamesIgnoresRemovalMarkers(t *testing.T) {
+	output := "KWT_GITHUB_TOKEN=secret\n-CUSTOM_FLEET_TOKEN\nPATH=/usr/bin\n"
+
+	got := setServerEnvNames(output)
+
+	want := []string{"KWT_GITHUB_TOKEN", "PATH"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("setServerEnvNames() = %v, want %v", got, want)
+	}
+}
+
 func TestMergeStripNamesUnionsPreservingFirstSeenOrder(t *testing.T) {
 	got := MergeStripNames(
 		[]string{"EDITOR", "PWD"},
@@ -155,7 +168,7 @@ func TestStripEnvNamesIgnoresUnmatchedAndMalformed(t *testing.T) {
 // them (serverStartExclusions); see TestSanitizedEnvironPreservesEditorAndVisual.
 func TestSanitizedEnvironDropsExactKeys(t *testing.T) {
 	exactKeys := []string{
-		"__CFBundleIdentifier", "OLDPWD", "PROMPT", "PROMPT_COMMAND",
+		"__CFBundleIdentifier", "KWT_GITHUB_TOKEN", "OLDPWD", "PROMPT", "PROMPT_COMMAND",
 		"PWD", "RPROMPT", "SHLVL", "TERM_PROGRAM",
 		"TERM_PROGRAM_VERSION", "WINDOWID", "_",
 	}
@@ -174,7 +187,7 @@ func TestSanitizedEnvironDropsExactKeys(t *testing.T) {
 // set (canonicalStripPrefixes) exhaustively, one prefix at a time.
 func TestSanitizedEnvironDropsPrefixedKeys(t *testing.T) {
 	prefixes := []string{
-		"ALACRITTY_", "CONDA_", "FZF_", "ITERM", "KITTY_", "KWT_", "NVM_",
+		"ALACRITTY_", "CONDA_", "FZF_", "ITERM", "KITTY_", "NVM_",
 		"PYENV_", "STARSHIP_", "VIRTUAL_ENV", "WEZTERM_", "WT_", "VSCODE_",
 	}
 	for _, prefix := range prefixes {
@@ -186,6 +199,16 @@ func TestSanitizedEnvironDropsPrefixedKeys(t *testing.T) {
 				t.Errorf("SanitizedEnviron(%q) = %v, want %v", entry, got, want)
 			}
 		})
+	}
+}
+
+func TestSanitizedEnvironPreservesKwtOperationalVariables(t *testing.T) {
+	env := []string{"KWT_HOME=/tmp/kwt", "KWT_LOG_LEVEL=debug", "PATH=/usr/bin"}
+
+	got := SanitizedEnviron(env)
+
+	if !reflect.DeepEqual(got, env) {
+		t.Errorf("SanitizedEnviron() = %v, want %v", got, env)
 	}
 }
 

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -26,12 +26,31 @@ var _ workspaceTmux = (*TmuxCommand)(nil)
 
 // WorkspaceRunner creates or reuses a tmux workspace session and attaches to it.
 type WorkspaceRunner struct {
-	tmux workspaceTmux
+	tmux            workspaceTmux
+	extraStripNames []string
 }
 
 // NewWorkspaceRunner returns a runner backed by the given tmux surface.
 func NewWorkspaceRunner(t workspaceTmux) *WorkspaceRunner {
-	return &WorkspaceRunner{tmux: t}
+	return NewWorkspaceRunnerWithStripNames(t, nil)
+}
+
+// NewWorkspaceRunnerWithStripNames installs caller-owned credential removal
+// markers in addition to kwt's canonical launcher-state set.
+func NewWorkspaceRunnerWithStripNames(
+	t workspaceTmux,
+	names []string,
+) *WorkspaceRunner {
+	extra := make([]string, 0, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			extra = append(extra, name)
+		}
+	}
+	return &WorkspaceRunner{
+		tmux:            t,
+		extraStripNames: extra,
+	}
 }
 
 // EnsureAndAttach attaches to the workspace session, creating it first if it
@@ -102,7 +121,13 @@ func (r *WorkspaceRunner) sessionStripNames(session string, sessionExists bool) 
 			sessionDerived = CanonicalStripNames(ParseServerEnvNames(output))
 		}
 	}
-	return MergeStripNames(CanonicalStripExactNames(), launcher, serverDerived, sessionDerived)
+	return MergeStripNames(
+		CanonicalStripExactNames(),
+		r.extraStripNames,
+		launcher,
+		serverDerived,
+		sessionDerived,
+	)
 }
 
 // create spawns the first pane as an inert placeholder (it spawns before the
@@ -136,12 +161,25 @@ func (r *WorkspaceRunner) create(
 	if err := r.tmux.RunCommandContext(ctx, bootCmd...); err != nil {
 		return r.abort(session, bootCmd, err)
 	}
-	defaultShellCmd := []string{"show-options", "-gv", "default-shell"}
+	defaultShellCmd := []string{
+		"show-options", "-v", "-t", session, "default-shell",
+	}
 	defaultShellOut, err := r.tmux.RunCommandOutputContext(ctx, defaultShellCmd...)
 	if err != nil {
 		return r.abort(session, defaultShellCmd, err)
 	}
 	defaultShell := strings.TrimSpace(defaultShellOut)
+	if defaultShell == "" {
+		defaultShellCmd = []string{"show-options", "-gv", "default-shell"}
+		defaultShellOut, err = r.tmux.RunCommandOutputContext(
+			ctx,
+			defaultShellCmd...,
+		)
+		if err != nil {
+			return r.abort(session, defaultShellCmd, err)
+		}
+		defaultShell = strings.TrimSpace(defaultShellOut)
+	}
 	if defaultShell == "" {
 		return r.abort(session, defaultShellCmd, fmt.Errorf("tmux returned an empty default-shell"))
 	}

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -46,6 +46,18 @@ func NewWorkspaceRunner(t workspaceTmux) *WorkspaceRunner {
 func (r *WorkspaceRunner) EnsureAndAttach(
 	ctx context.Context, session, worktreeDir string, layout models.Layout, insideTmux bool,
 ) error {
+	if err := r.Ensure(ctx, session, worktreeDir, layout); err != nil {
+		return err
+	}
+	return r.attach(session, insideTmux)
+}
+
+// Ensure creates or repairs the workspace session without attaching a client.
+// Automation callers can use this to establish kwt's canonical layout and
+// bootstrap before handing presentation to another ordinary tmux client.
+func (r *WorkspaceRunner) Ensure(
+	ctx context.Context, session, worktreeDir string, layout models.Layout,
+) error {
 	if r.tmux.HasSession(session) {
 		if err := r.repairBootstrap(ctx, session); err != nil {
 			return err
@@ -53,7 +65,7 @@ func (r *WorkspaceRunner) EnsureAndAttach(
 	} else if err := r.create(ctx, session, worktreeDir, layout); err != nil {
 		return err
 	}
-	return r.attach(session, insideTmux)
+	return nil
 }
 
 // sessionStripNames derives the remove-marker set for session: the

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -19,7 +19,7 @@ type workspaceTmux interface {
 	RunCommandOutputContext(ctx context.Context, args ...string) (string, error)
 	SwitchClient(target string) error
 	AttachSession(session string) error
-	AttachSessionWithoutEnvironment(session string) error
+	AttachSessionWithoutEnvironment(context.Context, string) error
 	KillSession(session string) error
 	GlobalEnvironment() (string, error)
 	SessionEnvironment(session string) (string, error)
@@ -159,7 +159,7 @@ func (r *WorkspaceRunner) AttachProtected(
 	if err := r.repairBootstrap(ctx, session, worktreeDir); err != nil {
 		return err
 	}
-	return r.tmux.AttachSessionWithoutEnvironment(session)
+	return r.tmux.AttachSessionWithoutEnvironment(ctx, session)
 }
 
 func (r *WorkspaceRunner) validateProtectedState(

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -136,7 +136,7 @@ func (r *WorkspaceRunner) create(
 	if err := r.tmux.RunCommandContext(ctx, bootCmd...); err != nil {
 		return r.abort(session, bootCmd, err)
 	}
-	defaultShellCmd := []string{"show-options", "-v", "-t", session, "default-shell"}
+	defaultShellCmd := []string{"show-options", "-gv", "default-shell"}
 	defaultShellOut, err := r.tmux.RunCommandOutputContext(ctx, defaultShellCmd...)
 	if err != nil {
 		return r.abort(session, defaultShellCmd, err)

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -20,37 +21,64 @@ type workspaceTmux interface {
 	KillSession(session string) error
 	GlobalEnvironment() (string, error)
 	SessionEnvironment(session string) (string, error)
+	sessionOption(session, option string) (string, error)
 }
 
 var _ workspaceTmux = (*TmuxCommand)(nil)
+
+// SessionSafetyError is safe to return through the machine-readable PR
+// contract because it names only the rejected tmux state, never its value.
+type SessionSafetyError struct {
+	Reason string
+}
+
+func (e *SessionSafetyError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Reason
+}
 
 // WorkspaceRunner creates or reuses a tmux workspace session and attaches to it.
 type WorkspaceRunner struct {
 	tmux            workspaceTmux
 	extraStripNames []string
+	credentialNames []string
+	protected       bool
+}
+
+// NewProtectedWorkspaceRunner requires credential-clean tmux state and a
+// matching kwt workspace marker before it reuses an existing session.
+func NewProtectedWorkspaceRunner(
+	t workspaceTmux,
+	credentialNames []string,
+) *WorkspaceRunner {
+	names := cleanNames(credentialNames)
+	return &WorkspaceRunner{
+		tmux:            t,
+		extraStripNames: names,
+		credentialNames: names,
+		protected:       true,
+	}
 }
 
 // NewWorkspaceRunner returns a runner backed by the given tmux surface.
 func NewWorkspaceRunner(t workspaceTmux) *WorkspaceRunner {
-	return NewWorkspaceRunnerWithStripNames(t, nil)
+	return &WorkspaceRunner{tmux: t}
 }
 
-// NewWorkspaceRunnerWithStripNames installs caller-owned credential removal
-// markers in addition to kwt's canonical launcher-state set.
-func NewWorkspaceRunnerWithStripNames(
-	t workspaceTmux,
-	names []string,
-) *WorkspaceRunner {
-	extra := make([]string, 0, len(names))
+func cleanNames(names []string) []string {
+	cleaned := make([]string, 0, len(names))
+	seen := make(map[string]bool)
 	for _, name := range names {
-		if name = strings.TrimSpace(name); name != "" {
-			extra = append(extra, name)
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
 		}
+		seen[name] = true
+		cleaned = append(cleaned, name)
 	}
-	return &WorkspaceRunner{
-		tmux:            t,
-		extraStripNames: extra,
-	}
+	return cleaned
 }
 
 // EnsureAndAttach attaches to the workspace session, creating it first if it
@@ -77,7 +105,17 @@ func (r *WorkspaceRunner) EnsureAndAttach(
 func (r *WorkspaceRunner) Ensure(
 	ctx context.Context, session, worktreeDir string, layout models.Layout,
 ) error {
-	if r.tmux.HasSession(session) {
+	sessionExists := r.tmux.HasSession(session)
+	if r.protected {
+		if err := r.validateProtectedState(
+			session,
+			worktreeDir,
+			sessionExists,
+		); err != nil {
+			return err
+		}
+	}
+	if sessionExists {
 		if err := r.repairBootstrap(ctx, session); err != nil {
 			return err
 		}
@@ -85,6 +123,75 @@ func (r *WorkspaceRunner) Ensure(
 		return err
 	}
 	return nil
+}
+
+func (r *WorkspaceRunner) validateProtectedState(
+	session, worktreeDir string,
+	sessionExists bool,
+) error {
+	globalEnvironment, err := r.tmux.GlobalEnvironment()
+	if err != nil {
+		if !sessionExists && errors.Is(err, errNoServerRunning) {
+			return nil
+		}
+		return fmt.Errorf("cannot verify tmux server environment: %w", err)
+	}
+	if name, ok := firstMatchingName(
+		setServerEnvNames(globalEnvironment),
+		r.credentialNames,
+	); ok {
+		return &SessionSafetyError{Reason: fmt.Sprintf(
+			"tmux server environment contains sensitive variable %s; remove it before starting the imported workspace",
+			name,
+		)}
+	}
+	if !sessionExists {
+		return nil
+	}
+
+	sessionEnvironment, err := r.tmux.SessionEnvironment(session)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot verify existing tmux session environment: %w",
+			err,
+		)
+	}
+	if name, ok := firstMatchingName(
+		setServerEnvNames(sessionEnvironment),
+		r.credentialNames,
+	); ok {
+		return &SessionSafetyError{Reason: fmt.Sprintf(
+			"existing tmux session contains sensitive variable %s; remove the session before retrying",
+			name,
+		)}
+	}
+	workspacePath, err := r.tmux.sessionOption(
+		session,
+		workspacePathOption,
+	)
+	workspacePath = strings.TrimSuffix(workspacePath, "\n")
+	workspacePath = strings.TrimSuffix(workspacePath, "\r")
+	if err != nil || workspacePath != worktreeDir {
+		return &SessionSafetyError{Reason: fmt.Sprintf(
+			"existing tmux session %q is not verified for workspace %q; remove or rename it before retrying",
+			session,
+			worktreeDir,
+		)}
+	}
+	return nil
+}
+
+func firstMatchingName(names, sensitive []string) (string, bool) {
+	sensitiveSet := make(map[string]bool, len(sensitive))
+	for _, name := range sensitive {
+		sensitiveSet[name] = true
+	}
+	for _, name := range names {
+		if sensitiveSet[name] {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // sessionStripNames derives the remove-marker set for session: the
@@ -158,6 +265,13 @@ func (r *WorkspaceRunner) create(
 	paneIDs = append(paneIDs, strings.TrimSpace(firstPane))
 
 	bootCmd := BuildSessionBootstrapCommand(session, stripNames)
+	if r.protected {
+		bootCmd = buildProtectedSessionBootstrapCommand(
+			session,
+			worktreeDir,
+			stripNames,
+		)
+	}
 	if err := r.tmux.RunCommandContext(ctx, bootCmd...); err != nil {
 		return r.abort(session, bootCmd, err)
 	}

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -162,6 +162,26 @@ func (r *WorkspaceRunner) AttachProtected(
 	return r.tmux.AttachSessionWithoutEnvironment(ctx, session)
 }
 
+// EnsureAndAttachProtected creates or repairs a protected workspace session
+// before attaching without tmux's client-environment update. This is the
+// convergent open path for persisted PR imports: the isolated session may not
+// exist yet when import omitted startup, or may have disappeared since import.
+func (r *WorkspaceRunner) EnsureAndAttachProtected(
+	ctx context.Context,
+	session, worktreeDir string,
+	layout models.Layout,
+) error {
+	if !r.protected {
+		return fmt.Errorf(
+			"protected attachment requires a protected workspace runner",
+		)
+	}
+	if err := r.Ensure(ctx, session, worktreeDir, layout); err != nil {
+		return err
+	}
+	return r.tmux.AttachSessionWithoutEnvironment(ctx, session)
+}
+
 func (r *WorkspaceRunner) validateProtectedState(
 	session, worktreeDir string,
 	sessionExists bool,

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -22,6 +23,15 @@ type workspaceTmux interface {
 	GlobalEnvironment() (string, error)
 	SessionEnvironment(session string) (string, error)
 	sessionOption(session, option string) (string, error)
+	globalOption(option string) (string, error)
+}
+
+// ProtectedWorkspaceSocketName returns the deterministic tmux socket name for
+// one protected workspace. The path participates in the identity so equal
+// session names from separate repositories cannot share a server.
+func ProtectedWorkspaceSocketName(session, worktreeDir string) string {
+	sum := sha256.Sum256([]byte(session + "\x00" + worktreeDir))
+	return fmt.Sprintf("kwt-pr-%x", sum[:8])
 }
 
 var _ workspaceTmux = (*TmuxCommand)(nil)
@@ -116,7 +126,7 @@ func (r *WorkspaceRunner) Ensure(
 		}
 	}
 	if sessionExists {
-		if err := r.repairBootstrap(ctx, session); err != nil {
+		if err := r.repairBootstrap(ctx, session, worktreeDir); err != nil {
 			return err
 		}
 	} else if err := r.create(ctx, session, worktreeDir, layout); err != nil {
@@ -266,10 +276,17 @@ func (r *WorkspaceRunner) create(
 
 	bootCmd := BuildSessionBootstrapCommand(session, stripNames)
 	if r.protected {
+		updateEnvironment, updateErr := r.protectedUpdateEnvironment(session)
+		if updateErr != nil {
+			return r.abort(session, []string{
+				"show-options", "-t", session, "update-environment",
+			}, updateErr)
+		}
 		bootCmd = buildProtectedSessionBootstrapCommand(
 			session,
 			worktreeDir,
 			stripNames,
+			updateEnvironment,
 		)
 	}
 	if err := r.tmux.RunCommandContext(ctx, bootCmd...); err != nil {
@@ -326,12 +343,52 @@ func (r *WorkspaceRunner) create(
 // including one an external tool created bare with new-session. The session is
 // not kwt's to tear down, so a failure is wrapped and returned without killing
 // it.
-func (r *WorkspaceRunner) repairBootstrap(ctx context.Context, session string) error {
-	bootCmd := BuildSessionBootstrapCommand(session, r.sessionStripNames(session, true))
+func (r *WorkspaceRunner) repairBootstrap(
+	ctx context.Context,
+	session, worktreeDir string,
+) error {
+	stripNames := r.sessionStripNames(session, true)
+	bootCmd := BuildSessionBootstrapCommand(session, stripNames)
+	if r.protected {
+		updateEnvironment, err := r.protectedUpdateEnvironment(session)
+		if err != nil {
+			return fmt.Errorf("cannot inspect protected tmux update-environment: %w", err)
+		}
+		bootCmd = buildProtectedSessionBootstrapCommand(
+			session,
+			worktreeDir,
+			stripNames,
+			updateEnvironment,
+		)
+	}
 	if err := r.tmux.RunCommandContext(ctx, bootCmd...); err != nil {
 		return wrapTmuxErr(bootCmd, err)
 	}
 	return nil
+}
+
+func (r *WorkspaceRunner) protectedUpdateEnvironment(session string) (string, error) {
+	value, err := r.tmux.sessionOption(session, "update-environment")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(value) == "" {
+		value, err = r.tmux.globalOption("update-environment")
+		if err != nil {
+			return "", err
+		}
+	}
+	protected := make(map[string]bool, len(r.credentialNames))
+	for _, name := range r.credentialNames {
+		protected[name] = true
+	}
+	kept := make([]string, 0)
+	for _, name := range strings.Fields(value) {
+		if !protected[name] {
+			kept = append(kept, name)
+		}
+	}
+	return strings.Join(kept, " "), nil
 }
 
 // abort wraps a construction-command failure and kills the just-created

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -19,6 +19,7 @@ type workspaceTmux interface {
 	RunCommandOutputContext(ctx context.Context, args ...string) (string, error)
 	SwitchClient(target string) error
 	AttachSession(session string) error
+	AttachSessionWithoutEnvironment(session string) error
 	KillSession(session string) error
 	GlobalEnvironment() (string, error)
 	SessionEnvironment(session string) (string, error)
@@ -133,6 +134,32 @@ func (r *WorkspaceRunner) Ensure(
 		return err
 	}
 	return nil
+}
+
+// AttachProtected verifies and repairs an existing protected session before
+// attaching without tmux's client-environment update. The -E attach is the
+// final enforcement point: session options are mutable by pane processes, so
+// attachment must not trust update-environment to remain filtered.
+func (r *WorkspaceRunner) AttachProtected(
+	ctx context.Context,
+	session, worktreeDir string,
+) error {
+	if !r.protected {
+		return fmt.Errorf("protected attachment requires a protected workspace runner")
+	}
+	if !r.tmux.HasSession(session) {
+		return &SessionSafetyError{Reason: fmt.Sprintf(
+			"protected tmux session %q is not running",
+			session,
+		)}
+	}
+	if err := r.validateProtectedState(session, worktreeDir, true); err != nil {
+		return err
+	}
+	if err := r.repairBootstrap(ctx, session, worktreeDir); err != nil {
+		return err
+	}
+	return r.tmux.AttachSessionWithoutEnvironment(session)
 }
 
 func (r *WorkspaceRunner) validateProtectedState(

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -29,6 +29,7 @@ type mockWorkspaceTmux struct {
 	paneSeq             int
 	switchedTo          string
 	attachedTo          string
+	protectedAttachedTo string
 	outputErr           error
 	failOutputOnCall    int
 	outputCalls         int
@@ -130,6 +131,13 @@ func (m *mockWorkspaceTmux) SwitchClient(target string) error {
 
 func (m *mockWorkspaceTmux) AttachSession(session string) error {
 	m.attachedTo = session
+	return nil
+}
+
+func (m *mockWorkspaceTmux) AttachSessionWithoutEnvironment(
+	session string,
+) error {
+	m.protectedAttachedTo = session
 	return nil
 }
 
@@ -378,6 +386,40 @@ func TestProtectedEnsureMarksCreatedSessionBeforeRespawn(t *testing.T) {
 		),
 		"DISPLAY SSH_AUTH_SOCK",
 	))
+}
+
+func TestProtectedAttachRepairsPolicyAndDisablesEnvironmentUpdate(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		hasSession:       true,
+		globalEnv:        "PATH=/bin\n",
+		sessionEnv:       "PATH=/bin\n",
+		sessionWorkspace: "/wt",
+		sessionUpdateEnv: "DISPLAY KWT_GITHUB_TOKEN KWT_FLEET_TOKEN",
+	}
+	r := NewProtectedWorkspaceRunner(
+		m,
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"},
+	)
+
+	err := r.AttachProtected(
+		context.Background(),
+		"workspace",
+		"/wt",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "workspace", m.protectedAttachedTo)
+	assert.Empty(t, m.attachedTo)
+	assert.Equal(t, [][]string{buildProtectedSessionBootstrapCommand(
+		"workspace",
+		"/wt",
+		MergeStripNames(
+			CanonicalStripExactNames(),
+			[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"},
+			StripEnvNames(os.Environ()),
+		),
+		"DISPLAY",
+	)}, m.calls)
 }
 
 func TestProtectedWorkspaceSocketNameIsStableAndWorkspaceSpecific(t *testing.T) {

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -24,24 +24,25 @@ import (
 // RunCommandContext (1-indexed), letting tests fail select-layout or a
 // pane-command invocation instead.
 type mockWorkspaceTmux struct {
-	hasSession        bool
-	calls             [][]string
-	paneSeq           int
-	switchedTo        string
-	attachedTo        string
-	outputErr         error
-	failOutputOnCall  int
-	outputCalls       int
-	failRunOnCall     int
-	runCalls          int
-	killSessionCalled bool
-	killedSession     string
-	defaultShell      string
-	globalEnv         string
-	globalEnvErr      error
-	sessionEnv        string
-	sessionEnvErr     error
-	sessionEnvQueried bool
+	hasSession          bool
+	calls               [][]string
+	paneSeq             int
+	switchedTo          string
+	attachedTo          string
+	outputErr           error
+	failOutputOnCall    int
+	outputCalls         int
+	failRunOnCall       int
+	runCalls            int
+	killSessionCalled   bool
+	killedSession       string
+	sessionDefaultShell string
+	globalDefaultShell  string
+	globalEnv           string
+	globalEnvErr        error
+	sessionEnv          string
+	sessionEnvErr       error
+	sessionEnvQueried   bool
 }
 
 func (m *mockWorkspaceTmux) HasSession(string) bool {
@@ -88,10 +89,13 @@ func (m *mockWorkspaceTmux) RunCommandOutputContext(
 		return "", fmt.Errorf("boom on call %d", m.outputCalls)
 	}
 	if len(args) > 0 && args[0] == "show-options" {
-		if m.defaultShell != "" {
-			return m.defaultShell + "\n", nil
+		if len(args) > 1 && args[1] == "-gv" {
+			if m.globalDefaultShell != "" {
+				return m.globalDefaultShell + "\n", nil
+			}
+			return "/bin/sh\n", nil
 		}
-		return "/bin/sh\n", nil
+		return m.sessionDefaultShell + "\n", nil
 	}
 	m.paneSeq++
 	return fmt.Sprintf("%%%d\n", m.paneSeq), nil
@@ -138,6 +142,7 @@ func TestEnsureAndAttachCreatesSendsToCapturedIDsAndAttaches(t *testing.T) {
 	want := [][]string{
 		{"new-session", "-d", "-P", "-F", "#{pane_id}", "-s", "s", "-c", "/wt", "sleep", "2147483647"},
 		expectedBootstrapCommand("s"),
+		{"show-options", "-v", "-t", "s", "default-shell"},
 		{"show-options", "-gv", "default-shell"},
 		{"respawn-pane", "-k", "-c", "/wt", "-t", "%1", "/bin/sh", "-l"},
 		{"split-window", "-P", "-F", "#{pane_id}", "-t", "s", "-c", "/wt"},
@@ -174,7 +179,10 @@ func TestEnsureCreatesWorkspaceWithoutAttaching(t *testing.T) {
 }
 
 func TestEnsureAndAttachQueriesServerDefaultShell(t *testing.T) {
-	m := &mockWorkspaceTmux{hasSession: false, defaultShell: "/opt/homebrew/bin/fish"}
+	m := &mockWorkspaceTmux{
+		hasSession:         false,
+		globalDefaultShell: "/opt/homebrew/bin/fish",
+	}
 	r := NewWorkspaceRunner(m)
 
 	err := r.EnsureAndAttach(
@@ -184,8 +192,66 @@ func TestEnsureAndAttachQueriesServerDefaultShell(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, m.calls,
+		[]string{"show-options", "-v", "-t", "workspace", "default-shell"},
+		"the session-local shell must be checked first")
+	assert.Contains(t, m.calls,
 		[]string{"show-options", "-gv", "default-shell"},
-		"the first pane must use the target tmux server's configured shell")
+		"an inherited shell must fall back to the server value")
+	assert.Contains(t, m.calls,
+		[]string{
+			"respawn-pane", "-k", "-c", "/wt", "-t", "%1",
+			"/opt/homebrew/bin/fish", "-l",
+		})
+}
+
+func TestEnsureAndAttachPrefersSessionDefaultShell(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		hasSession:          false,
+		sessionDefaultShell: "/bin/bash",
+		globalDefaultShell:  "/opt/homebrew/bin/fish",
+	}
+	r := NewWorkspaceRunner(m)
+
+	err := r.EnsureAndAttach(
+		context.Background(), "workspace", "/wt",
+		BlankLayout(), false,
+	)
+
+	require.NoError(t, err)
+	assert.NotContains(t, m.calls,
+		[]string{"show-options", "-gv", "default-shell"})
+	assert.Contains(t, m.calls,
+		[]string{
+			"respawn-pane", "-k", "-c", "/wt", "-t", "%1",
+			"/bin/bash", "-l",
+		})
+}
+
+func TestEnsureAddsCredentialRemovalMarkers(t *testing.T) {
+	t.Setenv("KWT_GITHUB_TOKEN", "provider-secret")
+	m := &mockWorkspaceTmux{hasSession: false}
+	r := NewWorkspaceRunnerWithStripNames(
+		m,
+		[]string{"CUSTOM_FLEET_TOKEN"},
+	)
+
+	err := r.Ensure(
+		context.Background(),
+		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	expected := BuildSessionBootstrapCommand(
+		"workspace",
+		MergeStripNames(
+			CanonicalStripExactNames(),
+			[]string{"CUSTOM_FLEET_TOKEN"},
+			StripEnvNames(os.Environ()),
+		),
+	)
+	assert.Contains(t, m.calls, expected)
 }
 
 // TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing pins
@@ -198,7 +264,7 @@ func TestEnsureAndAttachQueriesServerDefaultShell(t *testing.T) {
 func TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing(t *testing.T) {
 	m := &mockWorkspaceTmux{
 		hasSession: true,
-		globalEnv:  "STARSHIP_SESSION_KEY=abc\nHOME=/home/u",
+		globalEnv:  "KWT_GITHUB_TOKEN=secret\nSTARSHIP_SESSION_KEY=abc\nHOME=/home/u",
 		sessionEnv: "VSCODE_GIT_IPC_HANDLE=/tmp/ipc\nPATH=/bin",
 	}
 	r := NewWorkspaceRunner(m)
@@ -209,7 +275,8 @@ func TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing(t *te
 
 	want := [][]string{
 		expectedBootstrapCommand("s",
-			[]string{"STARSHIP_SESSION_KEY"}, []string{"VSCODE_GIT_IPC_HANDLE"}),
+			[]string{"KWT_GITHUB_TOKEN", "STARSHIP_SESSION_KEY"},
+			[]string{"VSCODE_GIT_IPC_HANDLE"}),
 	}
 	assert.Equal(t, want, m.calls, "existing session must be repaired but not re-created")
 	assert.Equal(t, 0, m.outputCalls, "repair issues no pane-capturing commands")
@@ -267,7 +334,7 @@ func TestEnsureAndAttachReturnsErrorOnCaptureFailure(t *testing.T) {
 // construction command failing must kill the now-partially-built session so
 // a subsequent EnsureAndAttach rebuilds instead of attaching to it broken.
 func TestEnsureAndAttachKillsPartialSessionOnCreateFailure(t *testing.T) {
-	m := &mockWorkspaceTmux{hasSession: false, failOutputOnCall: 3}
+	m := &mockWorkspaceTmux{hasSession: false, failOutputOnCall: 4}
 	r := NewWorkspaceRunner(m)
 	layout := models.Layout{Arrange: "even-horizontal", Panes: []string{"codex", "vim"}}
 

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -428,6 +428,44 @@ func TestProtectedAttachRepairsPolicyAndDisablesEnvironmentUpdate(t *testing.T) 
 	)}, m.calls)
 }
 
+func TestProtectedEnsureAndAttachCreatesMissingSession(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		globalEnv:       "PATH=/bin\n",
+		globalUpdateEnv: "DISPLAY KWT_GITHUB_TOKEN",
+	}
+	r := NewProtectedWorkspaceRunner(
+		m,
+		[]string{"KWT_GITHUB_TOKEN"},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.EnsureAndAttachProtected(
+		ctx,
+		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Same(t, ctx, m.protectedAttachCtx)
+	assert.Equal(t, "workspace", m.protectedAttachedTo)
+	assert.Contains(t, m.calls, BuildSessionCreateCommand(
+		"workspace",
+		"/wt",
+	))
+	assert.Contains(t, m.calls, buildProtectedSessionBootstrapCommand(
+		"workspace",
+		"/wt",
+		MergeStripNames(
+			CanonicalStripExactNames(),
+			[]string{"KWT_GITHUB_TOKEN"},
+			StripEnvNames(os.Environ()),
+		),
+		"DISPLAY",
+	))
+}
+
 func TestProtectedWorkspaceSocketNameIsStableAndWorkspaceSpecific(t *testing.T) {
 	first := ProtectedWorkspaceSocketName("kwt-workspace-a", "/worktrees/a")
 

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -156,6 +156,23 @@ func TestEnsureAndAttachCreatesSendsToCapturedIDsAndAttaches(t *testing.T) {
 		"the create path must not query the session table of a session that does not exist yet")
 }
 
+func TestEnsureCreatesWorkspaceWithoutAttaching(t *testing.T) {
+	m := &mockWorkspaceTmux{hasSession: false}
+	r := NewWorkspaceRunner(m)
+
+	err := r.Ensure(
+		context.Background(),
+		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, m.calls)
+	assert.Empty(t, m.attachedTo)
+	assert.Empty(t, m.switchedTo)
+}
+
 func TestEnsureAndAttachQueriesSessionEffectiveDefaultShell(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, defaultShell: "/opt/homebrew/bin/fish"}
 	r := NewWorkspaceRunner(m)

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -43,6 +43,8 @@ type mockWorkspaceTmux struct {
 	sessionEnv          string
 	sessionEnvErr       error
 	sessionEnvQueried   bool
+	sessionWorkspace    string
+	sessionOptionErr    error
 }
 
 func (m *mockWorkspaceTmux) HasSession(string) bool {
@@ -56,6 +58,10 @@ func (m *mockWorkspaceTmux) GlobalEnvironment() (string, error) {
 func (m *mockWorkspaceTmux) SessionEnvironment(string) (string, error) {
 	m.sessionEnvQueried = true
 	return m.sessionEnv, m.sessionEnvErr
+}
+
+func (m *mockWorkspaceTmux) sessionOption(string, string) (string, error) {
+	return m.sessionWorkspace, m.sessionOptionErr
 }
 
 // expectedBootstrapCommand derives the bootstrap invocation a test should
@@ -227,12 +233,84 @@ func TestEnsureAndAttachPrefersSessionDefaultShell(t *testing.T) {
 		})
 }
 
-func TestEnsureAddsCredentialRemovalMarkers(t *testing.T) {
-	t.Setenv("KWT_GITHUB_TOKEN", "provider-secret")
-	m := &mockWorkspaceTmux{hasSession: false}
-	r := NewWorkspaceRunnerWithStripNames(
+func TestProtectedEnsureRejectsSensitiveServerEnvironment(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		globalEnv: "KWT_GITHUB_TOKEN=secret\nKWT_HOME=/tmp/kwt\n",
+	}
+	r := NewProtectedWorkspaceRunner(
 		m,
-		[]string{"CUSTOM_FLEET_TOKEN"},
+		[]string{"KWT_GITHUB_TOKEN"},
+	)
+
+	err := r.Ensure(
+		context.Background(),
+		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KWT_GITHUB_TOKEN")
+	assert.Empty(t, m.calls)
+}
+
+func TestProtectedEnsureRejectsUnverifiedExistingSession(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		hasSession: true,
+		globalEnv:  "PATH=/bin\n",
+		sessionEnv: "PATH=/bin\n",
+	}
+	r := NewProtectedWorkspaceRunner(
+		m,
+		[]string{"KWT_GITHUB_TOKEN"},
+	)
+
+	err := r.Ensure(
+		context.Background(),
+		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not verified")
+	assert.Empty(t, m.calls)
+}
+
+func TestProtectedEnsureRejectsSensitiveExistingSession(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		hasSession:       true,
+		globalEnv:        "PATH=/bin\n",
+		sessionEnv:       "CUSTOM_FLEET_TOKEN=secret\n",
+		sessionWorkspace: "/wt",
+	}
+	r := NewProtectedWorkspaceRunner(
+		m,
+		[]string{"KWT_GITHUB_TOKEN", "CUSTOM_FLEET_TOKEN"},
+	)
+
+	err := r.Ensure(
+		context.Background(),
+		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CUSTOM_FLEET_TOKEN")
+	assert.Empty(t, m.calls)
+}
+
+func TestProtectedEnsureRepairsVerifiedExistingSession(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		hasSession:       true,
+		globalEnv:        "PATH=/bin\n",
+		sessionEnv:       "PATH=/bin\n",
+		sessionWorkspace: "/wt",
+	}
+	r := NewProtectedWorkspaceRunner(
+		m,
+		[]string{"KWT_GITHUB_TOKEN"},
 	)
 
 	err := r.Ensure(
@@ -243,15 +321,33 @@ func TestEnsureAddsCredentialRemovalMarkers(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	expected := BuildSessionBootstrapCommand(
+	assert.Equal(t, [][]string{expectedBootstrapCommand("workspace")}, m.calls)
+}
+
+func TestProtectedEnsureMarksCreatedSessionBeforeRespawn(t *testing.T) {
+	m := &mockWorkspaceTmux{globalEnv: "PATH=/bin\n"}
+	r := NewProtectedWorkspaceRunner(
+		m,
+		[]string{"KWT_GITHUB_TOKEN"},
+	)
+
+	err := r.Ensure(
+		context.Background(),
 		"workspace",
+		"/wt",
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, m.calls, buildProtectedSessionBootstrapCommand(
+		"workspace",
+		"/wt",
 		MergeStripNames(
 			CanonicalStripExactNames(),
-			[]string{"CUSTOM_FLEET_TOKEN"},
+			[]string{"KWT_GITHUB_TOKEN"},
 			StripEnvNames(os.Environ()),
 		),
-	)
-	assert.Contains(t, m.calls, expected)
+	))
 }
 
 // TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing pins

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -138,7 +138,7 @@ func TestEnsureAndAttachCreatesSendsToCapturedIDsAndAttaches(t *testing.T) {
 	want := [][]string{
 		{"new-session", "-d", "-P", "-F", "#{pane_id}", "-s", "s", "-c", "/wt", "sleep", "2147483647"},
 		expectedBootstrapCommand("s"),
-		{"show-options", "-v", "-t", "s", "default-shell"},
+		{"show-options", "-gv", "default-shell"},
 		{"respawn-pane", "-k", "-c", "/wt", "-t", "%1", "/bin/sh", "-l"},
 		{"split-window", "-P", "-F", "#{pane_id}", "-t", "s", "-c", "/wt"},
 		{"split-window", "-P", "-F", "#{pane_id}", "-t", "s", "-c", "/wt"},
@@ -173,7 +173,7 @@ func TestEnsureCreatesWorkspaceWithoutAttaching(t *testing.T) {
 	assert.Empty(t, m.switchedTo)
 }
 
-func TestEnsureAndAttachQueriesSessionEffectiveDefaultShell(t *testing.T) {
+func TestEnsureAndAttachQueriesServerDefaultShell(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, defaultShell: "/opt/homebrew/bin/fish"}
 	r := NewWorkspaceRunner(m)
 
@@ -184,8 +184,8 @@ func TestEnsureAndAttachQueriesSessionEffectiveDefaultShell(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, m.calls,
-		[]string{"show-options", "-v", "-t", "workspace", "default-shell"},
-		"the first pane must use the target session's effective shell")
+		[]string{"show-options", "-gv", "default-shell"},
+		"the first pane must use the target tmux server's configured shell")
 }
 
 // TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing pins

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -44,6 +44,8 @@ type mockWorkspaceTmux struct {
 	sessionEnvErr       error
 	sessionEnvQueried   bool
 	sessionWorkspace    string
+	sessionUpdateEnv    string
+	globalUpdateEnv     string
 	sessionOptionErr    error
 }
 
@@ -60,8 +62,22 @@ func (m *mockWorkspaceTmux) SessionEnvironment(string) (string, error) {
 	return m.sessionEnv, m.sessionEnvErr
 }
 
-func (m *mockWorkspaceTmux) sessionOption(string, string) (string, error) {
-	return m.sessionWorkspace, m.sessionOptionErr
+func (m *mockWorkspaceTmux) sessionOption(_ string, option string) (string, error) {
+	switch option {
+	case workspacePathOption:
+		return m.sessionWorkspace, m.sessionOptionErr
+	case "update-environment":
+		return m.sessionUpdateEnv, m.sessionOptionErr
+	default:
+		return "", m.sessionOptionErr
+	}
+}
+
+func (m *mockWorkspaceTmux) globalOption(option string) (string, error) {
+	if option == "update-environment" {
+		return m.globalUpdateEnv, nil
+	}
+	return "", nil
 }
 
 // expectedBootstrapCommand derives the bootstrap invocation a test should
@@ -307,10 +323,11 @@ func TestProtectedEnsureRepairsVerifiedExistingSession(t *testing.T) {
 		globalEnv:        "PATH=/bin\n",
 		sessionEnv:       "PATH=/bin\n",
 		sessionWorkspace: "/wt",
+		sessionUpdateEnv: "DISPLAY SSH_AUTH_SOCK KWT_GITHUB_TOKEN CUSTOM_FLEET_TOKEN",
 	}
 	r := NewProtectedWorkspaceRunner(
 		m,
-		[]string{"KWT_GITHUB_TOKEN"},
+		[]string{"KWT_GITHUB_TOKEN", "CUSTOM_FLEET_TOKEN"},
 	)
 
 	err := r.Ensure(
@@ -321,11 +338,23 @@ func TestProtectedEnsureRepairsVerifiedExistingSession(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, [][]string{expectedBootstrapCommand("workspace")}, m.calls)
+	assert.Equal(t, [][]string{buildProtectedSessionBootstrapCommand(
+		"workspace",
+		"/wt",
+		MergeStripNames(
+			CanonicalStripExactNames(),
+			[]string{"KWT_GITHUB_TOKEN", "CUSTOM_FLEET_TOKEN"},
+			StripEnvNames(os.Environ()),
+		),
+		"DISPLAY SSH_AUTH_SOCK",
+	)}, m.calls)
 }
 
 func TestProtectedEnsureMarksCreatedSessionBeforeRespawn(t *testing.T) {
-	m := &mockWorkspaceTmux{globalEnv: "PATH=/bin\n"}
+	m := &mockWorkspaceTmux{
+		globalEnv:       "PATH=/bin\n",
+		globalUpdateEnv: "DISPLAY KWT_GITHUB_TOKEN SSH_AUTH_SOCK",
+	}
 	r := NewProtectedWorkspaceRunner(
 		m,
 		[]string{"KWT_GITHUB_TOKEN"},
@@ -347,7 +376,16 @@ func TestProtectedEnsureMarksCreatedSessionBeforeRespawn(t *testing.T) {
 			[]string{"KWT_GITHUB_TOKEN"},
 			StripEnvNames(os.Environ()),
 		),
+		"DISPLAY SSH_AUTH_SOCK",
 	))
+}
+
+func TestProtectedWorkspaceSocketNameIsStableAndWorkspaceSpecific(t *testing.T) {
+	first := ProtectedWorkspaceSocketName("kwt-workspace-a", "/worktrees/a")
+
+	assert.Equal(t, first, ProtectedWorkspaceSocketName("kwt-workspace-a", "/worktrees/a"))
+	assert.NotEqual(t, first, ProtectedWorkspaceSocketName("kwt-workspace-a", "/worktrees/b"))
+	assert.Regexp(t, `^kwt-pr-[0-9a-f]{16}$`, first)
 }
 
 // TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing pins

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -30,6 +30,7 @@ type mockWorkspaceTmux struct {
 	switchedTo          string
 	attachedTo          string
 	protectedAttachedTo string
+	protectedAttachCtx  context.Context
 	outputErr           error
 	failOutputOnCall    int
 	outputCalls         int
@@ -135,8 +136,10 @@ func (m *mockWorkspaceTmux) AttachSession(session string) error {
 }
 
 func (m *mockWorkspaceTmux) AttachSessionWithoutEnvironment(
+	ctx context.Context,
 	session string,
 ) error {
+	m.protectedAttachCtx = ctx
 	m.protectedAttachedTo = session
 	return nil
 }
@@ -401,13 +404,16 @@ func TestProtectedAttachRepairsPolicyAndDisablesEnvironmentUpdate(t *testing.T) 
 		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"},
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	err := r.AttachProtected(
-		context.Background(),
+		ctx,
 		"workspace",
 		"/wt",
 	)
 
 	require.NoError(t, err)
+	assert.Same(t, ctx, m.protectedAttachCtx)
 	assert.Equal(t, "workspace", m.protectedAttachedTo)
 	assert.Empty(t, m.attachedTo)
 	assert.Equal(t, [][]string{buildProtectedSessionBootstrapCommand(

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -199,6 +199,25 @@ func (t *TmuxCommand) AttachSession(sessionName string) error {
 	return cmd.Run()
 }
 
+func (t *TmuxCommand) AttachSessionWithoutEnvironment(
+	sessionName string,
+) error {
+	cmd := t.attachSessionWithoutEnvironmentCmd(sessionName)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (t *TmuxCommand) attachSessionWithoutEnvironmentCmd(
+	sessionName string,
+) *exec.Cmd {
+	return t.newAttachCmd(
+		context.Background(),
+		[]string{"attach-session", "-E", "-t", sessionName},
+	)
+}
+
 // attachSessionCmd builds the attach-session invocation through the
 // attach-class exec seam; split out so tests can pin that the attach path
 // uses the full-strip sanitizer without needing a tty to run it.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -36,14 +36,33 @@ type SessionManagerInterface interface {
 }
 
 type TmuxCommand struct {
-	command string
+	command         string
+	extraStripNames map[string]bool
 }
 
 func NewTmuxCommand(command string) *TmuxCommand {
+	return NewTmuxCommandWithStripNames(command, nil)
+}
+
+// NewTmuxCommandWithStripNames adds caller-owned credential names to the
+// environment variables removed from every tmux subprocess.
+func NewTmuxCommandWithStripNames(
+	command string,
+	names []string,
+) *TmuxCommand {
 	if command == "" {
 		command = "tmux"
 	}
-	return &TmuxCommand{command: command}
+	extra := make(map[string]bool, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			extra[name] = true
+		}
+	}
+	return &TmuxCommand{
+		command:         command,
+		extraStripNames: extra,
+	}
 }
 
 func (t *TmuxCommand) NewSession(name, workDir string) error {
@@ -280,7 +299,7 @@ func (t *TmuxCommand) SessionEnvironment(session string) (string, error) {
 // predate context plumbing pass context.Background().
 func (t *TmuxCommand) newCmd(ctx context.Context, args []string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, t.command, args...)
-	cmd.Env = SanitizedEnviron(os.Environ())
+	cmd.Env = t.stripExtraNames(SanitizedEnviron(os.Environ()))
 	return cmd
 }
 
@@ -293,6 +312,15 @@ func (t *TmuxCommand) newCmd(ctx context.Context, args []string) *exec.Cmd {
 // client still carried them.
 func (t *TmuxCommand) newAttachCmd(ctx context.Context, args []string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, t.command, args...)
-	cmd.Env = AttachSanitizedEnviron(os.Environ())
+	cmd.Env = t.stripExtraNames(AttachSanitizedEnviron(os.Environ()))
 	return cmd
+}
+
+func (t *TmuxCommand) stripExtraNames(env []string) []string {
+	if len(t.extraStripNames) == 0 {
+		return env
+	}
+	return filteredEnviron(env, func(name string) bool {
+		return t.extraStripNames[name]
+	})
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -42,6 +42,7 @@ type SessionManagerInterface interface {
 
 type TmuxCommand struct {
 	command         string
+	socketName      string
 	extraStripNames map[string]bool
 }
 
@@ -55,6 +56,17 @@ func NewTmuxCommandWithStripNames(
 	command string,
 	names []string,
 ) *TmuxCommand {
+	return NewTmuxCommandForSocketWithStripNames(command, "", names)
+}
+
+// NewTmuxCommandForSocketWithStripNames targets a named tmux socket for every
+// invocation. A named socket gives protected workspaces a server boundary
+// separate from the user's ordinary tmux server.
+func NewTmuxCommandForSocketWithStripNames(
+	command string,
+	socketName string,
+	names []string,
+) *TmuxCommand {
 	if command == "" {
 		command = "tmux"
 	}
@@ -66,6 +78,7 @@ func NewTmuxCommandWithStripNames(
 	}
 	return &TmuxCommand{
 		command:         command,
+		socketName:      strings.TrimSpace(socketName),
 		extraStripNames: extra,
 	}
 }
@@ -312,6 +325,15 @@ func (t *TmuxCommand) sessionOption(session, option string) (string, error) {
 	)
 }
 
+func (t *TmuxCommand) globalOption(option string) (string, error) {
+	return t.RunCommandOutputContext(
+		context.Background(),
+		"show-options",
+		"-gv",
+		option,
+	)
+}
+
 // newCmd is the exec seam for every TmuxCommand method except the
 // attach-class commands (see newAttachCmd). It builds the *exec.Cmd for a
 // tmux invocation with Env set to a sanitized copy of the process environment
@@ -324,7 +346,7 @@ func (t *TmuxCommand) sessionOption(session, option string) (string, error) {
 // reads them at server start for its default key mode. Call sites that
 // predate context plumbing pass context.Background().
 func (t *TmuxCommand) newCmd(ctx context.Context, args []string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, t.command, args...)
+	cmd := exec.CommandContext(ctx, t.command, t.socketArgs(args)...)
 	cmd.Env = t.stripExtraNames(SanitizedEnviron(os.Environ()))
 	return cmd
 }
@@ -337,9 +359,18 @@ func (t *TmuxCommand) newCmd(ctx context.Context, args []string) *exec.Cmd {
 // session table, which would override the bootstrap's remove-markers if the
 // client still carried them.
 func (t *TmuxCommand) newAttachCmd(ctx context.Context, args []string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, t.command, args...)
+	cmd := exec.CommandContext(ctx, t.command, t.socketArgs(args)...)
 	cmd.Env = t.stripExtraNames(AttachSanitizedEnviron(os.Environ()))
 	return cmd
+}
+
+func (t *TmuxCommand) socketArgs(args []string) []string {
+	if t.socketName == "" {
+		return args
+	}
+	prefixed := make([]string, 0, len(args)+2)
+	prefixed = append(prefixed, "-L", t.socketName)
+	return append(prefixed, args...)
 }
 
 func (t *TmuxCommand) stripExtraNames(env []string) []string {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -200,9 +200,10 @@ func (t *TmuxCommand) AttachSession(sessionName string) error {
 }
 
 func (t *TmuxCommand) AttachSessionWithoutEnvironment(
+	ctx context.Context,
 	sessionName string,
 ) error {
-	cmd := t.attachSessionWithoutEnvironmentCmd(sessionName)
+	cmd := t.attachSessionWithoutEnvironmentCmd(ctx, sessionName)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -210,10 +211,11 @@ func (t *TmuxCommand) AttachSessionWithoutEnvironment(
 }
 
 func (t *TmuxCommand) attachSessionWithoutEnvironmentCmd(
+	ctx context.Context,
 	sessionName string,
 ) *exec.Cmd {
 	return t.newAttachCmd(
-		context.Background(),
+		ctx,
 		[]string{"attach-session", "-E", "-t", sessionName},
 	)
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -214,10 +214,17 @@ func (t *TmuxCommand) attachSessionWithoutEnvironmentCmd(
 	ctx context.Context,
 	sessionName string,
 ) *exec.Cmd {
-	return t.newAttachCmd(
+	cmd := t.newAttachCmd(
 		ctx,
 		[]string{"attach-session", "-E", "-t", sessionName},
 	)
+	// This command targets the protected workspace's isolated socket. A
+	// parent TMUX value tells tmux it is already inside a client on another
+	// server, which makes tmux reject the cross-server attachment as nested.
+	cmd.Env = filteredEnviron(cmd.Env, func(name string) bool {
+		return name == "TMUX" || name == "TMUX_PANE"
+	})
+	return cmd
 }
 
 // attachSessionCmd builds the attach-session invocation through the

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3,11 +3,16 @@ package tmux
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 )
+
+// errNoServerRunning distinguishes a clean first-session launch from a tmux
+// server whose environment could not be inspected.
+var errNoServerRunning = errors.New("tmux server is not running")
 
 // TmuxInterface defines the contract for tmux operations
 type TmuxInterface interface {
@@ -270,7 +275,15 @@ func (t *TmuxCommand) RunCommandOutputContext(ctx context.Context, args ...strin
 // when no server is running; callers treat that as "nothing to inspect" and
 // fall back to the launcher-derived strip set.
 func (t *TmuxCommand) GlobalEnvironment() (string, error) {
-	return t.RunCommandOutputContext(context.Background(), "show-environment", "-g")
+	output, err := t.RunCommandOutputContext(
+		context.Background(),
+		"show-environment",
+		"-g",
+	)
+	if err != nil && strings.Contains(err.Error(), "no server running") {
+		return "", fmt.Errorf("%w: %v", errNoServerRunning, err)
+	}
+	return output, err
 }
 
 // SessionEnvironment returns a session's own environment table via
@@ -284,6 +297,19 @@ func (t *TmuxCommand) GlobalEnvironment() (string, error) {
 // as "nothing to inspect" and fall back to the other sources.
 func (t *TmuxCommand) SessionEnvironment(session string) (string, error) {
 	return t.RunCommandOutputContext(context.Background(), "show-environment", "-t", session)
+}
+
+// sessionOption reads a session-local user option without falling back to a
+// global value. Missing options return the tmux command error to the caller.
+func (t *TmuxCommand) sessionOption(session, option string) (string, error) {
+	return t.RunCommandOutputContext(
+		context.Background(),
+		"show-options",
+		"-v",
+		"-t",
+		session,
+		option,
+	)
 }
 
 // newCmd is the exec seam for every TmuxCommand method except the

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"slices"
 	"testing"
 )
 
@@ -65,6 +66,31 @@ func TestNewCmdStripsConfiguredSensitiveEnvironmentName(t *testing.T) {
 		if hasEnvName(entry, "CUSTOM_FLEET_TOKEN") {
 			t.Errorf("newCmd().Env leaked configured credential: %v", cmd.Env)
 		}
+	}
+}
+
+func TestSocketCommandPrefixesEveryInvocationWithSocketName(t *testing.T) {
+	tc := NewTmuxCommandForSocketWithStripNames(
+		"tmux",
+		"kwt-pr-0123456789abcdef",
+		[]string{"KWT_GITHUB_TOKEN"},
+	)
+
+	cmd := tc.newCmd(
+		context.Background(),
+		[]string{"has-session", "-t", "workspace"},
+	)
+	attach := tc.newAttachCmd(
+		context.Background(),
+		[]string{"attach-session", "-t", "workspace"},
+	)
+
+	wantPrefix := []string{"tmux", "-L", "kwt-pr-0123456789abcdef"}
+	if len(cmd.Args) < len(wantPrefix) || !slices.Equal(cmd.Args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("newCmd args = %v, want prefix %v", cmd.Args, wantPrefix)
+	}
+	if len(attach.Args) < len(wantPrefix) || !slices.Equal(attach.Args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("newAttachCmd args = %v, want prefix %v", attach.Args, wantPrefix)
 	}
 }
 

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -16,7 +16,9 @@ import (
 // in bootstrap.go; see TestNewCmdPreservesEditorAndVisual).
 func TestNewCmdSanitizesEnvironment(t *testing.T) {
 	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
-	t.Setenv("KWT_TEST_UNRELATED_VAR", "keep-me")
+	t.Setenv("KWT_GITHUB_TOKEN", "secret")
+	t.Setenv("KWT_TEST_OTHER", "secret")
+	t.Setenv("UNRELATED_VAR", "keep-me")
 
 	tc := NewTmuxCommand("tmux")
 	cmd := tc.newCmd(context.Background(), []string{"has-session", "-t", "x"})
@@ -25,15 +27,39 @@ func TestNewCmdSanitizesEnvironment(t *testing.T) {
 		if hasEnvName(entry, "TERM_PROGRAM") {
 			t.Errorf("newCmd().Env leaked TERM_PROGRAM: %v", cmd.Env)
 		}
+		if hasEnvName(entry, "KWT_GITHUB_TOKEN") ||
+			hasEnvName(entry, "KWT_TEST_OTHER") {
+			t.Errorf("newCmd().Env leaked KWT-owned credentials: %v", cmd.Env)
+		}
 	}
 	found := false
 	for _, entry := range cmd.Env {
-		if hasEnvName(entry, "KWT_TEST_UNRELATED_VAR") {
+		if hasEnvName(entry, "UNRELATED_VAR") {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("newCmd().Env dropped unrelated var KWT_TEST_UNRELATED_VAR: %v", cmd.Env)
+		t.Errorf("newCmd().Env dropped unrelated var: %v", cmd.Env)
+	}
+}
+
+func TestNewCmdStripsConfiguredSensitiveEnvironmentName(t *testing.T) {
+	t.Setenv("CUSTOM_FLEET_TOKEN", "secret")
+	t.Setenv("UNRELATED_VAR", "keep-me")
+
+	tc := NewTmuxCommandWithStripNames(
+		"tmux",
+		[]string{"CUSTOM_FLEET_TOKEN"},
+	)
+	cmd := tc.newCmd(
+		context.Background(),
+		[]string{"has-session", "-t", "x"},
+	)
+
+	for _, entry := range cmd.Env {
+		if hasEnvName(entry, "CUSTOM_FLEET_TOKEN") {
+			t.Errorf("newCmd().Env leaked configured credential: %v", cmd.Env)
+		}
 	}
 }
 
@@ -102,7 +128,7 @@ func TestNewAttachCmdStripsEditorAndVisual(t *testing.T) {
 	t.Setenv("EDITOR", "vim")
 	t.Setenv("VISUAL", "code")
 	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
-	t.Setenv("KWT_TEST_UNRELATED_VAR", "keep-me")
+	t.Setenv("UNRELATED_VAR", "keep-me")
 
 	tc := NewTmuxCommand("tmux")
 	cmd := tc.newAttachCmd(context.Background(), []string{"attach-session", "-t", "x"})
@@ -118,7 +144,7 @@ func TestNewAttachCmdStripsEditorAndVisual(t *testing.T) {
 		if hasEnvName(entry, "TERM_PROGRAM") {
 			t.Errorf("newAttachCmd().Env leaked TERM_PROGRAM: %v", cmd.Env)
 		}
-		if hasEnvName(entry, "KWT_TEST_UNRELATED_VAR") {
+		if hasEnvName(entry, "UNRELATED_VAR") {
 			foundUnrelated = true
 		}
 	}

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -236,6 +236,38 @@ func TestProtectedAttachDisablesTmuxEnvironmentUpdate(t *testing.T) {
 	}
 }
 
+func TestProtectedAttachStripsParentTmuxIdentity(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+	t.Setenv("TMUX_PANE", "%7")
+	t.Setenv("UNRELATED_VAR", "keep-me")
+
+	tc := NewTmuxCommandForSocketWithStripNames(
+		"tmux",
+		"kwt-pr-0123456789abcdef",
+		nil,
+	)
+	cmd := tc.attachSessionWithoutEnvironmentCmd(
+		context.Background(),
+		"workspace",
+	)
+
+	foundUnrelated := false
+	for _, entry := range cmd.Env {
+		if hasEnvName(entry, "TMUX") {
+			t.Error("protected attach leaked TMUX")
+		}
+		if hasEnvName(entry, "TMUX_PANE") {
+			t.Error("protected attach leaked TMUX_PANE")
+		}
+		if hasEnvName(entry, "UNRELATED_VAR") {
+			foundUnrelated = true
+		}
+	}
+	if !foundUnrelated {
+		t.Error("protected attach dropped UNRELATED_VAR")
+	}
+}
+
 func hasEnvName(entry, name string) bool {
 	return len(entry) > len(name) && entry[:len(name)] == name && entry[len(name)] == '='
 }

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -215,6 +215,24 @@ func TestAttachPathsUseFullStripSanitizer(t *testing.T) {
 	}
 }
 
+func TestProtectedAttachDisablesTmuxEnvironmentUpdate(t *testing.T) {
+	tc := NewTmuxCommandForSocketWithStripNames(
+		"tmux",
+		"kwt-pr-0123456789abcdef",
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"},
+	)
+
+	cmd := tc.attachSessionWithoutEnvironmentCmd("workspace")
+
+	want := []string{
+		"tmux", "-L", "kwt-pr-0123456789abcdef",
+		"attach-session", "-E", "-t", "workspace",
+	}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("protected attach args = %v, want %v", cmd.Args, want)
+	}
+}
+
 func hasEnvName(entry, name string) bool {
 	return len(entry) > len(name) && entry[:len(name)] == name && entry[len(name)] == '='
 }

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewCmdSanitizesEnvironment(t *testing.T) {
 	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
 	t.Setenv("KWT_GITHUB_TOKEN", "secret")
-	t.Setenv("KWT_TEST_OTHER", "secret")
+	t.Setenv("KWT_HOME", "/tmp/kwt")
 	t.Setenv("UNRELATED_VAR", "keep-me")
 
 	tc := NewTmuxCommand("tmux")
@@ -27,19 +27,24 @@ func TestNewCmdSanitizesEnvironment(t *testing.T) {
 		if hasEnvName(entry, "TERM_PROGRAM") {
 			t.Errorf("newCmd().Env leaked TERM_PROGRAM: %v", cmd.Env)
 		}
-		if hasEnvName(entry, "KWT_GITHUB_TOKEN") ||
-			hasEnvName(entry, "KWT_TEST_OTHER") {
-			t.Errorf("newCmd().Env leaked KWT-owned credentials: %v", cmd.Env)
+		if hasEnvName(entry, "KWT_GITHUB_TOKEN") {
+			t.Errorf("newCmd().Env leaked GitHub credential: %v", cmd.Env)
 		}
 	}
-	found := false
+	foundUnrelated, foundKwtHome := false, false
 	for _, entry := range cmd.Env {
 		if hasEnvName(entry, "UNRELATED_VAR") {
-			found = true
+			foundUnrelated = true
+		}
+		if hasEnvName(entry, "KWT_HOME") {
+			foundKwtHome = true
 		}
 	}
-	if !found {
+	if !foundUnrelated {
 		t.Errorf("newCmd().Env dropped unrelated var: %v", cmd.Env)
+	}
+	if !foundKwtHome {
+		t.Errorf("newCmd().Env dropped KWT_HOME: %v", cmd.Env)
 	}
 }
 

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -222,7 +222,10 @@ func TestProtectedAttachDisablesTmuxEnvironmentUpdate(t *testing.T) {
 		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"},
 	)
 
-	cmd := tc.attachSessionWithoutEnvironmentCmd("workspace")
+	cmd := tc.attachSessionWithoutEnvironmentCmd(
+		context.Background(),
+		"workspace",
+	)
 
 	want := []string{
 		"tmux", "-L", "kwt-pr-0123456789abcdef",

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -5,14 +5,15 @@ import "time"
 
 // Worktree represents a Git worktree with its associated metadata.
 type Worktree struct {
-	Path        string    `json:"path"`         // Absolute path to the worktree directory
-	Branch      string    `json:"branch"`       // Branch name associated with this worktree
-	CommitHash  string    `json:"commit_hash"`  // Current HEAD commit hash
-	IsMain      bool      `json:"is_main"`      // Whether this is the main worktree
-	CreatedAt   time.Time `json:"created_at"`   // Worktree directory modification time
-	Repository  string    `json:"repository"`   // Repository slug, e.g. github.com/owner/name
-	SessionName string    `json:"session_name"` // Computed tmux workspace session name
-	Prunable    bool      `json:"-"`            // Git reports this worktree entry as stale/prunable
+	Path           string    `json:"path"`                       // Absolute path to the worktree directory
+	Branch         string    `json:"branch"`                     // Branch name associated with this worktree
+	CommitHash     string    `json:"commit_hash"`                // Current HEAD commit hash
+	IsMain         bool      `json:"is_main"`                    // Whether this is the main worktree
+	CreatedAt      time.Time `json:"created_at"`                 // Worktree directory modification time
+	Repository     string    `json:"repository"`                 // Repository slug, e.g. github.com/owner/name
+	SessionName    string    `json:"session_name"`               // Computed tmux workspace session name
+	TmuxSocketName string    `json:"tmux_socket_name,omitempty"` // Protected alternate tmux socket
+	Prunable       bool      `json:"-"`                          // Git reports this worktree entry as stale/prunable
 }
 
 // Branch represents a Git branch with its metadata.


### PR DESCRIPTION
External clients can import a pull request and receive kwt’s canonical tmux session name, but kwt previously offered no noninteractive way to make that session exist. Attempting to attach to the authoritative name therefore failed with “can’t find session”; creating the session independently would bypass kwt’s layout and environment bootstrap.

`pr import --start-session` now creates or repairs the canonical workspace without attaching kwt’s process, allowing another client to present its own ordinary tmux connection. The option is idempotent for both existing imports and existing sessions, and session-setup failures remain typed automation errors.

Real validation against an already-imported pull request also exposed that workspace creation queried `default-shell` as a session option. It is server-scoped on tmux, so the empty result caused kwt to tear down every new session. The corrected lookup created the exact reported session successfully, and a repeated import converged.

Validation: `make test`, `make build`, `make lint`, plus a real existing-import/session reproduction.