### PR TITLE
Make worktree discovery and creation feel immediate

### DIFF
--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1380,11 +1380,18 @@ func (b *tuiBackend) UnregisterWorkspace(row dashboard.Row) error {
 	if row.Workspace == nil {
 		return fmt.Errorf("no workspace selected")
 	}
+	// The TUI runs this concurrently with the load commands, which read
+	// cfg.Workspaces to build workspace rows and write the config file when
+	// they register the launch directory.
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if err := b.unregisterWorkspace(row.Workspace.Name); err != nil {
 		return err
 	}
 	if b.cfg != nil {
-		kept := b.cfg.Workspaces[:0]
+		// A new slice, not a filter in place: rewriting the backing array is
+		// what turns a concurrent read into duplicated rows.
+		kept := make([]models.Workspace, 0, len(b.cfg.Workspaces))
 		for _, workspace := range b.cfg.Workspaces {
 			if !samePath(workspace.Path, row.Workspace.Path) {
 				kept = append(kept, workspace)

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -506,7 +506,7 @@ func sameRegisteredProject(a, b models.Project) bool {
 		return true
 	}
 	if a.Repository != "" && b.Repository != "" {
-		return strings.EqualFold(a.Repository, b.Repository)
+		return equalRepositoryIdentity(a.Repository, b.Repository)
 	}
 	return false
 }
@@ -1010,18 +1010,26 @@ func (b *tuiBackend) projectForFleetInfo(info *dashboard.FleetInfo) (models.Proj
 	return models.Project{}, false
 }
 
-func sameRepositoryIdentity(left string, right string) bool {
+// equalRepositoryIdentity compares two repository identities with the host-aware
+// fold. A plain EqualFold would let a case-sensitive server's two repositories
+// match each other, and this decides which checkout a mutation runs against.
+func equalRepositoryIdentity(left string, right string) bool {
 	left = strings.TrimSpace(left)
 	right = strings.TrimSpace(right)
 	if left == "" || right == "" {
 		return false
 	}
-	if strings.EqualFold(left, right) {
+	return url.FoldRepositoryIdentity(left) == url.FoldRepositoryIdentity(right)
+}
+
+func sameRepositoryIdentity(left string, right string) bool {
+	if equalRepositoryIdentity(left, right) {
 		return true
 	}
 	normalizedLeft, leftErr := fleet.NormalizeRepositoryIdentity(left)
 	normalizedRight, rightErr := fleet.NormalizeRepositoryIdentity(right)
-	return leftErr == nil && rightErr == nil && strings.EqualFold(normalizedLeft, normalizedRight)
+	return leftErr == nil && rightErr == nil &&
+		equalRepositoryIdentity(normalizedLeft, normalizedRight)
 }
 
 func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, force bool) error {
@@ -1090,13 +1098,16 @@ func projectMatchesRow(project models.Project, row dashboard.Row) bool {
 	info := row.Entry.RepositoryInfo
 	stableCandidates := rowRepositoryIdentityCandidates(info)
 	for _, candidate := range stableCandidates {
-		if candidate != "" && strings.EqualFold(project.Repository, candidate) {
+		if equalRepositoryIdentity(project.Repository, candidate) {
 			return true
 		}
 	}
 	if len(stableCandidates) > 0 {
 		return false
 	}
+	// Below here the row has no stable identity, so these compare bare
+	// repository names rather than identities; host case-sensitivity does not
+	// apply to a name with no host attached.
 	if project.Repository != "" && info.Repository != "" && strings.EqualFold(project.Repository, info.Repository) {
 		return true
 	}

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -35,6 +35,7 @@ type tuiBackend struct {
 	cfg                       *models.Config
 	tmux                      *tmux.TmuxCommand
 	launchDir                 string
+	launchProjectRegistered   bool
 	launchWorkspaceRegistered bool
 	discoverGlobalWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
 	discoverProjectWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
@@ -79,34 +80,70 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 	}
 }
 
+func (b *tuiBackend) ListFast(ctx context.Context) ([]dashboard.Row, []string, error) {
+	return b.list(ctx, false)
+}
+
 func (b *tuiBackend) List(ctx context.Context) ([]dashboard.Row, []string, error) {
+	return b.list(ctx, true)
+}
+
+func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboard.Row, []string, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	entries, err := b.discoverGlobalWorktrees(b.cfg.Worktree.BaseDir)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to discover worktrees: %w", err)
+	var (
+		entries           []*discovery.GlobalWorktreeEntry
+		registeredEntries []*discovery.GlobalWorktreeEntry
+		launchEntries     []*discovery.GlobalWorktreeEntry
+		sessions          []string
+		discoveryErr      error
+		launchErr         error
+		sessionsErr       error
+		startup           sync.WaitGroup
+	)
+	startup.Add(4)
+	go func() {
+		defer startup.Done()
+		entries, discoveryErr = b.discoverGlobalWorktrees(b.cfg.Worktree.BaseDir)
+	}()
+	go func() {
+		defer startup.Done()
+		registeredEntries = b.discoverRegisteredProjectWorktrees()
+	}()
+	go func() {
+		defer startup.Done()
+		launchEntries, launchErr = b.discoverLaunchWorktrees(b.launchDir)
+	}()
+	go func() {
+		defer startup.Done()
+		sessions, sessionsErr = b.listSessions()
+	}()
+	startup.Wait()
+
+	if discoveryErr != nil {
+		return nil, nil, fmt.Errorf("failed to discover worktrees: %w", discoveryErr)
+	}
+	if launchErr != nil {
+		return nil, nil, fmt.Errorf("failed to discover launch repository worktrees: %w", launchErr)
+	}
+	if sessionsErr != nil {
+		return nil, nil, sessionsErr
 	}
 
-	entries = mergeTUIEntries(entries, b.discoverRegisteredProjectWorktrees())
-
-	launchEntries, err := b.discoverLaunchWorktrees(b.launchDir)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to discover launch repository worktrees: %w", err)
-	}
+	entries = mergeTUIEntries(entries, registeredEntries)
 	b.registerLaunchProject(launchEntries)
 	b.registerLaunchWorkspace(launchEntries)
 	entries = mergeTUIEntries(entries, launchEntries)
 
-	statusByPath, err := b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
-	if err != nil {
-		return nil, nil, err
+	var statusByPath map[string]*models.WorktreeStatus
+	if includeStatuses {
+		statusByPath, discoveryErr = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
+		if discoveryErr != nil {
+			return nil, nil, discoveryErr
+		}
 	}
 
-	sessions, err := b.listSessions()
-	if err != nil {
-		return nil, nil, err
-	}
 	liveSessions := make(map[string]bool, len(sessions))
 	for _, session := range sessions {
 		liveSessions[session] = true
@@ -279,14 +316,18 @@ func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWor
 	return entries
 }
 
+// registerLaunchProject persists the launch repository at most once per TUI
+// run. Both stages discover it, but rewriting config during each load would
+// put bookkeeping back on the startup and refresh paths.
 func (b *tuiBackend) registerLaunchProject(entries []*discovery.GlobalWorktreeEntry) {
-	if b.registerProject == nil {
+	if b.launchProjectRegistered || b.registerProject == nil {
 		return
 	}
 	project, ok := projectFromEntries(entries, b.launchDir)
 	if !ok {
 		return
 	}
+	b.launchProjectRegistered = true
 	if existing, found := b.projectByPath(project.Path); found {
 		if reusable, ok := reusableExistingProject(existing, project); ok {
 			project = reusable
@@ -852,16 +893,45 @@ func fleetMaterializeObservation(observations []fleet.Observation, currentHost s
 	return fleet.Observation{}, false
 }
 
-func (b *tuiBackend) CreateWorktree(ctx context.Context, row dashboard.Row, branch string) (string, error) {
+func (b *tuiBackend) CreateWorktree(
+	ctx context.Context,
+	row dashboard.Row,
+	branch string,
+	destination string,
+) (string, error) {
 	if row.Entry == nil {
 		return "", fmt.Errorf("no worktree selected")
 	}
-	path, err := worktree.New(git.New(row.Entry.Path), b.cfg).Add(branch, "", true)
+	path, err := worktree.New(git.New(row.Entry.Path), b.cfg).Add(
+		branch, destination, true,
+	)
 	if err != nil {
 		return "", err
 	}
 	publishTUIFleetBestEffort(ctx, b.cfg)
 	return path, nil
+}
+
+func (b *tuiBackend) PreviewWorktree(row dashboard.Row, branch string) (dashboard.Row, error) {
+	if row.Entry == nil {
+		return dashboard.Row{}, fmt.Errorf("no worktree selected")
+	}
+	manager := worktree.New(git.New(row.Entry.Path), b.cfg)
+	worktreePath, err := manager.PreparePath("", branch)
+	if err != nil {
+		return dashboard.Row{}, err
+	}
+
+	entry := *row.Entry
+	entry.Branch = branch
+	entry.Path = worktreePath
+	entry.CommitHash = ""
+	entry.IsMain = false
+	entry.CreatedAt = time.Time{}
+	return dashboard.Row{
+		Entry:  &entry,
+		Status: unknownStatusForEntry(&entry),
+	}, nil
 }
 
 func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row) (string, error) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -190,7 +190,7 @@ func (b *tuiBackend) mergeFleetRows(ctx context.Context, rows []dashboard.Row) (
 
 	byKey := make(map[string]int, len(rows))
 	for i := range rows {
-		if key := tuiFleetKeyForRow(rows[i]); key != "" {
+		if key := dashboard.FleetKeyForRow(rows[i]); key != "" {
 			byKey[key] = i
 		}
 	}
@@ -200,7 +200,7 @@ func (b *tuiBackend) mergeFleetRows(ctx context.Context, rows []dashboard.Row) (
 		// Local presence is decided by the rows just discovered on disk, not
 		// by hub observations for this host, which can be stale when a
 		// publish fails.
-		rowIndex, local := byKey[tuiFleetKey(fleetRow.ProjectIdentity, fleetRow.Kind, fleetRowRef(fleetRow))]
+		rowIndex, local := byKey[dashboard.FleetKey(fleetRow.ProjectIdentity, fleetRow.Kind, fleetRowRef(fleetRow))]
 		var localRow dashboard.Row
 		if local {
 			localRow = rows[rowIndex]
@@ -784,38 +784,6 @@ func readTUIFleetState(ctx context.Context, cfg *models.Config) (fleet.FleetStat
 		return fleet.FleetState{}, nil
 	}
 	return state, nil
-}
-
-func tuiFleetKeyForRow(row dashboard.Row) string {
-	if row.Fleet != nil {
-		return tuiFleetKey(row.Fleet.ProjectIdentity, row.Fleet.Kind, row.Fleet.Ref)
-	}
-	if row.Entry == nil || row.Entry.RepositoryInfo == nil {
-		return ""
-	}
-	identity := row.Entry.RepositoryInfo.FullPath
-	if identity == "" && row.Entry.RepositoryInfo.Host != "" && row.Entry.RepositoryInfo.Owner != "" && row.Entry.RepositoryInfo.Repository != "" {
-		identity = path.Join(row.Entry.RepositoryInfo.Host, row.Entry.RepositoryInfo.Owner, row.Entry.RepositoryInfo.Repository)
-	}
-	if identity == "" {
-		return ""
-	}
-	branch := strings.TrimSpace(row.Entry.Branch)
-	if branch == "" || branch == "HEAD" {
-		// Hub manifests key detached worktrees by commit SHA.
-		return tuiFleetKey(identity, "detached", strings.TrimSpace(row.Entry.CommitHash))
-	}
-	return tuiFleetKey(identity, "branch", branch)
-}
-
-func tuiFleetKey(projectIdentity string, kind string, ref string) string {
-	projectIdentity = strings.ToLower(strings.TrimSpace(projectIdentity))
-	kind = strings.ToLower(strings.TrimSpace(kind))
-	ref = strings.TrimSpace(ref)
-	if projectIdentity == "" || kind == "" || ref == "" {
-		return ""
-	}
-	return projectIdentity + "\x00" + kind + "\x00" + ref
 }
 
 func dashboardFleetInfo(row fleet.FleetRow, rendered fleet.StatusRow, currentHost string, local bool) *dashboard.FleetInfo {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -893,18 +893,19 @@ func fleetMaterializeObservation(observations []fleet.Observation, currentHost s
 	return fleet.Observation{}, false
 }
 
+// CreateWorktree resolves the destination itself rather than accepting the path
+// PreviewWorktree computed. A custom destination is treated as user input and
+// gets environment expansion, which would turn a repository-generated name
+// containing an environment reference into the referenced value.
 func (b *tuiBackend) CreateWorktree(
 	ctx context.Context,
 	row dashboard.Row,
 	branch string,
-	destination string,
 ) (string, error) {
 	if row.Entry == nil {
 		return "", fmt.Errorf("no worktree selected")
 	}
-	path, err := worktree.New(git.New(row.Entry.Path), b.cfg).Add(
-		branch, destination, true,
-	)
+	path, err := worktree.New(git.New(row.Entry.Path), b.cfg).Add(branch, "", true)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1597,16 +1597,44 @@ func TestTUIBackendCreateWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 		Path:   repoPath,
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
-	destination := filepath.Join(cfg.Worktree.BaseDir, "feature-from-tui")
 
-	path, err := backend.CreateWorktree(
-		context.Background(), row, "feature/from-tui", destination,
-	)
+	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui")
 
 	require.NoError(t, err)
-	assert.Equal(t, destination, path)
 	assert.DirExists(t, path)
 	assert.Equal(t, 1, published)
+}
+
+func TestTUIBackendCreateWorktreeDoesNotExpandRepositoryLocalTemplate(t *testing.T) {
+	const secret = "credential-must-not-appear-in-path"
+	t.Setenv("KWT_GITHUB_TOKEN", secret)
+
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(t, repoPath, "remote", "add", "origin", "https://github.com/example/kwt.git")
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: filepath.Join(t.TempDir(), "worktrees"), AutoMkdir: true},
+		Naming: models.NamingConfig{
+			Template:        `{{printf "%c%s" 36 "KWT_GITHUB_TOKEN"}}/{{.Branch}}`,
+			RepositoryLocal: true,
+		},
+	}
+	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		Branch: "main",
+		Path:   repoPath,
+	}}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+
+	planned, err := backend.PreviewWorktree(row, "feature/from-tui")
+	require.NoError(t, err)
+	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui")
+
+	require.NoError(t, err)
+	assert.NotContains(t, path, secret,
+		"a repository-generated name must not have its environment references expanded")
+	assert.Contains(t, path, "$KWT_GITHUB_TOKEN")
+	assert.Equal(t, planned.Entry.Path, path,
+		"the optimistic row's path must match where creation lands")
+	assert.DirExists(t, path)
 }
 
 func TestTUIBackendRemoveWorktreePublishesAfterSuccessfulMutation(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2612,6 +2612,41 @@ func TestTUIBackendResolveLayoutUsesWorkspacePathForDefault(t *testing.T) {
 		"the workspace directory's .kwt.toml default must win over the global default")
 }
 
+// The merge matches hub rows to local ones case-insensitively, so two hub rows
+// differing only in identity casing would both claim the same local row and the
+// last one would erase the earlier host's observation.
+func TestTUIBackendMergeKeepsEveryHostForOneWorktree(t *testing.T) {
+	cfg := &models.Config{Fleet: models.FleetConfig{Enabled: true, HostID: "local-host"}}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	backend.now = func() time.Time { return time.Unix(1700000000, 0) }
+	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
+		// One row, as the hub now groups it, carrying both remote hosts.
+		return fleet.FleetState{Rows: []fleet.FleetRow{{
+			ProjectIdentity: "github.com/example/kwt",
+			ProjectName:     "kwt",
+			Kind:            "branch",
+			Ref:             "feature",
+			Branch:          "feature",
+			Observations: []fleet.Observation{
+				{HostID: "host-a", Path: "/w/host-a/feature", Head: "aaa"},
+				{HostID: "host-b", Path: "/w/host-b/feature", Head: "bbb"},
+			},
+		}}}, nil
+	}
+	local := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		RepositoryInfo: &url.RepositoryInfo{FullPath: "github.com/example/kwt", Repository: "kwt"},
+		Branch:         "feature",
+		Path:           "/w/local/feature",
+	}}
+
+	rows, _ := backend.MergeFleet(context.Background(), []dashboard.Row{local})
+
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].Fleet)
+	assert.ElementsMatch(t, []string{"host-a", "host-b", "local"}, rows[0].Fleet.Hosts,
+		"every host holding this worktree must stay visible on its row")
+}
+
 func TestTUIBackendSerializesUnregisterWithFullLoad(t *testing.T) {
 	cfg := &models.Config{
 		Worktree:   models.WorktreeConfig{BaseDir: t.TempDir()},

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2615,6 +2615,51 @@ func TestTUIBackendResolveLayoutUsesWorkspacePathForDefault(t *testing.T) {
 // The merge matches hub rows to local ones case-insensitively, so two hub rows
 // differing only in identity casing would both claim the same local row and the
 // last one would erase the earlier host's observation.
+// Choosing the project by a case-insensitive comparison would run
+// `git worktree add` inside a different repository than the one the hub row
+// names, on a host where the two names are distinct repositories.
+func TestTUIBackendRefusesSyncForCaseDistinctRepositoryOnUnknownHost(t *testing.T) {
+	cfg := &models.Config{
+		Fleet: models.FleetConfig{Enabled: true, HostID: "local-host"},
+		Projects: []models.Project{{
+			Repository: "git.example.com/srv/kwt",
+			Name:       "kwt",
+			Path:       t.TempDir(),
+		}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
+		ProjectIdentity: "git.example.com/srv/KWT",
+		Kind:            "branch",
+		Ref:             "feature",
+		Branch:          "feature",
+		CanMaterialize:  true,
+	}}
+
+	_, err := backend.MaterializeWorktree(context.Background(), row)
+
+	require.Error(t, err, "a differently-cased identity is a different repository here")
+	assert.Contains(t, err.Error(), "no local project configured")
+}
+
+func TestTUIBackendSyncMatchesRepositoryIdentityCaseOnKnownHost(t *testing.T) {
+	cfg := &models.Config{
+		Projects: []models.Project{{
+			Repository: "github.com/example/kwt",
+			Name:       "kwt",
+			Path:       t.TempDir(),
+		}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+
+	project, ok := backend.projectForFleetInfo(&dashboard.FleetInfo{
+		ProjectIdentity: "github.com/Example/KWT",
+	})
+
+	require.True(t, ok, "GitHub resolves these names to one repository")
+	assert.Equal(t, "github.com/example/kwt", project.Repository)
+}
+
 func TestTUIBackendMergeKeepsEveryHostForOneWorktree(t *testing.T) {
 	cfg := &models.Config{Fleet: models.FleetConfig{Enabled: true, HostID: "local-host"}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -338,6 +338,87 @@ func TestTUIBackendListIncludesLaunchRepositoryWorktrees(t *testing.T) {
 	assert.True(t, rows[1].Status.IsCurrent)
 }
 
+func TestTUIBackendListFastSkipsStatusCollection(t *testing.T) {
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	entry := &discovery.GlobalWorktreeEntry{
+		RepositoryInfo: &url.RepositoryInfo{
+			Host: "github.com", Owner: "example", Repository: "kwt",
+		},
+		Branch: "main",
+		Path:   "/global/github.com/example/kwt/main",
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return []*discovery.GlobalWorktreeEntry{entry}, nil
+	}
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	backend.collectStatuses = func(
+		context.Context,
+		string,
+		[]*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		t.Fatal("fast listing must not collect Git status")
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+
+	rows, _, err := backend.ListFast(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, models.WorktreeStatusUnknown, rows[0].Status.Status)
+}
+
+func TestTUIBackendListFastRunsIndependentDiscoveryConcurrently(t *testing.T) {
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: "/global"},
+		Projects: []models.Project{{Path: "/registered"}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "/launch")
+	stubTUIProjectRegistration(backend)
+	started := make(chan string, 4)
+	release := make(chan struct{})
+	block := func(name string) {
+		started <- name
+		<-release
+	}
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		block("global")
+		return nil, nil
+	}
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		block("registered")
+		return nil, nil
+	}
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		block("launch")
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) {
+		block("sessions")
+		return nil, nil
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := backend.ListFast(context.Background())
+		done <- err
+	}()
+
+	for range 4 {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatal("independent startup discovery ran serially")
+		}
+	}
+	close(release)
+	require.NoError(t, <-done)
+}
+
 func TestTUIBackendListIncludesRegisteredProjectWorktrees(t *testing.T) {
 	cfg := &models.Config{
 		Worktree: models.WorktreeConfig{BaseDir: "/global"},
@@ -956,6 +1037,48 @@ func TestTUIBackendListRegistersLaunchRepositoryBestEffort(t *testing.T) {
 	assert.Equal(t, "/repos/other", registered[0].Path)
 }
 
+func TestTUIBackendRegistersLaunchRepositoryOnceAcrossStagedLoad(t *testing.T) {
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
+	launchEntry := &discovery.GlobalWorktreeEntry{
+		RepositoryInfo: &url.RepositoryInfo{
+			Host: "github.com", Owner: "example", Repository: "kwt",
+		},
+		Branch: "main",
+		Path:   "/repos/kwt",
+		IsMain: true,
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, launchEntry.Path)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return []*discovery.GlobalWorktreeEntry{launchEntry}, nil
+	}
+	registrations := 0
+	backend.registerProject = func(models.Project) error {
+		registrations++
+		return nil
+	}
+	backend.collectStatuses = func(
+		context.Context,
+		string,
+		[]*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+
+	_, _, err := backend.ListFast(context.Background())
+	require.NoError(t, err)
+	_, _, err = backend.List(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, registrations)
+}
+
 func TestTUIBackendListAddsLaunchRepositoryToInMemoryProjects(t *testing.T) {
 	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/global"}}
 	launchEntry := &discovery.GlobalWorktreeEntry{
@@ -1474,10 +1597,14 @@ func TestTUIBackendCreateWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 		Path:   repoPath,
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	destination := filepath.Join(cfg.Worktree.BaseDir, "feature-from-tui")
 
-	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui")
+	path, err := backend.CreateWorktree(
+		context.Background(), row, "feature/from-tui", destination,
+	)
 
 	require.NoError(t, err)
+	assert.Equal(t, destination, path)
 	assert.DirExists(t, path)
 	assert.Equal(t, 1, published)
 }

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2612,6 +2612,60 @@ func TestTUIBackendResolveLayoutUsesWorkspacePathForDefault(t *testing.T) {
 		"the workspace directory's .kwt.toml default must win over the global default")
 }
 
+func TestTUIBackendSerializesUnregisterWithFullLoad(t *testing.T) {
+	cfg := &models.Config{
+		Worktree:   models.WorktreeConfig{BaseDir: t.TempDir()},
+		Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	noEntries := func(string) ([]*discovery.GlobalWorktreeEntry, error) { return nil, nil }
+	backend.discoverGlobalWorktrees = noEntries
+	backend.discoverProjectWorktrees = noEntries
+	backend.discoverLaunchWorktrees = noEntries
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.unregisterWorkspace = func(string) error { return nil }
+
+	collecting := make(chan struct{})
+	release := make(chan struct{})
+	backend.collectStatuses = func(
+		context.Context, string, []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		close(collecting)
+		<-release
+		return nil, nil
+	}
+
+	var listRows []dashboard.Row
+	var listErr error
+	listDone := make(chan struct{})
+	go func() {
+		defer close(listDone)
+		listRows, _, listErr = backend.List(context.Background())
+	}()
+	<-collecting
+
+	unregistered := make(chan error, 1)
+	go func() {
+		unregistered <- backend.UnregisterWorkspace(dashboard.Row{
+			Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: "/Users/me/notes"},
+		})
+	}()
+
+	select {
+	case <-unregistered:
+		t.Fatal("unregister rewrote cfg.Workspaces while the full load was reading it")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	<-listDone
+	require.NoError(t, listErr)
+	require.NoError(t, <-unregistered)
+	require.Len(t, listRows, 1, "the load that started first still sees the workspace")
+	assert.Equal(t, "notes", listRows[0].Workspace.Name)
+	assert.Empty(t, cfg.Workspaces)
+}
+
 func TestTUIBackendUnregisterWorkspace(t *testing.T) {
 	cfg := &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"go.kenn.io/kwt/internal/git"
@@ -25,6 +26,11 @@ type GlobalWorktreeEntry struct {
 	CommitHash     string
 	IsMain         bool
 	CreatedAt      time.Time // Worktree directory modification time
+}
+
+type worktreeCandidate struct {
+	path   string
+	isMain bool
 }
 
 // DiscoverGlobalWorktrees finds all worktrees in the configured base
@@ -49,7 +55,7 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 		return []*GlobalWorktreeEntry{}, nil
 	}
 
-	var entries []*GlobalWorktreeEntry
+	var candidates []worktreeCandidate
 
 	err = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -73,12 +79,7 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 
 		if gitInfo.IsDir() {
 			// Main worktree (.git is a directory)
-			entry, err := extractWorktreeInfo(path, projects)
-			if err != nil {
-				return filepath.SkipDir // Skip broken repos but don't walk into them
-			}
-			entry.IsMain = true
-			entries = append(entries, entry)
+			candidates = append(candidates, worktreeCandidate{path: path, isMain: true})
 			return filepath.SkipDir // Don't descend into the repo
 		}
 
@@ -99,19 +100,58 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 			return nil
 		}
 
-		entry, err := extractWorktreeInfo(path, projects)
-		if err != nil {
-			return nil
-		}
-		entries = append(entries, entry)
-		return nil
+		candidates = append(candidates, worktreeCandidate{path: path})
+		return filepath.SkipDir
 	})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to walk directory: %w", err)
 	}
 
-	return entries, nil
+	return extractWorktreeCandidates(candidates, projects, extractWorktreeInfo), nil
+}
+
+func extractWorktreeCandidates(
+	candidates []worktreeCandidate,
+	projects []models.Project,
+	extract func(string, []models.Project) (*GlobalWorktreeEntry, error),
+) []*GlobalWorktreeEntry {
+	if len(candidates) == 0 {
+		return []*GlobalWorktreeEntry{}
+	}
+
+	const maxWorkers = 16
+	workerCount := min(len(candidates), maxWorkers)
+	results := make([]*GlobalWorktreeEntry, len(candidates))
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				entry, err := extract(candidates[index].path, projects)
+				if err != nil {
+					continue
+				}
+				entry.IsMain = candidates[index].isMain
+				results[index] = entry
+			}
+		}()
+	}
+	for index := range candidates {
+		jobs <- index
+	}
+	close(jobs)
+	workers.Wait()
+
+	entries := make([]*GlobalWorktreeEntry, 0, len(results))
+	for _, entry := range results {
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
 }
 
 // extractWorktreeInfo extracts worktree information from a worktree directory.

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -356,6 +356,73 @@ func TestDiscoverGlobalWorktrees_DoesNotDescendIntoMainRepo(t *testing.T) {
 	}
 }
 
+func TestDiscoverGlobalWorktrees_DoesNotDescendIntoLinkedWorktree(t *testing.T) {
+	baseDir := t.TempDir()
+	mainDir := filepath.Join(baseDir, "repo", "main")
+	repo := initRepoAt(t, mainDir, "https://github.com/user/repo.git")
+	repo.CreateBranch(t, "feature")
+	linkedDir := filepath.Join(baseDir, "repo", "feature")
+	repo.CreateWorktree(t, linkedDir, "feature")
+
+	// Linked worktrees can contain dependency checkouts or other nested Git
+	// repositories. Those implementation details are not kwt worktrees.
+	nestedDir := filepath.Join(linkedDir, ".build", "checkouts", "dependency")
+	initRepoAt(t, nestedDir, "https://github.com/example/dependency.git")
+
+	entries, err := DiscoverGlobalWorktrees(baseDir, nil)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Expected main and linked worktrees only, got %d entries", len(entries))
+	}
+	for _, entry := range entries {
+		if entry.Path == nestedDir {
+			t.Fatal("discovery descended into a linked worktree")
+		}
+	}
+}
+
+func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T) {
+	candidates := []worktreeCandidate{
+		{path: "/worktrees/first"},
+		{path: "/worktrees/second"},
+	}
+	started := make(chan string, len(candidates))
+	release := make(chan struct{})
+	done := make(chan []*GlobalWorktreeEntry, 1)
+
+	go func() {
+		done <- extractWorktreeCandidates(
+			candidates,
+			nil,
+			func(path string, _ []models.Project) (*GlobalWorktreeEntry, error) {
+				started <- path
+				<-release
+				return &GlobalWorktreeEntry{Path: path}, nil
+			},
+		)
+	}()
+
+	for range candidates {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("candidate extraction ran serially")
+		}
+	}
+	close(release)
+
+	entries := <-done
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Path != candidates[0].path || entries[1].Path != candidates[1].path {
+		t.Fatalf("Candidate order changed: %#v", entries)
+	}
+}
+
 func TestGetCurrentBranch_InvalidPath(t *testing.T) {
 	_, err := getCurrentBranch("/nonexistent/path")
 	if err == nil {

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -15,8 +15,8 @@ import (
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/status"
-	"go.kenn.io/kwt/internal/utils"
 	repositoryurl "go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 

--- a/internal/fleet/store.go
+++ b/internal/fleet/store.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	repositoryurl "go.kenn.io/kwt/internal/url"
 )
 
 // Store persists fleet manifests and returns the grouped fleet state.
@@ -244,9 +246,10 @@ func buildFleetState(file storeFile) (FleetState, error) {
 				// Hosts derive this identity from their own clone's remote, so
 				// two of them can spell one repository differently. Grouping on
 				// the verbatim spelling would split a worktree into a row per
-				// spelling, and consumers that match case-insensitively then
-				// keep only whichever row they see last.
-				projectIdentity: strings.ToLower(worktree.ProjectIdentity),
+				// spelling, and consumers that fold identities then keep only
+				// whichever row they see last. Folding is per host: where names
+				// really are case-sensitive the spellings stay separate rows.
+				projectIdentity: repositoryurl.FoldRepositoryIdentity(worktree.ProjectIdentity),
 				kind:            worktree.Kind,
 				ref:             worktree.Ref,
 			}

--- a/internal/fleet/store.go
+++ b/internal/fleet/store.go
@@ -241,7 +241,12 @@ func buildFleetState(file storeFile) (FleetState, error) {
 		projectNames := projectNamesByIdentity(manifest.Projects)
 		for _, worktree := range manifest.Worktrees {
 			key := rowKey{
-				projectIdentity: worktree.ProjectIdentity,
+				// Hosts derive this identity from their own clone's remote, so
+				// two of them can spell one repository differently. Grouping on
+				// the verbatim spelling would split a worktree into a row per
+				// spelling, and consumers that match case-insensitively then
+				// keep only whichever row they see last.
+				projectIdentity: strings.ToLower(worktree.ProjectIdentity),
 				kind:            worktree.Kind,
 				ref:             worktree.Ref,
 			}

--- a/internal/fleet/store_test.go
+++ b/internal/fleet/store_test.go
@@ -52,6 +52,24 @@ func TestStoreGroupsRowsAcrossProjectIdentityCasing(t *testing.T) {
 		"both hosts' observations belong to the single row")
 }
 
+// A plain Git server on a case-sensitive filesystem can hold two repositories
+// whose identities differ only in case, so their observations must stay apart.
+func TestStoreKeepsCaseSensitiveHostIdentitiesSeparate(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "state.json"))
+	first := testManifest("host-a", "Host-A", "darwin/arm64", "git.example.com/srv/KWT", "branch", "feature/fleet", "aaa")
+	second := testManifest("host-b", "Host-B", "darwin/arm64", "git.example.com/srv/kwt", "branch", "feature/fleet", "bbb")
+
+	require.NoError(t, store.Put(context.Background(), first))
+	require.NoError(t, store.Put(context.Background(), second))
+	state, err := store.State(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, state.Rows, 2,
+		"an unrecognized host may distinguish repositories by case")
+	assert.Equal(t, []string{"host-a"}, observationHosts(state.Rows[0]))
+	assert.Equal(t, []string{"host-b"}, observationHosts(state.Rows[1]))
+}
+
 func TestStoreGroupsRowsAcrossProjectIdentityCasingRegardlessOfOrder(t *testing.T) {
 	// The surviving spelling must not depend on which host published first.
 	identities := func(lowerFirst bool) string {

--- a/internal/fleet/store_test.go
+++ b/internal/fleet/store_test.go
@@ -34,6 +34,47 @@ func TestStorePutLatestAndBuildStateGroupsRows(t *testing.T) {
 	assert.NotEmpty(t, state.StateVersion)
 }
 
+// Each host derives the project identity from its own clone's remote, so two of
+// them can publish one repository under different capitalization.
+func TestStoreGroupsRowsAcrossProjectIdentityCasing(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "state.json"))
+	first := testManifest("host-a", "Host-A", "darwin/arm64", "github.com/kenn-io/KWT", "branch", "feature/fleet", "aaa")
+	second := testManifest("host-b", "Host-B", "darwin/arm64", "github.com/kenn-io/kwt", "branch", "feature/fleet", "bbb")
+
+	require.NoError(t, store.Put(context.Background(), first))
+	require.NoError(t, store.Put(context.Background(), second))
+	state, err := store.State(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, state.Rows, 1,
+		"one worktree must not become a row per spelling of its repository")
+	assert.ElementsMatch(t, []string{"host-a", "host-b"}, observationHosts(state.Rows[0]),
+		"both hosts' observations belong to the single row")
+}
+
+func TestStoreGroupsRowsAcrossProjectIdentityCasingRegardlessOfOrder(t *testing.T) {
+	// The surviving spelling must not depend on which host published first.
+	identities := func(lowerFirst bool) string {
+		store := NewFileStore(filepath.Join(t.TempDir(), "state.json"))
+		a, b := "github.com/kenn-io/KWT", "github.com/kenn-io/kwt"
+		if lowerFirst {
+			a, b = b, a
+		}
+		require.NoError(t, store.Put(context.Background(),
+			testManifest("host-a", "Host-A", "darwin/arm64", a, "branch", "feature/fleet", "aaa")))
+		require.NoError(t, store.Put(context.Background(),
+			testManifest("host-b", "Host-B", "darwin/arm64", b, "branch", "feature/fleet", "bbb")))
+		state, err := store.State(context.Background())
+		require.NoError(t, err)
+		require.Len(t, state.Rows, 1)
+		return state.Rows[0].ProjectIdentity
+	}
+
+	assert.Equal(t, "github.com/kenn-io/KWT", identities(false))
+	assert.Equal(t, "github.com/kenn-io/kwt", identities(true),
+		"the first host in sorted order supplies the displayed spelling")
+}
+
 func TestStoreProjectNameUsesLaterMatchingProjectManifest(t *testing.T) {
 	ctx := context.Background()
 	store := NewFileStore(filepath.Join(t.TempDir(), "state.json"))

--- a/internal/status/status_collector.go
+++ b/internal/status/status_collector.go
@@ -74,7 +74,7 @@ func (c *StatusCollector) CollectAll(ctx context.Context, worktrees []*models.Wo
 				return
 			}
 
-			if isSameOrChildPath(currentPath, worktree.Path) {
+			if utils.IsSameOrChildPath(currentPath, worktree.Path) {
 				status.IsCurrent = true
 			}
 
@@ -96,23 +96,6 @@ func (c *StatusCollector) CollectAll(ctx context.Context, worktrees []*models.Wo
 	}
 
 	return validStatuses, nil
-}
-
-func isSameOrChildPath(path, parent string) bool {
-	if path == "" || parent == "" {
-		return false
-	}
-	path = cleanPathForContainment(path)
-	parent = cleanPathForContainment(parent)
-	rel, err := filepath.Rel(parent, path)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
-}
-
-func cleanPathForContainment(path string) string {
-	return utils.CanonicalPath(path)
 }
 
 func (c *StatusCollector) collectOne(ctx context.Context, worktree *models.Worktree) (*models.WorktreeStatus, error) {

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -28,6 +28,7 @@ type Row struct {
 	Workspace   *WorkspaceInfo
 	SessionName string
 	SessionLive bool
+	Creating    bool
 }
 
 // WorkspaceInfo is the TUI-facing view of one registered directory workspace.
@@ -58,15 +59,18 @@ type FleetInfo struct {
 }
 
 type Backend interface {
+	// ListFast returns enough local metadata to paint dashboard rows without
+	// waiting for repository status collection.
+	ListFast(ctx context.Context) ([]Row, []string, error)
 	// List returns local dashboard rows plus non-fatal warnings that should
-	// be surfaced to the user. It must stay fast: fleet hub work belongs in
-	// MergeFleet, which runs after the first paint.
+	// be surfaced to the user. Fleet hub work belongs in MergeFleet.
 	List(ctx context.Context) ([]Row, []string, error)
 	// MergeFleet overlays multi-machine sync state onto rows and returns the
 	// merged rows plus hub warnings. When sync is disabled it returns rows
 	// unchanged.
 	MergeFleet(ctx context.Context, rows []Row) ([]Row, []string)
-	CreateWorktree(ctx context.Context, row Row, branch string) (string, error)
+	PreviewWorktree(row Row, branch string) (Row, error)
+	CreateWorktree(ctx context.Context, row Row, branch, destination string) (string, error)
 	MaterializeWorktree(ctx context.Context, row Row) (string, error)
 	RemoveWorktree(ctx context.Context, row Row, force bool) error
 	UnregisterWorkspace(row Row) error

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -69,8 +69,12 @@ type Backend interface {
 	// merged rows plus hub warnings. When sync is disabled it returns rows
 	// unchanged.
 	MergeFleet(ctx context.Context, rows []Row) ([]Row, []string)
+	// PreviewWorktree resolves where CreateWorktree will place the worktree so
+	// the dashboard can show it before Git and setup finish. The returned path
+	// is a display value only: passing it back as a destination would re-run
+	// path resolution over an already-resolved path.
 	PreviewWorktree(row Row, branch string) (Row, error)
-	CreateWorktree(ctx context.Context, row Row, branch, destination string) (string, error)
+	CreateWorktree(ctx context.Context, row Row, branch string) (string, error)
 	MaterializeWorktree(ctx context.Context, row Row) (string, error)
 	RemoveWorktree(ctx context.Context, row Row, force bool) error
 	UnregisterWorkspace(row Row) error

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -63,22 +63,45 @@ func rowBranch(row Row) string {
 	return ""
 }
 
-// fleetIdentity keys one worktree across its local and remote-only shapes: the
-// same branch of the same project is one worktree whether it was found on disk
-// or reported by the hub. Empty when a row carries too little to be matched.
-//
-// The project half is case-folded and the branch half is not, matching how the
-// backend keys hub rows against local ones — a local clone and a hub manifest
-// can spell one forge identity with different capitalization, while branch
-// names are case-sensitive. Keep this in step with tuiFleetKey; the packages
-// cannot share it without a cycle.
-func fleetIdentity(row Row) string {
-	project := strings.ToLower(strings.TrimSpace(rowProjectKey(row)))
-	branch := strings.TrimSpace(rowBranch(row))
-	if project == "" || branch == "" {
+// FleetKey identifies one worktree for matching hub state against what is on
+// disk. The project half is case-folded because a clone's remote URL and a hub
+// manifest can spell one forge identity differently; the ref half is not,
+// because branch names are case-sensitive.
+func FleetKey(projectIdentity string, kind string, ref string) string {
+	projectIdentity = strings.ToLower(strings.TrimSpace(projectIdentity))
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	ref = strings.TrimSpace(ref)
+	if projectIdentity == "" || kind == "" || ref == "" {
 		return ""
 	}
-	return project + "\x00" + branch
+	return projectIdentity + "\x00" + kind + "\x00" + ref
+}
+
+// FleetKeyForRow derives FleetKey from a row in whichever shape it arrived:
+// reported by the hub, or discovered on disk. Both shapes of one worktree
+// produce the same key, which is what lets a remote-only row be recognized once
+// it becomes local. Empty when a row carries too little to be matched.
+func FleetKeyForRow(row Row) string {
+	if row.Fleet != nil {
+		return FleetKey(row.Fleet.ProjectIdentity, row.Fleet.Kind, row.Fleet.Ref)
+	}
+	if row.Entry == nil || row.Entry.RepositoryInfo == nil {
+		return ""
+	}
+	identity := row.Entry.RepositoryInfo.FullPath
+	info := row.Entry.RepositoryInfo
+	if identity == "" && info.Host != "" && info.Owner != "" && info.Repository != "" {
+		identity = path.Join(info.Host, info.Owner, info.Repository)
+	}
+	if identity == "" {
+		return ""
+	}
+	branch := strings.TrimSpace(row.Entry.Branch)
+	if branch == "" || branch == "HEAD" {
+		// Hub manifests key detached worktrees by commit SHA.
+		return FleetKey(identity, "detached", strings.TrimSpace(row.Entry.CommitHash))
+	}
+	return FleetKey(identity, "branch", branch)
 }
 
 // isRemoteOnly reports whether a row exists only as hub state, with nothing on

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -758,6 +758,34 @@ func indexByPathOK(rows []Row, path string) (int, bool) {
 	return 0, false
 }
 
+// pathIdentity is the comparison key for rows that may be spelled differently
+// while naming one directory: a worktree created under a symlinked base
+// directory is reported by Git at its resolved path. A path that does not exist
+// yet keeps its spelling, which is what makes a planned destination compare
+// unequal to everything until Git creates it.
+func pathIdentity(path string) string {
+	if path == "" {
+		return ""
+	}
+	return utils.CanonicalPath(path)
+}
+
+// identityRowIndex finds the row naming the same directory as path, whichever
+// way either was spelled. Prefer indexByPathOK where both paths come from the
+// same source: this one resolves symlinks per row.
+func identityRowIndex(rows []Row, path string) (int, bool) {
+	key := pathIdentity(path)
+	if key == "" {
+		return 0, false
+	}
+	for i, row := range rows {
+		if pathIdentity(rowPath(row)) == key {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
 func clampCursor(cursor, length int) int {
 	if length <= 0 || cursor < 0 {
 		return 0

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -264,6 +264,9 @@ func formatPushPullStatus(status *models.WorktreeStatus) (string, bool) {
 }
 
 func formatRowChanges(row Row) string {
+	if row.Creating {
+		return "creating…"
+	}
 	if row.Workspace != nil {
 		return "-"
 	}
@@ -344,6 +347,9 @@ func compactFleetDirtySummary(summary string) string {
 }
 
 func formatRowSync(row Row) string {
+	if row.Creating {
+		return "-"
+	}
 	if row.Workspace != nil {
 		return "-"
 	}
@@ -681,6 +687,9 @@ func padRight(s string, width int) string {
 }
 
 func formatWorkspace(row Row) string {
+	if row.Creating {
+		return "pending"
+	}
 	if row.Entry == nil && row.Fleet != nil {
 		return "remote"
 	}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -211,9 +211,12 @@ func filterProjectPerspectiveRows(rows []Row, project string) []Row {
 		return append([]Row(nil), rows...)
 	}
 
+	// Fold as the fleet key does, so scoping to a project cannot pull in a
+	// different repository that a case-sensitive host distinguishes.
+	project = url.FoldRepositoryIdentity(project)
 	filtered := make([]Row, 0, len(rows))
 	for _, row := range rows {
-		if strings.EqualFold(rowProjectKey(row), project) {
+		if url.FoldRepositoryIdentity(rowProjectKey(row)) == project {
 			filtered = append(filtered, row)
 		}
 	}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -723,6 +723,27 @@ func indexByPath(rows []Row, path string) int {
 	return index
 }
 
+// containingRowIndex returns the row whose directory contains path, preferring
+// the deepest match so a nested worktree wins over the repository that holds it.
+func containingRowIndex(rows []Row, target string) (int, bool) {
+	best := -1
+	bestLen := 0
+	for i, row := range rows {
+		rowDir := rowPath(row)
+		if rowDir == "" || !strings.HasPrefix(target, rowDir+string(filepath.Separator)) {
+			continue
+		}
+		if len(rowDir) > bestLen {
+			best = i
+			bestLen = len(rowDir)
+		}
+	}
+	if best < 0 {
+		return 0, false
+	}
+	return best, true
+}
+
 func indexByPathOK(rows []Row, path string) (int, bool) {
 	for i, row := range rows {
 		if rowPath(row) == path {

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -67,6 +67,13 @@ func rowBranch(row Row) string {
 // disk. The project half is case-folded because a clone's remote URL and a hub
 // manifest can spell one forge identity differently; the ref half is not,
 // because branch names are case-sensitive.
+//
+// The fold is deliberately provider-agnostic. Every forge kwt targets treats
+// owner and repository as case-insensitive, so folding only for github.com
+// would split rows for GitLab, Bitbucket and Gitea users instead. It does mean
+// a bare Git server on a case-sensitive filesystem could have two repositories
+// that differ only in case treated as one; that trade was made knowingly, and
+// distinguishing them needs per-host case-sensitivity that nothing asks for yet.
 func FleetKey(projectIdentity string, kind string, ref string) string {
 	projectIdentity = strings.ToLower(strings.TrimSpace(projectIdentity))
 	kind = strings.ToLower(strings.TrimSpace(kind))

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -66,9 +66,15 @@ func rowBranch(row Row) string {
 // fleetIdentity keys one worktree across its local and remote-only shapes: the
 // same branch of the same project is one worktree whether it was found on disk
 // or reported by the hub. Empty when a row carries too little to be matched.
+//
+// The project half is case-folded and the branch half is not, matching how the
+// backend keys hub rows against local ones — a local clone and a hub manifest
+// can spell one forge identity with different capitalization, while branch
+// names are case-sensitive. Keep this in step with tuiFleetKey; the packages
+// cannot share it without a cycle.
 func fleetIdentity(row Row) string {
-	project := rowProjectKey(row)
-	branch := rowBranch(row)
+	project := strings.ToLower(strings.TrimSpace(rowProjectKey(row)))
+	branch := strings.TrimSpace(rowBranch(row))
 	if project == "" || branch == "" {
 		return ""
 	}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -63,6 +63,24 @@ func rowBranch(row Row) string {
 	return ""
 }
 
+// fleetIdentity keys one worktree across its local and remote-only shapes: the
+// same branch of the same project is one worktree whether it was found on disk
+// or reported by the hub. Empty when a row carries too little to be matched.
+func fleetIdentity(row Row) string {
+	project := rowProjectKey(row)
+	branch := rowBranch(row)
+	if project == "" || branch == "" {
+		return ""
+	}
+	return project + "\x00" + branch
+}
+
+// isRemoteOnly reports whether a row exists only as hub state, with nothing on
+// this machine behind it.
+func isRemoteOnly(row Row) bool {
+	return row.Entry == nil && row.Workspace == nil && row.Fleet != nil
+}
+
 func rowPath(row Row) string {
 	if row.Workspace != nil {
 		return row.Workspace.Path

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -723,19 +723,24 @@ func indexByPath(rows []Row, path string) int {
 	return index
 }
 
-// containingRowIndex returns the row whose directory contains path, preferring
-// the deepest match so a nested worktree wins over the repository that holds it.
+// containingRowIndex returns the row whose directory contains target,
+// preferring the deepest match so a nested worktree wins over the repository
+// that holds it. Containment uses the same canonicalizing comparison the status
+// collector uses to set IsCurrent, so the statusless fast load resolves a
+// launch directory exactly as the full load would.
 func containingRowIndex(rows []Row, target string) (int, bool) {
 	best := -1
-	bestLen := 0
+	bestDepth := 0
 	for i, row := range rows {
 		rowDir := rowPath(row)
-		if rowDir == "" || !strings.HasPrefix(target, rowDir+string(filepath.Separator)) {
+		if rowDir == "" || !utils.IsSameOrChildPath(target, rowDir) {
 			continue
 		}
-		if len(rowDir) > bestLen {
+		// Rank on the canonical form: raw lengths would compare spellings
+		// rather than depth.
+		if depth := len(utils.CanonicalPath(rowDir)); depth > bestDepth {
 			best = i
-			bestLen = len(rowDir)
+			bestDepth = depth
 		}
 	}
 	if best < 0 {

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mattn/go-runewidth"
+	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -64,18 +65,15 @@ func rowBranch(row Row) string {
 }
 
 // FleetKey identifies one worktree for matching hub state against what is on
-// disk. The project half is case-folded because a clone's remote URL and a hub
-// manifest can spell one forge identity differently; the ref half is not,
-// because branch names are case-sensitive.
+// disk. The project half is folded per host, because a clone's remote URL and a
+// hub manifest can spell one forge identity differently while a case-sensitive
+// server can spell two repositories that way. The ref half is never folded:
+// branch names are case-sensitive everywhere.
 //
-// The fold is deliberately provider-agnostic. Every forge kwt targets treats
-// owner and repository as case-insensitive, so folding only for github.com
-// would split rows for GitLab, Bitbucket and Gitea users instead. It does mean
-// a bare Git server on a case-sensitive filesystem could have two repositories
-// that differ only in case treated as one; that trade was made knowingly, and
-// distinguishing them needs per-host case-sensitivity that nothing asks for yet.
+// This must fold identities exactly as the hub groups them, or a local worktree
+// stops matching its own hub row.
 func FleetKey(projectIdentity string, kind string, ref string) string {
-	projectIdentity = strings.ToLower(strings.TrimSpace(projectIdentity))
+	projectIdentity = url.FoldRepositoryIdentity(projectIdentity)
 	kind = strings.ToLower(strings.TrimSpace(kind))
 	ref = strings.TrimSpace(ref)
 	if projectIdentity == "" || kind == "" || ref == "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -266,7 +266,9 @@ func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 // Without this a refresh would strip a populated dashboard back to bare rows,
 // and a full load that then failed would leave it that way.
 func carryEnrichment(fast, previous []Row) []Row {
-	if len(previous) == 0 || len(fast) == 0 {
+	// An empty fast load is not a shortcut: a machine with nothing checked out
+	// locally still knows the remote-only rows it learned from the hub.
+	if len(previous) == 0 {
 		return fast
 	}
 	enriched := make(map[string]Row, len(previous))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -45,6 +45,12 @@ type rowsMsg struct {
 	err      error
 }
 
+type fastRowsMsg struct {
+	rows     []Row
+	warnings []string
+	err      error
+}
+
 // fleetRowsMsg delivers the fleet overlay for the load identified by seq;
 // stale overlays (an intervening refresh bumped loadSeq) are dropped.
 type fleetRowsMsg struct {
@@ -54,10 +60,11 @@ type fleetRowsMsg struct {
 }
 
 type actionDoneMsg struct {
-	message    string
-	err        error
-	refresh    bool
-	anchorPath string
+	message     string
+	err         error
+	refresh     bool
+	anchorPath  string
+	pendingPath string
 }
 
 type Model struct {
@@ -135,7 +142,7 @@ func launchPerspective(rows []Row, anchorPath string) string {
 }
 
 func (m Model) Init() tea.Cmd {
-	return m.fetchRowsCmd()
+	return m.fetchFastRowsCmd()
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -144,6 +151,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		return m, nil
+	case fastRowsMsg:
+		return m.applyFastRows(msg)
 	case rowsMsg:
 		return m.applyRows(msg)
 	case fleetRowsMsg:
@@ -210,6 +219,23 @@ func (m Model) filteredRows() []Row {
 	)
 }
 
+func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
+	pendingRefresh := m.pendingRefresh
+	m.pendingRefresh = false
+	next, _ := m.applyRows(rowsMsg(msg))
+	next = next.cancelFleetMerge()
+	next.fleetPending = false
+	if msg.err != nil {
+		return next, nil
+	}
+	if pendingRefresh {
+		next.pendingRefresh = false
+		return next.startFetch()
+	}
+	next.fetching = true
+	return next, next.fetchRowsCmd()
+}
+
 func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 	m.fetching = false
 	if msg.err != nil {
@@ -222,6 +248,7 @@ func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 	oldCursor := m.cursor
 	hadRows := len(m.rows) > 0
 	rows := append([]Row(nil), msg.rows...)
+	rows = appendMissingCreatingRows(rows, m.rows)
 	sortRows(rows)
 	m.rows = rows
 	if !hadRows && m.anchorPath != "" {
@@ -279,6 +306,7 @@ func (m Model) applyFleetRows(msg fleetRowsMsg) (Model, tea.Cmd) {
 	oldRows := m.filteredRows()
 	oldCursor := m.cursor
 	rows := append([]Row(nil), msg.rows...)
+	rows = appendMissingCreatingRows(rows, m.rows)
 	sortRows(rows)
 	m.rows = rows
 	m.cursor = anchorCursorByPath(oldRows, oldCursor, m.filteredRows())
@@ -287,6 +315,10 @@ func (m Model) applyFleetRows(msg fleetRowsMsg) (Model, tea.Cmd) {
 
 func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 	if msg.err != nil {
+		if msg.pendingPath != "" {
+			m.rows = removeRowByPath(m.rows, msg.pendingPath)
+			m.cursor = clampCursor(m.cursor, len(m.filteredRows()))
+		}
 		m.err = msg.err
 		m.message = ""
 		return m, nil
@@ -322,7 +354,31 @@ func (m Model) startFetch() (Model, tea.Cmd) {
 	m.fetching = true
 	m.fleetPending = false
 	m = m.cancelFleetMerge()
-	return m, m.fetchRowsCmd()
+	return m, m.fetchFastRowsCmd()
+}
+
+func appendMissingCreatingRows(rows, current []Row) []Row {
+	seen := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		seen[rowPath(row)] = true
+	}
+	for _, row := range current {
+		path := rowPath(row)
+		if row.Creating && path != "" && !seen[path] {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func removeRowByPath(rows []Row, path string) []Row {
+	filtered := rows[:0]
+	for _, row := range rows {
+		if rowPath(row) != path {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
 }
 
 func (m Model) cancelFleetMerge() Model {
@@ -466,7 +522,7 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 				return m, nil
 			}
 			row := m.selectedRow()
-			return m, m.createWorktreeCmd(row, branch)
+			return m.startCreateWorktree(row, branch)
 		case inputFilter:
 			m.inputMode = inputNone
 			m.input.Blur()
@@ -481,6 +537,21 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	}
 
 	return m.updateTextInput(msg)
+}
+
+func (m Model) startCreateWorktree(row Row, branch string) (Model, tea.Cmd) {
+	planned, err := m.backend.PreviewWorktree(row, branch)
+	if err != nil {
+		m.err = err
+		m.message = ""
+		return m, nil
+	}
+	planned.Creating = true
+	m.rows = append(m.rows, planned)
+	sortRows(m.rows)
+	m.cursor = indexByPath(m.filteredRows(), rowPath(planned))
+	m.message = fmt.Sprintf("creating %s", branch)
+	return m, m.createWorktreeCmd(row, branch, rowPath(planned))
 }
 
 func (m Model) handlePaste(msg tea.PasteMsg) (Model, tea.Cmd) {
@@ -593,6 +664,10 @@ func (m Model) handleConfirmKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 func (m Model) openSelected() (Model, tea.Cmd) {
 	row := m.selectedRow()
+	if row.Creating {
+		m.message = "worktree is still being created"
+		return m, nil
+	}
 	if row.Entry == nil && row.Workspace == nil {
 		if row.Fleet != nil && row.Fleet.CanMaterialize {
 			m.message = "press s to sync this worktree"
@@ -610,6 +685,10 @@ func (m Model) openSelected() (Model, tea.Cmd) {
 
 func (m Model) shellSelected() (Model, tea.Cmd) {
 	row := m.selectedRow()
+	if row.Creating {
+		m.message = "worktree is still being created"
+		return m, nil
+	}
 	if row.Entry == nil && row.Workspace == nil {
 		m.message = "sync this worktree before opening a shell"
 		return m, nil
@@ -805,6 +884,14 @@ func (m Model) fetchRowsCmd() tea.Cmd {
 	}
 }
 
+func (m Model) fetchFastRowsCmd() tea.Cmd {
+	backend := m.backend
+	return func() tea.Msg {
+		rows, warnings, err := backend.ListFast(context.Background())
+		return fastRowsMsg{rows: rows, warnings: warnings, err: err}
+	}
+}
+
 func (m Model) fleetRowsCmd(ctx context.Context, seq int, rows []Row) tea.Cmd {
 	backend := m.backend
 	// Copy: the merge mutates row elements while the UI keeps rendering the
@@ -816,16 +903,19 @@ func (m Model) fleetRowsCmd(ctx context.Context, seq int, rows []Row) tea.Cmd {
 	}
 }
 
-func (m Model) createWorktreeCmd(row Row, branch string) tea.Cmd {
+func (m Model) createWorktreeCmd(row Row, branch, pendingPath string) tea.Cmd {
 	return func() tea.Msg {
-		path, err := m.backend.CreateWorktree(context.Background(), row, branch)
+		path, err := m.backend.CreateWorktree(
+			context.Background(), row, branch, pendingPath,
+		)
 		if err != nil {
-			return actionDoneMsg{err: err}
+			return actionDoneMsg{err: err, pendingPath: pendingPath}
 		}
 		return actionDoneMsg{
-			message:    fmt.Sprintf("created %s", branch),
-			refresh:    true,
-			anchorPath: path,
+			message:     fmt.Sprintf("created %s", branch),
+			refresh:     true,
+			anchorPath:  path,
+			pendingPath: pendingPath,
 		}
 	}
 }
@@ -891,8 +981,10 @@ func (m Model) renderHeader() string {
 		repoCount[rowRepoName(row)] = true
 	}
 	spinner := ""
-	if m.fetching {
+	if m.fetching && len(m.rows) == 0 {
 		spinner = " · fetching"
+	} else if m.fetching {
+		spinner = " · checking"
 	} else if m.fleetPending {
 		spinner = " · syncing"
 	}
@@ -1016,6 +1108,9 @@ func (m Model) renderStatusLine() string {
 
 func (m Model) renderSelectionDetails() string {
 	row := m.selectedRow()
+	if row.Creating {
+		return fmt.Sprintf("creating %s\n%s", rowLabel(row), abbreviateHome(rowPath(row)))
+	}
 	if row.Entry == nil && row.Fleet != nil {
 		location := "remote"
 		if row.Fleet.MaterializeHost != "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -280,9 +280,13 @@ func carryEnrichment(fast, previous []Row) []Row {
 
 	rows := make([]Row, 0, len(fast))
 	discovered := make(map[string]bool, len(fast))
+	onDisk := make(map[string]bool, len(fast))
 	for _, row := range fast {
 		if key := FleetKeyForRow(row); key != "" {
 			discovered[key] = true
+		}
+		if path := rowPath(row); path != "" {
+			onDisk[path] = true
 		}
 		if before, ok := enriched[rowPath(row)]; ok && sameCheckout(before, row) {
 			if before.Status != nil {
@@ -294,13 +298,55 @@ func carryEnrichment(fast, previous []Row) []Row {
 	}
 
 	for _, row := range previous {
-		// A remote-only row whose worktree the fast load just found on disk has
-		// become local; the local row carries it now.
-		if isRemoteOnly(row) && !discovered[FleetKeyForRow(row)] {
+		// A row the fast load just found needs nothing carried: its local shape
+		// supersedes whatever the hub said about it.
+		if discovered[FleetKeyForRow(row)] {
+			continue
+		}
+		if isRemoteOnly(row) {
 			rows = append(rows, row)
+			continue
+		}
+		// Matching on path, not on the fleet key: the key is derived from Fleet
+		// for a row that has one and from the entry otherwise, so the two shapes
+		// of one worktree do not always agree. Its path does.
+		if onDisk[rowPath(row)] {
+			continue
+		}
+		if projected, ok := remoteProjection(row); ok {
+			rows = append(rows, projected)
 		}
 	}
 	return rows
+}
+
+// remoteProjection reduces a row that was local to what the hub still says about
+// it, for use when the fast load no longer finds it on disk. Deleting the local
+// worktree of something that also lives on other hosts should not hide those
+// hosts, which is what dropping the row outright would do until a fleet merge
+// re-derived it — and none follows a full load that fails.
+//
+// The projection keeps no local state and offers no sync: the hub reading it
+// came from is now a load older than the row it replaced, so it is worth
+// displaying but not worth acting on until the next merge confirms it.
+func remoteProjection(row Row) (Row, bool) {
+	if row.Fleet == nil {
+		return Row{}, false
+	}
+	hosts := make([]string, 0, len(row.Fleet.Hosts))
+	for _, host := range row.Fleet.Hosts {
+		if host != "" && host != "local" {
+			hosts = append(hosts, host)
+		}
+	}
+	if len(hosts) == 0 {
+		return Row{}, false
+	}
+	fleetInfo := *row.Fleet
+	fleetInfo.Hosts = hosts
+	fleetInfo.Local = false
+	fleetInfo.CanMaterialize = false
+	return Row{Fleet: &fleetInfo}, true
 }
 
 // sameCheckout reports whether two rows sharing a path describe the same

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -147,7 +147,7 @@ func launchPerspective(rows []Row, anchorPath string) string {
 // status's IsCurrent flag so the fast load, which has no statuses, resolves
 // the anchor as well as the full load does.
 func anchorRowIndex(rows []Row, anchorPath string) (int, bool) {
-	if index, ok := indexByPathOK(rows, anchorPath); ok {
+	if index, ok := identityRowIndex(rows, anchorPath); ok {
 		return index, true
 	}
 	if index, ok := containingRowIndex(rows, anchorPath); ok {
@@ -276,7 +276,9 @@ func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 	newRows := m.filteredRows()
 
 	if m.anchorPath != "" {
-		if index, ok := indexByPathOK(newRows, m.anchorPath); ok {
+		// An anchor set by a completed action holds the path the backend
+		// computed, which Git may report back at its resolved spelling.
+		if index, ok := identityRowIndex(newRows, m.anchorPath); ok {
 			m.cursor = index
 			m.anchorPath = ""
 		} else if m.pendingRefresh {
@@ -392,25 +394,44 @@ func (m Model) startFetch() (Model, tea.Cmd) {
 // their creation command is still running. Git publishes a worktree before copy
 // and setup commands finish, so discovery alone does not mean creation is done.
 func mergeCreatingRows(rows, current []Row, creating []string) []Row {
+	// Identities cost a symlink resolution per row, so skip the merge entirely
+	// unless a creation is actually pending.
+	if len(creating) == 0 && !hasCreatingRow(current) {
+		return rows
+	}
 	inFlight := make(map[string]bool, len(creating))
 	for _, path := range creating {
-		inFlight[path] = true
+		if key := pathIdentity(path); key != "" {
+			inFlight[key] = true
+		}
 	}
 	seen := make(map[string]bool, len(rows))
 	for i := range rows {
-		path := rowPath(rows[i])
-		seen[path] = true
-		if inFlight[path] {
+		key := pathIdentity(rowPath(rows[i]))
+		if key == "" {
+			continue
+		}
+		seen[key] = true
+		if inFlight[key] {
 			rows[i].Creating = true
 		}
 	}
 	for _, row := range current {
-		path := rowPath(row)
-		if row.Creating && path != "" && !seen[path] {
+		key := pathIdentity(rowPath(row))
+		if row.Creating && key != "" && !seen[key] {
 			rows = append(rows, row)
 		}
 	}
 	return rows
+}
+
+func hasCreatingRow(rows []Row) bool {
+	for _, row := range rows {
+		if row.Creating {
+			return true
+		}
+	}
+	return false
 }
 
 func withoutPath(paths []string, path string) []string {
@@ -602,7 +623,7 @@ func (m Model) startCreateWorktree(row Row, branch string) (Model, tea.Cmd) {
 	// A second row at the same path would make the placeholder and the row it
 	// collides with indistinguishable, so a failed creation would roll back
 	// both. Git would reject the creation anyway; say so before starting it.
-	if index, ok := indexByPathOK(m.rows, pendingPath); ok {
+	if index, ok := identityRowIndex(m.rows, pendingPath); ok {
 		if m.rows[index].Creating {
 			m.message = fmt.Sprintf("%s is already being created", rowLabel(m.rows[index]))
 		} else {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -95,8 +95,12 @@ type Model struct {
 	err                 error
 	handoff             Handoff
 	anchorPath          string
-	width               int
-	height              int
+	// creating holds the destinations of worktree creations whose command has
+	// not returned yet. Git publishes a worktree before copy and setup commands
+	// finish, so a discovered row is not proof that creation is complete.
+	creating []string
+	width    int
+	height   int
 }
 
 func NewModel(backend Backend, baseDir string) Model {
@@ -128,17 +132,28 @@ func (m Model) WithInitialAnchor(path string) Model {
 }
 
 // launchPerspective resolves the project key of the row the TUI was launched
-// from: an exact anchor path match (repo root or workspace), else the row
-// whose worktree contains the launch directory. Empty when launched outside
-// any known worktree, which leaves the view unscoped.
+// from. Empty when launched outside any known worktree, which leaves the view
+// unscoped.
 func launchPerspective(rows []Row, anchorPath string) string {
-	if index, ok := indexByPathOK(rows, anchorPath); ok {
-		return rowProjectKey(rows[index])
-	}
-	if index, ok := currentRowIndex(rows); ok {
+	if index, ok := anchorRowIndex(rows, anchorPath); ok {
 		return rowProjectKey(rows[index])
 	}
 	return ""
+}
+
+// anchorRowIndex resolves the row the anchor path belongs to: an exact path
+// match (repo root or workspace), else the row whose directory contains the
+// anchor. Containment is resolved from row paths rather than the collected
+// status's IsCurrent flag so the fast load, which has no statuses, resolves
+// the anchor as well as the full load does.
+func anchorRowIndex(rows []Row, anchorPath string) (int, bool) {
+	if index, ok := indexByPathOK(rows, anchorPath); ok {
+		return index, true
+	}
+	if index, ok := containingRowIndex(rows, anchorPath); ok {
+		return index, true
+	}
+	return currentRowIndex(rows)
 }
 
 func (m Model) Init() tea.Cmd {
@@ -248,7 +263,7 @@ func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 	oldCursor := m.cursor
 	hadRows := len(m.rows) > 0
 	rows := append([]Row(nil), msg.rows...)
-	rows = appendMissingCreatingRows(rows, m.rows)
+	rows = mergeCreatingRows(rows, m.rows, m.creating)
 	sortRows(rows)
 	m.rows = rows
 	if !hadRows && m.anchorPath != "" {
@@ -263,10 +278,12 @@ func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 		} else if m.pendingRefresh {
 			m.cursor = anchorCursorByPath(oldRows, oldCursor, newRows)
 		} else if !hadRows {
-			// An initial anchor that matches nothing keeps the first-load
-			// behavior of selecting the current worktree.
+			// An initial anchor pointing inside a worktree selects that
+			// worktree; one that matches nothing keeps the first-load behavior
+			// of selecting the current worktree.
+			anchor := m.anchorPath
 			m.anchorPath = ""
-			if index, ok := currentRowIndex(newRows); ok {
+			if index, ok := anchorRowIndex(newRows, anchor); ok {
 				m.cursor = index
 			} else {
 				m.cursor = anchorCursorByPath(oldRows, oldCursor, newRows)
@@ -306,7 +323,7 @@ func (m Model) applyFleetRows(msg fleetRowsMsg) (Model, tea.Cmd) {
 	oldRows := m.filteredRows()
 	oldCursor := m.cursor
 	rows := append([]Row(nil), msg.rows...)
-	rows = appendMissingCreatingRows(rows, m.rows)
+	rows = mergeCreatingRows(rows, m.rows, m.creating)
 	sortRows(rows)
 	m.rows = rows
 	m.cursor = anchorCursorByPath(oldRows, oldCursor, m.filteredRows())
@@ -314,6 +331,9 @@ func (m Model) applyFleetRows(msg fleetRowsMsg) (Model, tea.Cmd) {
 }
 
 func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
+	if msg.pendingPath != "" {
+		m.creating = withoutPath(m.creating, msg.pendingPath)
+	}
 	if msg.err != nil {
 		if msg.pendingPath != "" {
 			m.rows = removeRowByPath(m.rows, msg.pendingPath)
@@ -322,6 +342,12 @@ func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 		m.err = msg.err
 		m.message = ""
 		return m, nil
+	}
+	if msg.pendingPath != "" && msg.anchorPath != "" && msg.pendingPath != msg.anchorPath {
+		// The preview mispredicted the destination; drop the row it added so it
+		// cannot outlive the creation it stood in for.
+		m.rows = removeRowByPath(m.rows, msg.pendingPath)
+		m.cursor = clampCursor(m.cursor, len(m.filteredRows()))
 	}
 	m.err = nil
 	m.message = msg.message
@@ -357,10 +383,22 @@ func (m Model) startFetch() (Model, tea.Cmd) {
 	return m, m.fetchFastRowsCmd()
 }
 
-func appendMissingCreatingRows(rows, current []Row) []Row {
+// mergeCreatingRows keeps pending creations visible across a listing that has
+// not discovered them yet, and re-flags the ones a listing did discover while
+// their creation command is still running. Git publishes a worktree before copy
+// and setup commands finish, so discovery alone does not mean creation is done.
+func mergeCreatingRows(rows, current []Row, creating []string) []Row {
+	inFlight := make(map[string]bool, len(creating))
+	for _, path := range creating {
+		inFlight[path] = true
+	}
 	seen := make(map[string]bool, len(rows))
-	for _, row := range rows {
-		seen[rowPath(row)] = true
+	for i := range rows {
+		path := rowPath(rows[i])
+		seen[path] = true
+		if inFlight[path] {
+			rows[i].Creating = true
+		}
 	}
 	for _, row := range current {
 		path := rowPath(row)
@@ -369,6 +407,16 @@ func appendMissingCreatingRows(rows, current []Row) []Row {
 		}
 	}
 	return rows
+}
+
+func withoutPath(paths []string, path string) []string {
+	kept := make([]string, 0, len(paths))
+	for _, candidate := range paths {
+		if candidate != path {
+			kept = append(kept, candidate)
+		}
+	}
+	return kept
 }
 
 func removeRowByPath(rows []Row, path string) []Row {
@@ -547,11 +595,13 @@ func (m Model) startCreateWorktree(row Row, branch string) (Model, tea.Cmd) {
 		return m, nil
 	}
 	planned.Creating = true
+	pendingPath := rowPath(planned)
+	m.creating = append(m.creating, pendingPath)
 	m.rows = append(m.rows, planned)
 	sortRows(m.rows)
-	m.cursor = indexByPath(m.filteredRows(), rowPath(planned))
+	m.cursor = indexByPath(m.filteredRows(), pendingPath)
 	m.message = fmt.Sprintf("creating %s", branch)
-	return m, m.createWorktreeCmd(row, branch, rowPath(planned))
+	return m, m.createWorktreeCmd(row, branch, pendingPath)
 }
 
 func (m Model) handlePaste(msg tea.PasteMsg) (Model, tea.Cmd) {
@@ -723,6 +773,10 @@ func (m Model) cycleLayout() (Model, tea.Cmd) {
 
 func (m Model) startNewBranch() (Model, tea.Cmd) {
 	row := m.selectedRow()
+	if row.Creating {
+		m.message = "worktree is still being created"
+		return m, nil
+	}
 	if row.Workspace != nil {
 		m.message = "not a git worktree"
 		return m, nil
@@ -808,6 +862,10 @@ func (m Model) cursorAfterProjectChange(selectedPath string) int {
 
 func (m Model) startDelete() (Model, tea.Cmd) {
 	row := m.selectedRow()
+	if row.Creating {
+		m.message = "worktree is still being created"
+		return m, nil
+	}
 	if row.Workspace != nil {
 		m.confirm = confirmState{
 			kind: confirmUnregister,
@@ -905,9 +963,7 @@ func (m Model) fleetRowsCmd(ctx context.Context, seq int, rows []Row) tea.Cmd {
 
 func (m Model) createWorktreeCmd(row Row, branch, pendingPath string) tea.Cmd {
 	return func() tea.Msg {
-		path, err := m.backend.CreateWorktree(
-			context.Background(), row, branch, pendingPath,
-		)
+		path, err := m.backend.CreateWorktree(context.Background(), row, branch)
 		if err != nil {
 			return actionDoneMsg{err: err, pendingPath: pendingPath}
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -281,10 +281,10 @@ func carryEnrichment(fast, previous []Row) []Row {
 	rows := make([]Row, 0, len(fast))
 	discovered := make(map[string]bool, len(fast))
 	for _, row := range fast {
-		if identity := fleetIdentity(row); identity != "" {
-			discovered[identity] = true
+		if key := FleetKeyForRow(row); key != "" {
+			discovered[key] = true
 		}
-		if before, ok := enriched[rowPath(row)]; ok {
+		if before, ok := enriched[rowPath(row)]; ok && sameCheckout(before, row) {
 			if before.Status != nil {
 				row.Status = before.Status
 			}
@@ -296,11 +296,33 @@ func carryEnrichment(fast, previous []Row) []Row {
 	for _, row := range previous {
 		// A remote-only row whose worktree the fast load just found on disk has
 		// become local; the local row carries it now.
-		if isRemoteOnly(row) && !discovered[fleetIdentity(row)] {
+		if isRemoteOnly(row) && !discovered[FleetKeyForRow(row)] {
 			rows = append(rows, row)
 		}
 	}
 	return rows
+}
+
+// sameCheckout reports whether two rows sharing a path describe the same
+// checkout. A worktree that switched branches keeps its path, so matching on
+// path alone would hand the new branch the previous one's status and hub state.
+func sameCheckout(before, now Row) bool {
+	branch := rowBranch(now)
+	if branch != rowBranch(before) {
+		return false
+	}
+	if branch == "" || branch == "HEAD" {
+		// Detached: the commit is what distinguishes one checkout from another.
+		return entryCommit(before) == entryCommit(now)
+	}
+	return true
+}
+
+func entryCommit(row Row) string {
+	if row.Entry == nil {
+		return ""
+	}
+	return row.Entry.CommitHash
 }
 
 func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
@@ -503,10 +525,18 @@ func withoutPath(paths []string, path string) []string {
 	return kept
 }
 
+// removeRowByPath drops every row naming the given directory. It compares by
+// identity because a discovery pass can replace a placeholder's path with Git's
+// resolved spelling of it, and a row left behind here keeps its creating flag
+// forever.
 func removeRowByPath(rows []Row, path string) []Row {
+	key := pathIdentity(path)
+	if key == "" {
+		return rows
+	}
 	filtered := rows[:0]
 	for _, row := range rows {
-		if rowPath(row) != path {
+		if pathIdentity(rowPath(row)) != key {
 			filtered = append(filtered, row)
 		}
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -237,7 +237,11 @@ func (m Model) filteredRows() []Row {
 func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 	pendingRefresh := m.pendingRefresh
 	m.pendingRefresh = false
-	next, _ := m.applyRows(rowsMsg(msg))
+	next, _ := m.applyRows(rowsMsg{
+		rows:     carryEnrichment(msg.rows, m.rows),
+		warnings: msg.warnings,
+		err:      msg.err,
+	})
 	next = next.cancelFleetMerge()
 	next.fleetPending = false
 	if msg.err != nil {
@@ -253,6 +257,48 @@ func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 	}
 	next.fetching = true
 	return next, next.fetchRowsCmd()
+}
+
+// carryEnrichment keeps what a fast load cannot know. ListFast is authoritative
+// about which worktrees exist locally, but it collects no statuses and no hub
+// state, so rows it lists keep the status and fleet overlay the last full load
+// gave them, and remote-only rows survive until a fleet merge revises them.
+// Without this a refresh would strip a populated dashboard back to bare rows,
+// and a full load that then failed would leave it that way.
+func carryEnrichment(fast, previous []Row) []Row {
+	if len(previous) == 0 || len(fast) == 0 {
+		return fast
+	}
+	enriched := make(map[string]Row, len(previous))
+	for _, row := range previous {
+		if path := rowPath(row); path != "" {
+			enriched[path] = row
+		}
+	}
+
+	rows := make([]Row, 0, len(fast))
+	discovered := make(map[string]bool, len(fast))
+	for _, row := range fast {
+		if identity := fleetIdentity(row); identity != "" {
+			discovered[identity] = true
+		}
+		if before, ok := enriched[rowPath(row)]; ok {
+			if before.Status != nil {
+				row.Status = before.Status
+			}
+			row.Fleet = before.Fleet
+		}
+		rows = append(rows, row)
+	}
+
+	for _, row := range previous {
+		// A remote-only row whose worktree the fast load just found on disk has
+		// become local; the local row carries it now.
+		if isRemoteOnly(row) && !discovered[fleetIdentity(row)] {
+			rows = append(rows, row)
+		}
+	}
+	return rows
 }
 
 func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -241,7 +241,11 @@ func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 	next = next.cancelFleetMerge()
 	next.fleetPending = false
 	if msg.err != nil {
-		return next, nil
+		// applyRows could not act on the queued refresh because it was cleared
+		// above, and no full load follows a failed fast load, so run it here or
+		// the completed action's result never reaches the dashboard.
+		next.pendingRefresh = pendingRefresh
+		return next.startPendingRefresh()
 	}
 	if pendingRefresh {
 		next.pendingRefresh = false

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -342,8 +342,7 @@ func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 	}
 	if msg.err != nil {
 		if msg.pendingPath != "" {
-			m.rows = removeRowByPath(m.rows, msg.pendingPath)
-			m.cursor = clampCursor(m.cursor, len(m.filteredRows()))
+			m = m.dropPendingRow(msg.pendingPath)
 		}
 		m.err = msg.err
 		m.message = ""
@@ -352,8 +351,7 @@ func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 	if msg.pendingPath != "" && msg.anchorPath != "" && msg.pendingPath != msg.anchorPath {
 		// The preview mispredicted the destination; drop the row it added so it
 		// cannot outlive the creation it stood in for.
-		m.rows = removeRowByPath(m.rows, msg.pendingPath)
-		m.cursor = clampCursor(m.cursor, len(m.filteredRows()))
+		m = m.dropPendingRow(msg.pendingPath)
 	}
 	m.err = nil
 	m.message = msg.message
@@ -368,6 +366,19 @@ func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 		return m.startFetch()
 	}
 	return m, nil
+}
+
+// dropPendingRow removes an optimistic creation row and supersedes any fleet
+// overlay still in flight. That overlay carries the rows it was dispatched
+// with, so applying it afterwards would put the row back — and with nothing
+// left in creating to retire it, its creating flag would never clear.
+func (m Model) dropPendingRow(path string) Model {
+	m.rows = removeRowByPath(m.rows, path)
+	m.cursor = clampCursor(m.cursor, len(m.filteredRows()))
+	m = m.cancelFleetMerge()
+	m.fleetPending = false
+	m.loadSeq++
+	return m
 }
 
 func (m Model) startPendingRefresh() (Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -594,8 +594,19 @@ func (m Model) startCreateWorktree(row Row, branch string) (Model, tea.Cmd) {
 		m.message = ""
 		return m, nil
 	}
-	planned.Creating = true
 	pendingPath := rowPath(planned)
+	// A second row at the same path would make the placeholder and the row it
+	// collides with indistinguishable, so a failed creation would roll back
+	// both. Git would reject the creation anyway; say so before starting it.
+	if index, ok := indexByPathOK(m.rows, pendingPath); ok {
+		if m.rows[index].Creating {
+			m.message = fmt.Sprintf("%s is already being created", rowLabel(m.rows[index]))
+		} else {
+			m.message = fmt.Sprintf("worktree already exists at %s", abbreviateHome(pendingPath))
+		}
+		return m, nil
+	}
+	planned.Creating = true
 	m.creating = append(m.creating, pendingPath)
 	m.rows = append(m.rows, planned)
 	sortRows(m.rows)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1219,6 +1219,72 @@ func TestModelQueuesActionRefreshWhileFetchInFlight(t *testing.T) {
 	assert.IsType(t, fastRowsMsg{}, msg)
 }
 
+func TestFastRefreshKeepsEnrichmentWhenFullLoadFails(t *testing.T) {
+	enriched := testRow("kwt", "feature", "/w/kwt/feature")
+	enriched.Status.GitStatus.Modified = 3
+	enriched.Status.LastActivity = time.Now()
+	enriched.Fleet = &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		Kind:            "branch",
+		Ref:             "feature",
+		Branch:          "feature",
+		Hosts:           []string{"host-b"},
+	}
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/remote",
+		Branch:          "feature/remote",
+		CanMaterialize:  true,
+	}}
+	backend := &fakeBackend{}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{enriched}})
+	model, _ = updateModel(t, model, fleetRowsMsg{seq: model.loadSeq, rows: []Row{enriched, remoteOnly}})
+	require.Len(t, model.rows, 2)
+
+	// A refresh repaints from the fast load, which reports the worktree with no
+	// status and no hub state at all.
+	bare := testRow("kwt", "feature", "/w/kwt/feature")
+	bare.Status.GitStatus = models.GitStatus{}
+	bare.Status.LastActivity = time.Time{}
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{bare}})
+	model, _ = updateModel(t, model, rowsMsg{err: errors.New("status collection failed")})
+
+	require.Len(t, model.rows, 2, "the remote-only row must outlive a failed full load")
+	index, ok := indexByPathOK(model.rows, "/w/kwt/feature")
+	require.True(t, ok)
+	assert.Equal(t, 3, model.rows[index].Status.GitStatus.Modified,
+		"the last collected status is better than none while the load is broken")
+	assert.NotNil(t, model.rows[index].Fleet, "fleet metadata must survive the fast repaint")
+	assert.Contains(t, stripANSI(viewContent(model)), "status collection failed")
+}
+
+func TestFastRefreshDropsRemoteRowThatBecameLocal(t *testing.T) {
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/remote",
+		Branch:          "feature/remote",
+		CanMaterialize:  true,
+	}}
+	local := testRow("kwt", "feature/remote", "/w/kwt/feature-remote")
+	local.Entry.RepositoryInfo.FullPath = "github.com/example/kwt"
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{remoteOnly}})
+	require.Len(t, model.rows, 1)
+
+	// Materializing it makes the next fast load report it as a local worktree.
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{local}})
+
+	require.Len(t, model.rows, 1,
+		"a materialized worktree must not appear as both a local and a remote row")
+	assert.NotNil(t, model.rows[0].Entry)
+}
+
 func TestModelKeepsQueuedActionRefreshWhenFastLoadFails(t *testing.T) {
 	backend := &fakeBackend{
 		rows: []Row{testRow("kwt", "feature", "/w/kwt/feature")},

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1118,6 +1118,37 @@ func TestModelQueuesActionRefreshWhileFetchInFlight(t *testing.T) {
 	assert.IsType(t, fastRowsMsg{}, msg)
 }
 
+func TestModelKeepsQueuedActionRefreshWhenFastLoadFails(t *testing.T) {
+	backend := &fakeBackend{
+		rows: []Row{testRow("kwt", "feature", "/w/kwt/feature")},
+	}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: backend.rows})
+
+	model, refreshCmd := updateModel(t, model, press("r"))
+	require.NotNil(t, refreshCmd)
+	require.True(t, model.fetching)
+
+	model, actionCmd := updateModel(t, model, actionDoneMsg{
+		message: "removed kwt:feature",
+		refresh: true,
+	})
+	require.Nil(t, actionCmd)
+
+	// Nothing else retries the queued refresh, so losing it here would leave the
+	// removed worktree on screen until the user refreshes by hand.
+	model, queuedRefreshCmd := updateModel(t, model, fastRowsMsg{
+		err: errors.New("discovery failed"),
+	})
+
+	require.NotNil(t, queuedRefreshCmd, "a failed fast load must still run the queued refresh")
+	assert.False(t, model.pendingRefresh, "the queued refresh is consumed, not re-queued")
+	before := backend.fastListCalls
+	msg := queuedRefreshCmd()
+	assert.Equal(t, before+1, backend.fastListCalls)
+	assert.IsType(t, fastRowsMsg{}, msg)
+}
+
 func TestModelPreservesCreateAnchorAcrossQueuedRefresh(t *testing.T) {
 	staleRows := []Row{testRow("kwt", "feature", "/w/kwt/feature")}
 	newPath := "/w/kwt/new-feature"

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -814,6 +814,53 @@ func TestModelKeepsCreatingFlagWhenDiscoveryFindsPendingWorktree(t *testing.T) {
 		"the flag clears once the creation command returns")
 }
 
+func TestModelRejectsCreateAtAnExistingWorktreePath(t *testing.T) {
+	existing := "/w/kwt/feature"
+	backend := &fakeBackend{createPath: existing}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kwt", "feature", existing),
+	}})
+
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature"))
+	model, createCmd := updateModel(t, model, press("enter"))
+
+	assert.Nil(t, createCmd, "git would reject a worktree at an occupied path")
+	assert.Contains(t, model.message, "worktree already exists at")
+	require.Len(t, model.rows, 2, "no placeholder may share a path with an existing row")
+	index, ok := indexByPathOK(model.rows, existing)
+	require.True(t, ok)
+	assert.False(t, model.rows[index].Creating,
+		"the existing worktree must not be marked pending")
+}
+
+func TestModelRejectsSecondCreateAtAPendingPath(t *testing.T) {
+	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kata", "main", "/w/kata/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-pending"))
+	model, _ = updateModel(t, model, press("enter"))
+	require.Len(t, model.rows, 3)
+
+	// The same destination reached from a different base repository while the
+	// first creation is still in flight.
+	model, _ = updateModel(t, model, press("G"))
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-pending"))
+	model, secondCmd := updateModel(t, model, press("enter"))
+
+	assert.Nil(t, secondCmd)
+	assert.Contains(t, model.message, "is already being created")
+	assert.Len(t, model.rows, 3, "the in-flight placeholder must not be duplicated")
+	assert.Len(t, model.creating, 1)
+}
+
 func TestModelRejectsDeleteWhileWorktreeIsBeingCreated(t *testing.T) {
 	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
 	model := NewModel(backend, "/worktrees")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1419,6 +1419,63 @@ func TestModelRemovesFailedCreationDiscoveredAtItsResolvedPath(t *testing.T) {
 	assert.False(t, ok, "a row left here would stay marked creating forever")
 }
 
+func TestFastRefreshProjectsDeletedLocalWorktreeStillHeldElsewhere(t *testing.T) {
+	shared := testRow("kwt", "feature", "/w/kwt/feature")
+	shared.Fleet = &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature",
+		Branch:          "feature",
+		Hosts:           []string{"local", "host-b"},
+		Local:           true,
+	}
+	other := testRow("kata", "main", "/w/kata/main")
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{shared, other}})
+	require.Len(t, model.rows, 2)
+
+	// The worktree is deleted locally but still exists on host-b, and the full
+	// load that would refresh hub state then fails.
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{other}})
+	model, _ = updateModel(t, model, rowsMsg{err: errors.New("discovery failed")})
+
+	require.Len(t, model.rows, 2,
+		"deleting the local copy must not hide the hosts that still have it")
+	index, ok := indexByPathOK(model.rows, "")
+	require.True(t, ok, "the surviving row is remote-only, so it has no local path")
+	projected := model.rows[index]
+	assert.Nil(t, projected.Entry, "no local entry survives a worktree that is gone")
+	assert.Nil(t, projected.Status)
+	require.NotNil(t, projected.Fleet)
+	assert.Equal(t, []string{"host-b"}, projected.Fleet.Hosts)
+	assert.False(t, projected.Fleet.Local)
+	assert.False(t, projected.Fleet.CanMaterialize,
+		"syncing from a reading this stale needs a fresh merge to confirm it first")
+}
+
+func TestFastRefreshDropsDeletedWorktreeHeldNowhereElse(t *testing.T) {
+	onlyLocal := testRow("kwt", "feature", "/w/kwt/feature")
+	onlyLocal.Fleet = &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		Kind:            "branch",
+		Ref:             "feature",
+		Branch:          "feature",
+		Hosts:           []string{"local"},
+		Local:           true,
+	}
+	other := testRow("kata", "main", "/w/kata/main")
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{onlyLocal, other}})
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{other}})
+
+	assert.Len(t, model.rows, 1,
+		"a worktree no host holds is simply gone, not remote")
+}
+
 func TestFastRefreshKeepsRemoteRowOnCaseSensitiveHost(t *testing.T) {
 	remoteOnly := Row{Fleet: &FleetInfo{
 		ProjectIdentity: "git.example.com/srv/KWT",

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1419,6 +1419,27 @@ func TestModelRemovesFailedCreationDiscoveredAtItsResolvedPath(t *testing.T) {
 	assert.False(t, ok, "a row left here would stay marked creating forever")
 }
 
+func TestFastRefreshKeepsRemoteRowOnCaseSensitiveHost(t *testing.T) {
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "git.example.com/srv/KWT",
+		ProjectName:     "KWT",
+		Kind:            "branch",
+		Ref:             "feature/remote",
+		Branch:          "feature/remote",
+		CanMaterialize:  true,
+	}}
+	local := testRow("kwt", "feature/remote", "/w/kwt/feature-remote")
+	local.Entry.RepositoryInfo.FullPath = "git.example.com/srv/kwt"
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{remoteOnly}})
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{local}})
+
+	assert.Len(t, model.rows, 2,
+		"an unrecognized host may distinguish these repositories by case")
+}
+
 func TestFastRefreshKeepsRemoteRowWithDifferentBranchCase(t *testing.T) {
 	remoteOnly := Row{Fleet: &FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1307,6 +1309,34 @@ func TestAnchorPrefersDeepestContainingWorktree(t *testing.T) {
 
 	assert.Equal(t, "/w/kwt/main/vendor/dep", rowPath(model.selectedRow()),
 		"a nested worktree must win over the repository that contains it")
+}
+
+// The launch directory is symlink-resolved before it becomes the anchor, but
+// discovered row paths are not, so the two spellings of one directory only
+// match under a canonicalizing comparison.
+func TestAnchorResolvesWorktreeReachedThroughSymlink(t *testing.T) {
+	realDir := t.TempDir()
+	worktreeDir := filepath.Join(realDir, "kata-feature")
+	launchDir := filepath.Join(worktreeDir, "internal")
+	require.NoError(t, os.MkdirAll(launchDir, 0o755))
+
+	linkRoot := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, linkRoot); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	resolvedLaunch, err := filepath.EvalSymlinks(launchDir)
+	require.NoError(t, err)
+
+	other := testRow("kwt", "main", "/w/kwt/main")
+	other.Status.LastActivity = time.Now()
+	// The row path reaches the same directory through the symlink.
+	launch := testRow("kata", "feature", filepath.Join(linkRoot, "kata-feature"))
+
+	model := NewModel(&fakeBackend{}, "/worktrees").WithInitialAnchor(resolvedLaunch)
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{other, launch}})
+
+	assert.Equal(t, rowPath(launch), rowPath(model.selectedRow()),
+		"a symlinked ancestor must not hide the worktree containing the launch directory")
 }
 
 func TestAnchorIgnoresSiblingPathPrefix(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -863,6 +863,73 @@ func TestModelRejectsSecondCreateAtAPendingPath(t *testing.T) {
 	assert.Len(t, model.creating, 1)
 }
 
+// symlinkedWorktreeBase returns a base directory and a symlink to it, modelling
+// a worktree base the user reaches through a link: PreparePath keeps the link
+// spelling while Git reports the resolved one.
+func symlinkedWorktreeBase(t *testing.T) (real string, link string) {
+	t.Helper()
+	real, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	link = filepath.Join(t.TempDir(), "base")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	return real, link
+}
+
+func TestModelMatchesPendingCreationAcrossSymlinkedPaths(t *testing.T) {
+	realBase, linkBase := symlinkedWorktreeBase(t)
+	previewPath := filepath.Join(linkBase, "feature")
+	discoveredPath := filepath.Join(realBase, "feature")
+
+	backend := &fakeBackend{createPath: previewPath}
+	model := NewModel(backend, realBase)
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature"))
+	model, createCmd := updateModel(t, model, press("enter"))
+	require.NotNil(t, createCmd)
+	require.Len(t, model.rows, 2)
+
+	// Git publishes the worktree and the next listing reports its resolved path
+	// while copy and setup commands are still running.
+	require.NoError(t, os.MkdirAll(discoveredPath, 0o755))
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kwt", "feature", discoveredPath),
+	}})
+
+	require.Len(t, model.rows, 2,
+		"the placeholder and the worktree it stands for must not both be listed")
+	index, ok := indexByPathOK(model.rows, discoveredPath)
+	require.True(t, ok)
+	assert.True(t, model.rows[index].Creating,
+		"the discovered worktree stays pending until its creation command returns")
+}
+
+func TestModelRejectsCreateAtASymlinkEquivalentPath(t *testing.T) {
+	realBase, linkBase := symlinkedWorktreeBase(t)
+	existingPath := filepath.Join(realBase, "feature")
+	require.NoError(t, os.MkdirAll(existingPath, 0o755))
+
+	backend := &fakeBackend{createPath: filepath.Join(linkBase, "feature")}
+	model := NewModel(backend, realBase)
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kwt", "feature", existingPath),
+	}})
+
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature"))
+	model, createCmd := updateModel(t, model, press("enter"))
+
+	assert.Nil(t, createCmd, "the destination is occupied however it is spelled")
+	assert.Contains(t, model.message, "worktree already exists at")
+	assert.Len(t, model.rows, 2)
+}
+
 func TestModelRejectsDeleteWhileWorktreeIsBeingCreated(t *testing.T) {
 	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
 	model := NewModel(backend, "/worktrees")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -737,6 +737,38 @@ func TestModelRemovesOptimisticWorktreeWhenCreateFails(t *testing.T) {
 	assert.Contains(t, stripANSI(viewContent(model)), "creation failed")
 }
 
+func TestModelDropsFailedCreationFromInFlightFleetMerge(t *testing.T) {
+	pendingPath := "/w/kwt/feature-broken"
+	backend := &fakeBackend{createPath: pendingPath}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-broken"))
+	model, createCmd := updateModel(t, model, press("enter"))
+	require.NotNil(t, createCmd)
+
+	// A load lands while the creation is still running, so the fleet merge it
+	// dispatches snapshots the placeholder.
+	model, fleetCmd := updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	require.NotNil(t, fleetCmd)
+	staleFleetMsg := fleetCmd()
+
+	backend.createErr = errors.New("creation failed")
+	model, _ = updateModel(t, model, createCmd())
+	require.Len(t, model.rows, 1, "the failed creation's row is removed")
+
+	model, _ = updateModel(t, model, staleFleetMsg)
+
+	assert.Len(t, model.rows, 1,
+		"a fleet merge holding the failed placeholder must not restore it")
+	_, restored := indexByPathOK(model.rows, pendingPath)
+	assert.False(t, restored, "the removed placeholder would never clear its creating flag")
+}
+
 func TestModelKeepsCreatingWorktreeAcrossFleetRefresh(t *testing.T) {
 	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
 	model := NewModel(backend, "/worktrees")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1336,6 +1336,89 @@ func TestFastRefreshDropsRemoteRowDifferingOnlyInIdentityCase(t *testing.T) {
 	assert.NotNil(t, model.rows[0].Entry)
 }
 
+// A detached worktree is keyed by commit, not by the literal branch "HEAD",
+// so its local and remote-only shapes have to agree.
+func TestFastRefreshDropsDetachedRemoteRowThatBecameLocal(t *testing.T) {
+	const commit = "0f1e2d3c4b5a69788796a5b4c3d2e1f0a1b2c3d4"
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "detached",
+		Ref:             commit,
+	}}
+	local := testRow("kwt", "HEAD", "/w/kwt/detached")
+	local.Entry.RepositoryInfo.FullPath = "github.com/example/kwt"
+	local.Entry.CommitHash = commit
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{remoteOnly}})
+	require.Len(t, model.rows, 1)
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{local}})
+
+	require.Len(t, model.rows, 1,
+		"a detached worktree must not appear as both a local and a remote row")
+	assert.NotNil(t, model.rows[0].Entry)
+}
+
+func TestFastRefreshDropsEnrichmentWhenTheWorktreeSwitchedBranches(t *testing.T) {
+	before := testRow("kwt", "feature", "/w/kwt/feature")
+	before.Status.GitStatus.Modified = 4
+	before.Fleet = &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		Kind:            "branch",
+		Ref:             "feature",
+		Branch:          "feature",
+		Hosts:           []string{"host-b"},
+	}
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{before}})
+
+	// git switch inside the worktree: same path, different branch.
+	switched := testRow("kwt", "other", "/w/kwt/feature")
+	switched.Status.GitStatus = models.GitStatus{}
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{switched}})
+
+	require.Len(t, model.rows, 1)
+	assert.Zero(t, model.rows[0].Status.GitStatus.Modified,
+		"another branch's uncommitted changes must not be attributed to this one")
+	assert.Nil(t, model.rows[0].Fleet,
+		"hub state belongs to the branch it was collected for")
+}
+
+func TestModelRemovesFailedCreationDiscoveredAtItsResolvedPath(t *testing.T) {
+	realBase, linkBase := symlinkedWorktreeBase(t)
+	previewPath := filepath.Join(linkBase, "feature")
+	discoveredPath := filepath.Join(realBase, "feature")
+
+	backend := &fakeBackend{createPath: previewPath}
+	model := NewModel(backend, realBase)
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature"))
+	model, createCmd := updateModel(t, model, press("enter"))
+	require.NotNil(t, createCmd)
+
+	// Git published the worktree, so discovery replaces the placeholder's link
+	// spelling with the resolved one before setup fails and rolls it back.
+	require.NoError(t, os.MkdirAll(discoveredPath, 0o755))
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kwt", "feature", discoveredPath),
+	}})
+	require.Len(t, model.rows, 2)
+
+	backend.createErr = errors.New("setup command failed")
+	model, _ = updateModel(t, model, createCmd())
+
+	assert.Len(t, model.rows, 1,
+		"the rolled-back worktree must not survive under its resolved spelling")
+	_, ok := indexByPathOK(model.rows, discoveredPath)
+	assert.False(t, ok, "a row left here would stay marked creating forever")
+}
+
 func TestFastRefreshKeepsRemoteRowWithDifferentBranchCase(t *testing.T) {
 	remoteOnly := Row{Fleet: &FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -32,7 +32,6 @@ type fakeBackend struct {
 	mergeFleetCalls int
 	mergeCtx        context.Context
 	createCalls     []string
-	createPaths     []string
 	materializeRows []string
 	removeCalls     []string
 	removeForces    []bool
@@ -57,9 +56,8 @@ func (b *fakeBackend) MergeFleet(ctx context.Context, rows []Row) ([]Row, []stri
 	return append(append([]Row(nil), rows...), b.fleetRows...), b.fleetWarnings
 }
 
-func (b *fakeBackend) CreateWorktree(ctx context.Context, row Row, branch, destination string) (string, error) {
+func (b *fakeBackend) CreateWorktree(ctx context.Context, row Row, branch string) (string, error) {
 	b.createCalls = append(b.createCalls, rowPath(row)+":"+branch)
-	b.createPaths = append(b.createPaths, destination)
 	return b.createPath, b.createErr
 }
 
@@ -717,7 +715,6 @@ func TestModelShowsNewWorktreeWhileCreateIsInFlight(t *testing.T) {
 
 	_ = createCmd()
 	assert.Equal(t, []string{"/w/kwt/main:feature-fast"}, backend.createCalls)
-	assert.Equal(t, []string{"/w/kwt/feature-fast"}, backend.createPaths)
 }
 
 func TestModelRemovesOptimisticWorktreeWhenCreateFails(t *testing.T) {
@@ -779,6 +776,79 @@ func TestModelKeepsCreatedWorktreeUntilRefreshFindsIt(t *testing.T) {
 	assert.Equal(t, "/w/kwt/feature-created", rowPath(model.selectedRow()))
 	assert.True(t, model.selectedRow().Creating,
 		"the optimistic row stays pending until a fresh listing confirms it")
+}
+
+func TestModelKeepsCreatingFlagWhenDiscoveryFindsPendingWorktree(t *testing.T) {
+	pendingPath := "/w/kwt/feature-discovered"
+	backend := &fakeBackend{createPath: pendingPath}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-discovered"))
+	model, createCmd := updateModel(t, model, press("enter"))
+	require.NotNil(t, createCmd)
+
+	// Git publishes the worktree before copy and setup commands finish, so a
+	// listing can discover it while creation is still running.
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kwt", "feature-discovered", pendingPath),
+	}})
+
+	require.Equal(t, pendingPath, rowPath(model.selectedRow()))
+	assert.True(t, model.selectedRow().Creating,
+		"a discovered worktree stays pending until its creation command returns")
+
+	model, _ = updateModel(t, model, press("enter"))
+	assert.Equal(t, "worktree is still being created", model.message)
+	assert.Empty(t, backend.openCalls)
+
+	model, _ = updateModel(t, model, createCmd())
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+		testRow("kwt", "feature-discovered", pendingPath),
+	}})
+	assert.False(t, model.selectedRow().Creating,
+		"the flag clears once the creation command returns")
+}
+
+func TestModelRejectsDeleteWhileWorktreeIsBeingCreated(t *testing.T) {
+	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-pending"))
+	model, _ = updateModel(t, model, press("enter"))
+	require.True(t, model.selectedRow().Creating)
+
+	model, _ = updateModel(t, model, press("d"))
+
+	assert.Equal(t, confirmNone, model.confirm.kind,
+		"removing a worktree mid-creation would race git worktree add and setup")
+	assert.Equal(t, "worktree is still being created", model.message)
+	assert.Empty(t, backend.removeCalls)
+}
+
+func TestModelRejectsNewBranchWhileWorktreeIsBeingCreated(t *testing.T) {
+	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-pending"))
+	model, _ = updateModel(t, model, press("enter"))
+	require.True(t, model.selectedRow().Creating)
+
+	model, _ = updateModel(t, model, press("n"))
+
+	assert.Equal(t, inputNone, model.inputMode,
+		"the pending directory has no repository to branch from yet")
+	assert.Equal(t, "worktree is still being created", model.message)
 }
 
 func TestModelMaterializeRemoteOnlyFleetRow(t *testing.T) {
@@ -1121,6 +1191,57 @@ func TestLaunchProjectPerspectiveFallsBackToCurrentRow(t *testing.T) {
 	rows := model.filteredRows()
 	require.Len(t, rows, 1, "launching from inside a worktree must filter to its repo")
 	assert.Equal(t, "/w/kata/feature", rowPath(rows[0]))
+}
+
+// The fast load carries no collected statuses, so IsCurrent is never set on its
+// rows. Containment has to come from the row paths or launching from a
+// subdirectory loses both the perspective and the selection.
+func TestFastLoadResolvesAnchorInsideWorktreeWithoutStatuses(t *testing.T) {
+	other := testRow("kwt", "main", "/w/kwt/main")
+	other.Status.LastActivity = time.Now()
+	launch := testRow("kata", "feature", "/w/kata/feature")
+	launch.Status.IsCurrent = false
+	backend := &fakeBackend{rows: []Row{other, launch}}
+	model := NewModel(backend, "/worktrees").WithInitialAnchor("/w/kata/feature/sub/dir")
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: backend.rows})
+
+	rows := model.filteredRows()
+	require.Len(t, rows, 1, "the fast load must scope the view to the launch repo")
+	assert.Equal(t, "/w/kata/feature", rowPath(rows[0]))
+	assert.Equal(t, "/w/kata/feature", rowPath(model.selectedRow()))
+
+	// The full load that follows keeps the resolved selection.
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{other, launch}})
+	assert.Equal(t, "/w/kata/feature", rowPath(model.selectedRow()))
+}
+
+func TestAnchorPrefersDeepestContainingWorktree(t *testing.T) {
+	// The containing repository sorts first, so only depth-preferring
+	// containment can select the nested worktree.
+	repo := testRow("kwt", "main", "/w/kwt/main")
+	repo.Status.LastActivity = time.Now()
+	nested := testRow("dep", "main", "/w/kwt/main/vendor/dep")
+	model := NewModel(&fakeBackend{}, "/worktrees").
+		WithInitialAnchor("/w/kwt/main/vendor/dep/internal")
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{repo, nested}})
+
+	assert.Equal(t, "/w/kwt/main/vendor/dep", rowPath(model.selectedRow()),
+		"a nested worktree must win over the repository that contains it")
+}
+
+func TestAnchorIgnoresSiblingPathPrefix(t *testing.T) {
+	sibling := testRow("kwt", "feat", "/w/kwt/feat")
+	unrelated := testRow("kata", "main", "/w/kata/main")
+	model := NewModel(&fakeBackend{}, "/worktrees").
+		WithInitialAnchor("/w/kwt/feat-two/sub")
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{sibling, unrelated}})
+
+	assert.Empty(t, model.projectPerspective,
+		"/w/kwt/feat must not be treated as containing /w/kwt/feat-two/sub")
+	assert.Len(t, model.filteredRows(), 2)
 }
 
 func TestNoLaunchProjectPerspectiveOutsideAnyRepo(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -27,16 +27,23 @@ type fakeBackend struct {
 	removeErr       error
 	killErr         error
 	openErr         error
+	fastListCalls   int
 	listCalls       int
 	mergeFleetCalls int
 	mergeCtx        context.Context
 	createCalls     []string
+	createPaths     []string
 	materializeRows []string
 	removeCalls     []string
 	removeForces    []bool
 	killCalls       []string
 	openCalls       []string
 	unregistered    []Row
+}
+
+func (b *fakeBackend) ListFast(ctx context.Context) ([]Row, []string, error) {
+	b.fastListCalls++
+	return append([]Row(nil), b.rows...), nil, nil
 }
 
 func (b *fakeBackend) List(ctx context.Context) ([]Row, []string, error) {
@@ -50,9 +57,21 @@ func (b *fakeBackend) MergeFleet(ctx context.Context, rows []Row) ([]Row, []stri
 	return append(append([]Row(nil), rows...), b.fleetRows...), b.fleetWarnings
 }
 
-func (b *fakeBackend) CreateWorktree(ctx context.Context, row Row, branch string) (string, error) {
+func (b *fakeBackend) CreateWorktree(ctx context.Context, row Row, branch, destination string) (string, error) {
 	b.createCalls = append(b.createCalls, rowPath(row)+":"+branch)
+	b.createPaths = append(b.createPaths, destination)
 	return b.createPath, b.createErr
+}
+
+func (b *fakeBackend) PreviewWorktree(row Row, branch string) (Row, error) {
+	if b.createErr != nil {
+		return Row{}, b.createErr
+	}
+	entry := *row.Entry
+	entry.Branch = branch
+	entry.Path = b.createPath
+	entry.IsMain = false
+	return Row{Entry: &entry}, nil
 }
 
 func (b *fakeBackend) RemoveWorktree(ctx context.Context, row Row, force bool) error {
@@ -119,6 +138,26 @@ func updateModel(t *testing.T, model Model, msg tea.Msg) (Model, tea.Cmd) {
 
 func viewContent(model Model) string {
 	return model.View().Content
+}
+
+func TestModelPaintsFastRowsBeforeLoadingFullStatus(t *testing.T) {
+	backend := &fakeBackend{
+		rows: []Row{testRow("kwt", "main", "/w/kwt/main")},
+	}
+	model := NewModel(backend, "/worktrees")
+
+	fastCmd := model.Init()
+	fastMsg := fastCmd()
+
+	assert.Equal(t, 1, backend.fastListCalls)
+	assert.Zero(t, backend.listCalls)
+
+	model, fullCmd := updateModel(t, model, fastMsg)
+	assert.Contains(t, stripANSI(viewContent(model)), "main")
+	require.NotNil(t, fullCmd)
+
+	_ = fullCmd()
+	assert.Equal(t, 1, backend.listCalls)
 }
 
 func TestWorkspaceRowActions(t *testing.T) {
@@ -660,6 +699,88 @@ func TestModelNewBranchAcceptsPaste(t *testing.T) {
 	assert.Equal(t, []string{"/w/kwt/main:feature/pasted"}, backend.createCalls)
 }
 
+func TestModelShowsNewWorktreeWhileCreateIsInFlight(t *testing.T) {
+	backend := &fakeBackend{createPath: "/w/kwt/feature-fast"}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-fast"))
+
+	model, createCmd := updateModel(t, model, press("enter"))
+
+	require.NotNil(t, createCmd)
+	assert.Empty(t, backend.createCalls, "Git creation must remain asynchronous")
+	assert.Equal(t, "/w/kwt/feature-fast", rowPath(model.selectedRow()))
+	assert.Contains(t, stripANSI(viewContent(model)), "creating")
+
+	_ = createCmd()
+	assert.Equal(t, []string{"/w/kwt/main:feature-fast"}, backend.createCalls)
+	assert.Equal(t, []string{"/w/kwt/feature-fast"}, backend.createPaths)
+}
+
+func TestModelRemovesOptimisticWorktreeWhenCreateFails(t *testing.T) {
+	backend := &fakeBackend{createPath: "/w/kwt/feature-broken"}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-broken"))
+	model, createCmd := updateModel(t, model, press("enter"))
+	backend.createErr = errors.New("creation failed")
+
+	model, _ = updateModel(t, model, createCmd())
+
+	assert.Len(t, model.rows, 1)
+	assert.Equal(t, "/w/kwt/main", rowPath(model.rows[0]))
+	assert.Contains(t, stripANSI(viewContent(model)), "creation failed")
+}
+
+func TestModelKeepsCreatingWorktreeAcrossFleetRefresh(t *testing.T) {
+	backend := &fakeBackend{createPath: "/w/kwt/feature-pending"}
+	model := NewModel(backend, "/worktrees")
+	model, fleetCmd := updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+	require.NotNil(t, fleetCmd)
+
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-pending"))
+	model, _ = updateModel(t, model, press("enter"))
+	require.Len(t, model.rows, 2)
+
+	model, _ = updateModel(t, model, fleetCmd())
+
+	require.Len(t, model.rows, 2)
+	assert.Equal(t, "/w/kwt/feature-pending", rowPath(model.selectedRow()))
+	assert.True(t, model.selectedRow().Creating)
+}
+
+func TestModelKeepsCreatedWorktreeUntilRefreshFindsIt(t *testing.T) {
+	backend := &fakeBackend{
+		rows:       []Row{testRow("kwt", "main", "/w/kwt/main")},
+		createPath: "/w/kwt/feature-created",
+	}
+	model := NewModel(backend, "/worktrees")
+	model, staleFullCmd := updateModel(t, model, fastRowsMsg{rows: backend.rows})
+	require.NotNil(t, staleFullCmd)
+
+	model, _ = updateModel(t, model, press("n"))
+	model, _ = updateModel(t, model, paste("feature-created"))
+	model, createCmd := updateModel(t, model, press("enter"))
+	model, _ = updateModel(t, model, createCmd())
+	require.True(t, model.pendingRefresh)
+
+	model, _ = updateModel(t, model, staleFullCmd())
+
+	require.Len(t, model.rows, 2)
+	assert.Equal(t, "/w/kwt/feature-created", rowPath(model.selectedRow()))
+	assert.True(t, model.selectedRow().Creating,
+		"the optimistic row stays pending until a fresh listing confirms it")
+}
+
 func TestModelMaterializeRemoteOnlyFleetRow(t *testing.T) {
 	row := Row{Fleet: &FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
@@ -870,14 +991,14 @@ func TestModelQueuesActionRefreshWhileFetchInFlight(t *testing.T) {
 	require.Nil(t, actionCmd)
 
 	backend.rows = []Row{testRow("kwt", "main", "/w/kwt/main")}
-	model, queuedRefreshCmd := updateModel(t, model, rowsMsg{rows: backend.rows})
+	model, queuedRefreshCmd := updateModel(t, model, fastRowsMsg{rows: backend.rows})
 
 	require.NotNil(t, queuedRefreshCmd)
 	assert.True(t, model.fetching)
-	before := backend.listCalls
+	before := backend.fastListCalls
 	msg := queuedRefreshCmd()
-	assert.Equal(t, before+1, backend.listCalls)
-	assert.IsType(t, rowsMsg{}, msg)
+	assert.Equal(t, before+1, backend.fastListCalls)
+	assert.IsType(t, fastRowsMsg{}, msg)
 }
 
 func TestModelPreservesCreateAnchorAcrossQueuedRefresh(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1261,6 +1261,32 @@ func TestFastRefreshKeepsEnrichmentWhenFullLoadFails(t *testing.T) {
 	assert.Contains(t, stripANSI(viewContent(model)), "status collection failed")
 }
 
+func TestFastRefreshKeepsRemoteRowsWithNoLocalWorktrees(t *testing.T) {
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/remote",
+		Branch:          "feature/remote",
+		CanMaterialize:  true,
+	}}
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{remoteOnly}})
+	require.Len(t, model.rows, 1)
+
+	// Nothing is checked out on this machine, so the fast load reports no rows.
+	model, _ = updateModel(t, model, fastRowsMsg{rows: nil})
+	require.Len(t, model.rows, 1,
+		"an empty local snapshot says nothing about worktrees on other hosts")
+
+	// The full load then fails, so no fleet merge follows to put them back.
+	model, _ = updateModel(t, model, rowsMsg{err: errors.New("discovery failed")})
+
+	require.Len(t, model.rows, 1)
+	assert.True(t, isRemoteOnly(model.rows[0]))
+	assert.Equal(t, "feature/remote", model.rows[0].Fleet.Branch)
+}
+
 func TestFastRefreshDropsRemoteRowThatBecameLocal(t *testing.T) {
 	remoteOnly := Row{Fleet: &FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1311,6 +1311,52 @@ func TestFastRefreshDropsRemoteRowThatBecameLocal(t *testing.T) {
 	assert.NotNil(t, model.rows[0].Entry)
 }
 
+// A hub manifest and a local clone can spell one forge identity differently;
+// only the branch half of the key is case-sensitive.
+func TestFastRefreshDropsRemoteRowDifferingOnlyInIdentityCase(t *testing.T) {
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "github.com/Example/KWT",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/remote",
+		Branch:          "feature/remote",
+		CanMaterialize:  true,
+	}}
+	local := testRow("kwt", "feature/remote", "/w/kwt/feature-remote")
+	local.Entry.RepositoryInfo.FullPath = "github.com/example/kwt"
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{remoteOnly}})
+	require.Len(t, model.rows, 1)
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{local}})
+
+	require.Len(t, model.rows, 1,
+		"owner and repository casing must not split one worktree into two rows")
+	assert.NotNil(t, model.rows[0].Entry)
+}
+
+func TestFastRefreshKeepsRemoteRowWithDifferentBranchCase(t *testing.T) {
+	remoteOnly := Row{Fleet: &FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "Feature/Remote",
+		Branch:          "Feature/Remote",
+		CanMaterialize:  true,
+	}}
+	local := testRow("kwt", "feature/remote", "/w/kwt/feature-remote")
+	local.Entry.RepositoryInfo.FullPath = "github.com/example/kwt"
+
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{remoteOnly}})
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{local}})
+
+	assert.Len(t, model.rows, 2,
+		"branch names are case-sensitive, so these are two different worktrees")
+}
+
 func TestModelKeepsQueuedActionRefreshWhenFastLoadFails(t *testing.T) {
 	backend := &fakeBackend{
 		rows: []Row{testRow("kwt", "feature", "/w/kwt/feature")},

--- a/internal/url/identity.go
+++ b/internal/url/identity.go
@@ -119,6 +119,52 @@ func CanonicalRepositoryInfoFromRemote(raw string) (*RepositoryInfo, bool) {
 // passesCanonicalIdentityPrechecks applies the shared precondition of both
 // canonical bars: the value must be a plausible identity candidate and must
 // not carry a credential-shaped authority or SCP path.
+// caseInsensitiveRepositoryPathHosts are the hosts known to treat owner and
+// repository names case-insensitively, so two spellings there name one
+// repository. Hosts absent from this set are assumed case-sensitive, which is
+// the safe default: mistakenly folding a case-sensitive host silently credits
+// one repository's state to another, while mistakenly preserving a
+// case-insensitive one merely shows a repository twice. Self-hosted forges
+// cannot be recognized from a hostname and land on the safe side.
+var caseInsensitiveRepositoryPathHosts = map[string]bool{
+	"bitbucket.org": true,
+	"codeberg.org":  true,
+	"github.com":    true,
+	"gitlab.com":    true,
+}
+
+// FoldRepositoryIdentity normalizes a canonical repository identity for
+// comparison between spellings that name the same repository. The host is
+// always folded because DNS is case-insensitive; the owner and repository path
+// is folded only for hosts that resolve names case-insensitively, so a plain
+// Git server on a case-sensitive filesystem keeps two repositories differing
+// only in case distinct.
+//
+// Callers that compare identities must all fold them the same way, or one side
+// stops recognizing the other's spelling.
+func FoldRepositoryIdentity(identity string) string {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return ""
+	}
+	authority, remainder, ok := strings.Cut(identity, "/")
+	authority = strings.ToLower(authority)
+	if !ok {
+		return authority
+	}
+	if caseInsensitiveRepositoryPathHosts[hostWithoutPort(authority)] {
+		remainder = strings.ToLower(remainder)
+	}
+	return authority + "/" + remainder
+}
+
+func hostWithoutPort(authority string) string {
+	if host, _, err := net.SplitHostPort(authority); err == nil {
+		return host
+	}
+	return authority
+}
+
 func passesCanonicalIdentityPrechecks(raw string) bool {
 	return isCanonicalIdentityCandidate(raw) &&
 		!hasCredentialBearingAuthoritySlug(raw) &&

--- a/internal/url/identity_test.go
+++ b/internal/url/identity_test.go
@@ -278,3 +278,68 @@ func TestCanonicalRepositoryIdentityRejectsCredentialBearingRemotes(t *testing.T
 		}
 	}
 }
+
+func TestFoldRepositoryIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity string
+		expected string
+	}{
+		{
+			name:     "Case-insensitive host folds owner and repository",
+			identity: "GitHub.com/Kenn-Io/KWT",
+			expected: "github.com/kenn-io/kwt",
+		},
+		{
+			name:     "GitLab subgroups fold too",
+			identity: "gitlab.com/Group/SubGroup/Project",
+			expected: "gitlab.com/group/subgroup/project",
+		},
+		{
+			name:     "Unknown host keeps its path case",
+			identity: "Git.Example.Com/srv/git/Repo",
+			expected: "git.example.com/srv/git/Repo",
+		},
+		{
+			name:     "Self-hosted forge is treated as case-sensitive",
+			identity: "gitlab.internal.example/Group/Project",
+			expected: "gitlab.internal.example/Group/Project",
+		},
+		{
+			name:     "Explicit port does not defeat host matching",
+			identity: "GitHub.com:443/Kenn-Io/KWT",
+			expected: "github.com:443/kenn-io/kwt",
+		},
+		{
+			name:     "Host without a path still folds",
+			identity: "GitHub.com",
+			expected: "github.com",
+		},
+		{
+			name:     "Empty stays empty",
+			identity: "   ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FoldRepositoryIdentity(tt.identity); got != tt.expected {
+				t.Errorf("FoldRepositoryIdentity(%q) = %q, want %q", tt.identity, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFoldRepositoryIdentityIsIdempotent(t *testing.T) {
+	for _, identity := range []string{
+		"GitHub.com/Kenn-Io/KWT",
+		"Git.Example.Com/srv/git/Repo",
+		"GitHub.com:443/Kenn-Io/KWT",
+	} {
+		once := FoldRepositoryIdentity(identity)
+		if twice := FoldRepositoryIdentity(once); twice != once {
+			t.Errorf("FoldRepositoryIdentity(%q) is not idempotent: %q then %q", identity, once, twice)
+		}
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -107,6 +107,20 @@ func CanonicalPath(path string) string {
 	return filepath.Clean(path)
 }
 
+// IsSameOrChildPath reports whether path names parent or a directory nested
+// inside it. Both sides are canonicalized first, so a launch directory reached
+// through a symlink still matches the worktree that contains it.
+func IsSameOrChildPath(path, parent string) bool {
+	if path == "" || parent == "" {
+		return false
+	}
+	rel, err := filepath.Rel(CanonicalPath(parent), CanonicalPath(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
 // TildePath replaces the home directory portion of a path with ~.
 // If the path doesn't start with the home directory, it returns the original path.
 func TildePath(path string) string {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -322,3 +322,47 @@ func TestEscapeForShell(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSameOrChildPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		parent   string
+		expected bool
+	}{
+		{name: "Same directory", path: "/w/kwt/main", parent: "/w/kwt/main", expected: true},
+		{name: "Direct child", path: "/w/kwt/main/internal", parent: "/w/kwt/main", expected: true},
+		{name: "Nested descendant", path: "/w/kwt/main/a/b/c", parent: "/w/kwt/main", expected: true},
+		{name: "Unclean input", path: "/w/kwt/main/./a/../a", parent: "/w/kwt/main/", expected: true},
+		{name: "Sibling sharing a name prefix", path: "/w/kwt/feat-two", parent: "/w/kwt/feat"},
+		{name: "Parent of the directory", path: "/w/kwt", parent: "/w/kwt/main"},
+		{name: "Unrelated directory", path: "/w/kata/main", parent: "/w/kwt/main"},
+		{name: "Empty path", path: "", parent: "/w/kwt/main"},
+		{name: "Empty parent", path: "/w/kwt/main", parent: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSameOrChildPath(tt.path, tt.parent); got != tt.expected {
+				t.Errorf("IsSameOrChildPath(%q, %q) = %v, want %v",
+					tt.path, tt.parent, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsSameOrChildPathResolvesSymlinkedAncestor(t *testing.T) {
+	realDir := t.TempDir()
+	child := filepath.Join(realDir, "worktree", "internal")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("failed to create child directory: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+
+	if !IsSameOrChildPath(child, filepath.Join(link, "worktree")) {
+		t.Errorf("a parent reached through a symlink must still contain %q", child)
+	}
+}


### PR DESCRIPTION
## Why

Opening the dashboard was gated by recursive filesystem discovery and full Git status collection. Linked worktrees were traversed as ordinary directories, so nested dependency checkouts and build artifacts could turn a small worktree list into several seconds of startup latency. Worktree creation had the same responsiveness problem: the TUI showed nothing until Git and post-setup work completed, leaving users unsure whether the action had started.

The dashboard should become useful as soon as structural worktree metadata is available, while slower enrichment and mutations remain visible background work. An optimistic creation row also needs to survive overlapping status and fleet refreshes so progress does not flicker or disappear.

## Approach

Discovery now stops at every worktree boundary, resolves candidate metadata concurrently with a bounded worker pool, and loads independent dashboard sources concurrently. The TUI paints lightweight rows first, then enriches them with Git status and fleet state. New worktrees are planned at their exact destination and appear immediately with a creating/pending state until a fresh listing confirms them; failures remove the optimistic row and surface the error.

## Validation

- `make test`
- `make build`
- `make lint`
- `go vet ./...`
- Race tests for `internal/discovery`, `internal/tui`, and `internal/cmd`
- Warm `kwt list -g` on the same 20-row dataset improved from about 5.5 seconds to about 0.09 seconds