### PR TITLE
Keep imported PR session startup inert

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -76,12 +76,13 @@ for pull-request clients. kwt owns provider calls, ref handling, branch and
 workspace naming, normal worktree creation and setup, push configuration,
 provenance, and tmux session naming. See [Pull-request
 automation](pull-requests.md) for the JSON and exit-status contract.
-`pr import --start-session` additionally establishes that canonical session
-without attaching, for clients that provide their own ordinary tmux
-presentation. Its workspace record includes `tmux_socket_name`; attach with
-`kwt pr attach <workspace.path>`, which verifies the persisted identity,
-creates or repairs the protected session when needed, and uses
-`attach-session -E`.
+Every imported workspace record includes `tmux_socket_name`.
+`pr import --start-session` additionally establishes a blank shell-only
+session without attaching, for clients that provide their own ordinary tmux
+presentation. It does not execute configured layouts or agent commands.
+Attach with `kwt pr attach <workspace.path>`, which verifies the persisted
+identity, creates or repairs that protected blank session when needed, and
+uses `attach-session -E`.
 
 ### Repository identity fallback
 
@@ -187,15 +188,15 @@ plus the remove-markers — never construction or pane commands), so a session
 another tool created bare converges on consistent behavior for windows opened
 after that attach.
 
-PR imports use a stricter reuse boundary. `pr import --start-session` records
-the canonical workspace path when it creates the session on a deterministic,
-workspace-specific socket and reuses only a same-named session with that exact
-marker. The isolated server starts without the provider or configured fleet
-credential. The protected session also masks those names and filters them from
-`update-environment`. Clients must use `kwt pr attach <workspace.path>`;
-because tmux options are mutable, that command creates or repairs the
-configured protected session and enforces `attach-session -E` rather than
-trusting the current option value.
+PR imports use a stricter reuse boundary. Every import reports a deterministic,
+workspace-specific socket. `pr import --start-session` and `pr attach` create
+one blank shell session, record the canonical workspace path, and reuse only a
+same-named session with that exact marker. They never execute configured layout
+or agent commands. The isolated server starts without the provider or
+configured fleet credential. The protected session also masks those names and
+filters them from `update-environment`. Because tmux options are mutable,
+`pr attach` enforces `attach-session -E` rather than trusting the current
+option value.
 
 The repair path deliberately does not rewrite panes in an externally created
 session that is already running; it only makes future windows consistent. In a

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -22,24 +22,26 @@ kwt pr import 17 --project github.com/acme/widget \
   --start-session --json
 ```
 
-`--start-session` creates or repairs the `session_name` returned by the import
-using kwt's configured default layout and workspace bootstrap, then leaves it
-detached for the caller. The response also includes `tmux_socket_name`; clients
-must attach through kwt's protected path:
+Every successful import response includes the deterministic
+`tmux_socket_name`, whether or not a session was started. `--start-session`
+creates or repairs the returned `session_name` as a single blank shell session
+and leaves it detached for the caller. It never runs configured layouts, agent
+commands, or commands from the imported checkout. Clients must attach through
+kwt's protected path:
 
 ```sh
 kwt pr attach <workspace.path>
 ```
 
 The attach command resolves the persisted workspace identity, verifies the
-recorded project clone and exact live worktree identity, validates the current
-layout configuration, and creates or repairs the session on its isolated
-server before executing `attach-session -E` so tmux cannot import client
-environment variables. This makes the command converge imports created without
-`--start-session`, imports whose startup failed, and sessions that disappeared
-after import. A parent tmux client identity is removed before attachment, so
-the command also works when invoked from a pane connected to another tmux
-server. A
+recorded project clone and exact live worktree identity, and creates or repairs
+a single blank shell session on its isolated server before executing
+`attach-session -E` so tmux cannot import client environment variables. It
+never runs configured layout or agent commands. This makes the command converge
+imports created without `--start-session`, imports whose startup failed, and
+sessions that disappeared after import. A parent tmux client identity is
+removed before attachment, so the command also works when invoked from a pane
+connected to another tmux server. A
 deleted project, reused path, or branch, repository, or session-name mismatch
 fails closed. Prunable entries and paths without a live Git worktree are not
 accepted. The registered project's canonical identity remains authoritative
@@ -50,10 +52,9 @@ conflicting registrations fail closed. Ordinary `kwt open` and dashboard open
 actions refuse imported workspaces because they use the normal tmux server;
 use `kwt pr attach <workspace.path>` instead. The protected attach path is
 idempotent for an already imported worktree or a verified session that kwt
-created for the same workspace. Kwt validates layout and agent configuration
-before import mutation. If runtime session establishment fails after the
-import becomes durable, the command still exits successfully and returns the
-imported workspace with an explicit
+created for the same workspace. If runtime session establishment fails after
+the import becomes durable, the command still exits successfully and returns
+the imported workspace with an explicit
 `session_start_error`:
 
 ```json

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -149,6 +149,11 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
+	result.Workspace.TmuxSocketName = tmux.ProtectedWorkspaceSocketName(
+		result.Workspace.SessionName,
+		result.Workspace.Path,
+	)
+	result.PullRequest.Workspace = &result.Workspace
 	if prStartSession {
 		socketName, startErr := startPRWorkspaceSession(
 			cmd.Context(),
@@ -167,11 +172,9 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 				false,
 				startErr,
 			)
-			result.PullRequest.Workspace = &result.Workspace
 			return writePRJSON(cmd, result)
 		}
 		result.Workspace.TmuxSocketName = socketName
-		result.PullRequest.Workspace = &result.Workspace
 	}
 	return writePRJSON(cmd, result)
 }
@@ -520,24 +523,14 @@ func defaultValidatePRWorkspaceSessionConfig(
 func preparePRWorkspaceSessionLayout(
 	cfg *models.Config,
 ) (models.Layout, error) {
-	if err := tmux.ValidateLayouts(cfg.Layouts, cfg.Agents); err != nil {
-		return models.Layout{}, err
+	if cfg == nil {
+		return models.Layout{}, fmt.Errorf("kwt configuration is unavailable")
 	}
-	layout, err := tmux.ResolveLayout(
-		cfg.Layouts,
-		"",
-		false,
-		"",
-		nil,
-	)
-	if err != nil {
-		return models.Layout{}, err
-	}
-	layout, err = tmux.ResolvePaneCommands(layout, cfg.Agents)
-	if err != nil {
-		return models.Layout{}, err
-	}
-	return layout, nil
+	// Imported contributor-controlled content must never trigger configured
+	// layout or agent commands merely because a client imported or opened it.
+	// A protected PR workspace starts as one ordinary login shell; the user
+	// may explicitly run anything else after inspecting the checkout.
+	return tmux.BlankLayout(), nil
 }
 
 func defaultAttachPRWorkspaceSession(

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -284,8 +284,36 @@ func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 			require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
 			assert.Equal(t, status, got.Status)
 			assert.Equal(t, "https://github.com/acme/widget/pull/17", service.gotSelector)
+			socketName := tmux.ProtectedWorkspaceSocketName(
+				got.Workspace.SessionName,
+				got.Workspace.Path,
+			)
+			assert.Equal(t, socketName, got.Workspace.TmuxSocketName)
+			assert.Equal(
+				t,
+				socketName,
+				tryRequireWorkspace(t, got.PullRequest.Workspace).TmuxSocketName,
+			)
 		})
 	}
+}
+
+func TestProtectedPRWorkspaceSessionIgnoresConfiguredLayout(t *testing.T) {
+	cfg := &models.Config{
+		Layouts: models.LayoutsConfig{
+			Default: "project",
+			Presets: []models.Layout{{
+				Name:    "project",
+				Arrange: "tiled",
+				Panes:   []string{"make run-from-imported-checkout"},
+			}},
+		},
+	}
+
+	layout, err := preparePRWorkspaceSessionLayout(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, tmux.BlankLayout(), layout)
 }
 
 func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
@@ -308,7 +336,16 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 		gotConfig *models.Config,
 	) (string, error) {
 		started = true
-		assert.Equal(t, workspace, got)
+		assert.Equal(t, workspace.Path, got.Path)
+		assert.Equal(t, workspace.SessionName, got.SessionName)
+		assert.Equal(
+			t,
+			tmux.ProtectedWorkspaceSocketName(
+				workspace.SessionName,
+				workspace.Path,
+			),
+			got.TmuxSocketName,
+		)
 		assert.Same(t, cfg, gotConfig)
 		return "kwt-pr-0123456789abcdef", nil
 	}


### PR DESCRIPTION
Importing contributor-controlled code must not execute configured project layouts or agent commands as a side effect. This always reports the deterministic protected socket for a durable import and restricts both optional startup and later protected attachment to one blank login-shell pane, preserving a useful open path without treating import as consent to run repository-dependent automation.