### PR TITLE
Route trusted Linux builds to managed runners

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,4 +12,4 @@ jobs:
   run:
     uses: kenn-io/kwt/.github/workflows/ci.yml@main
     with:
-      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,18 +1,15 @@
 name: CI
 
-# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
-# main-branch workflow, whose Linux jobs can use the managed public fleet.
+# The PR dispatcher always calls the main-pinned workflow. That workflow
+# independently routes same-repository Linux jobs to the managed public fleet
+# and fork jobs to GitHub-hosted runners.
 on:
   pull_request:
-  pull_request_target:
 
 permissions: read-all
 
 jobs:
   run:
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     uses: kenn-io/kwt/.github/workflows/ci.yml@main
     with:
       checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,18 @@
+name: CI
+
+# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
+# main-branch workflow, whose Linux jobs can use the managed public fleet.
+on:
+  pull_request:
+  pull_request_target:
+
+permissions: read-all
+
+jobs:
+  run:
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    uses: kenn-io/kwt/.github/workflows/ci.yml@main
+    with:
+      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -11,5 +11,3 @@ permissions: read-all
 jobs:
   run:
     uses: kenn-io/kwt/.github/workflows/ci.yml@main
-    with:
-      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test:
     name: Go (${{ matrix.os }})
-    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && github.repository == 'kenn-io/kwt' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: CI
 
 on:
   workflow_call:
-    inputs:
-      checkout_ref:
-        description: Git ref to check out
-        required: false
-        type: string
-        default: ""
   push:
     branches:
       - main
@@ -51,8 +45,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,23 @@
 name: CI
 
 on:
-  pull_request:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to check out
+        required: false
+        type: string
+        default: ""
   push:
     branches:
       - main
-
 permissions:
   contents: read
 
 jobs:
   test:
     name: Go (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test:
     name: Go (${{ matrix.os }})
-    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -1,0 +1,20 @@
+name: Workflow validation
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          version: 1.7.12
+          shellcheck: false
+          pyflakes: false


### PR DESCRIPTION
## Summary

- route canonical same-repository Linux pull requests and main-branch builds to managed Linux runners, with forks and noncanonical copies falling back to GitHub-hosted runners
- invoke the reusable workflow from `main` and let checkout use the caller event's immutable SHA without accepting a dispatcher-supplied ref
- lint proposed workflow revisions on GitHub-hosted infrastructure

The managed runner group admits only the listed reusable workflow file from `main`; PR-controlled dispatcher changes therefore cannot target it directly. The reusable-workflow bootstrap is incorporated in this branch.