### PR TITLE
Expose noninteractive project registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The dashboard lists worktrees from the global base directory and from projects
 recorded in `config.toml`. Running `kwt` inside a repository registers or
 refreshes that project entry, so future dashboard launches can see its
 worktrees even when they are outside `worktree.basedir`.
+Noninteractive clients can register an existing checkout explicitly with
+`kwt projects add /absolute/repository/path --json`.
 
 ### Repository Setup
 
@@ -225,7 +227,7 @@ spaces.
 | `kwt open`       | Fuzzy-pick and attach to a workspace      |
 | `kwt list`       | List worktrees                            |
 | `kwt status`     | Show git status, sync state, and activity |
-| `kwt projects`   | List registered project repositories      |
+| `kwt projects`   | List or register project repositories     |
 | `kwt pr`         | Discover and import pull requests as JSON |
 | `kwt get`        | Print a matching worktree path            |
 | `kwt cd`         | Open a shell in a matching worktree       |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -69,6 +69,38 @@ paths that live outside the configured worktree base directory without
 parsing the config file. `repository` uses the same `host/owner/name` slug as
 `kwt list --json`'s `repository` field, so the two surfaces can be joined.
 
+`kwt projects add <path>` registers an existing Git checkout without opening
+the dashboard. A linked-worktree path resolves to its main repository before
+registration, and repeating the command updates the existing entry rather than
+adding a duplicate.
+
+With `--json`, success returns:
+
+```json
+{
+  "status": "registered",
+  "project": {
+    "repository": "github.com/kenn-io/kwt",
+    "name": "kwt",
+    "path": "/home/wesm/code/kwt",
+    "last_touched": "2026-07-27T11:16:16Z"
+  }
+}
+```
+
+Failures return a stable error envelope on stdout. `invalid_repository` exits
+2; `registration_failed` exits 1. Both are non-retryable:
+
+```json
+{
+  "error": {
+    "code": "invalid_repository",
+    "message": "/missing is not an accessible Git repository",
+    "retryable": false
+  }
+}
+```
+
 ## `kwt pr`
 
 `kwt pr list` and `kwt pr import` are the noninteractive, structured boundary

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -64,6 +64,8 @@ The dashboard lists worktrees from the configured base directory, the current
 launch repository, and registered projects. Running `kwt` inside a repository
 registers or refreshes that repository so future dashboard launches can find its
 worktrees from anywhere.
+Automation and graphical clients can perform the same explicit registration
+without opening the dashboard by running `kwt projects add <path> --json`.
 
 Project entries are discovery metadata, not worktree-creation policy:
 

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
@@ -16,7 +18,9 @@ import (
 
 var (
 	projectsJSON       bool
+	projectsAddJSON    bool
 	loadProjectsConfig = config.Load
+	registerProject    = config.RegisterProject
 )
 
 var projectsCmd = &cobra.Command{
@@ -35,9 +39,18 @@ that external automation can consume without parsing the config file.`,
 	RunE:              runProjects,
 }
 
+var projectsAddCmd = &cobra.Command{
+	Use:   "add <path>",
+	Short: "Register an existing Git repository",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProjectsAdd,
+}
+
 func init() {
 	rootCmd.AddCommand(projectsCmd)
 	projectsCmd.Flags().BoolVar(&projectsJSON, "json", false, "Output in JSON format")
+	projectsAddCmd.Flags().BoolVar(&projectsAddJSON, "json", false, "Output a machine-readable result")
+	projectsCmd.AddCommand(projectsAddCmd)
 }
 
 func runProjects(cmd *cobra.Command, args []string) error {
@@ -64,6 +77,152 @@ func runProjects(cmd *cobra.Command, args []string) error {
 		t.Row(project.Name, project.Repository, project.Path, project.LastTouched)
 	}
 	return t.Println()
+}
+
+type projectAddResult struct {
+	Status  string         `json:"status"`
+	Project models.Project `json:"project"`
+}
+
+type projectCommandErrorBody struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
+type projectCommandErrorEnvelope struct {
+	Error projectCommandErrorBody `json:"error"`
+}
+
+type projectCommandError struct {
+	body     projectCommandErrorBody
+	exitCode int
+}
+
+func (e *projectCommandError) Error() string { return e.body.Message }
+func (e *projectCommandError) ExitCode() int { return e.exitCode }
+
+func runProjectsAdd(cmd *cobra.Command, args []string) error {
+	project, err := resolveProjectForRegistration(args[0])
+	if err != nil {
+		return writeProjectCommandError(
+			cmd,
+			"invalid_repository",
+			err.Error(),
+			2,
+		)
+	}
+	cfg, err := loadProjectsConfig()
+	if err != nil {
+		return writeProjectCommandError(
+			cmd,
+			"registration_failed",
+			fmt.Sprintf("failed to load projects: %v", err),
+			1,
+		)
+	}
+	for _, existing := range cfg.Projects {
+		if !samePath(existing.Path, project.Path) {
+			continue
+		}
+		if reusable, ok := reusableExistingProject(existing, project); ok {
+			project = reusable
+		}
+		break
+	}
+	project.LastTouched = time.Now().UTC().Format(time.RFC3339)
+	if err := registerProject(project); err != nil {
+		return writeProjectCommandError(
+			cmd,
+			"registration_failed",
+			fmt.Sprintf("failed to register project: %v", err),
+			1,
+		)
+	}
+
+	if projectsAddJSON {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(projectAddResult{
+			Status:  "registered",
+			Project: project,
+		})
+	}
+	_, err = fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"registered project %s at %s\n",
+		project.Name,
+		project.Path,
+	)
+	return err
+}
+
+func resolveProjectForRegistration(path string) (models.Project, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return models.Project{}, fmt.Errorf("repository path is required")
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return models.Project{}, fmt.Errorf(
+			"resolve repository path %q: %w",
+			path,
+			err,
+		)
+	}
+	if resolved, err := filepath.EvalSymlinks(absolutePath); err == nil {
+		absolutePath = resolved
+	}
+	repositoryGit := git.New(absolutePath)
+	mainPath, err := repositoryGit.GetMainRepositoryPath()
+	if err != nil {
+		return models.Project{}, fmt.Errorf(
+			"%s is not an accessible Git repository",
+			absolutePath,
+		)
+	}
+	if resolved, err := filepath.EvalSymlinks(mainPath); err == nil {
+		mainPath = resolved
+	}
+	info, err := worktree.RepositoryInfoFromGit(repositoryGit)
+	if err != nil {
+		return models.Project{}, fmt.Errorf(
+			"resolve repository identity for %s: %w",
+			absolutePath,
+			err,
+		)
+	}
+	name := info.Repository
+	if name == "" {
+		name = filepath.Base(mainPath)
+	}
+	return models.Project{
+		Repository: info.FullPath,
+		Name:       name,
+		Path:       mainPath,
+	}, nil
+}
+
+func writeProjectCommandError(
+	cmd *cobra.Command,
+	code string,
+	message string,
+	exitCode int,
+) error {
+	body := projectCommandErrorBody{
+		Code:      code,
+		Message:   message,
+		Retryable: false,
+	}
+	cmd.Root().SilenceUsage = true
+	cmd.Root().SilenceErrors = true
+	if projectsAddJSON {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		_ = encoder.Encode(projectCommandErrorEnvelope{Error: body})
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "kwt projects: %s: %s\n", code, message)
+	return &projectCommandError{body: body, exitCode: exitCode}
 }
 
 // canonicalizeProjectIdentities returns a copy of projects with every

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -255,13 +257,40 @@ func writeProjectCommandError(
 	}
 	cmd.Root().SilenceUsage = true
 	cmd.Root().SilenceErrors = true
-	if projectsJSON || projectsAddJSON {
+	if projectCommandJSONRequested() {
 		encoder := json.NewEncoder(cmd.OutOrStdout())
 		encoder.SetIndent("", "  ")
 		_ = encoder.Encode(projectCommandErrorEnvelope{Error: body})
 	}
 	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "kwt projects: %s: %s\n", code, message)
 	return &projectCommandError{body: body, exitCode: exitCode}
+}
+
+func projectCommandJSONRequested() bool {
+	if projectsJSON || projectsAddJSON {
+		return true
+	}
+	// pflag stops at the first parse error, so a later --json never reaches
+	// the bound variable. Preserve the caller's output choice from raw argv.
+	requested := false
+	for _, argument := range os.Args[1:] {
+		if argument == "--" {
+			break
+		}
+		if argument == "--json" {
+			requested = true
+			continue
+		}
+		name, value, ok := strings.Cut(argument, "=")
+		if !ok || name != "--json" {
+			continue
+		}
+		enabled, err := strconv.ParseBool(value)
+		if err == nil {
+			requested = enabled
+		}
+	}
+	return requested
 }
 
 // canonicalizeProjectIdentities returns a copy of projects with every

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -31,18 +31,28 @@ var projectsCmd = &cobra.Command{
 Registered projects hold main-repository paths that may live outside the
 configured worktree base directory. Use --json for a machine-readable surface
 that external automation can consume without parsing the config file.`,
-	Args: cobra.NoArgs,
+	Args: projectsNoArgs,
 	// Isolation: projects is a global registry surface and must not merge the
 	// caller's cwd .kwt.toml. The command still propagates global config
 	// initialization failures through Cobra.
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return requireConfigInitialization() },
-	RunE:              runProjects,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireConfigInitialization(); err != nil {
+			return writeProjectCommandError(
+				cmd,
+				"registration_failed",
+				fmt.Sprintf("failed to initialize configuration: %v", err),
+				1,
+			)
+		}
+		return nil
+	},
+	RunE: runProjects,
 }
 
 var projectsAddCmd = &cobra.Command{
 	Use:   "add <path>",
 	Short: "Register an existing Git repository",
-	Args:  cobra.ExactArgs(1),
+	Args:  projectsExactArgs(1),
 	RunE:  runProjectsAdd,
 }
 
@@ -51,6 +61,9 @@ func init() {
 	projectsCmd.Flags().BoolVar(&projectsJSON, "json", false, "Output in JSON format")
 	projectsAddCmd.Flags().BoolVar(&projectsAddJSON, "json", false, "Output a machine-readable result")
 	projectsCmd.AddCommand(projectsAddCmd)
+	projectsCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return writeProjectCommandError(cmd, "invalid_repository", err.Error(), 2)
+	})
 }
 
 func runProjects(cmd *cobra.Command, args []string) error {
@@ -101,6 +114,32 @@ type projectCommandError struct {
 
 func (e *projectCommandError) Error() string { return e.body.Message }
 func (e *projectCommandError) ExitCode() int { return e.exitCode }
+
+func projectsNoArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return writeProjectCommandError(
+		cmd,
+		"invalid_repository",
+		"this command does not accept positional arguments",
+		2,
+	)
+}
+
+func projectsExactArgs(count int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) == count {
+			return nil
+		}
+		return writeProjectCommandError(
+			cmd,
+			"invalid_repository",
+			fmt.Sprintf("expected %d repository path, received %d", count, len(args)),
+			2,
+		)
+	}
+}
 
 func runProjectsAdd(cmd *cobra.Command, args []string) error {
 	project, err := resolveProjectForRegistration(args[0])
@@ -216,7 +255,7 @@ func writeProjectCommandError(
 	}
 	cmd.Root().SilenceUsage = true
 	cmd.Root().SilenceErrors = true
-	if projectsAddJSON {
+	if projectsJSON || projectsAddJSON {
 		encoder := json.NewEncoder(cmd.OutOrStdout())
 		encoder.SetIndent("", "  ")
 		_ = encoder.Encode(projectCommandErrorEnvelope{Error: body})

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/git"
@@ -409,4 +412,76 @@ func TestRunProjectsAddJSONWritesStableInvalidRepositoryError(t *testing.T) {
 	assert.False(t, response.Error.Retryable)
 	assert.NotEmpty(t, response.Error.Message)
 	assert.Contains(t, stderr.String(), "invalid_repository")
+}
+
+func TestProjectsAddArgumentValidationUsesStructuredErrors(t *testing.T) {
+	projectsAddJSON = true
+	t.Cleanup(func() { projectsAddJSON = false })
+	cmd, stdout, stderr := projectsTestCommand()
+
+	err := projectsExactArgs(1)(cmd, nil)
+
+	var exitErr *projectCommandError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 2, exitErr.ExitCode())
+	var envelope projectCommandErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "invalid_repository", envelope.Error.Code)
+	assert.Contains(t, stderr.String(), "invalid_repository")
+}
+
+func TestProjectsAddFlagValidationUsesStructuredErrors(t *testing.T) {
+	projectsAddJSON = true
+	t.Cleanup(func() { projectsAddJSON = false })
+	cmd, stdout, stderr := projectsTestCommand()
+
+	err := projectsCmd.FlagErrorFunc()(cmd, errors.New("unknown flag: --bogus"))
+
+	var exitErr *projectCommandError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 2, exitErr.ExitCode())
+	var envelope projectCommandErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "invalid_repository", envelope.Error.Code)
+	assert.Contains(t, stderr.String(), "invalid_repository")
+}
+
+func TestProjectsConfigInitializationFailureUsesJSONContract(t *testing.T) {
+	if os.Getenv("KWT_TEST_PROJECTS_CONFIG_INIT_FAILURE") == "1" {
+		rootCmd.SetArgs([]string{"projects", "add", "/missing", "--json"})
+		rootCmd.SetOut(os.Stdout)
+		rootCmd.SetErr(os.Stderr)
+		Execute()
+		return
+	}
+
+	kwtHome := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(kwtHome, "config.toml"), []byte("invalid = [\n"), 0o600))
+	cmd := exec.Command(os.Args[0], "-test.run=^TestProjectsConfigInitializationFailureUsesJSONContract$")
+	cmd.Env = append(os.Environ(),
+		"KWT_TEST_PROJECTS_CONFIG_INIT_FAILURE=1",
+		"KWT_HOME="+kwtHome,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	var envelope projectCommandErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "registration_failed", envelope.Error.Code)
+	assert.Contains(t, stderr.String(), "registration_failed")
+}
+
+func projectsTestCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	return cmd, stdout, stderr
 }

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -344,4 +345,68 @@ func TestRunProjectsJSONEmptyIsArray(t *testing.T) {
 	if len(got) != 0 {
 		t.Errorf("expected empty array, got %d entries", len(got))
 	}
+}
+
+func TestRunProjectsAddJSONRegistersCanonicalProject(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	canonicalRepoPath, err := filepath.EvalSymlinks(repoPath)
+	require.NoError(t, err)
+	runTUITestGit(t, repoPath, "remote", "add", "origin", "git@github.com:acme/widget.git")
+	linkedPath := filepath.Join(t.TempDir(), "linked")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "linked", linkedPath)
+
+	originalRegister := registerProject
+	t.Cleanup(func() { registerProject = originalRegister })
+	var registered models.Project
+	registerProject = func(project models.Project) error {
+		registered = project
+		return nil
+	}
+	projectsAddJSON = true
+	t.Cleanup(func() { projectsAddJSON = false })
+	stdout := &bytes.Buffer{}
+	projectsAddCmd.SetOut(stdout)
+
+	require.NoError(t, runProjectsAdd(projectsAddCmd, []string{linkedPath}))
+
+	var response struct {
+		Status  string         `json:"status"`
+		Project models.Project `json:"project"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
+	assert.Equal(t, "registered", response.Status)
+	assert.Equal(t, "github.com/acme/widget", response.Project.Repository)
+	assert.Equal(t, canonicalRepoPath, response.Project.Path)
+	assert.NotEmpty(t, response.Project.LastTouched)
+	assert.Equal(t, response.Project, registered)
+}
+
+func TestRunProjectsAddJSONWritesStableInvalidRepositoryError(t *testing.T) {
+	projectsAddJSON = true
+	t.Cleanup(func() { projectsAddJSON = false })
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	projectsAddCmd.SetOut(stdout)
+	projectsAddCmd.SetErr(stderr)
+
+	err := runProjectsAdd(
+		projectsAddCmd,
+		[]string{filepath.Join(t.TempDir(), "missing")},
+	)
+
+	var exitErr interface{ ExitCode() int }
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 2, exitErr.ExitCode())
+	var response struct {
+		Error struct {
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			Retryable bool   `json:"retryable"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
+	assert.Equal(t, "invalid_repository", response.Error.Code)
+	assert.False(t, response.Error.Retryable)
+	assert.NotEmpty(t, response.Error.Message)
+	assert.Contains(t, stderr.String(), "invalid_repository")
 }

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -430,14 +430,30 @@ func TestProjectsAddArgumentValidationUsesStructuredErrors(t *testing.T) {
 	assert.Contains(t, stderr.String(), "invalid_repository")
 }
 
-func TestProjectsAddFlagValidationUsesStructuredErrors(t *testing.T) {
-	projectsAddJSON = true
-	t.Cleanup(func() { projectsAddJSON = false })
-	cmd, stdout, stderr := projectsTestCommand()
+func TestProjectsAddUnknownFlagBeforeJSONUsesStructuredError(t *testing.T) {
+	if os.Getenv("KWT_TEST_PROJECTS_UNKNOWN_FLAG") == "1" {
+		os.Args = []string{
+			os.Args[0],
+			"projects",
+			"add",
+			"--bogus",
+			"--json",
+		}
+		rootCmd.SetOut(os.Stdout)
+		rootCmd.SetErr(os.Stderr)
+		Execute()
+		return
+	}
 
-	err := projectsCmd.FlagErrorFunc()(cmd, errors.New("unknown flag: --bogus"))
+	cmd := exec.Command(os.Args[0], "-test.run=^TestProjectsAddUnknownFlagBeforeJSONUsesStructuredError$")
+	cmd.Env = append(os.Environ(), "KWT_TEST_PROJECTS_UNKNOWN_FLAG=1")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	var exitErr *projectCommandError
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 2, exitErr.ExitCode())
 	var envelope projectCommandErrorEnvelope

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -805,6 +806,16 @@ func sameProject(existing, next models.Project) bool {
 		return true
 	}
 	if existing.Repository != "" && next.Repository != "" {
+		existingIdentity, existingOK := repositoryurl.CanonicalRepositoryIdentity(
+			existing.Repository,
+		)
+		nextIdentity, nextOK := repositoryurl.CanonicalRepositoryIdentity(
+			next.Repository,
+		)
+		if existingOK && nextOK {
+			return repositoryurl.FoldRepositoryIdentity(existingIdentity) ==
+				repositoryurl.FoldRepositoryIdentity(nextIdentity)
+		}
 		return existing.Repository == next.Repository
 	}
 	return existing.Path == next.Path

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -996,6 +996,34 @@ func TestRegisterProjectUpdatesExistingProject(t *testing.T) {
 	assert.Equal(t, wantSecondPath, cfg.Projects[0].Path)
 }
 
+func TestRegisterProjectMatchesCaseInsensitiveRepositoryIdentity(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	t.Setenv("KWT_HOME", t.TempDir())
+	require.NoError(t, Init())
+
+	firstPath := t.TempDir()
+	secondPath := t.TempDir()
+	require.NoError(t, RegisterProject(models.Project{
+		Repository: "github.com/Acme/Widget",
+		Name:       "widget",
+		Path:       firstPath,
+	}))
+	require.NoError(t, RegisterProject(models.Project{
+		Repository: "github.com/acme/widget",
+		Name:       "widget",
+		Path:       secondPath,
+	}))
+	wantSecondPath, err := filepath.EvalSymlinks(secondPath)
+	require.NoError(t, err)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Len(t, cfg.Projects, 1)
+	assert.Equal(t, wantSecondPath, cfg.Projects[0].Path)
+}
+
 func TestRegisterProjectUpgradesPathFallbackByPath(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(func() { viper.Reset() })


### PR DESCRIPTION
Fresh hosts can receive a kwt binary but still cannot populate the project registry without opening the TUI or editing kwt configuration directly. This adds a supported machine-readable projects add command so external clients can onboard an existing checkout explicitly.

Registration resolves linked worktrees to their canonical main repository, preserves an existing stable identity, and converges repeated calls on one registry entry. Structured success and error envelopes provide a durable automation boundary without exposing configuration internals.

Validated with the full Go test suite, lint, build, and an isolated end-to-end run that registered the same repository twice and observed one canonical JSON project entry.
