### PR TITLE
Create missing workspace sessions before attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ kwt add -b feature/new-ui
 # Create without launching tmux
 kwt add --no-launch -b feature/new-ui
 
-# Attach to an existing worktree workspace
+# Open a worktree workspace, creating its session when needed
 kwt open
+
+# Establish an exact workspace session for another tmux client
+kwt open /path/to/worktree --start-session
 
 # Inspect worktrees and git status
 kwt list
@@ -224,7 +227,7 @@ spaces.
 | ---------------- | ----------------------------------------- |
 | `kwt`, `kwt tui` | Cross-project dashboard                   |
 | `kwt add`        | Create a worktree                         |
-| `kwt open`       | Fuzzy-pick and attach to a workspace      |
+| `kwt open`       | Open or establish a workspace session     |
 | `kwt list`       | List worktrees                            |
 | `kwt status`     | Show git status, sync state, and activity |
 | `kwt projects`   | List or register project repositories     |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,7 +54,9 @@ the canonical tmux workspace with its resolved layout before attaching.
 `kwt open <exact-worktree-path> --start-session` performs the same layout and
 session bootstrap without attaching a client. Use it before an external
 ordinary tmux client attaches to a session that may not exist yet. The exact
-path requirement keeps this automation mode noninteractive and unambiguous.
+path is resolved directly from Git rather than the global worktree base, which
+keeps this automation mode noninteractive and supports linked worktrees stored
+outside that base.
 Protected pull-request imports remain restricted to `kwt pr attach`.
 
 ## `kwt list`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ stable command surface.
 | ---------------- | ------------------------------------------------------ |
 | `kwt`, `kwt tui` | Open the cross-project and multi-machine dashboard.    |
 | `kwt add`        | Create a worktree and optionally launch its workspace. |
-| `kwt open`       | Fuzzy-pick and attach to a workspace.                  |
+| `kwt open`       | Open or establish a worktree workspace session.        |
 | `kwt list`       | List worktrees.                                        |
 | `kwt status`     | Show Git status, sync state, and activity.             |
 | `kwt projects`   | List registered project repositories.                  |
@@ -28,6 +28,7 @@ stable command surface.
 ```sh
 kwt add -b fix/parser-race
 kwt open parser
+kwt open /path/to/worktree --start-session
 kwt status
 kwt pr list --project github.com/acme/widget --json
 kwt pr import 17 --project github.com/acme/widget \
@@ -44,6 +45,18 @@ When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local
 `main`, then `master`, then the branch checked out in the primary worktree.
 
+## `kwt open`
+
+With no argument, `kwt open` fuzzy-picks a worktree. A pattern narrows the
+cross-project list and opens the sole match directly. Kwt creates or repairs
+the canonical tmux workspace with its resolved layout before attaching.
+
+`kwt open <exact-worktree-path> --start-session` performs the same layout and
+session bootstrap without attaching a client. Use it before an external
+ordinary tmux client attaches to a session that may not exist yet. The exact
+path requirement keeps this automation mode noninteractive and unambiguous.
+Protected pull-request imports remain restricted to `kwt pr attach`.
+
 ## `kwt list`
 
 `--json` emits an array of objects with `path`, `branch`, `commit_hash`, `is_main`,
@@ -51,11 +64,11 @@ default branch. If that remote base is unavailable, it falls back to local
 slug, or a `local/<path>` fallback for a repository without a usable remote —
 see below), and `session_name` (the tmux workspace session name kwt attaches to).
 An imported pull-request worktree additionally includes `tmux_socket_name` for
-its protected workspace-specific server. To
-converge on the same session, prefer an attach-only command — `tmux
-attach-session -t <session_name>` on the normal server, or `kwt pr attach
-<path>` when `tmux_socket_name` is present — so you never create the session
-bare or bypass its protected attach policy. See [Attaching from other
+its protected workspace-specific server. To converge on the same session, run
+`kwt open <path> --start-session` before an ordinary attach-only client, or
+`kwt pr attach <path>` when `tmux_socket_name` is present. This lets kwt create
+the session when needed without a client creating it bare or bypassing its
+protected attach policy. See [Attaching from other
 tools](#attaching-from-other-tools) before using `new-session`.
 `kwt open` and dashboard open actions refuse protected pull-request imports
 and direct the user through `kwt pr attach`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ stable command surface.
 | `kwt list`       | List worktrees.                                        |
 | `kwt status`     | Show Git status, sync state, and activity.             |
 | `kwt projects`   | List registered project repositories.                  |
-| `kwt pr`         | Discover and import pull requests through JSON.         |
+| `kwt pr`         | Discover and import pull requests through JSON.        |
 | `kwt get`        | Print a matching worktree path.                        |
 | `kwt cd`         | Open a shell in a matching worktree.                   |
 | `kwt exec`       | Run a command in a matching worktree.                  |
@@ -207,7 +207,7 @@ pane applications resolving tmux's own `TERM`.
 
 ### Attaching from other tools
 
-kwt applies this bootstrap when it *creates* a session. A session that some
+kwt applies this bootstrap when it _creates_ a session. A session that some
 other tool created — for example with `tmux new-session -A -s <session_name>`,
 which attaches if the session exists but otherwise creates it bare — starts
 without the `default-command` and remove-markers, so its windows would not
@@ -216,7 +216,7 @@ match kwt's until repaired.
 Two rules keep external tools consistent with kwt:
 
 - **When the session already exists, attach only:** use `tmux attach-session -t
-  <session_name>` (or `switch-client -t` from inside tmux). Attach-only commands
+<session_name>` (or `switch-client -t` from inside tmux). Attach-only commands
   never create a bare session, so there is nothing to repair.
 - **If your tool creates the session itself, apply the equivalent bootstrap:**
   set `default-command` to `""` and add a session-scoped remove-marker

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -85,26 +85,43 @@ func runOpen(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("--start-session requires an exact worktree path")
 		}
 
-		entries, err := discovery.DiscoverGlobalWorktrees(ctx.Config.Worktree.BaseDir, ctx.Config.Projects)
-		if err != nil {
-			return fmt.Errorf("failed to discover worktrees: %w", err)
-		}
-		if len(entries) == 0 {
-			if len(args) == 1 {
-				return fmt.Errorf("could not resolve worktree %s", args[0])
-			}
-			ctx.Printer.PrintInfo("No worktrees found in " + ctx.Config.Worktree.BaseDir)
-			return nil
-		}
-
 		finder := ctx.GetGlobalFinder()
 		var entry *discovery.GlobalWorktreeEntry
 		requestedPath := ""
-		if len(args) == 1 {
+		if openStartSession {
 			requestedPath = args[0]
-			if openStartSession {
-				entry = findEntryByPath(entries, requestedPath)
-			} else {
+			var err error
+			entry, err = discovery.DiscoverWorktree(
+				requestedPath,
+				ctx.Config.Projects,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"could not resolve worktree %s: %w",
+					requestedPath,
+					err,
+				)
+			}
+		} else {
+			entries, err := discovery.DiscoverGlobalWorktrees(
+				ctx.Config.Worktree.BaseDir,
+				ctx.Config.Projects,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to discover worktrees: %w", err)
+			}
+			if len(entries) == 0 {
+				if len(args) == 1 {
+					return fmt.Errorf("could not resolve worktree %s", args[0])
+				}
+				ctx.Printer.PrintInfo(
+					"No worktrees found in " + ctx.Config.Worktree.BaseDir,
+				)
+				return nil
+			}
+
+			if len(args) == 1 {
+				requestedPath = args[0]
 				matches := discovery.FilterGlobalWorktrees(
 					entries,
 					requestedPath,
@@ -125,15 +142,15 @@ func runOpen(cmd *cobra.Command, args []string) error {
 					}
 					entry = findEntryByPath(matches, selected.Path)
 				}
+			} else {
+				worktrees := discovery.ConvertToWorktreeModels(entries, false)
+				selected, err := finder.SelectWorktree(worktrees)
+				if err != nil {
+					return fmt.Errorf("selection cancelled: %w", err)
+				}
+				requestedPath = selected.Path
+				entry = findEntryByPath(entries, requestedPath)
 			}
-		} else {
-			worktrees := discovery.ConvertToWorktreeModels(entries, false)
-			selected, err := finder.SelectWorktree(worktrees)
-			if err != nil {
-				return fmt.Errorf("selection cancelled: %w", err)
-			}
-			requestedPath = selected.Path
-			entry = findEntryByPath(entries, requestedPath)
 		}
 
 		if entry == nil || entry.RepositoryInfo == nil {

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -10,22 +10,44 @@ import (
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
 var (
 	openLayout       string
 	openSelectLayout bool
+	openStartSession bool
+
+	newOpenWorkspaceRunner = func() openWorkspaceRunner {
+		return tmux.NewWorkspaceRunner(tmux.NewTmuxCommand(""))
+	}
 )
 
+type openWorkspaceRunner interface {
+	Ensure(context.Context, string, string, models.Layout) error
+	EnsureAndAttach(
+		context.Context,
+		string,
+		string,
+		models.Layout,
+		bool,
+	) error
+}
+
 var openCmd = &cobra.Command{
-	Use:   "open",
+	Use:   "open [pattern]",
 	Short: "Open a worktree workspace from any repository",
 	Long: `Fuzzy-pick a worktree across all repositories in the configured base
 directory and attach to its tmux workspace, creating the workspace with the
-resolved layout if it does not yet exist.`,
+resolved layout if it does not yet exist. A pattern filters the worktree list.
+Pass an exact worktree path with --start-session to create or repair the
+workspace without attaching.`,
 	Example: `  # Pick a worktree and open its workspace
   kwt open
+
+  # Ensure an exact worktree workspace exists without attaching
+  kwt open /path/to/worktree --start-session
 
   # Force a specific layout
   kwt open --layout focus
@@ -36,6 +58,7 @@ resolved layout if it does not yet exist.`,
 	// root cwd merge keeps the global config pristine while still
 	// propagating global config initialization failures.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return requireConfigInitialization() },
+	Args:              cobra.MaximumNArgs(1),
 	RunE:              runOpen,
 }
 
@@ -44,6 +67,12 @@ func init() {
 	openCmd.Flags().StringVar(&openLayout, "layout", "", "Workspace layout preset to launch (\"none\" = blank session)")
 	openCmd.Flags().BoolVarP(&openSelectLayout, "select-layout", "L", false,
 		"Fuzzy-pick a workspace layout")
+	openCmd.Flags().BoolVar(
+		&openStartSession,
+		"start-session",
+		false,
+		"ensure an exact worktree's workspace exists without attaching",
+	)
 	openCmd.MarkFlagsMutuallyExclusive("layout", "select-layout")
 }
 
@@ -52,26 +81,63 @@ func runOpen(cmd *cobra.Command, args []string) error {
 		if err := tmux.ValidateLayouts(ctx.Config.Layouts, ctx.Config.Agents); err != nil {
 			return err
 		}
+		if openStartSession && len(args) != 1 {
+			return fmt.Errorf("--start-session requires an exact worktree path")
+		}
 
 		entries, err := discovery.DiscoverGlobalWorktrees(ctx.Config.Worktree.BaseDir, ctx.Config.Projects)
 		if err != nil {
 			return fmt.Errorf("failed to discover worktrees: %w", err)
 		}
 		if len(entries) == 0 {
+			if len(args) == 1 {
+				return fmt.Errorf("could not resolve worktree %s", args[0])
+			}
 			ctx.Printer.PrintInfo("No worktrees found in " + ctx.Config.Worktree.BaseDir)
 			return nil
 		}
 
 		finder := ctx.GetGlobalFinder()
-		worktrees := discovery.ConvertToWorktreeModels(entries, false)
-		selected, err := finder.SelectWorktree(worktrees)
-		if err != nil {
-			return fmt.Errorf("selection cancelled: %w", err)
+		var entry *discovery.GlobalWorktreeEntry
+		requestedPath := ""
+		if len(args) == 1 {
+			requestedPath = args[0]
+			if openStartSession {
+				entry = findEntryByPath(entries, requestedPath)
+			} else {
+				matches := discovery.FilterGlobalWorktrees(
+					entries,
+					requestedPath,
+				)
+				switch len(matches) {
+				case 0:
+				case 1:
+					entry = matches[0]
+				default:
+					selected, selectErr := finder.SelectWorktree(
+						discovery.ConvertToWorktreeModels(matches, true),
+					)
+					if selectErr != nil {
+						return fmt.Errorf(
+							"selection cancelled: %w",
+							selectErr,
+						)
+					}
+					entry = findEntryByPath(matches, selected.Path)
+				}
+			}
+		} else {
+			worktrees := discovery.ConvertToWorktreeModels(entries, false)
+			selected, err := finder.SelectWorktree(worktrees)
+			if err != nil {
+				return fmt.Errorf("selection cancelled: %w", err)
+			}
+			requestedPath = selected.Path
+			entry = findEntryByPath(entries, requestedPath)
 		}
 
-		entry := findEntryByPath(entries, selected.Path)
 		if entry == nil || entry.RepositoryInfo == nil {
-			return fmt.Errorf("could not resolve repository info for %s", selected.Path)
+			return fmt.Errorf("could not resolve worktree %s", requestedPath)
 		}
 
 		return openSelectedWorktree(
@@ -85,6 +151,7 @@ func runOpen(cmd *cobra.Command, args []string) error {
 				}
 				return *sel, nil
 			},
+			openStartSession,
 		)
 	})(cmd, args)
 }
@@ -94,6 +161,7 @@ func openSelectedWorktree(
 	ctx *CommandContext,
 	entry *discovery.GlobalWorktreeEntry,
 	selectLayout func([]models.Layout) (models.Layout, error),
+	startSession bool,
 ) error {
 	if err := rejectProtectedWorkspaceOpen(commandCtx, entry.Path); err != nil {
 		return err
@@ -132,7 +200,10 @@ func openSelectedWorktree(
 	}
 
 	session := tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path)
-	runner := tmux.NewWorkspaceRunner(tmux.NewTmuxCommand(""))
+	runner := newOpenWorkspaceRunner()
+	if startSession {
+		return runner.Ensure(commandCtx, session, entry.Path, layout)
+	}
 	return runner.EnsureAndAttach(
 		commandCtx, session, entry.Path, layout, os.Getenv("TMUX") != "",
 	)
@@ -150,8 +221,9 @@ func shouldLoadTargetDefault(layoutFlag string, selectLayout bool) bool {
 func findEntryByPath(
 	entries []*discovery.GlobalWorktreeEntry, path string,
 ) *discovery.GlobalWorktreeEntry {
+	path = utils.CanonicalPath(path)
 	for _, e := range entries {
-		if e.Path == path {
+		if utils.CanonicalPath(e.Path) == path {
 			return e
 		}
 	}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -74,6 +74,7 @@ func init() {
 		"ensure an exact worktree's workspace exists without attaching",
 	)
 	openCmd.MarkFlagsMutuallyExclusive("layout", "select-layout")
+	openCmd.MarkFlagsMutuallyExclusive("start-session", "select-layout")
 }
 
 func runOpen(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -169,6 +169,7 @@ func runOpen(cmd *cobra.Command, args []string) error {
 				return *sel, nil
 			},
 			openStartSession,
+			config.StdinInteractive(),
 		)
 	})(cmd, args)
 }
@@ -179,6 +180,7 @@ func openSelectedWorktree(
 	entry *discovery.GlobalWorktreeEntry,
 	selectLayout func([]models.Layout) (models.Layout, error),
 	startSession bool,
+	stdinInteractive bool,
 ) error {
 	if err := rejectProtectedWorkspaceOpen(commandCtx, entry.Path); err != nil {
 		return err
@@ -195,7 +197,10 @@ func openSelectedWorktree(
 		if err != nil {
 			return fmt.Errorf("failed to find repository root: %w", err)
 		}
-		targetDefault, err = config.LoadRepoLayoutDefault(repoRoot, config.StdinInteractive())
+		targetDefault, err = config.LoadRepoLayoutDefault(
+			repoRoot,
+			stdinInteractive && !startSession,
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,6 +94,7 @@ func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 		},
 		nil,
 		false,
+		false,
 	)
 
 	require.Error(t, err)
@@ -123,9 +127,63 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 		},
 		nil,
 		true,
+		false,
 	)
 
 	require.NoError(t, err)
+	assert.True(t, runner.ensured)
+	assert.False(t, runner.attached)
+}
+
+func TestOpenSelectedWorktreeStartSessionDoesNotPromptForTargetTrust(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	repo := t.TempDir()
+	gitInit := exec.Command("git", "init", "-b", "main", repo)
+	require.NoError(t, gitInit.Run())
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, ".kwt.toml"),
+		[]byte("[layouts]\ndefault = \"focus\"\n"),
+		0o644,
+	))
+
+	runner := &recordingOpenWorkspaceRunner{}
+	oldNewRunner := newOpenWorkspaceRunner
+	oldLayout := openLayout
+	oldSelectLayout := openSelectLayout
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = oldNewRunner
+		openLayout = oldLayout
+		openSelectLayout = oldSelectLayout
+	})
+	newOpenWorkspaceRunner = func() openWorkspaceRunner { return runner }
+	openLayout = ""
+	openSelectLayout = false
+
+	stderr, err := os.Create(filepath.Join(t.TempDir(), "stderr"))
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = stderr
+	err = openSelectedWorktree(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		&discovery.GlobalWorktreeEntry{
+			Path:   repo,
+			Branch: "feature",
+			RepositoryInfo: &url.RepositoryInfo{
+				FullPath: "github.com/acme/widget",
+			},
+		},
+		nil,
+		true,
+		true,
+	)
+	os.Stderr = oldStderr
+	require.NoError(t, stderr.Close())
+	output, readErr := os.ReadFile(stderr.Name())
+	require.NoError(t, readErr)
+
+	require.NoError(t, err)
+	assert.NotContains(t, string(output), "Trust this file and load it?")
 	assert.True(t, runner.ensured)
 	assert.False(t, runner.attached)
 }

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -8,9 +8,29 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+type recordingOpenWorkspaceRunner struct {
+	ensured  bool
+	attached bool
+}
+
+func (r *recordingOpenWorkspaceRunner) Ensure(
+	context.Context, string, string, models.Layout,
+) error {
+	r.ensured = true
+	return nil
+}
+
+func (r *recordingOpenWorkspaceRunner) EnsureAndAttach(
+	context.Context, string, string, models.Layout, bool,
+) error {
+	r.attached = true
+	return nil
+}
 
 func TestFindEntryByPath(t *testing.T) {
 	a := &discovery.GlobalWorktreeEntry{
@@ -70,10 +90,44 @@ func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 			},
 		},
 		nil,
+		false,
 	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kwt pr attach")
+}
+
+func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
+	runner := &recordingOpenWorkspaceRunner{}
+	oldNewRunner := newOpenWorkspaceRunner
+	oldLayout := openLayout
+	oldSelectLayout := openSelectLayout
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = oldNewRunner
+		openLayout = oldLayout
+		openSelectLayout = oldSelectLayout
+	})
+	newOpenWorkspaceRunner = func() openWorkspaceRunner { return runner }
+	openLayout = tmux.BlankLayoutName
+	openSelectLayout = false
+
+	err := openSelectedWorktree(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		&discovery.GlobalWorktreeEntry{
+			Path:   t.TempDir(),
+			Branch: "feature",
+			RepositoryInfo: &url.RepositoryInfo{
+				FullPath: "github.com/acme/widget",
+			},
+		},
+		nil,
+		true,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, runner.ensured)
+	assert.False(t, runner.attached)
 }
 
 // TestOpenCmdIsolatesFromCwdConfig guards the config-isolation invariant:

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -68,6 +68,33 @@ func TestShouldLoadTargetDefault(t *testing.T) {
 	}
 }
 
+func TestOpenStartSessionFlagGroups(t *testing.T) {
+	startSession := openCmd.Flags().Lookup("start-session")
+	selectLayout := openCmd.Flags().Lookup("select-layout")
+	layout := openCmd.Flags().Lookup("layout")
+	require.NotNil(t, startSession)
+	require.NotNil(t, selectLayout)
+	require.NotNil(t, layout)
+
+	oldStartSessionChanged := startSession.Changed
+	oldSelectLayoutChanged := selectLayout.Changed
+	oldLayoutChanged := layout.Changed
+	t.Cleanup(func() {
+		startSession.Changed = oldStartSessionChanged
+		selectLayout.Changed = oldSelectLayoutChanged
+		layout.Changed = oldLayoutChanged
+	})
+
+	startSession.Changed = true
+	selectLayout.Changed = true
+	layout.Changed = false
+	require.Error(t, openCmd.ValidateFlagGroups())
+
+	selectLayout.Changed = false
+	layout.Changed = true
+	require.NoError(t, openCmd.ValidateFlagGroups())
+}
+
 func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 	t *testing.T,
 ) {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -111,6 +111,34 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 	return extractWorktreeCandidates(candidates, projects, extractWorktreeInfo), nil
 }
 
+// DiscoverWorktree resolves one exact worktree root independently of the
+// configured global base directory. Automation callers already holding a path
+// from repository-local inventory can therefore establish that workspace even
+// when the linked worktree lives elsewhere.
+func DiscoverWorktree(path string, projects []models.Project) (*GlobalWorktreeEntry, error) {
+	expanded, err := utils.ExpandPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand worktree path: %w", err)
+	}
+	repositoryGit := git.New(expanded)
+	root, err := repositoryGit.GetRepositoryPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find worktree root: %w", err)
+	}
+	if utils.CanonicalPath(root) != utils.CanonicalPath(expanded) {
+		return nil, fmt.Errorf("path is not a worktree root")
+	}
+	entry, err := extractWorktreeInfo(root, projects)
+	if err != nil {
+		return nil, err
+	}
+	if mainRoot, mainErr := repositoryGit.GetMainRepositoryPath(); mainErr == nil {
+		entry.IsMain =
+			utils.CanonicalPath(mainRoot) == utils.CanonicalPath(root)
+	}
+	return entry, nil
+}
+
 func extractWorktreeCandidates(
 	candidates []worktreeCandidate,
 	projects []models.Project,

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -11,6 +11,7 @@ import (
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -293,6 +294,35 @@ func TestDiscoverGlobalWorktrees_RegisteredIdentityWinsForForkOrigin(t *testing.
 		if got := entry.Model().SessionName; got != wantSession {
 			t.Errorf("entry %s: SessionName = %q, want %q", entry.Path, got, wantSession)
 		}
+	}
+}
+
+func TestDiscoverWorktreeResolvesLinkedPathOutsideGlobalBase(t *testing.T) {
+	mainDir := filepath.Join(t.TempDir(), "registered", "widget")
+	repo := initRepoAt(t, mainDir, "https://github.com/fork/widget.git")
+	repo.CreateBranch(t, "feature")
+	worktreePath := filepath.Join(t.TempDir(), "external", "feature")
+	repo.CreateWorktree(t, worktreePath, "feature")
+
+	entry, err := DiscoverWorktree(worktreePath, []models.Project{{
+		Repository: "github.com/acme/widget",
+		Path:       mainDir,
+	}})
+
+	if err != nil {
+		t.Fatalf("DiscoverWorktree() error = %v", err)
+	}
+	if utils.CanonicalPath(entry.Path) != utils.CanonicalPath(worktreePath) {
+		t.Errorf("Path = %q, want %q", entry.Path, worktreePath)
+	}
+	if entry.RepositoryInfo == nil {
+		t.Fatal("RepositoryInfo = nil")
+	}
+	if entry.RepositoryInfo.FullPath != "github.com/acme/widget" {
+		t.Errorf(
+			"RepositoryInfo.FullPath = %q, want github.com/acme/widget",
+			entry.RepositoryInfo.FullPath,
+		)
 	}
 }
 

--- a/internal/tmux/bootstrap_integration_test.go
+++ b/internal/tmux/bootstrap_integration_test.go
@@ -14,6 +14,42 @@ import (
 	"go.kenn.io/kwt/pkg/models"
 )
 
+func TestGlobalEnvironmentReadsFreshNamedServer(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not found in PATH")
+	}
+
+	socket := fmt.Sprintf("kwt-envtest-%d-%d", os.Getpid(), time.Now().UnixNano())
+	t.Cleanup(func() { killPrivateTmuxServer(socket) })
+	t.Setenv("KWT_FRESH_SERVER_CANARY", "visible")
+	t.Setenv("KWT_GITHUB_TOKEN", "must-not-reach-server")
+
+	command := NewTmuxCommandForSocketWithStripNames(
+		"tmux",
+		socket,
+		[]string{"KWT_GITHUB_TOKEN"},
+	)
+	globalEnvironment, err := command.GlobalEnvironment()
+	if err != nil {
+		t.Fatalf("read fresh server environment: %v", err)
+	}
+	if !strings.Contains(
+		globalEnvironment,
+		"KWT_FRESH_SERVER_CANARY=visible",
+	) {
+		t.Errorf(
+			"fresh server environment omitted the launcher canary; got:\n%s",
+			globalEnvironment,
+		)
+	}
+	if strings.Contains(globalEnvironment, "KWT_GITHUB_TOKEN=") {
+		t.Errorf(
+			"fresh server environment leaked the configured credential; got:\n%s",
+			globalEnvironment,
+		)
+	}
+}
+
 // TestStripEnvMasksGlobalEnvForSessionOnly exercises the real session
 // bootstrap sequence against a private tmux server and confirms that a
 // variable present in the server-global environment at server-start time is

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -3,7 +3,6 @@ package tmux
 import (
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -188,9 +187,6 @@ func (r *WorkspaceRunner) validateProtectedState(
 ) error {
 	globalEnvironment, err := r.tmux.GlobalEnvironment()
 	if err != nil {
-		if !sessionExists && errors.Is(err, errNoServerRunning) {
-			return nil
-		}
 		return fmt.Errorf("cannot verify tmux server environment: %w", err)
 	}
 	if name, ok := firstMatchingName(

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3,16 +3,11 @@ package tmux
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 )
-
-// errNoServerRunning distinguishes a clean first-session launch from a tmux
-// server whose environment could not be inspected.
-var errNoServerRunning = errors.New("tmux server is not running")
 
 // TmuxInterface defines the contract for tmux operations
 type TmuxInterface interface {
@@ -311,20 +306,19 @@ func (t *TmuxCommand) RunCommandOutputContext(ctx context.Context, args ...strin
 	return stdout.String(), nil
 }
 
-// GlobalEnvironment returns the tmux server's global environment table via
-// show-environment -g, one "NAME=VALUE" (or "-NAME") entry per line. It fails
-// when no server is running; callers treat that as "nothing to inspect" and
-// fall back to the launcher-derived strip set.
+// GlobalEnvironment returns the tmux server's global environment table, one
+// "NAME=VALUE" (or "-NAME") entry per line. start-server is a no-op for an
+// existing server; on a fresh named socket it lets show-environment inspect
+// the sanitized server state without interpreting platform-specific
+// connection errors. The empty server exits after the command sequence.
 func (t *TmuxCommand) GlobalEnvironment() (string, error) {
-	output, err := t.RunCommandOutputContext(
+	return t.RunCommandOutputContext(
 		context.Background(),
+		"start-server",
+		";",
 		"show-environment",
 		"-g",
 	)
-	if err != nil && strings.Contains(err.Error(), "no server running") {
-		return "", fmt.Errorf("%w: %v", errNoServerRunning, err)
-	}
-	return output, err
 }
 
 // SessionEnvironment returns a session's own environment table via


### PR DESCRIPTION
A tmux workspace may be absent both on a fresh protected socket and for an ordinary worktree that has not been opened yet. Protected attachment previously depended on one platform-specific no-server error phrase, while ordinary external clients had no exact-path way to ask kwt to apply its layout and environment bootstrap without taking over the terminal.

Start and inspect a fresh tmux server atomically for protected workspaces, and add `kwt open <path> --start-session` for ordinary worktrees. The exact path is resolved directly through Git rather than the configured global base, so repository-local inventory can establish linked worktrees stored elsewhere. Both paths remain owned by kwt: protected imports stay isolated and inert, while ordinary sessions receive their configured layout before another tmux client attaches.

Validated with the full test, build, and lint gates; a protected workspace on a fresh socket with tmux 3.7b; and an ordinary linked worktree outside the global base.