### PR TITLE
Handle transferred repositories in PR commands

### DIFF
--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -117,7 +117,11 @@ use either the registered or resolved repository URL during that transition.
 Existing imports from the same project clone remain discoverable through the
 verified alias pair; the next import migrates their repository, project,
 same-repository source, workspace, and record-key identities to the resolved
-repository atomically.
+repository atomically. Provenance retains the canonical alias history so later
+transfers remain connected through a previously verified identity. Protected
+attachment requires that history to overlap the live registered identity and
+validates the recorded deterministic session against its own historical
+repository identity.
 
 ## Authentication
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -114,6 +114,10 @@ identity. This resolution is operation-local and does not rewrite the
 registered project, whose identity may intentionally name an upstream
 repository while the checkout's origin points to a fork. Import selectors may
 use either the registered or resolved repository URL during that transition.
+Existing imports from the same project clone remain discoverable through the
+verified alias pair; the next import migrates their repository, project,
+same-repository source, workspace, and record-key identities to the resolved
+repository atomically.
 
 ## Authentication
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -106,6 +106,15 @@ multiple projects, kwt returns `repository_mismatch`; callers must use the
 repository identity or path. `--state` accepts `open`, `closed`, or `all` and
 defaults to `open`.
 
+Before listing or importing pull requests, kwt resolves the selected repository
+through GitHub and uses the current canonical identity for the provider request,
+workspace, and provenance. GitHub repository transfers and renames therefore
+continue to work when the project registry still contains the previous
+identity. This resolution is operation-local and does not rewrite the
+registered project, whose identity may intentionally name an upstream
+repository while the checkout's origin points to a fork. Import selectors may
+use either the registered or resolved repository URL during that transition.
+
 ## Authentication
 
 GitHub API authentication is resolved without prompting:

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -412,19 +412,19 @@ and return a stable nonzero status. For example:
 }
 ```
 
-| Exit | Error code                     | Meaning |
-| ---: | ------------------------------ | ------- |
-| 2    | `invalid_pull_request_selector` | Invalid state, URL, opaque ID, or number. |
-| 3    | `authentication_failed`         | GitHub API or Git authentication failed. |
-| 4    | `repository_mismatch` / `unsupported_provider` | Project selection or provider mismatch. |
-| 5    | `pull_request_not_found`        | The selected PR or repository is missing. |
-| 6    | `inaccessible_head`             | The fork or source branch is unavailable. |
-| 7    | `naming_conflict`               | The generated branch or workspace is occupied. |
-| 8    | `network_failure`               | A retryable provider or Git network failure. |
-| 9    | `workspace_creation_failed`     | Worktree creation, setup, push config, persistence, or session-configuration preflight failed. |
-| 10   | `malformed_provider_response`   | GitHub returned an invalid success response. |
-| 11   | `import_conflict`               | Concurrent state or the selected head SHA changed. |
-| 12   | `unsupported_git_version`        | Git is too old for isolated per-worktree push configuration. |
+| Exit | Error code                                     | Meaning                                                                                        |
+| ---: | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+|    2 | `invalid_pull_request_selector`                | Invalid state, URL, opaque ID, or number.                                                      |
+|    3 | `authentication_failed`                        | GitHub API or Git authentication failed.                                                       |
+|    4 | `repository_mismatch` / `unsupported_provider` | Project selection or provider mismatch.                                                        |
+|    5 | `pull_request_not_found`                       | The selected PR or repository is missing.                                                      |
+|    6 | `inaccessible_head`                            | The fork or source branch is unavailable.                                                      |
+|    7 | `naming_conflict`                              | The generated branch or workspace is occupied.                                                 |
+|    8 | `network_failure`                              | A retryable provider or Git network failure.                                                   |
+|    9 | `workspace_creation_failed`                    | Worktree creation, setup, push config, persistence, or session-configuration preflight failed. |
+|   10 | `malformed_provider_response`                  | GitHub returned an invalid success response.                                                   |
+|   11 | `import_conflict`                              | Concurrent state or the selected head SHA changed.                                             |
+|   12 | `unsupported_git_version`                      | Git is too old for isolated per-worktree push configuration.                                   |
 
 GitHub primary and secondary rate limits, including HTTP 429 responses, use
 `network_failure` with `retryable: true`.

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -34,6 +34,7 @@ var (
 	loadPRConfig                     = config.Load
 	loadPRTargetConfig               = config.LoadForTarget
 	newPRService                     = defaultNewPRService
+	newPRGitHubProvider              = pullrequest.NewAuthenticatedGitHubProvider
 	validatePRProjectRoot            = defaultValidatePRProjectRoot
 	inspectPRProjectClone            = defaultInspectPRProjectClone
 	validatePRWorkspaceSessionConfig = defaultValidatePRWorkspaceSessionConfig
@@ -107,7 +108,7 @@ func runPRList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	service, _, err := preparePRService(cmd.Context(), project)
+	service, _, project, err := preparePRService(cmd.Context(), project)
 	if err != nil {
 		return writePRError(cmd, err)
 	}
@@ -128,12 +129,19 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	if _, err := pullrequest.ParseSelector(args[0], project.Identity); err != nil {
-		return writePRError(cmd, err)
-	}
-	service, cfg, err := preparePRService(cmd.Context(), project)
+	number, err := pullrequest.ParseSelectorNumber(args[0])
 	if err != nil {
 		return writePRError(cmd, err)
+	}
+	registeredIdentity := project.Identity
+	service, cfg, project, err := preparePRService(cmd.Context(), project)
+	if err != nil {
+		return writePRError(cmd, err)
+	}
+	if _, err := pullrequest.ParseSelector(args[0], registeredIdentity); err != nil {
+		if _, resolvedErr := pullrequest.ParseSelector(args[0], project.Identity); resolvedErr != nil {
+			return writePRError(cmd, resolvedErr)
+		}
 	}
 	if prStartSession {
 		if err := validatePRWorkspaceSessionConfig(cfg); err != nil {
@@ -145,7 +153,7 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 			))
 		}
 	}
-	result, err := service.Import(cmd.Context(), project, args[0])
+	result, err := service.Import(cmd.Context(), project, fmt.Sprintf("%d", number))
 	if err != nil {
 		return writePRError(cmd, err)
 	}
@@ -452,21 +460,21 @@ func preparePRProject() (pullrequest.Project, error) {
 func preparePRService(
 	ctx context.Context,
 	project pullrequest.Project,
-) (prService, *models.Config, error) {
+) (prService, *models.Config, pullrequest.Project, error) {
 	project, err := validatePRProjectRoot(project)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, project, err
 	}
 	cfg, err := loadPRTargetConfig(project.Path, false)
 	if err != nil {
-		return nil, nil, pullrequest.NewError(
+		return nil, nil, project, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation, "failed to load selected project configuration", false, err)
 	}
-	service, err := newPRService(ctx, cfg, project)
+	service, project, err := newPRService(ctx, cfg, project)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, project, err
 	}
-	return service, cfg, nil
+	return service, cfg, project, nil
 }
 
 func defaultStartPRWorkspaceSession(
@@ -588,17 +596,45 @@ func protectedCredentialNames(cfg *models.Config) []string {
 	return protected
 }
 
-func defaultNewPRService(ctx context.Context, cfg *models.Config, project pullrequest.Project) (prService, error) {
-	provider, err := pullrequest.NewAuthenticatedGitHubProvider(ctx)
+func defaultNewPRService(
+	ctx context.Context,
+	cfg *models.Config,
+	project pullrequest.Project,
+) (prService, pullrequest.Project, error) {
+	provider, err := newPRGitHubProvider(ctx)
 	if err != nil {
-		return nil, err
+		return nil, project, err
 	}
+	info, ok := urlutil.CanonicalRepositoryInfo(project.Identity)
+	if !ok {
+		return nil, project, pullrequest.NewError(
+			pullrequest.CodeUnsupportedProvider,
+			fmt.Sprintf("project %q is not a supported github.com repository", project.Identity),
+			false,
+			nil,
+		)
+	}
+	repository, err := provider.ResolveRepository(ctx, pullrequest.Repository{
+		Provider: "github",
+		Identity: pullrequest.NormalizeRepositoryIdentity(info.FullPath),
+		Host:     info.Host,
+		Owner:    info.Owner,
+		Name:     info.Repository,
+	})
+	if err != nil {
+		return nil, project, err
+	}
+	project.Identity = repository.Identity
 	g := gitadapter.New(project.Path)
 	manager := worktree.New(g, cfg)
 	backend := pullrequest.NewGitBackend(
 		g, manager, project, cfg.Fleet.TokenEnv,
 	)
-	return pullrequest.NewService(provider, backend, pullrequest.NewFileStore(prStorePath())), nil
+	return pullrequest.NewService(
+		provider,
+		backend,
+		pullrequest.NewFileStore(prStorePath()),
+	), project, nil
 }
 
 func resolvePRProject(cfg *models.Config, selector string) (pullrequest.Project, error) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -263,7 +263,7 @@ func importedWorkspaceProvenance(
 	record := matches[0]
 	liveProject, liveWorkspaces, err := inspectPRProjectClone(
 		ctx,
-		record.Project,
+		record,
 	)
 	if err != nil {
 		return pullrequest.Provenance{}, pullrequest.NewError(
@@ -273,8 +273,8 @@ func importedWorkspaceProvenance(
 			err,
 		)
 	}
-	if !samePRProjectClone(record.Project, liveProject) ||
-		!containsPRWorkspace(liveWorkspaces, record.Workspace) {
+	if !samePRProjectClone(record, liveProject) ||
+		!containsPRWorkspace(liveWorkspaces, record) {
 		return pullrequest.Provenance{}, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation,
 			"workspace no longer matches its pull-request provenance",
@@ -320,12 +320,12 @@ func rejectProtectedWorkspaceOpen(
 
 func defaultInspectPRProjectClone(
 	ctx context.Context,
-	recorded pullrequest.Project,
+	recorded pullrequest.Provenance,
 ) (pullrequest.Project, []pullrequest.Workspace, error) {
 	if err := ctx.Err(); err != nil {
 		return pullrequest.Project{}, nil, err
 	}
-	project, err := validatePRProjectRoot(recorded)
+	project, err := validatePRProjectRoot(recorded.Project)
 	if err != nil {
 		return pullrequest.Project{}, nil, err
 	}
@@ -339,7 +339,7 @@ func defaultInspectPRProjectClone(
 	registered := make([]models.Project, 0, 1)
 	for _, candidate := range cfg.Projects {
 		if utils.CanonicalPath(candidate.Path) !=
-			utils.CanonicalPath(recorded.Path) {
+			utils.CanonicalPath(recorded.Project.Path) {
 			continue
 		}
 		registered = append(registered, candidate)
@@ -352,7 +352,11 @@ func defaultInspectPRProjectClone(
 	if len(registered) == 1 &&
 		!pullrequest.EqualRepositoryIdentity(
 			publishableProjectRepository(registered[0]),
-			recorded.Identity,
+			recorded.Project.Identity,
+		) &&
+		!pullrequest.ProvenanceHasRepositoryIdentity(
+			recorded,
+			publishableProjectRepository(registered[0]),
 		) {
 		return pullrequest.Project{}, nil, fmt.Errorf(
 			"registered project conflicts with recorded identity",
@@ -380,6 +384,17 @@ func defaultInspectPRProjectClone(
 		return pullrequest.Project{}, nil, err
 	}
 	project.Identity = pullrequest.NormalizeRepositoryIdentity(info.FullPath)
+	if !pullrequest.EqualRepositoryIdentity(
+		recorded.Project.Identity,
+		project.Identity,
+	) && !pullrequest.ProvenanceHasRepositoryIdentity(
+		recorded,
+		project.Identity,
+	) {
+		return pullrequest.Project{}, nil, fmt.Errorf(
+			"live project conflicts with recorded identity",
+		)
+	}
 	return project, livePRWorkspaces(info, project, live), nil
 }
 
@@ -417,31 +432,73 @@ func liveGitWorktreePath(path string) bool {
 }
 
 func samePRProjectClone(
-	left, right pullrequest.Project,
+	recorded pullrequest.Provenance,
+	live pullrequest.Project,
 ) bool {
-	return pullrequest.EqualRepositoryIdentity(
-		left.Identity,
-		right.Identity,
-	) && utils.CanonicalPath(left.Path) == utils.CanonicalPath(right.Path)
+	if utils.CanonicalPath(recorded.Project.Path) !=
+		utils.CanonicalPath(live.Path) {
+		return false
+	}
+	if pullrequest.EqualRepositoryIdentity(
+		recorded.Project.Identity,
+		live.Identity,
+	) {
+		return true
+	}
+	return pullrequest.ProvenanceHasRepositoryIdentity(
+		recorded,
+		recorded.Project.Identity,
+	) && pullrequest.ProvenanceHasRepositoryIdentity(
+		recorded,
+		live.Identity,
+	)
 }
 
 func containsPRWorkspace(
 	live []pullrequest.Workspace,
-	recorded pullrequest.Workspace,
+	recorded pullrequest.Provenance,
 ) bool {
 	for _, candidate := range live {
 		if utils.CanonicalPath(candidate.Path) ==
-			utils.CanonicalPath(recorded.Path) &&
-			candidate.Branch == recorded.Branch &&
-			pullrequest.EqualRepositoryIdentity(
-				candidate.Repository,
-				recorded.Repository,
-			) &&
-			candidate.SessionName == recorded.SessionName {
+			utils.CanonicalPath(recorded.Workspace.Path) &&
+			candidate.Branch == recorded.Workspace.Branch &&
+			prWorkspaceIdentityMatches(candidate, recorded) {
 			return true
 		}
 	}
 	return false
+}
+
+func prWorkspaceIdentityMatches(
+	live pullrequest.Workspace,
+	recorded pullrequest.Provenance,
+) bool {
+	if pullrequest.EqualRepositoryIdentity(
+		live.Repository,
+		recorded.Workspace.Repository,
+	) {
+		return live.SessionName == recorded.Workspace.SessionName
+	}
+	if !pullrequest.ProvenanceHasRepositoryIdentity(
+		recorded,
+		live.Repository,
+	) || !pullrequest.ProvenanceHasRepositoryIdentity(
+		recorded,
+		recorded.Workspace.Repository,
+	) {
+		return false
+	}
+	info, ok := urlutil.CanonicalRepositoryInfo(
+		recorded.Workspace.Repository,
+	)
+	if !ok {
+		return false
+	}
+	return recorded.Workspace.SessionName == tmux.WorkspaceSessionName(
+		info,
+		recorded.Workspace.Branch,
+		recorded.Workspace.Path,
+	)
 }
 
 func preparePRProject() (pullrequest.Project, error) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -601,26 +601,15 @@ func defaultNewPRService(
 	cfg *models.Config,
 	project pullrequest.Project,
 ) (prService, pullrequest.Project, error) {
+	requestedRepository, err := pullrequest.RepositoryFromProject(project)
+	if err != nil {
+		return nil, project, err
+	}
 	provider, err := newPRGitHubProvider(ctx)
 	if err != nil {
 		return nil, project, err
 	}
-	info, ok := urlutil.CanonicalRepositoryInfo(project.Identity)
-	if !ok {
-		return nil, project, pullrequest.NewError(
-			pullrequest.CodeUnsupportedProvider,
-			fmt.Sprintf("project %q is not a supported github.com repository", project.Identity),
-			false,
-			nil,
-		)
-	}
-	repository, err := provider.ResolveRepository(ctx, pullrequest.Repository{
-		Provider: "github",
-		Identity: pullrequest.NormalizeRepositoryIdentity(info.FullPath),
-		Host:     info.Host,
-		Owner:    info.Owner,
-		Name:     info.Repository,
-	})
+	repository, err := provider.ResolveRepository(ctx, requestedRepository)
 	if err != nil {
 		return nil, project, err
 	}
@@ -634,6 +623,8 @@ func defaultNewPRService(
 		provider,
 		backend,
 		pullrequest.NewFileStore(prStorePath()),
+		requestedRepository.Identity,
+		repository.Identity,
 	), project, nil
 }
 

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -85,7 +85,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	validatePRProjectRoot = func(project pullrequest.Project) (pullrequest.Project, error) { return project, nil }
 	inspectPRProjectClone = func(
 		context.Context,
-		pullrequest.Project,
+		pullrequest.Provenance,
 	) (pullrequest.Project, []pullrequest.Workspace, error) {
 		return pullrequest.Project{}, nil, nil
 	}
@@ -582,7 +582,7 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	withPRCommandDeps(t, cfg, &fakePRService{})
 	inspectPRProjectClone = func(
 		context.Context,
-		pullrequest.Project,
+		pullrequest.Provenance,
 	) (pullrequest.Project, []pullrequest.Workspace, error) {
 		return project, []pullrequest.Workspace{workspace}, nil
 	}
@@ -600,6 +600,86 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	cmd, _, _ := prTestCommand()
 
 	err := runPRAttach(cmd, []string{workspace.Path})
+
+	require.NoError(t, err)
+	assert.True(t, attached)
+}
+
+func TestRunPRAttachUsesTransferredProvenanceAliasHistory(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	registeredIdentity := "github.com/legacy/widget"
+	resolvedIdentity := "github.com/current/widget"
+	workspacePath := "/worktrees/pr-33"
+	branch := "pr-33"
+	resolvedInfo, ok := urlutil.CanonicalRepositoryInfo(resolvedIdentity)
+	require.True(t, ok)
+	registeredInfo, ok := urlutil.CanonicalRepositoryInfo(registeredIdentity)
+	require.True(t, ok)
+	record := pullrequest.Provenance{
+		PullRequestID: "github:github.com/current/widget#33",
+		Repository:    resolvedIdentity,
+		RepositoryAliases: []string{
+			registeredIdentity,
+			"github.com/middle/widget",
+			resolvedIdentity,
+		},
+		Project: pullrequest.Project{
+			Identity: resolvedIdentity,
+			Path:     "/repos/widget",
+		},
+		Workspace: pullrequest.Workspace{
+			Path:       workspacePath,
+			Branch:     branch,
+			Repository: resolvedIdentity,
+			SessionName: tmux.WorkspaceSessionName(
+				resolvedInfo,
+				branch,
+				workspacePath,
+			),
+		},
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[record.PullRequestID] = record
+			return nil
+		},
+	))
+	cfg := testPRConfig()
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	inspectPRProjectClone = func(
+		_ context.Context,
+		got pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		assert.Equal(t, record, got)
+		return pullrequest.Project{
+				Identity: registeredIdentity,
+				Path:     record.Project.Path,
+			}, []pullrequest.Workspace{{
+				Path:       workspacePath,
+				Branch:     branch,
+				Repository: registeredIdentity,
+				SessionName: tmux.WorkspaceSessionName(
+					registeredInfo,
+					branch,
+					workspacePath,
+				),
+			}}, nil
+	}
+	attached := false
+	attachPRWorkspaceSession = func(
+		_ context.Context,
+		got pullrequest.Workspace,
+		gotConfig *models.Config,
+	) error {
+		attached = true
+		assert.Equal(t, record.Workspace, got)
+		assert.Same(t, cfg, gotConfig)
+		return nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRAttach(cmd, []string{workspacePath})
 
 	require.NoError(t, err)
 	assert.True(t, attached)
@@ -629,7 +709,7 @@ func TestRunPRAttachRejectsStaleProvenanceAgainstLiveInventory(t *testing.T) {
 	withPRCommandDeps(t, testPRConfig(), &fakePRService{})
 	inspectPRProjectClone = func(
 		context.Context,
-		pullrequest.Project,
+		pullrequest.Provenance,
 	) (pullrequest.Project, []pullrequest.Workspace, error) {
 		live := recorded
 		live.Branch = "unrelated"
@@ -681,13 +761,124 @@ func TestInspectPRProjectCloneUsesRegisteredIdentityOverForkOrigin(
 
 	project, workspaces, err := defaultInspectPRProjectClone(
 		context.Background(),
-		recorded,
+		pullrequest.Provenance{
+			Repository: recorded.Identity,
+			Project:    recorded,
+		},
 	)
 
 	require.NoError(t, err)
 	assert.Equal(t, recorded.Identity, project.Identity)
 	require.NotEmpty(t, workspaces)
 	assert.Equal(t, recorded.Identity, workspaces[0].Repository)
+}
+
+func TestInspectPRProjectCloneAcceptsTransferredRegisteredAlias(
+	t *testing.T,
+) {
+	repo := newPRInspectionRepo(t)
+	runPRInspectionGit(
+		t,
+		repo,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/current/widget.git",
+	)
+	registeredIdentity := "github.com/legacy/widget"
+	recorded := pullrequest.Provenance{
+		Repository: "github.com/current/widget",
+		RepositoryAliases: []string{
+			registeredIdentity,
+			"github.com/middle/widget",
+			"github.com/current/widget",
+		},
+		Project: pullrequest.Project{
+			Identity: "github.com/current/widget",
+			Name:     "widget",
+			Path:     repo,
+		},
+	}
+	oldLoad := loadPRConfig
+	t.Cleanup(func() { loadPRConfig = oldLoad })
+	loadPRConfig = func() (*models.Config, error) {
+		return &models.Config{Projects: []models.Project{{
+			Repository: registeredIdentity,
+			Name:       recorded.Project.Name,
+			Path:       recorded.Project.Path,
+		}}}, nil
+	}
+
+	project, workspaces, err := defaultInspectPRProjectClone(
+		context.Background(),
+		recorded,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, registeredIdentity, project.Identity)
+	require.NotEmpty(t, workspaces)
+	assert.Equal(t, registeredIdentity, workspaces[0].Repository)
+}
+
+func TestTransferredProvenanceMatchesLiveWorkspaceAcrossAliases(
+	t *testing.T,
+) {
+	path := "/worktrees/pr-32"
+	branch := "pr-32"
+	recordedInfo, ok := urlutil.CanonicalRepositoryInfo(
+		"github.com/current/widget",
+	)
+	require.True(t, ok)
+	liveInfo, ok := urlutil.CanonicalRepositoryInfo(
+		"github.com/legacy/widget",
+	)
+	require.True(t, ok)
+	record := pullrequest.Provenance{
+		Repository: "github.com/current/widget",
+		RepositoryAliases: []string{
+			"github.com/legacy/widget",
+			"github.com/middle/widget",
+			"github.com/current/widget",
+		},
+		Project: pullrequest.Project{
+			Identity: "github.com/current/widget",
+			Path:     "/repos/widget",
+		},
+		Workspace: pullrequest.Workspace{
+			Repository: "github.com/current/widget",
+			Branch:     branch,
+			Path:       path,
+			SessionName: tmux.WorkspaceSessionName(
+				recordedInfo,
+				branch,
+				path,
+			),
+		},
+	}
+	liveProject := pullrequest.Project{
+		Identity: "github.com/legacy/widget",
+		Path:     record.Project.Path,
+	}
+	liveWorkspace := pullrequest.Workspace{
+		Repository: liveProject.Identity,
+		Branch:     branch,
+		Path:       path,
+		SessionName: tmux.WorkspaceSessionName(
+			liveInfo,
+			branch,
+			path,
+		),
+	}
+
+	assert.True(t, samePRProjectClone(record, liveProject))
+	assert.True(t, containsPRWorkspace([]pullrequest.Workspace{
+		liveWorkspace,
+	}, record))
+
+	record.Workspace.SessionName = "tampered"
+	assert.False(t, containsPRWorkspace([]pullrequest.Workspace{
+		liveWorkspace,
+	}, record))
 }
 
 func TestInspectPRProjectCloneUsesLiveIdentityWithoutRegistration(
@@ -715,7 +906,10 @@ func TestInspectPRProjectCloneUsesLiveIdentityWithoutRegistration(
 
 	project, workspaces, err := defaultInspectPRProjectClone(
 		context.Background(),
-		recorded,
+		pullrequest.Provenance{
+			Repository: recorded.Identity,
+			Project:    recorded,
+		},
 	)
 
 	require.NoError(t, err)
@@ -745,7 +939,10 @@ func TestInspectPRProjectCloneRejectsConflictingRegistration(
 
 	_, _, err := defaultInspectPRProjectClone(
 		context.Background(),
-		recorded,
+		pullrequest.Provenance{
+			Repository: recorded.Identity,
+			Project:    recorded,
+		},
 	)
 
 	require.Error(t, err)
@@ -780,7 +977,10 @@ func TestInspectPRProjectCloneRejectsAmbiguousRegistrations(
 
 	_, _, err := defaultInspectPRProjectClone(
 		context.Background(),
-		recorded,
+		pullrequest.Provenance{
+			Repository: recorded.Identity,
+			Project:    recorded,
+		},
 	)
 
 	require.Error(t, err)

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-github/v89/github"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +50,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldLoad := loadPRConfig
 	oldTargetLoad := loadPRTargetConfig
 	oldNew := newPRService
+	oldProvider := newPRGitHubProvider
 	oldValidateRoot := validatePRProjectRoot
 	oldProject := prProject
 	oldState := prState
@@ -58,6 +63,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		loadPRConfig = oldLoad
 		loadPRTargetConfig = oldTargetLoad
 		newPRService = oldNew
+		newPRGitHubProvider = oldProvider
 		validatePRProjectRoot = oldValidateRoot
 		prProject = oldProject
 		prState = oldState
@@ -69,7 +75,13 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	})
 	loadPRConfig = func() (*models.Config, error) { return cfg, nil }
 	loadPRTargetConfig = func(string, bool) (*models.Config, error) { return cfg, nil }
-	newPRService = func(context.Context, *models.Config, pullrequest.Project) (prService, error) { return service, nil }
+	newPRService = func(
+		_ context.Context,
+		_ *models.Config,
+		project pullrequest.Project,
+	) (prService, pullrequest.Project, error) {
+		return service, project, nil
+	}
 	validatePRProjectRoot = func(project pullrequest.Project) (pullrequest.Project, error) { return project, nil }
 	inspectPRProjectClone = func(
 		context.Context,
@@ -88,9 +100,18 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 func TestRunPRImportValidatesSelectorBeforeAuthentication(t *testing.T) {
 	withPRCommandDeps(t, testPRConfig(), &fakePRService{})
 	called := false
-	newPRService = func(context.Context, *models.Config, pullrequest.Project) (prService, error) {
+	newPRService = func(
+		_ context.Context,
+		_ *models.Config,
+		project pullrequest.Project,
+	) (prService, pullrequest.Project, error) {
 		called = true
-		return nil, pullrequest.NewError(pullrequest.CodeAuthentication, "authentication required", false, nil)
+		return nil, project, pullrequest.NewError(
+			pullrequest.CodeAuthentication,
+			"authentication required",
+			false,
+			nil,
+		)
 	}
 	cmd, stdout, _ := prTestCommand()
 
@@ -151,14 +172,18 @@ func TestPreparePRServiceLoadsSelectedTargetConfiguration(t *testing.T) {
 		return target, nil
 	}
 	var received *models.Config
-	newPRService = func(_ context.Context, cfg *models.Config, _ pullrequest.Project) (prService, error) {
+	newPRService = func(
+		_ context.Context,
+		cfg *models.Config,
+		project pullrequest.Project,
+	) (prService, pullrequest.Project, error) {
 		received = cfg
-		return &fakePRService{}, nil
+		return &fakePRService{}, project, nil
 	}
 
 	project, err := preparePRProject()
 	require.NoError(t, err)
-	_, _, err = preparePRService(context.Background(), project)
+	_, _, _, err = preparePRService(context.Background(), project)
 
 	require.NoError(t, err)
 	assert.Equal(t, "/repos/widget", loadedPath)
@@ -185,7 +210,7 @@ func TestPreparePRServiceRejectsPathOutsideMainRepositoryRootBeforeLoadingConfig
 		return testPRConfig(), nil
 	}
 
-	_, _, err := preparePRService(context.Background(), pullrequest.Project{
+	_, _, _, err := preparePRService(context.Background(), pullrequest.Project{
 		Identity: "github.com/acme/widget", Name: "widget", Path: subdir,
 	})
 
@@ -267,6 +292,119 @@ func TestRunPRListWritesStructuredOutput(t *testing.T) {
 	assert.Empty(t, stderr.String())
 }
 
+func TestRunPRListUsesResolvedTransferredRepository(t *testing.T) {
+	service := &fakePRService{}
+	cfg := testPRConfig()
+	cfg.Projects[0].Repository = "github.com/legacy/widget"
+	withPRCommandDeps(t, cfg, service)
+	newPRService = func(
+		_ context.Context,
+		_ *models.Config,
+		project pullrequest.Project,
+	) (prService, pullrequest.Project, error) {
+		project.Identity = "github.com/acme/widget"
+		return service, project, nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRList(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/acme/widget", service.gotProject.Identity)
+}
+
+func TestRunPRImportUsesResolvedTransferredRepository(t *testing.T) {
+	for _, selector := range []string{
+		"1166",
+		"https://github.com/legacy/widget/pull/1166",
+		"https://github.com/acme/widget/pull/1166",
+	} {
+		t.Run(selector, func(t *testing.T) {
+			service := &fakePRService{result: pullrequest.ImportResult{
+				Status: pullrequest.ImportCreated,
+				Workspace: pullrequest.Workspace{
+					ID: "ws", Path: "/worktrees/ws", SessionName: "kwt-workspace-ws",
+				},
+			}}
+			cfg := testPRConfig()
+			cfg.Projects[0].Repository = "github.com/legacy/widget"
+			withPRCommandDeps(t, cfg, service)
+			newPRService = func(
+				_ context.Context,
+				_ *models.Config,
+				project pullrequest.Project,
+			) (prService, pullrequest.Project, error) {
+				project.Identity = "github.com/acme/widget"
+				return service, project, nil
+			}
+			cmd, _, _ := prTestCommand()
+
+			err := runPRImport(cmd, []string{selector})
+
+			require.NoError(t, err)
+			assert.Equal(t, "github.com/acme/widget", service.gotProject.Identity)
+			assert.Equal(t, "1166", service.gotSelector)
+		})
+	}
+}
+
+func TestRunPRImportRejectsSelectorOutsideRegisteredAndResolvedRepositories(t *testing.T) {
+	service := &fakePRService{}
+	cfg := testPRConfig()
+	cfg.Projects[0].Repository = "github.com/legacy/widget"
+	withPRCommandDeps(t, cfg, service)
+	newPRService = func(
+		_ context.Context,
+		_ *models.Config,
+		project pullrequest.Project,
+	) (prService, pullrequest.Project, error) {
+		project.Identity = "github.com/acme/widget"
+		return service, project, nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRImport(cmd, []string{"https://github.com/other/widget/pull/1166"})
+
+	assertPRCode(t, err, pullrequest.CodeInvalidSelector)
+	assert.Empty(t, service.gotSelector)
+}
+
+func TestDefaultNewPRServiceResolvesTransferredRepository(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/legacy/widget", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"name":"widget",
+			"full_name":"acme/widget",
+			"clone_url":"https://github.com/acme/widget.git"
+		}`)
+	}))
+	defer server.Close()
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&baseURL, nil))
+	require.NoError(t, err)
+	oldProvider := newPRGitHubProvider
+	t.Cleanup(func() { newPRGitHubProvider = oldProvider })
+	newPRGitHubProvider = func(context.Context) (*pullrequest.GitHubProvider, error) {
+		return pullrequest.NewGitHubProvider(client), nil
+	}
+	project := pullrequest.Project{
+		Identity: "github.com/legacy/widget",
+		Name:     "widget",
+		Path:     "/repos/widget",
+	}
+
+	service, resolved, err := defaultNewPRService(
+		context.Background(),
+		&models.Config{},
+		project,
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "github.com/acme/widget", resolved.Identity)
+}
+
 func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 	for _, status := range []pullrequest.ImportStatus{pullrequest.ImportCreated, pullrequest.ImportExisting} {
 		t.Run(string(status), func(t *testing.T) {
@@ -283,7 +421,7 @@ func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 			var got pullrequest.ImportResult
 			require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
 			assert.Equal(t, status, got.Status)
-			assert.Equal(t, "https://github.com/acme/widget/pull/17", service.gotSelector)
+			assert.Equal(t, "17", service.gotSelector)
 			socketName := tmux.ProtectedWorkspaceSocketName(
 				got.Workspace.SessionName,
 				got.Workspace.Path,

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -405,6 +405,29 @@ func TestDefaultNewPRServiceResolvesTransferredRepository(t *testing.T) {
 	assert.Equal(t, "github.com/acme/widget", resolved.Identity)
 }
 
+func TestDefaultNewPRServiceRejectsNestedRepositoryIdentity(t *testing.T) {
+	oldProvider := newPRGitHubProvider
+	t.Cleanup(func() { newPRGitHubProvider = oldProvider })
+	called := false
+	newPRGitHubProvider = func(context.Context) (*pullrequest.GitHubProvider, error) {
+		called = true
+		return nil, errors.New("must not authenticate")
+	}
+
+	_, _, err := defaultNewPRService(
+		context.Background(),
+		&models.Config{},
+		pullrequest.Project{
+			Identity: "github.com/acme/team/widget",
+			Name:     "widget",
+			Path:     "/repos/widget",
+		},
+	)
+
+	assertPRCode(t, err, pullrequest.CodeUnsupportedProvider)
+	assert.False(t, called)
+}
+
 func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 	for _, status := range []pullrequest.ImportStatus{pullrequest.ImportCreated, pullrequest.ImportExisting} {
 		t.Run(string(status), func(t *testing.T) {

--- a/internal/pullrequest/github.go
+++ b/internal/pullrequest/github.go
@@ -62,6 +62,21 @@ func NewGitHubProvider(client *github.Client) *GitHubProvider {
 	return &GitHubProvider{client: client}
 }
 
+func (p *GitHubProvider) ResolveRepository(
+	ctx context.Context, repository Repository,
+) (Repository, error) {
+	if p == nil || p.client == nil {
+		return Repository{}, NewError(CodeNetwork, "GitHub client is not configured", false, nil)
+	}
+	githubRepository, _, err := p.client.Repositories.Get(
+		ctx, repository.Owner, repository.Name,
+	)
+	if err != nil {
+		return Repository{}, classifyGitHubError(err, "resolve repository")
+	}
+	return mapGitHubRepository(githubRepository)
+}
+
 func (p *GitHubProvider) List(ctx context.Context, repository Repository, state string) ([]PullRequest, error) {
 	if p == nil || p.client == nil {
 		return nil, NewError(CodeNetwork, "GitHub client is not configured", false, nil)

--- a/internal/pullrequest/github_test.go
+++ b/internal/pullrequest/github_test.go
@@ -96,6 +96,34 @@ func TestGitHubProviderNormalizesRepositoryIdentityCase(t *testing.T) {
 	assert.Equal(t, "Acme", repository.Owner)
 }
 
+func TestGitHubProviderResolvesTransferredRepository(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/legacy/widget", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"name":"widget",
+			"full_name":"acme/widget",
+			"clone_url":"https://github.com/acme/widget.git",
+			"ssh_url":"git@github.com:acme/widget.git"
+		}`)
+	}))
+	defer server.Close()
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&baseURL, nil))
+	require.NoError(t, err)
+	provider := NewGitHubProvider(client)
+
+	repository, err := provider.ResolveRepository(context.Background(), Repository{
+		Provider: "github", Identity: "github.com/legacy/widget",
+		Host: "github.com", Owner: "legacy", Name: "widget",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/acme/widget", repository.Identity)
+	assert.Equal(t, "acme", repository.Owner)
+	assert.Equal(t, "widget", repository.Name)
+}
+
 func TestGitHubProviderClassifiesFailures(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -263,29 +263,70 @@ func repositoryFromProject(project Project) (Repository, error) {
 }
 
 func ParseSelector(selector, repository string) (int, error) {
+	number, selectorRepository, err := parseSelector(selector)
+	if err != nil {
+		return 0, err
+	}
+	if selectorRepository != "" &&
+		!EqualRepositoryIdentity(selectorRepository, repository) {
+		return 0, NewError(
+			CodeInvalidSelector,
+			"pull-request selector does not match the selected repository",
+			false,
+			nil,
+		)
+	}
+	return number, nil
+}
+
+// ParseSelectorNumber validates a selector's provider syntax and returns its
+// pull-request number without authorizing its repository identity.
+func ParseSelectorNumber(selector string) (int, error) {
+	number, _, err := parseSelector(selector)
+	return number, err
+}
+
+func parseSelector(selector string) (int, string, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
-		return 0, NewError(CodeInvalidSelector, "pull-request selector is empty", false, nil)
+		return 0, "", NewError(
+			CodeInvalidSelector,
+			"pull-request selector is empty",
+			false,
+			nil,
+		)
 	}
 	if number, err := strconv.Atoi(selector); err == nil && number > 0 {
-		return number, nil
+		return number, "", nil
 	}
-	prefix := "github:" + NormalizeRepositoryIdentity(repository) + "#"
-	if strings.HasPrefix(strings.ToLower(selector), prefix) {
-		if number, err := strconv.Atoi(selector[len(prefix):]); err == nil && number > 0 {
-			return number, nil
+	if strings.HasPrefix(strings.ToLower(selector), "github:") {
+		identity, numberText, ok := strings.Cut(selector[len("github:"):], "#")
+		parts := strings.Split(NormalizeRepositoryIdentity(identity), "/")
+		if ok && len(parts) == 3 && parts[0] == "github.com" &&
+			parts[1] != "" && parts[2] != "" {
+			if number, err := strconv.Atoi(numberText); err == nil && number > 0 {
+				return number, strings.Join(parts, "/"), nil
+			}
 		}
 	}
 	parsed, err := url.Parse(selector)
 	if err == nil && strings.EqualFold(parsed.Host, "github.com") {
 		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-		if len(parts) == 4 && strings.EqualFold(parts[2], "pull") && EqualRepositoryIdentity("github.com/"+parts[0]+"/"+parts[1], repository) {
+		if len(parts) == 4 && parts[0] != "" && parts[1] != "" &&
+			strings.EqualFold(parts[2], "pull") {
 			if number, convertErr := strconv.Atoi(parts[3]); convertErr == nil && number > 0 {
-				return number, nil
+				return number, NormalizeRepositoryIdentity(
+					"github.com/" + parts[0] + "/" + parts[1],
+				), nil
 			}
 		}
 	}
-	return 0, NewError(CodeInvalidSelector, "pull-request selector does not match the selected repository", false, nil)
+	return 0, "", NewError(
+		CodeInvalidSelector,
+		"pull-request selector does not match the selected repository",
+		false,
+		nil,
+	)
 }
 
 func importBranchName(pr PullRequest) string {

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -30,17 +30,31 @@ type Store interface {
 }
 
 type Service struct {
-	provider Provider
-	backend  WorkspaceBackend
-	store    Store
+	provider          Provider
+	backend           WorkspaceBackend
+	store             Store
+	projectIdentities []string
 }
 
-func NewService(provider Provider, backend WorkspaceBackend, store Store) *Service {
-	return &Service{provider: provider, backend: backend, store: store}
+func NewService(
+	provider Provider,
+	backend WorkspaceBackend,
+	store Store,
+	projectIdentities ...string,
+) *Service {
+	service := &Service{provider: provider, backend: backend, store: store}
+	for _, identity := range projectIdentities {
+		identity = NormalizeRepositoryIdentity(identity)
+		if identity == "" || service.hasProjectIdentity(identity) {
+			continue
+		}
+		service.projectIdentities = append(service.projectIdentities, identity)
+	}
+	return service
 }
 
 func (s *Service) List(ctx context.Context, project Project, state string) ([]PullRequest, error) {
-	repository, err := repositoryFromProject(project)
+	repository, err := RepositoryFromProject(project)
 	if err != nil {
 		return nil, err
 	}
@@ -68,9 +82,9 @@ func (s *Service) List(ctx context.Context, project Project, state string) ([]Pu
 	}
 	for i := range prs {
 		prs[i].Source.IsFork = !EqualRepositoryIdentity(prs[i].Source.Repository.Identity, prs[i].Repository.Identity)
-		_, record, ok := findProvenance(records, prs[i])
-		if ok && sameProjectClone(record.Project, project) &&
-			provenanceSourceMatches(record, prs[i]) {
+		_, record, ok := s.findProvenance(records, prs[i])
+		if ok && s.sameProjectClone(record.Project, project) &&
+			s.provenanceSourceMatches(record, prs[i]) {
 			if workspace, live := matchingProvenanceWorkspace(paths, record); live {
 				prs[i].Imported = true
 				prs[i].Workspace = &workspace
@@ -81,7 +95,7 @@ func (s *Service) List(ctx context.Context, project Project, state string) ([]Pu
 }
 
 func (s *Service) Import(ctx context.Context, project Project, selector string) (result ImportResult, err error) {
-	repository, err := repositoryFromProject(project)
+	repository, err := RepositoryFromProject(project)
 	if err != nil {
 		return result, err
 	}
@@ -116,9 +130,9 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 		for _, workspace := range workspaces {
 			byPath[utils.CanonicalPath(workspace.Path)] = workspace
 		}
-		recordKey, record, ok := findProvenance(records, pr)
+		recordKey, record, ok := s.findProvenance(records, pr)
 		if ok {
-			if !sameProjectClone(record.Project, project) {
+			if !s.sameProjectClone(record.Project, project) {
 				return NewError(
 					CodeConflict,
 					"pull request is recorded for a different project clone",
@@ -130,7 +144,7 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 					return NewError(CodeConflict,
 						"existing import has incomplete source provenance", false, nil)
 				}
-				if !provenanceSourceMatches(record, pr) {
+				if !s.provenanceSourceMatches(record, pr) {
 					return NewError(CodeConflict,
 						"pull-request source repository or branch changed after import", false, nil)
 				}
@@ -138,10 +152,13 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 					delete(records, recordKey)
 				}
 				record.PullRequestID = pr.ID
-				record.Repository = NormalizeRepositoryIdentity(record.Repository)
+				record.Provider = pr.Provider
+				record.Repository = pr.Repository.Identity
+				record.Number = pr.Number
+				record.URL = pr.URL
 				record.SourceRepo = NormalizeRepositoryIdentity(pr.Source.Repository.Identity)
 				record.SourceBranch = pr.Source.Name
-				record.Project.Identity = NormalizeRepositoryIdentity(record.Project.Identity)
+				record.Project.Identity = project.Identity
 				record.Workspace = workspace
 				records[pr.ID] = record
 				result = ImportResult{Status: ImportExisting, PullRequest: pr, Project: project, Workspace: workspace}
@@ -209,12 +226,16 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 	return result, err
 }
 
-func findProvenance(records map[string]Provenance, pr PullRequest) (string, Provenance, bool) {
+func (s *Service) findProvenance(
+	records map[string]Provenance,
+	pr PullRequest,
+) (string, Provenance, bool) {
 	if record, ok := records[pr.ID]; ok {
 		return pr.ID, record, true
 	}
 	for key, record := range records {
-		if record.Number != pr.Number || !EqualRepositoryIdentity(record.Repository, pr.Repository.Identity) {
+		if record.Number != pr.Number ||
+			!s.sameProjectRepository(record.Repository, pr.Repository.Identity) {
 			continue
 		}
 		if record.Provider != "" && !strings.EqualFold(record.Provider, pr.Provider) {
@@ -225,8 +246,8 @@ func findProvenance(records map[string]Provenance, pr PullRequest) (string, Prov
 	return "", Provenance{}, false
 }
 
-func sameProjectClone(left, right Project) bool {
-	return EqualRepositoryIdentity(left.Identity, right.Identity) &&
+func (s *Service) sameProjectClone(left, right Project) bool {
+	return s.sameProjectRepository(left.Identity, right.Identity) &&
 		utils.CanonicalPath(left.Path) == utils.CanonicalPath(right.Path)
 }
 
@@ -238,19 +259,44 @@ func matchingProvenanceWorkspace(byPath map[string]Workspace, record Provenance)
 	return workspace, true
 }
 
-func provenanceSourceMatches(record Provenance, pr PullRequest) bool {
-	if !provenanceSourceComplete(record) ||
-		!EqualRepositoryIdentity(record.SourceRepo, pr.Source.Repository.Identity) {
+func (s *Service) provenanceSourceMatches(record Provenance, pr PullRequest) bool {
+	if !provenanceSourceComplete(record) || record.SourceBranch != pr.Source.Name {
 		return false
 	}
-	return record.SourceBranch == pr.Source.Name
+	if EqualRepositoryIdentity(record.SourceRepo, pr.Source.Repository.Identity) {
+		return true
+	}
+	return s.sameProjectRepository(
+		record.SourceRepo,
+		pr.Source.Repository.Identity,
+	) && s.sameProjectRepository(
+		pr.Source.Repository.Identity,
+		pr.Repository.Identity,
+	)
 }
 
 func provenanceSourceComplete(record Provenance) bool {
 	return strings.TrimSpace(record.SourceRepo) != "" && strings.TrimSpace(record.SourceBranch) != ""
 }
 
-func repositoryFromProject(project Project) (Repository, error) {
+func (s *Service) sameProjectRepository(left, right string) bool {
+	if EqualRepositoryIdentity(left, right) {
+		return true
+	}
+	return s.hasProjectIdentity(left) && s.hasProjectIdentity(right)
+}
+
+func (s *Service) hasProjectIdentity(identity string) bool {
+	for _, candidate := range s.projectIdentities {
+		if EqualRepositoryIdentity(candidate, identity) {
+			return true
+		}
+	}
+	return false
+}
+
+// RepositoryFromProject validates and parses a GitHub project identity.
+func RepositoryFromProject(project Project) (Repository, error) {
 	identity := NormalizeRepositoryIdentity(project.Identity)
 	parts := strings.Split(identity, "/")
 	if len(parts) != 3 || parts[0] != "github.com" || parts[1] == "" || parts[2] == "" {

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -44,11 +44,14 @@ func NewService(
 ) *Service {
 	service := &Service{provider: provider, backend: backend, store: store}
 	for _, identity := range projectIdentities {
-		identity = NormalizeRepositoryIdentity(identity)
-		if identity == "" || service.hasProjectIdentity(identity) {
+		repository, err := RepositoryFromProject(Project{Identity: identity})
+		if err != nil || service.hasProjectIdentity(repository.Identity) {
 			continue
 		}
-		service.projectIdentities = append(service.projectIdentities, identity)
+		service.projectIdentities = append(
+			service.projectIdentities,
+			repository.Identity,
+		)
 	}
 	return service
 }
@@ -83,7 +86,7 @@ func (s *Service) List(ctx context.Context, project Project, state string) ([]Pu
 	for i := range prs {
 		prs[i].Source.IsFork = !EqualRepositoryIdentity(prs[i].Source.Repository.Identity, prs[i].Repository.Identity)
 		_, record, ok := s.findProvenance(records, prs[i])
-		if ok && s.sameProjectClone(record.Project, project) &&
+		if ok && s.sameProjectClone(record, project) &&
 			s.provenanceSourceMatches(record, prs[i]) {
 			if workspace, live := matchingProvenanceWorkspace(paths, record); live {
 				prs[i].Imported = true
@@ -132,7 +135,7 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 		}
 		recordKey, record, ok := s.findProvenance(records, pr)
 		if ok {
-			if !s.sameProjectClone(record.Project, project) {
+			if !s.sameProjectClone(record, project) {
 				return NewError(
 					CodeConflict,
 					"pull request is recorded for a different project clone",
@@ -151,9 +154,11 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 				if recordKey != pr.ID {
 					delete(records, recordKey)
 				}
+				aliases := s.mergedRepositoryAliases(record)
 				record.PullRequestID = pr.ID
 				record.Provider = pr.Provider
 				record.Repository = pr.Repository.Identity
+				record.RepositoryAliases = aliases
 				record.Number = pr.Number
 				record.URL = pr.URL
 				record.SourceRepo = NormalizeRepositoryIdentity(pr.Source.Repository.Identity)
@@ -193,6 +198,9 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 
 		newRecord := Provenance{
 			PullRequestID: pr.ID, Provider: pr.Provider, Repository: pr.Repository.Identity,
+			RepositoryAliases: s.mergedRepositoryAliases(Provenance{
+				Repository: pr.Repository.Identity,
+			}),
 			Number: pr.Number, URL: pr.URL, HeadSHA: pr.HeadSHA,
 			SourceRepo: pr.Source.Repository.Identity, SourceBranch: pr.Source.Name,
 			Project: project, Workspace: workspace,
@@ -235,7 +243,7 @@ func (s *Service) findProvenance(
 	}
 	for key, record := range records {
 		if record.Number != pr.Number ||
-			!s.sameProjectRepository(record.Repository, pr.Repository.Identity) {
+			!s.recordRepositoryMatches(record, pr.Repository.Identity) {
 			continue
 		}
 		if record.Provider != "" && !strings.EqualFold(record.Provider, pr.Provider) {
@@ -246,9 +254,20 @@ func (s *Service) findProvenance(
 	return "", Provenance{}, false
 }
 
-func (s *Service) sameProjectClone(left, right Project) bool {
-	return s.sameProjectRepository(left.Identity, right.Identity) &&
-		utils.CanonicalPath(left.Path) == utils.CanonicalPath(right.Path)
+func (s *Service) sameProjectClone(record Provenance, current Project) bool {
+	if utils.CanonicalPath(record.Project.Path) !=
+		utils.CanonicalPath(current.Path) {
+		return false
+	}
+	if EqualRepositoryIdentity(record.Project.Identity, current.Identity) {
+		return true
+	}
+	return ProvenanceHasRepositoryIdentity(
+		record,
+		record.Project.Identity,
+	) && s.hasProjectIdentity(
+		current.Identity,
+	) && s.recordAliasesConnected(record)
 }
 
 func matchingProvenanceWorkspace(byPath map[string]Workspace, record Provenance) (Workspace, bool) {
@@ -266,24 +285,34 @@ func (s *Service) provenanceSourceMatches(record Provenance, pr PullRequest) boo
 	if EqualRepositoryIdentity(record.SourceRepo, pr.Source.Repository.Identity) {
 		return true
 	}
-	return s.sameProjectRepository(
+	return ProvenanceHasRepositoryIdentity(
+		record,
 		record.SourceRepo,
-		pr.Source.Repository.Identity,
-	) && s.sameProjectRepository(
+	) && EqualRepositoryIdentity(
 		pr.Source.Repository.Identity,
 		pr.Repository.Identity,
-	)
+	) && s.hasProjectIdentity(
+		pr.Repository.Identity,
+	) && s.recordAliasesConnected(record)
 }
 
 func provenanceSourceComplete(record Provenance) bool {
 	return strings.TrimSpace(record.SourceRepo) != "" && strings.TrimSpace(record.SourceBranch) != ""
 }
 
-func (s *Service) sameProjectRepository(left, right string) bool {
-	if EqualRepositoryIdentity(left, right) {
+func (s *Service) recordRepositoryMatches(
+	record Provenance,
+	current string,
+) bool {
+	if EqualRepositoryIdentity(record.Repository, current) {
 		return true
 	}
-	return s.hasProjectIdentity(left) && s.hasProjectIdentity(right)
+	return ProvenanceHasRepositoryIdentity(
+		record,
+		record.Repository,
+	) && s.hasProjectIdentity(
+		current,
+	) && s.recordAliasesConnected(record)
 }
 
 func (s *Service) hasProjectIdentity(identity string) bool {
@@ -293,6 +322,89 @@ func (s *Service) hasProjectIdentity(identity string) bool {
 		}
 	}
 	return false
+}
+
+func (s *Service) recordAliasesConnected(record Provenance) bool {
+	for _, identity := range provenanceRepositoryIdentities(record) {
+		if s.hasProjectIdentity(identity) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) mergedRepositoryAliases(record Provenance) []string {
+	identities := provenanceRepositoryIdentities(record)
+	for _, identity := range s.projectIdentities {
+		identities = appendCanonicalRepositoryIdentity(
+			identities,
+			identity,
+		)
+	}
+	if len(identities) < 2 {
+		return nil
+	}
+	return identities
+}
+
+// ProvenanceHasRepositoryIdentity reports whether identity belongs to the
+// canonical repository alias history recorded for an import.
+func ProvenanceHasRepositoryIdentity(
+	record Provenance,
+	identity string,
+) bool {
+	for _, candidate := range provenanceRepositoryIdentities(record) {
+		if EqualRepositoryIdentity(candidate, identity) {
+			return true
+		}
+	}
+	return false
+}
+
+func provenanceRepositoryIdentities(record Provenance) []string {
+	repository, err := RepositoryFromProject(Project{
+		Identity: record.Repository,
+	})
+	if err != nil {
+		return nil
+	}
+	if len(record.RepositoryAliases) == 0 {
+		return []string{repository.Identity}
+	}
+	var identities []string
+	for _, identity := range record.RepositoryAliases {
+		identities = appendCanonicalRepositoryIdentity(
+			identities,
+			identity,
+		)
+	}
+	foundRepository := false
+	for _, identity := range identities {
+		if EqualRepositoryIdentity(identity, repository.Identity) {
+			foundRepository = true
+			break
+		}
+	}
+	if !foundRepository {
+		return nil
+	}
+	return identities
+}
+
+func appendCanonicalRepositoryIdentity(
+	identities []string,
+	identity string,
+) []string {
+	repository, err := RepositoryFromProject(Project{Identity: identity})
+	if err != nil {
+		return identities
+	}
+	for _, candidate := range identities {
+		if EqualRepositoryIdentity(candidate, repository.Identity) {
+			return identities
+		}
+	}
+	return append(identities, repository.Identity)
 }
 
 // RepositoryFromProject validates and parses a GitHub project identity.

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -689,9 +689,117 @@ func TestImportMigratesTransferredRepositoryProvenance(t *testing.T) {
 	migrated := store.records[pr.ID]
 	assert.Equal(t, pr.ID, migrated.PullRequestID)
 	assert.Equal(t, pr.Repository.Identity, migrated.Repository)
+	assert.ElementsMatch(t, []string{
+		legacyIdentity,
+		testProject().Identity,
+	}, migrated.RepositoryAliases)
 	assert.Equal(t, testProject().Identity, migrated.Project.Identity)
 	assert.Equal(t, pr.Source.Repository.Identity, migrated.SourceRepo)
 	assert.Equal(t, workspace, migrated.Workspace)
+}
+
+func TestImportMigratesConsecutiveRepositoryTransfers(t *testing.T) {
+	pr := testPR(54, false)
+	backend := newFakeBackend()
+	workspace := Workspace{
+		ID: "ws-54", Repository: testProject().Identity,
+		Branch: "pr-54-feature-widgets", Path: "/worktrees/54", State: "ready",
+	}
+	backend.workspaces = []Workspace{workspace}
+	store := newMemoryStore()
+	firstIdentity := "github.com/legacy/widget"
+	intermediateIdentity := "github.com/middle/widget"
+	intermediateID := OpaqueID(intermediateIdentity, pr.Number)
+	store.records[intermediateID] = Provenance{
+		PullRequestID: intermediateID,
+		Provider:      "github",
+		Repository:    intermediateIdentity,
+		RepositoryAliases: []string{
+			firstIdentity,
+			intermediateIdentity,
+		},
+		Number: pr.Number,
+		Project: Project{
+			Identity: intermediateIdentity,
+			Path:     testProject().Path,
+		},
+		Workspace: Workspace{
+			ID: "middle-ws", Repository: intermediateIdentity,
+			Branch: workspace.Branch, Path: workspace.Path, State: "ready",
+		},
+		SourceRepo:   intermediateIdentity,
+		SourceBranch: pr.Source.Name,
+	}
+	service := NewService(
+		&fakeProvider{prs: []PullRequest{pr}},
+		backend,
+		store,
+		firstIdentity,
+		testProject().Identity,
+	)
+
+	result, err := service.Import(context.Background(), testProject(), "54")
+
+	require.NoError(t, err)
+	assert.Equal(t, ImportExisting, result.Status)
+	assert.Zero(t, backend.createCalls)
+	assert.NotContains(t, store.records, intermediateID)
+	require.Contains(t, store.records, pr.ID)
+	migrated := store.records[pr.ID]
+	assert.ElementsMatch(t, []string{
+		firstIdentity,
+		intermediateIdentity,
+		testProject().Identity,
+	}, migrated.RepositoryAliases)
+	assert.Equal(t, pr.Repository.Identity, migrated.Repository)
+	assert.Equal(t, testProject().Identity, migrated.Project.Identity)
+	assert.Equal(t, pr.Source.Repository.Identity, migrated.SourceRepo)
+}
+
+func TestImportDoesNotTrustRepositoryOutsidePersistedAliasHistory(
+	t *testing.T,
+) {
+	pr := testPR(57, false)
+	backend := newFakeBackend()
+	store := newMemoryStore()
+	legacyIdentity := "github.com/legacy/widget"
+	intermediateIdentity := "github.com/middle/widget"
+	unlistedIdentity := "github.com/unlisted/widget"
+	recordID := OpaqueID(unlistedIdentity, pr.Number)
+	store.records[recordID] = Provenance{
+		PullRequestID: recordID,
+		Provider:      "github",
+		Repository:    unlistedIdentity,
+		RepositoryAliases: []string{
+			legacyIdentity,
+			intermediateIdentity,
+		},
+		Number: pr.Number,
+		Project: Project{
+			Identity: intermediateIdentity,
+			Path:     testProject().Path,
+		},
+		Workspace: Workspace{
+			ID: "unlisted-ws", Repository: intermediateIdentity,
+			Branch: "pr-57-feature-widgets", Path: "/worktrees/57", State: "ready",
+		},
+		SourceRepo:   intermediateIdentity,
+		SourceBranch: pr.Source.Name,
+	}
+	service := NewService(
+		&fakeProvider{prs: []PullRequest{pr}},
+		backend,
+		store,
+		legacyIdentity,
+		testProject().Identity,
+	)
+
+	result, err := service.Import(context.Background(), testProject(), "57")
+
+	require.NoError(t, err)
+	assert.Equal(t, ImportCreated, result.Status)
+	assert.Equal(t, 1, backend.createCalls)
+	assert.Contains(t, store.records, recordID)
 }
 
 func TestImportDoesNotTreatProjectAliasAsForkSource(t *testing.T) {

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -433,6 +433,21 @@ func TestParseSelectorAcceptsMixedCaseGitHubIdentity(t *testing.T) {
 	}
 }
 
+func TestParseSelectorNumberValidatesShapeWithoutRepositoryIdentity(t *testing.T) {
+	for _, selector := range []string{
+		"17",
+		"github:github.com/legacy/widget#17",
+		"https://github.com/acme/widget/pull/17",
+	} {
+		number, err := ParseSelectorNumber(selector)
+		require.NoError(t, err)
+		assert.Equal(t, 17, number)
+	}
+
+	_, err := ParseSelectorNumber("https://github.com/acme/widget/issues/17")
+	assertErrorCode(t, err, CodeInvalidSelector)
+}
+
 func TestImportForkCreatesAndUsesForkRemote(t *testing.T) {
 	pr := testPR(32, true)
 	backend := newFakeBackend()

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -365,6 +365,46 @@ func TestListRecognizesLegacyCasedProvenance(t *testing.T) {
 	assert.Equal(t, &workspace, got[0].Workspace)
 }
 
+func TestListRecognizesTransferredRepositoryProvenance(t *testing.T) {
+	pr := testPR(26, false)
+	backend := newFakeBackend()
+	workspace := Workspace{
+		ID: "ws-26", Repository: testProject().Identity,
+		Branch: "pr-26-feature-widgets", Path: "/worktrees/26", State: "ready",
+	}
+	backend.workspaces = []Workspace{workspace}
+	store := newMemoryStore()
+	legacyIdentity := "github.com/legacy/widget"
+	legacyID := OpaqueID(legacyIdentity, pr.Number)
+	store.records[legacyID] = Provenance{
+		PullRequestID: legacyID,
+		Provider:      "github",
+		Repository:    legacyIdentity,
+		Number:        pr.Number,
+		Project: Project{
+			Identity: legacyIdentity,
+			Path:     testProject().Path,
+		},
+		Workspace:    workspace,
+		SourceRepo:   legacyIdentity,
+		SourceBranch: pr.Source.Name,
+	}
+	service := NewService(
+		&fakeProvider{prs: []PullRequest{pr}},
+		backend,
+		store,
+		legacyIdentity,
+		testProject().Identity,
+	)
+
+	got, err := service.List(context.Background(), testProject(), "open")
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Imported)
+	assert.Equal(t, &workspace, got[0].Workspace)
+}
+
 func TestImportSameRepositoryUsesMatchingRemoteAndCanonicalName(t *testing.T) {
 	pr := testPR(31, false)
 	backend := newFakeBackend()
@@ -604,6 +644,95 @@ func TestImportMigratesLegacyCasedProvenance(t *testing.T) {
 	assert.Equal(t, pr.Source.Name, store.records[pr.ID].SourceBranch)
 }
 
+func TestImportMigratesTransferredRepositoryProvenance(t *testing.T) {
+	pr := testPR(49, false)
+	backend := newFakeBackend()
+	workspace := Workspace{
+		ID: "ws-49", Repository: testProject().Identity,
+		Branch: "pr-49-feature-widgets", Path: "/worktrees/49", State: "ready",
+	}
+	backend.workspaces = []Workspace{workspace}
+	store := newMemoryStore()
+	legacyIdentity := "github.com/legacy/widget"
+	legacyID := OpaqueID(legacyIdentity, pr.Number)
+	store.records[legacyID] = Provenance{
+		PullRequestID: legacyID,
+		Provider:      "github",
+		Repository:    legacyIdentity,
+		Number:        pr.Number,
+		Project: Project{
+			Identity: legacyIdentity,
+			Path:     testProject().Path,
+		},
+		Workspace: Workspace{
+			ID: "legacy-ws", Repository: legacyIdentity,
+			Branch: workspace.Branch, Path: workspace.Path, State: "ready",
+		},
+		SourceRepo:   legacyIdentity,
+		SourceBranch: pr.Source.Name,
+	}
+	service := NewService(
+		&fakeProvider{prs: []PullRequest{pr}},
+		backend,
+		store,
+		legacyIdentity,
+		testProject().Identity,
+	)
+
+	result, err := service.Import(context.Background(), testProject(), "49")
+
+	require.NoError(t, err)
+	assert.Equal(t, ImportExisting, result.Status)
+	assert.Zero(t, backend.createCalls)
+	assert.NotContains(t, store.records, legacyID)
+	require.Contains(t, store.records, pr.ID)
+	migrated := store.records[pr.ID]
+	assert.Equal(t, pr.ID, migrated.PullRequestID)
+	assert.Equal(t, pr.Repository.Identity, migrated.Repository)
+	assert.Equal(t, testProject().Identity, migrated.Project.Identity)
+	assert.Equal(t, pr.Source.Repository.Identity, migrated.SourceRepo)
+	assert.Equal(t, workspace, migrated.Workspace)
+}
+
+func TestImportDoesNotTreatProjectAliasAsForkSource(t *testing.T) {
+	pr := testPR(50, true)
+	backend := newFakeBackend()
+	workspace := Workspace{
+		ID: "ws-50", Repository: testProject().Identity,
+		Branch: "pr-50-feature-widgets", Path: "/worktrees/50", State: "ready",
+	}
+	backend.workspaces = []Workspace{workspace}
+	store := newMemoryStore()
+	legacyIdentity := "github.com/legacy/widget"
+	legacyID := OpaqueID(legacyIdentity, pr.Number)
+	store.records[legacyID] = Provenance{
+		PullRequestID: legacyID,
+		Provider:      "github",
+		Repository:    legacyIdentity,
+		Number:        pr.Number,
+		Project: Project{
+			Identity: legacyIdentity,
+			Path:     testProject().Path,
+		},
+		Workspace:    workspace,
+		SourceRepo:   legacyIdentity,
+		SourceBranch: pr.Source.Name,
+	}
+	service := NewService(
+		&fakeProvider{prs: []PullRequest{pr}},
+		backend,
+		store,
+		legacyIdentity,
+		testProject().Identity,
+	)
+
+	_, err := service.Import(context.Background(), testProject(), "50")
+
+	assertErrorCode(t, err, CodeConflict)
+	assert.Zero(t, backend.createCalls)
+	assert.Contains(t, store.records, legacyID)
+}
+
 func TestConcurrentImportConverges(t *testing.T) {
 	pr := testPR(42, false)
 	backend := newFakeBackend()
@@ -666,6 +795,14 @@ func TestImportRejectsRepositoryMismatch(t *testing.T) {
 	_, err := service.Import(context.Background(), testProject(), "53")
 
 	assertErrorCode(t, err, CodeRepositoryMismatch)
+}
+
+func TestRepositoryFromProjectRejectsNestedGitHubPath(t *testing.T) {
+	_, err := RepositoryFromProject(Project{
+		Identity: "github.com/acme/team/widget",
+	})
+
+	assertErrorCode(t, err, CodeUnsupportedProvider)
 }
 
 func TestImportPropagatesTypedProviderFailures(t *testing.T) {

--- a/internal/pullrequest/store.go
+++ b/internal/pullrequest/store.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -45,7 +46,13 @@ func (s *FileStore) Update(ctx context.Context, fn func(map[string]Provenance) e
 		if err := fn(records); err != nil {
 			return err
 		}
-		if maps.Equal(original, records) {
+		if maps.EqualFunc(
+			original,
+			records,
+			func(left, right Provenance) bool {
+				return reflect.DeepEqual(left, right)
+			},
+		) {
 			return nil
 		}
 		return s.save(records)

--- a/internal/pullrequest/store_test.go
+++ b/internal/pullrequest/store_test.go
@@ -16,7 +16,15 @@ import (
 func TestFileStorePersistsProvenance(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "pull-requests.json")
 	store := NewFileStore(path)
-	record := Provenance{PullRequestID: "github:github.com/acme/widget#1", Number: 1}
+	record := Provenance{
+		PullRequestID: "github:github.com/acme/widget#1",
+		Repository:    "github.com/acme/widget",
+		RepositoryAliases: []string{
+			"github.com/legacy/widget",
+			"github.com/acme/widget",
+		},
+		Number: 1,
+	}
 
 	require.NoError(t, store.Update(context.Background(), func(records map[string]Provenance) error {
 		records[record.PullRequestID] = record

--- a/internal/pullrequest/types.go
+++ b/internal/pullrequest/types.go
@@ -112,16 +112,17 @@ type workspacePartialCleanup struct {
 }
 
 type Provenance struct {
-	PullRequestID string    `json:"pull_request_id"`
-	Provider      string    `json:"provider"`
-	Repository    string    `json:"repository"`
-	Number        int       `json:"number"`
-	URL           string    `json:"url"`
-	HeadSHA       string    `json:"head_sha"`
-	SourceRepo    string    `json:"source_repository"`
-	SourceBranch  string    `json:"source_branch"`
-	Project       Project   `json:"project"`
-	Workspace     Workspace `json:"workspace"`
+	PullRequestID     string    `json:"pull_request_id"`
+	Provider          string    `json:"provider"`
+	Repository        string    `json:"repository"`
+	RepositoryAliases []string  `json:"repository_aliases,omitempty"`
+	Number            int       `json:"number"`
+	URL               string    `json:"url"`
+	HeadSHA           string    `json:"head_sha"`
+	SourceRepo        string    `json:"source_repository"`
+	SourceBranch      string    `json:"source_branch"`
+	Project           Project   `json:"project"`
+	Workspace         Workspace `json:"workspace"`
 }
 
 type ImportStatus string


### PR DESCRIPTION
Registered project identities intentionally override fork remotes, but that same pinning leaves aliases stale after a GitHub repository transfer or rename. GitHub then returns the pull request under its current canonical identity, which kwt previously rejected as a malformed provider response even though the response was valid.

PR commands now validate the selected project with the strict GitHub owner/repository parser and resolve it through GitHub before constructing the provider and workspace backend. The resolution is operation-local, preserving deliberate upstream registrations while preventing malformed nested identities from being collapsed into another repository.

Provenance now retains a canonical repository alias history seeded by GitHub-verified registered and resolved identities. Existing imports from the same clone remain visible, and later imports atomically migrate their record key, repository, project, same-repository source, and workspace identities. Requiring persisted history to overlap the currently verified pair keeps consecutive transfers and renames connected while malformed histories, unrelated repositories, and fork sources remain fail-closed.

Protected attachment is transfer-aware without weakening clone or workspace verification: the live registered identity must belong to the persisted alias history, the project path and branch must still match, and a cross-alias workspace must carry the deterministic session name for its recorded historical identity.