### PR TITLE
Open exact worktree paths outside the global base

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ kwt add --no-launch -b feature/new-ui
 # Open a worktree workspace, creating its session when needed
 kwt open
 
-# Establish an exact workspace session for another tmux client
+# Open an exact worktree, even when it is outside the global worktree base
+kwt open /path/to/worktree
+
+# Establish that exact workspace session for another tmux client
 kwt open /path/to/worktree --start-session
 
 # Inspect worktrees and git status

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,6 +51,10 @@ With no argument, `kwt open` fuzzy-picks a worktree. A pattern narrows the
 cross-project list and opens the sole match directly. Kwt creates or repairs
 the canonical tmux workspace with its resolved layout before attaching.
 
+An exact worktree-root path is resolved directly from Git before pattern
+matching, including registered primary checkouts and linked worktrees outside
+the configured global worktree base.
+
 `kwt open <exact-worktree-path> --start-session` performs the same layout and
 session bootstrap without attaching a client. Use it before an external
 ordinary tmux client attaches to a session that may not exist yet. The exact

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -41,10 +41,14 @@ var openCmd = &cobra.Command{
 	Long: `Fuzzy-pick a worktree across all repositories in the configured base
 directory and attach to its tmux workspace, creating the workspace with the
 resolved layout if it does not yet exist. A pattern filters the worktree list.
-Pass an exact worktree path with --start-session to create or repair the
-workspace without attaching.`,
+An exact worktree path resolves directly even when it is outside the configured
+base directory. Add --start-session to create or repair the workspace without
+attaching.`,
 	Example: `  # Pick a worktree and open its workspace
   kwt open
+
+  # Open one exact worktree path directly
+  kwt open /path/to/worktree
 
   # Ensure an exact worktree workspace exists without attaching
   kwt open /path/to/worktree --start-session
@@ -86,77 +90,24 @@ func runOpen(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("--start-session requires an exact worktree path")
 		}
 
-		finder := ctx.GetGlobalFinder()
-		var entry *discovery.GlobalWorktreeEntry
-		requestedPath := ""
-		if openStartSession {
-			requestedPath = args[0]
-			var err error
-			entry, err = discovery.DiscoverWorktree(
+		entry, requestedPath, err := resolveOpenWorktree(
+			ctx,
+			args,
+			openStartSession,
+		)
+		if err != nil {
+			return err
+		}
+		if entry == nil {
+			return nil
+		}
+		if entry.RepositoryInfo == nil {
+			return fmt.Errorf(
+				"could not resolve worktree %s",
 				requestedPath,
-				ctx.Config.Projects,
 			)
-			if err != nil {
-				return fmt.Errorf(
-					"could not resolve worktree %s: %w",
-					requestedPath,
-					err,
-				)
-			}
-		} else {
-			entries, err := discovery.DiscoverGlobalWorktrees(
-				ctx.Config.Worktree.BaseDir,
-				ctx.Config.Projects,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to discover worktrees: %w", err)
-			}
-			if len(entries) == 0 {
-				if len(args) == 1 {
-					return fmt.Errorf("could not resolve worktree %s", args[0])
-				}
-				ctx.Printer.PrintInfo(
-					"No worktrees found in " + ctx.Config.Worktree.BaseDir,
-				)
-				return nil
-			}
-
-			if len(args) == 1 {
-				requestedPath = args[0]
-				matches := discovery.FilterGlobalWorktrees(
-					entries,
-					requestedPath,
-				)
-				switch len(matches) {
-				case 0:
-				case 1:
-					entry = matches[0]
-				default:
-					selected, selectErr := finder.SelectWorktree(
-						discovery.ConvertToWorktreeModels(matches, true),
-					)
-					if selectErr != nil {
-						return fmt.Errorf(
-							"selection cancelled: %w",
-							selectErr,
-						)
-					}
-					entry = findEntryByPath(matches, selected.Path)
-				}
-			} else {
-				worktrees := discovery.ConvertToWorktreeModels(entries, false)
-				selected, err := finder.SelectWorktree(worktrees)
-				if err != nil {
-					return fmt.Errorf("selection cancelled: %w", err)
-				}
-				requestedPath = selected.Path
-				entry = findEntryByPath(entries, requestedPath)
-			}
 		}
-
-		if entry == nil || entry.RepositoryInfo == nil {
-			return fmt.Errorf("could not resolve worktree %s", requestedPath)
-		}
+		finder := ctx.GetGlobalFinder()
 
 		return openSelectedWorktree(
 			cmd.Context(),
@@ -173,6 +124,103 @@ func runOpen(cmd *cobra.Command, args []string) error {
 			config.StdinInteractive(),
 		)
 	})(cmd, args)
+}
+
+func resolveOpenWorktree(
+	ctx *CommandContext,
+	args []string,
+	startSession bool,
+) (*discovery.GlobalWorktreeEntry, string, error) {
+	requestedPath := ""
+	if startSession {
+		requestedPath = args[0]
+		entry, err := discovery.DiscoverWorktree(
+			requestedPath,
+			ctx.Config.Projects,
+		)
+		if err != nil {
+			return nil, requestedPath, fmt.Errorf(
+				"could not resolve worktree %s: %w",
+				requestedPath,
+				err,
+			)
+		}
+		return entry, requestedPath, nil
+	}
+
+	if len(args) == 1 {
+		requestedPath = args[0]
+		if entry, err := discovery.DiscoverWorktree(
+			requestedPath,
+			ctx.Config.Projects,
+		); err == nil {
+			return entry, requestedPath, nil
+		}
+	}
+
+	entries, err := discovery.DiscoverGlobalWorktrees(
+		ctx.Config.Worktree.BaseDir,
+		ctx.Config.Projects,
+	)
+	if err != nil {
+		return nil, requestedPath, fmt.Errorf(
+			"failed to discover worktrees: %w",
+			err,
+		)
+	}
+	if len(entries) == 0 {
+		if len(args) == 1 {
+			return nil, requestedPath, fmt.Errorf(
+				"could not resolve worktree %s",
+				args[0],
+			)
+		}
+		ctx.Printer.PrintInfo(
+			"No worktrees found in " + ctx.Config.Worktree.BaseDir,
+		)
+		return nil, requestedPath, nil
+	}
+
+	var entry *discovery.GlobalWorktreeEntry
+	finder := ctx.GetGlobalFinder()
+	if len(args) == 1 {
+		matches := discovery.FilterGlobalWorktrees(entries, requestedPath)
+		switch len(matches) {
+		case 0:
+		case 1:
+			entry = matches[0]
+		default:
+			selected, selectErr := finder.SelectWorktree(
+				discovery.ConvertToWorktreeModels(matches, true),
+			)
+			if selectErr != nil {
+				return nil, requestedPath, fmt.Errorf(
+					"selection cancelled: %w",
+					selectErr,
+				)
+			}
+			entry = findEntryByPath(matches, selected.Path)
+		}
+	} else {
+		worktrees := discovery.ConvertToWorktreeModels(entries, false)
+		selected, selectErr := finder.SelectWorktree(worktrees)
+		if selectErr != nil {
+			return nil, requestedPath, fmt.Errorf(
+				"selection cancelled: %w",
+				selectErr,
+			)
+		}
+		requestedPath = selected.Path
+		entry = findEntryByPath(entries, requestedPath)
+	}
+
+	if entry == nil || entry.RepositoryInfo == nil {
+		return nil, requestedPath, fmt.Errorf(
+			"could not resolve worktree %s",
+			requestedPath,
+		)
+	}
+	return entry, requestedPath, nil
 }
 
 func openSelectedWorktree(

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -13,6 +13,7 @@ import (
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -93,6 +94,53 @@ func TestOpenStartSessionFlagGroups(t *testing.T) {
 	selectLayout.Changed = false
 	layout.Changed = true
 	require.NoError(t, openCmd.ValidateFlagGroups())
+}
+
+func TestResolveOpenWorktreeAcceptsExactPrimaryPathOutsideGlobalBase(
+	t *testing.T,
+) {
+	t.Setenv("GIT_AUTHOR_NAME", "Test User")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Test User")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+	repo := filepath.Join(t.TempDir(), "registered", "widget")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	require.NoError(t, exec.Command("git", "init", "-b", "main", repo).Run())
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "README.md"),
+		[]byte("# widget\n"),
+		0o644,
+	))
+	gitCommand := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		require.NoError(t, cmd.Run())
+	}
+	gitCommand("add", "README.md")
+	gitCommand("commit", "-m", "initial")
+
+	entry, requestedPath, err := resolveOpenWorktree(
+		&CommandContext{Config: &models.Config{
+			Worktree: models.WorktreeConfig{
+				BaseDir: filepath.Join(t.TempDir(), "global-worktrees"),
+			},
+			Projects: []models.Project{{
+				Repository: "github.com/acme/widget",
+				Path:       repo,
+			}},
+		}},
+		[]string{repo},
+		false,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, repo, requestedPath)
+	assert.Equal(t, utils.CanonicalPath(repo), utils.CanonicalPath(entry.Path))
+	assert.True(t, entry.IsMain)
+	require.NotNil(t, entry.RepositoryInfo)
+	assert.Equal(t, "github.com/acme/widget", entry.RepositoryInfo.FullPath)
 }
 
 func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(


### PR DESCRIPTION
`kwt open <argument>` currently treats an ordinary attached-open argument only as a fuzzy pattern over the configured global worktree directory. Registered primary checkouts commonly live outside that directory, so even an authoritative root path fails before kwt can create or bind its tmux workspace.

Resolve valid worktree-root paths directly through Git before falling back to the existing fuzzy lookup. This gives primary and externally located linked worktrees the same layout-aware, atomic create-or-attach behavior while preserving branch and repository pattern matching.

Validation: `make test`, `make build`, and `make lint` pass. A controlled primary-checkout probe advanced through resolution to a deliberately failing tmux shim, confirming the exact path reached workspace creation.