### PR TITLE
Finish partially removed worktree cleanup

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -542,6 +542,48 @@ func TestRemoveWorktree(t *testing.T) {
 	}
 }
 
+func TestRemoveWorktreeCleansDirectoryAfterGitDeregistersWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell wrapper")
+	}
+
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "partially-removed")
+	worktreePath := filepath.Join(t.TempDir(), "remove-wt")
+	repo.CreateWorktree(t, worktreePath, "partially-removed")
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find git executable: %v", err)
+	}
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	wrapper := `#!/bin/sh
+if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then
+	"$REAL_GIT" "$@" || exit $?
+	mkdir -p "$3"
+	printf 'created during removal\n' > "$3/residual"
+	printf "error: failed to delete '%s': Directory not empty\n" "$3" >&2
+	exit 1
+fi
+exec "$REAL_GIT" "$@"
+`
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+		t.Fatalf("write git wrapper: %v", err)
+	}
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err = New(repo.Path).RemoveWorktree(worktreePath, false)
+
+	if err != nil {
+		t.Fatalf("RemoveWorktree() error = %v", err)
+	}
+	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree path still exists after removal: stat error = %v", statErr)
+	}
+}
+
 func TestPruneWorktrees(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -574,7 +574,7 @@ exec "$REAL_GIT" "$@"
 	t.Setenv("REAL_GIT", realGit)
 	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	err = New(repo.Path).RemoveWorktree(worktreePath, false)
+	err = New(worktreePath).RemoveWorktree(worktreePath, false)
 
 	if err != nil {
 		t.Fatalf("RemoveWorktree() error = %v", err)

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -131,7 +131,11 @@ func (g *Git) AddWorktreeFromBase(path, branch, baseBranch string) error {
 // RemoveWorktree removes a worktree.
 func (g *Git) RemoveWorktree(path string, force bool) error {
 	canonicalPath := utils.CanonicalPath(path)
-	wasRegistered, _ := g.hasRegisteredWorktree(canonicalPath)
+	registryGit := g
+	if mainRoot, err := g.getMainRepoRoot(); err == nil {
+		registryGit = New(mainRoot)
+	}
+	wasRegistered, _ := registryGit.hasRegisteredWorktree(canonicalPath)
 
 	args := []string{"worktree", "remove"}
 	if force {
@@ -139,7 +143,7 @@ func (g *Git) RemoveWorktree(path string, force bool) error {
 	}
 	args = append(args, path)
 	if _, err := g.run(args...); err != nil {
-		stillRegistered, listErr := g.hasRegisteredWorktree(canonicalPath)
+		stillRegistered, listErr := registryGit.hasRegisteredWorktree(canonicalPath)
 		if wasRegistered && listErr == nil && !stillRegistered {
 			if removeErr := os.RemoveAll(path); removeErr != nil {
 				return fmt.Errorf(

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	gitworktree "go.kenn.io/kit/git/worktree"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -129,15 +130,42 @@ func (g *Git) AddWorktreeFromBase(path, branch, baseBranch string) error {
 
 // RemoveWorktree removes a worktree.
 func (g *Git) RemoveWorktree(path string, force bool) error {
+	canonicalPath := utils.CanonicalPath(path)
+	wasRegistered, _ := g.hasRegisteredWorktree(canonicalPath)
+
 	args := []string{"worktree", "remove"}
 	if force {
 		args = append(args, "--force")
 	}
 	args = append(args, path)
 	if _, err := g.run(args...); err != nil {
+		stillRegistered, listErr := g.hasRegisteredWorktree(canonicalPath)
+		if wasRegistered && listErr == nil && !stillRegistered {
+			if removeErr := os.RemoveAll(path); removeErr != nil {
+				return fmt.Errorf(
+					"failed to remove worktree: %w (Git deregistered the worktree but directory cleanup failed: %v)",
+					err,
+					removeErr,
+				)
+			}
+			return nil
+		}
 		return fmt.Errorf("failed to remove worktree: %w", err)
 	}
 	return nil
+}
+
+func (g *Git) hasRegisteredWorktree(canonicalPath string) (bool, error) {
+	output, err := g.run("worktree", "list", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range gitworktree.ParsePorcelain(output) {
+		if utils.CanonicalPath(entry.Path) == canonicalPath {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // PruneWorktrees removes worktree information for deleted directories.


### PR DESCRIPTION
Git can successfully deregister a worktree and still report failure when a concurrently created filesystem entry prevents the final directory deletion. kwt currently surfaces that partial success as a failed removal, leaving an orphaned directory behind even though Git no longer recognizes it as a worktree.

This change treats that narrow transition as recoverable: cleanup is completed only when the target was registered before removal and is provably absent from Git’s registry afterward. Dirty worktrees and other failures that leave registration intact continue to fail normally, so the recovery does not broaden force-removal behavior.

Validation:
- `make test`
- `make build`
- `make lint` and formatting checks via the push hook
- Deterministic regression reproducing deregistration followed by `Directory not empty`