### PR TITLE
Make existing branches first-class worktree sources

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,4 +1,10 @@
 review_guidelines = """
+Normative policy:
+
+- `docs/development/threat-model.md` is the project's security boundary. Apply
+  it before assigning security severity. Do not invent a stronger sandbox model
+  for local Git operations than that document defines.
+
 Threat model for multi-machine sync (fleet):
 
 - The hub and all spokes are the same user's machines sharing a bearer
@@ -30,6 +36,33 @@ Threat model for local execution:
 - Repository *contents* remain untrusted for machine-level configuration
   (the `.kwt.toml` rule above), but command resolution through the
   user's PATH is the user's domain, not the repository's.
+
+Threat model for existing-branch worktrees:
+
+- Checking out a selected local or remote branch is an explicit user action and
+  establishes the same accepted boundary as `git checkout`. After successful
+  creation, ordinary Git discovery, status, log, diff, and fleet observation
+  are expected. Do not flag these operations merely because trusted local Git
+  configuration may invoke hooks, filters, credential helpers, or
+  `core.fsmonitor`; that configuration belongs to the user under the local
+  execution model above.
+- The unreviewed registry marker defers KWT-owned repository automation and
+  workspace creation; it is not a sandbox boundary for normal Git inspection.
+  Snapshot staleness or concurrent marker changes are correctness issues unless
+  they cause a concrete consequence that remains in scope under the normative
+  threat model. Do not demand locks or per-operation registry rechecks solely
+  to prevent status/discovery from entering a checked-out worktree.
+- Existing-branch creation must still treat branch names, refs, remote metadata,
+  and checkout contents as data: never interpolate them into shell source,
+  environment expansion, credentials, or paths outside the user-selected or
+  configured destination.
+  Automated materialization disables repository hooks, checkout filters, and
+  recursive submodule updates, strips KWT-managed credentials, and skips
+  `copy_files`, `setup_commands`, layouts, and pane commands.
+- After creation, the worktree appears in normal status and fleet output.
+  Explicit `kwt open` or dashboard Enter acknowledges it and opts into trusted
+  layout/pane commands. Do not require status placeholders, hidden rows, or
+  fleet exclusion as security controls.
 
 Threat model for pull-request discovery and import:
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
 branch. If that remote base is unavailable, it falls back to local `main`, then
 `master`, then the branch checked out in the primary worktree.
 
-Remote-source worktrees are inert on creation: branch mutation and checkout
+Existing-branch worktrees are inert on creation: branch mutation and checkout
 run without repository-configured hooks or filters and without kwt credential
 variables, and `kwt` does not copy configured files, run setup commands,
 inspect status, publish the worktree to fleet, or launch a layout against
-contributor-controlled content. Remote branch names are treated literally
+contributor-controlled content. Existing branch names are treated literally
 when building the destination path. Review the checkout first, then use
 `kwt open` to acknowledge it and explicitly create and attach its workspace.
 
@@ -191,8 +191,8 @@ visible at roughly 100 columns. Select a remote-only branch row and press `s` to
 sync that branch locally. Press `c` on a local row to open a shell there.
 Remote-only sync verifies the created worktree against the hub-reported commit
 when one is available, and skips repository setup (`copy_files` and
-`setup_commands`). Remote-source `kwt add --from` worktrees have the same inert
-creation boundary; setup hooks run only for local and newly created branches.
+`setup_commands`). Existing local and remote branches use the same inert
+creation boundary; setup hooks run only for newly created branches.
 
 Useful commands:
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ branch. If that remote base is unavailable, it falls back to local `main`, then
 Existing-branch worktrees are inert on creation: branch mutation and checkout
 run without repository-configured hooks or filters and without kwt credential
 variables, and `kwt` does not copy configured files, run setup commands,
-inspect status, publish the worktree to fleet, or launch a layout against
-contributor-controlled content. Existing branch names are treated literally
-when building the destination path. Review the checkout first, then use
-`kwt open` to acknowledge it and explicitly create and attach its workspace.
+or launch a layout against contributor-controlled content. Existing branch
+names are treated literally when building the destination path. The checkout
+still participates in ordinary status and fleet observation. Review it before
+using `kwt open` to explicitly create and attach its workspace.
 
 ### Dashboard Keys
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ kwt add -b feature/new-ui
 # Create without launching tmux
 kwt add --no-launch -b feature/new-ui
 
+# Create a tracking worktree from an existing remote branch
+kwt add --from origin/feature/review feature/review
+
 # Open a worktree workspace, creating its session when needed
 kwt open
 
@@ -74,7 +77,8 @@ branch. If that remote base is unavailable, it falls back to local `main`, then
 | --------- | --------------------------------------- |
 | `up/down` | Move selection                          |
 | `enter`   | Attach to selected workspace            |
-| `n`       | Create a worktree in the active project |
+| `n`       | Create a new branch and worktree         |
+| `b`       | Search existing branches for a worktree  |
 | `L`       | Select workspace layout                 |
 | `P`       | Switch active project perspective       |
 | `p`       | Filter visible projects                 |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ kwt add --no-launch -b feature/new-ui
 # Create a tracking worktree from an existing remote branch
 kwt add --from origin/feature/review feature/review
 
+# After reviewing that checkout, explicitly start its workspace
+kwt open "$(kwt get feature/review)"
+
 # Open a worktree workspace, creating its session when needed
 kwt open
 
@@ -70,6 +73,11 @@ kwt remove -b feature/new-ui
 When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
 branch. If that remote base is unavailable, it falls back to local `main`, then
 `master`, then the branch checked out in the primary worktree.
+
+Remote-source worktrees are inert on creation: `kwt` does not copy configured
+files, run setup commands, or launch a layout against contributor-controlled
+content. Review the checkout first, then use `kwt open` to explicitly create
+and attach its workspace.
 
 ### Dashboard Keys
 
@@ -180,7 +188,8 @@ visible at roughly 100 columns. Select a remote-only branch row and press `s` to
 sync that branch locally. Press `c` on a local row to open a shell there.
 Remote-only sync verifies the created worktree against the hub-reported commit
 when one is available, and skips repository setup (`copy_files` and
-`setup_commands`); those hooks run for locally initiated `kwt add` worktrees.
+`setup_commands`). Remote-source `kwt add --from` worktrees have the same inert
+creation boundary; setup hooks run only for local and newly created branches.
 
 Useful commands:
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ branch. If that remote base is unavailable, it falls back to local `main`, then
 | --------- | --------------------------------------- |
 | `up/down` | Move selection                          |
 | `enter`   | Attach to selected workspace            |
-| `n`       | Create a new branch and worktree         |
-| `b`       | Search existing branches for a worktree  |
+| `n`       | Create a new branch and worktree        |
+| `b`       | Search existing branches for a worktree |
 | `L`       | Select workspace layout                 |
 | `P`       | Switch active project perspective       |
 | `p`       | Filter visible projects                 |

--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
 branch. If that remote base is unavailable, it falls back to local `main`, then
 `master`, then the branch checked out in the primary worktree.
 
-Remote-source worktrees are inert on creation: checkout runs without
-repository-configured hooks or filters and without kwt credential variables,
-and `kwt` does not copy configured files, run setup commands, or launch a
-layout against contributor-controlled content. Review the checkout first,
-then use `kwt open` to explicitly create and attach its workspace.
+Remote-source worktrees are inert on creation: branch mutation and checkout
+run without repository-configured hooks or filters and without kwt credential
+variables, and `kwt` does not copy configured files, run setup commands,
+inspect status, publish the worktree to fleet, or launch a layout against
+contributor-controlled content. Remote branch names are treated literally
+when building the destination path. Review the checkout first, then use
+`kwt open` to acknowledge it and explicitly create and attach its workspace.
 
 ### Dashboard Keys
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
 branch. If that remote base is unavailable, it falls back to local `main`, then
 `master`, then the branch checked out in the primary worktree.
 
-Remote-source worktrees are inert on creation: `kwt` does not copy configured
-files, run setup commands, or launch a layout against contributor-controlled
-content. Review the checkout first, then use `kwt open` to explicitly create
-and attach its workspace.
+Remote-source worktrees are inert on creation: checkout runs without
+repository-configured hooks or filters and without kwt credential variables,
+and `kwt` does not copy configured files, run setup commands, or launch a
+layout against contributor-controlled content. Review the checkout first,
+then use `kwt open` to explicitly create and attach its workspace.
 
 ### Dashboard Keys
 

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -1,0 +1,81 @@
+# Threat model
+
+`kwt` is a local developer tool, not a sandbox for Git repositories. Security
+reviews should distinguish data controlled by a branch from execution policy
+already controlled by the machine's owner.
+
+## Trusted local state
+
+The following are trusted because changing any of them already gives the local
+user or an attacker equivalent code-execution capability outside `kwt`:
+
+- the operating-system account and its environment;
+- executables on `PATH`, shell and tmux configuration, and agent commands;
+- global `kwt` configuration;
+- an existing repository's Git configuration, hooks, remotes, URL rewrites,
+  credential helpers, filters, and fsmonitor configuration; and
+- authenticated fleet peers belonging to the same user.
+
+Consequently, ordinary Git inspection after a successful checkout—including
+status, log, diff, ref discovery, and fleet metadata collection—is within the
+accepted execution boundary. If trusted Git configuration deliberately invokes
+a helper while performing those operations, `kwt` does not try to provide a
+stronger sandbox than Git. Registry staleness that changes when inspection
+occurs is a correctness concern, not a security boundary bypass.
+
+## Untrusted inputs
+
+Branch and ref names, pull-request metadata, remote repository contents, and
+repository file contents are untrusted data. They must not be interpolated into
+shell commands, environment-variable expansion, credentials, remote
+destinations, or paths outside the user-selected or configured destination.
+
+Repository-local `.kwt.toml` is separately trust-gated. Even a trusted local
+file cannot set machine-level fleet credentials or endpoints. Trusting that
+file authorizes its repository-scoped policy; it does not authorize branch
+names or remote metadata to become shell syntax.
+
+## Worktree creation and repository automation
+
+Checking out a local or remote branch is an explicit user action and establishes
+the same boundary as checking it out with Git directly. `kwt` still makes
+creation unsurprising:
+
+- ref and branch values are passed as arguments, never shell source;
+- automated checkout disables configured hooks, filters, and recursive
+  submodule updates;
+- imported existing branches do not automatically run `copy_files`,
+  `setup_commands`, layouts, or pane commands; and
+- `kwt`-managed tokens are removed from checkout and workspace processes.
+
+After checkout, the worktree participates in normal status, discovery, and
+fleet observation. Opening it is the explicit opt-in to create its configured
+workspace and run any trusted layout or pane commands.
+
+## Secrets and machine-level policy
+
+`kwt` bearer tokens, token-file locations, and credential-bearing remote URLs
+must not be exposed to repository-controlled processes, printed, persisted in
+shared state, or published to fleet. Fleet configuration is global-only, and
+non-loopback fleet transport requires HTTPS.
+
+Ordinary developer credentials and environment variables outside `kwt`'s own
+credential surfaces remain the user's responsibility.
+
+## Out of scope
+
+Do not report an issue as a `kwt` vulnerability when exploitation requires:
+
+- a malicious binary already on the user's `PATH`;
+- hostile shell, tmux, Git, hook, filter, fsmonitor, or credential-helper
+  configuration already installed by the local user;
+- another malicious process running as the same operating-system user;
+- a compromised authenticated fleet machine; or
+- treating a normal Git command after checkout as crossing an untrusted-code
+  execution boundary.
+
+These assumptions may still expose usability or correctness bugs. Severity
+should follow the concrete consequence within the boundaries above: credential
+disclosure, command injection by branch-controlled data, trust bypass, writes
+outside configured roots, or pushes to the wrong repository are security
+issues; stale UI state, compatibility, and ordinary Git behavior are not.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -33,7 +33,8 @@ Useful keys:
 | Key     | Action                                                  |
 | ------- | ------------------------------------------------------- |
 | `enter` | Attach to the selected workspace.                       |
-| `n`     | Create a worktree in the active project perspective.    |
+| `n`     | Create a new branch and worktree.                        |
+| `b`     | Search local and remote branches for a worktree.         |
 | `P`     | Switch the active project perspective.                  |
 | `p`     | Filter visible projects by name.                        |
 | `/`     | Search rows within the active perspective/filter.       |
@@ -54,6 +55,15 @@ kwt add -b feature/new-ui
 When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
 branch. If that remote base is unavailable, it falls back to local `main`, then
 `master`, then the branch checked out in the primary worktree.
+
+To use an existing branch, press `b` in the dashboard and search the available
+local and remote branches. From the CLI, pass the local branch directly or
+retain an exact remote source with `--from`:
+
+```sh
+kwt add feature/local
+kwt add --from origin/feature/review feature/review
+```
 
 By default, `kwt add` creates the worktree and launches a tmux workspace — a
 blank single-pane session unless a [layout](../reference/configuration.md) is

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -65,12 +65,12 @@ kwt add feature/local
 kwt add --from origin/feature/review feature/review
 ```
 
-An existing remote branch is untrusted until you inspect it. Remote-source
-creation disables repository-configured Git hooks and checkout filters,
-removes kwt credential variables from Git, treats branch names literally in
-destination paths, and skips `copy_files`, `setup_commands`, status and fleet
-inspection, and workspace launch. After reviewing the checkout, explicitly
-acknowledge it and create its workspace:
+An existing local or remote branch is untrusted until you inspect it.
+Existing-branch creation disables repository-configured Git hooks and checkout
+filters, removes kwt credential variables from Git, treats branch names
+literally in destination paths, and skips `copy_files`, `setup_commands`,
+status and fleet inspection, and workspace launch. After reviewing the
+checkout, explicitly acknowledge it and create its workspace:
 
 ```sh
 kwt open "$(kwt get feature/review)"

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -33,8 +33,8 @@ Useful keys:
 | Key     | Action                                                  |
 | ------- | ------------------------------------------------------- |
 | `enter` | Attach to the selected workspace.                       |
-| `n`     | Create a new branch and worktree.                        |
-| `b`     | Search local and remote branches for a worktree.         |
+| `n`     | Create a new branch and worktree.                       |
+| `b`     | Search local and remote branches for a worktree.        |
 | `P`     | Switch the active project perspective.                  |
 | `p`     | Filter visible projects by name.                        |
 | `/`     | Search rows within the active perspective/filter.       |

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -66,8 +66,10 @@ kwt add --from origin/feature/review feature/review
 ```
 
 An existing remote branch is untrusted until you inspect it. Remote-source
-creation skips `copy_files`, `setup_commands`, and workspace launch. After
-reviewing the checkout, explicitly create and attach its workspace:
+creation disables repository-configured checkout hooks and filters, removes
+kwt credential variables from Git, and skips `copy_files`, `setup_commands`,
+and workspace launch. After reviewing the checkout, explicitly create and
+attach its workspace:
 
 ```sh
 kwt open "$(kwt get feature/review)"

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -65,12 +65,12 @@ kwt add feature/local
 kwt add --from origin/feature/review feature/review
 ```
 
-An existing local or remote branch is untrusted until you inspect it.
 Existing-branch creation disables repository-configured Git hooks and checkout
 filters, removes kwt credential variables from Git, treats branch names
-literally in destination paths, and skips `copy_files`, `setup_commands`,
-status and fleet inspection, and workspace launch. After reviewing the
-checkout, explicitly acknowledge it and create its workspace:
+literally in destination paths, and skips `copy_files`, `setup_commands`, and
+workspace launch. Ordinary status and fleet observation remain available.
+After reviewing the checkout, explicitly acknowledge it and create its
+workspace:
 
 ```sh
 kwt open "$(kwt get feature/review)"

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -66,10 +66,11 @@ kwt add --from origin/feature/review feature/review
 ```
 
 An existing remote branch is untrusted until you inspect it. Remote-source
-creation disables repository-configured checkout hooks and filters, removes
-kwt credential variables from Git, and skips `copy_files`, `setup_commands`,
-and workspace launch. After reviewing the checkout, explicitly create and
-attach its workspace:
+creation disables repository-configured Git hooks and checkout filters,
+removes kwt credential variables from Git, treats branch names literally in
+destination paths, and skips `copy_files`, `setup_commands`, status and fleet
+inspection, and workspace launch. After reviewing the checkout, explicitly
+acknowledge it and create its workspace:
 
 ```sh
 kwt open "$(kwt get feature/review)"

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -65,9 +65,18 @@ kwt add feature/local
 kwt add --from origin/feature/review feature/review
 ```
 
-By default, `kwt add` creates the worktree and launches a tmux workspace — a
-blank single-pane session unless a [layout](../reference/configuration.md) is
-selected. To create without launching:
+An existing remote branch is untrusted until you inspect it. Remote-source
+creation skips `copy_files`, `setup_commands`, and workspace launch. After
+reviewing the checkout, explicitly create and attach its workspace:
+
+```sh
+kwt open "$(kwt get feature/review)"
+```
+
+For local and newly created branches, `kwt add` launches a tmux workspace by
+default — a blank single-pane session unless a
+[layout](../reference/configuration.md) is selected. To create without
+launching:
 
 ```sh
 kwt add --no-launch -b feature/new-ui

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,10 +59,9 @@ kwt builds the destination path. Submodules are not recursively updated during
 creation; inspect the superproject first, then update submodules explicitly
 after acknowledgement.
 
-The created worktree remains marked unreviewed, so automatic status collection
-does not run Git inside it and fleet publication omits it. Review the checkout
-and run `kwt open <worktree>` as the explicit acknowledgement that re-enables
-normal inspection and opts in to its layout and pane commands.
+The created worktree participates in ordinary status and fleet observation.
+Review the checkout and run `kwt open <worktree>` as the explicit
+acknowledgement that opts in to its layout and pane commands.
 
 `kwt branches --json` emits only candidates not already checked out, with
 `name`, a source-qualified display `label`, the full source ref, and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,6 +7,7 @@ stable command surface.
 | ---------------- | ------------------------------------------------------ |
 | `kwt`, `kwt tui` | Open the cross-project and multi-machine dashboard.    |
 | `kwt add`        | Create a worktree and optionally launch its workspace. |
+| `kwt branches`   | List branches available for a new worktree.            |
 | `kwt open`       | Open or establish a worktree workspace session.        |
 | `kwt list`       | List worktrees.                                        |
 | `kwt status`     | Show Git status, sync state, and activity.             |
@@ -27,6 +28,8 @@ stable command surface.
 
 ```sh
 kwt add -b fix/parser-race
+kwt add --from origin/fix/review fix/review
+kwt branches --json
 kwt open parser
 kwt open /path/to/worktree --start-session
 kwt status
@@ -44,6 +47,12 @@ kwt config set --local layouts.default stack
 When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local
 `main`, then `master`, then the branch checked out in the primary worktree.
+
+`kwt add <branch>` checks out an existing local branch. Use
+`kwt add --from <remote-ref> <branch>` when a remote candidate must become a
+local tracking branch. `kwt branches --json` emits only candidates not already
+checked out, with `name`, exact `source`, and `is_remote` fields for interactive
+clients.
 
 ## `kwt open`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,8 +52,10 @@ default branch. If that remote base is unavailable, it falls back to local
 `kwt add --from <remote-ref> <branch>` when a remote candidate must become a
 local tracking branch. This remote-source path does not copy files, run setup
 commands, or launch a workspace; `--layout` and `--select-layout` are rejected.
-Review the checkout and run `kwt open <worktree>` as the separate opt-in to its
-layout and pane commands.
+Git checkout runs with an empty hooks directory, configured smudge and process
+filters disabled, and kwt credential variables removed. Review the checkout
+and run `kwt open <worktree>` as the separate opt-in to its layout and pane
+commands.
 
 `kwt branches --json` emits only candidates not already checked out, with
 `name`, full source ref, and `is_remote` fields for interactive clients.
@@ -209,15 +211,16 @@ explicit, documented exception, so they cannot silently drift apart:
   itself now keeps them.
 
 The full list: exact names `__CFBundleIdentifier`, `EDITOR`,
-`KWT_GITHUB_TOKEN`, `OLDPWD`, `PROMPT`, `PROMPT_COMMAND`, `PWD`, `RPROMPT`,
-`SHLVL`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VISUAL`, `WINDOWID`, `_`; and
-prefixes `ALACRITTY_`, `CONDA_`, `FZF_`, `ITERM`, `KITTY_`, `NVM_`, `PYENV_`,
-`STARSHIP_`, `VIRTUAL_ENV`, `WEZTERM_`, `WT_`, `VSCODE_`. Operational kwt
-variables such as `KWT_HOME` are preserved. PR workspace bootstrap additionally
-removes the exact variable named by `fleet.token_env`, both from tmux
-subprocesses and from the session environment. `EDITOR` and
-`VISUAL` are excluded from exec-time sanitization only, per above; every
-other name in this list is treated identically by both mechanisms.
+`KWT_FLEET_TOKEN`, `KWT_GITHUB_TOKEN`, `OLDPWD`, `PROMPT`, `PROMPT_COMMAND`,
+`PWD`, `RPROMPT`, `SHLVL`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VISUAL`,
+`WINDOWID`, `_`; and prefixes `ALACRITTY_`, `CONDA_`, `FZF_`, `ITERM`,
+`KITTY_`, `NVM_`, `PYENV_`, `STARSHIP_`, `VIRTUAL_ENV`, `WEZTERM_`, `WT_`,
+`VSCODE_`. Every kwt workspace also removes the exact variable named by
+`fleet.token_env`, case-insensitively, both from tmux subprocesses and from
+the session environment. Operational kwt variables such as `KWT_HOME` are
+preserved. `EDITOR` and `VISUAL` are excluded from exec-time sanitization
+only, per above; every other name in this list is treated identically by both
+mechanisms.
 
 `TERMINFO` is deliberately excluded from the whole list: it is functional
 terminal configuration (a custom terminfo database path), not transient

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,9 +50,13 @@ default branch. If that remote base is unavailable, it falls back to local
 
 `kwt add <branch>` checks out an existing local branch. Use
 `kwt add --from <remote-ref> <branch>` when a remote candidate must become a
-local tracking branch. `kwt branches --json` emits only candidates not already
-checked out, with `name`, exact `source`, and `is_remote` fields for interactive
-clients.
+local tracking branch. This remote-source path does not copy files, run setup
+commands, or launch a workspace; `--layout` and `--select-layout` are rejected.
+Review the checkout and run `kwt open <worktree>` as the separate opt-in to its
+layout and pane commands.
+
+`kwt branches --json` emits only candidates not already checked out, with
+`name`, full source ref, and `is_remote` fields for interactive clients.
 
 ## `kwt open`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,8 +50,10 @@ default branch. If that remote base is unavailable, it falls back to local
 
 `kwt add <branch>` checks out an existing local branch. Use
 `kwt add --from <remote-ref> <branch>` when a remote candidate must become a
-local tracking branch. Neither existing-branch path copies files, runs setup
-commands, or launches a workspace; `--layout` and `--select-layout` are rejected.
+local tracking branch. Shorthand such as `origin/topic` is accepted, but kwt
+verifies it against fetched refs and passes the full `refs/remotes/...` identity
+to Git. Neither existing-branch path copies files, runs setup commands, or
+launches a workspace; `--layout` and `--select-layout` are rejected.
 Git branch mutation and checkout run with an empty hooks directory, configured
 smudge and process filters disabled, and kwt credential variables removed.
 Environment references in the source-derived branch name remain literal when

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,11 +50,11 @@ default branch. If that remote base is unavailable, it falls back to local
 
 `kwt add <branch>` checks out an existing local branch. Use
 `kwt add --from <remote-ref> <branch>` when a remote candidate must become a
-local tracking branch. This remote-source path does not copy files, run setup
-commands, or launch a workspace; `--layout` and `--select-layout` are rejected.
+local tracking branch. Neither existing-branch path copies files, runs setup
+commands, or launches a workspace; `--layout` and `--select-layout` are rejected.
 Git branch mutation and checkout run with an empty hooks directory, configured
 smudge and process filters disabled, and kwt credential variables removed.
-Environment references in the remote-derived branch name remain literal when
+Environment references in the source-derived branch name remain literal when
 kwt builds the destination path.
 
 The created worktree remains marked unreviewed, so automatic status collection

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,10 +52,15 @@ default branch. If that remote base is unavailable, it falls back to local
 `kwt add --from <remote-ref> <branch>` when a remote candidate must become a
 local tracking branch. This remote-source path does not copy files, run setup
 commands, or launch a workspace; `--layout` and `--select-layout` are rejected.
-Git checkout runs with an empty hooks directory, configured smudge and process
-filters disabled, and kwt credential variables removed. Review the checkout
-and run `kwt open <worktree>` as the separate opt-in to its layout and pane
-commands.
+Git branch mutation and checkout run with an empty hooks directory, configured
+smudge and process filters disabled, and kwt credential variables removed.
+Environment references in the remote-derived branch name remain literal when
+kwt builds the destination path.
+
+The created worktree remains marked unreviewed, so automatic status collection
+does not run Git inside it and fleet publication omits it. Review the checkout
+and run `kwt open <worktree>` as the explicit acknowledgement that re-enables
+normal inspection and opts in to its layout and pane commands.
 
 `kwt branches --json` emits only candidates not already checked out, with
 `name`, full source ref, and `is_remote` fields for interactive clients.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,9 @@ commands, or launches a workspace; `--layout` and `--select-layout` are rejected
 Git branch mutation and checkout run with an empty hooks directory, configured
 smudge and process filters disabled, and kwt credential variables removed.
 Environment references in the source-derived branch name remain literal when
-kwt builds the destination path.
+kwt builds the destination path. Submodules are not recursively updated during
+creation; inspect the superproject first, then update submodules explicitly
+after acknowledgement.
 
 The created worktree remains marked unreviewed, so automatic status collection
 does not run Git inside it and fleet publication omits it. Review the checkout
@@ -63,7 +65,8 @@ and run `kwt open <worktree>` as the explicit acknowledgement that re-enables
 normal inspection and opts in to its layout and pane commands.
 
 `kwt branches --json` emits only candidates not already checked out, with
-`name`, full source ref, and `is_remote` fields for interactive clients.
+`name`, a source-qualified display `label`, the full source ref, and
+`is_remote` fields for interactive clients.
 
 ## `kwt open`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -47,7 +47,10 @@ Repository-local path fields cannot reference environment variables, including
 influenced by repository-local naming are not environment-expanded after
 rendering, so a template cannot synthesize a reference. Environment expansion
 remains available for paths in the global configuration and for explicit
-command-line paths.
+command-line paths. In a global naming template, expansion applies only to
+literal template text, preserving Go template variables inside actions.
+Global `naming.sanitize_chars` replacement values expand before branch
+sanitization.
 
 Pane entries are shell commands. `agent:<name>` expands through the `[agents]`
 table before tmux starts, so command flags live in one local config file.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -52,6 +52,10 @@ literal template text, preserving Go template variables inside actions.
 Global `naming.sanitize_chars` replacement values expand before branch
 sanitization.
 
+Resolved worktree and directory-workspace paths cannot contain `#`, which tmux
+reserves for format expansion. kwt rejects such paths before creating or
+registering a workspace.
+
 Pane entries are shell commands. `agent:<name>` expands through the `[agents]`
 table before tmux starts, so command flags live in one local config file.
 

--- a/docs/workflows/agent-workspaces.md
+++ b/docs/workflows/agent-workspaces.md
@@ -41,5 +41,6 @@ quiet.
 ## Cross-project steering
 
 The dashboard is project-aware. Use `P` to set the active project perspective
-before creating a worktree, then `n` to create it without leaving the TUI. Use
-lowercase `p` for a temporary project-name filter and `/` for row search.
+before creating a worktree. Press `n` for a new branch or `b` to search local
+and remote branches that are not already checked out. Use lowercase `p` for a
+temporary project-name filter and `/` for row search.

--- a/docs/workflows/agent-workspaces.md
+++ b/docs/workflows/agent-workspaces.md
@@ -43,6 +43,7 @@ quiet.
 The dashboard is project-aware. Use `P` to set the active project perspective
 before creating a worktree. Press `n` for a new branch or `b` to search local
 and remote branches that are not already checked out. A selected remote branch
-is checked out without setup hooks or workspace commands; review it before
-pressing `enter` to create and attach its session. Use lowercase `p` for a
-temporary project-name filter and `/` for row search.
+is checked out without repository hooks, configured filters, setup commands,
+or workspace commands; review it before pressing `enter` to create and attach
+its session. Use lowercase `p` for a temporary project-name filter and `/` for
+row search.

--- a/docs/workflows/agent-workspaces.md
+++ b/docs/workflows/agent-workspaces.md
@@ -44,6 +44,7 @@ The dashboard is project-aware. Use `P` to set the active project perspective
 before creating a worktree. Press `n` for a new branch or `b` to search local
 and remote branches that are not already checked out. A selected remote branch
 is checked out without repository hooks, configured filters, setup commands,
-or workspace commands; review it before pressing `enter` to create and attach
-its session. Use lowercase `p` for a temporary project-name filter and `/` for
-row search.
+status or fleet inspection, or workspace commands. Review it before pressing
+`enter`; that explicit attach acknowledges the checkout, enables normal
+inspection, and creates its session. Use lowercase `p` for a temporary
+project-name filter and `/` for row search.

--- a/docs/workflows/agent-workspaces.md
+++ b/docs/workflows/agent-workspaces.md
@@ -42,5 +42,7 @@ quiet.
 
 The dashboard is project-aware. Use `P` to set the active project perspective
 before creating a worktree. Press `n` for a new branch or `b` to search local
-and remote branches that are not already checked out. Use lowercase `p` for a
+and remote branches that are not already checked out. A selected remote branch
+is checked out without setup hooks or workspace commands; review it before
+pressing `enter` to create and attach its session. Use lowercase `p` for a
 temporary project-name filter and `/` for row search.

--- a/docs/workflows/directory-workspaces.md
+++ b/docs/workflows/directory-workspaces.md
@@ -28,8 +28,8 @@ auto-registered.
 Workspace rows show the workspace name under REPO, the path under BRANCH, and
 session liveness under WORKSPACE; Git-specific columns show `-`. Rows match `/`
 search by name and path. `K` kills a live session, and `d` unregisters the
-workspace after confirmation. Git actions such as `n` (new branch) and `s`
-(sync) do not apply and say so in the status line.
+workspace after confirmation. Git actions such as `n` (new branch), `b`
+(existing branch), and `s` (sync) do not apply and say so in the status line.
 
 ## Sessions and layouts
 

--- a/docs/workflows/directory-workspaces.md
+++ b/docs/workflows/directory-workspaces.md
@@ -16,7 +16,8 @@ kwt workspace remove protos
 Names default to the directory base name and must be unique. Re-adding the same
 directory updates its name. `remove` only unregisters: it never deletes the
 directory, and a live tmux session is left running with a hint on how to kill
-it.
+it. Workspace paths cannot contain `#`, which tmux reserves for format
+expansion.
 
 ## Open from the dashboard
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -34,6 +34,7 @@ nav = [
   ] },
   { "Development" = [
     { "Contributing" = "development/contributing.md" },
+    { "Threat model" = "development/threat-model.md" },
   ] },
 ]
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -47,9 +48,11 @@ When -b creates a branch, kwt fetches origin and starts from its default branch.
 If that remote base is unavailable, it falls back to local main, then master,
 then the branch checked out in the primary worktree.
 
-Use --from with an exact remote ref to create a local tracking branch and its
-worktree. Existing-branch worktrees skip repository setup and workspace launch
-until you inspect the checkout and explicitly open it.`,
+Use --from with a fetched remote ref to create a local tracking branch and its
+worktree. Shorthand such as origin/topic is verified and resolved to its full
+refs/remotes/... identity before creation. Existing-branch worktrees skip
+repository setup and workspace launch until you inspect the checkout and
+explicitly open it.`,
 	Example: `  # Create worktree from existing branch
   kwt add feature/new-ui
 
@@ -102,6 +105,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	return ExecuteWithArgs(true, func(ctx *CommandContext, cmd *cobra.Command, args []string) error {
 		var branch string
 		var path string
+		remoteSource := addFrom
 
 		if addInteractive {
 			if len(args) > 0 {
@@ -120,7 +124,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 			branch = selectedBranch.Name
 			if selectedBranch.IsRemote {
-				addFrom = selectedBranch.Source
+				remoteSource = selectedBranch.Source
 			}
 		} else {
 			if len(args) < 1 {
@@ -187,8 +191,23 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 
 		var worktreePath string
-		if addFrom != "" {
-			worktreePath, err = ctx.WorktreeManager.AddTracking(branch, addFrom, path)
+		if remoteSource != "" {
+			branches, listErr := ctx.Git.ListBranches(true)
+			if listErr != nil {
+				return fmt.Errorf("list fetched remote refs: %w", listErr)
+			}
+			remoteSource, err = resolveRemoteBranchSource(
+				branches,
+				remoteSource,
+			)
+			if err != nil {
+				return err
+			}
+			worktreePath, err = ctx.WorktreeManager.AddTracking(
+				branch,
+				remoteSource,
+				path,
+			)
 		} else {
 			worktreePath, err = ctx.WorktreeManager.Add(branch, path, addBranch)
 		}
@@ -240,6 +259,39 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	})(cmd, args)
+}
+
+func resolveRemoteBranchSource(
+	branches []models.Branch,
+	requested string,
+) (string, error) {
+	var match string
+	for _, branch := range branches {
+		if !branch.IsRemote {
+			continue
+		}
+		shortSource := strings.TrimPrefix(
+			branch.Source,
+			"refs/remotes/",
+		)
+		if requested != branch.Source && requested != shortSource {
+			continue
+		}
+		if match != "" && match != branch.Source {
+			return "", fmt.Errorf(
+				"remote ref %q is ambiguous; use a full refs/remotes/... ref",
+				requested,
+			)
+		}
+		match = branch.Source
+	}
+	if match == "" {
+		return "", fmt.Errorf(
+			"remote ref %q was not found; fetch it first",
+			requested,
+		)
+	}
+	return match, nil
 }
 
 // printAddResult reports a successful worktree creation.

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -48,7 +48,7 @@ If that remote base is unavailable, it falls back to local main, then master,
 then the branch checked out in the primary worktree.
 
 Use --from with an exact remote ref to create a local tracking branch and its
-worktree. Remote-source worktrees skip repository setup and workspace launch
+worktree. Existing-branch worktrees skip repository setup and workspace launch
 until you inspect the checkout and explicitly open it.`,
 	Example: `  # Create worktree from existing branch
   kwt add feature/new-ui
@@ -153,10 +153,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		// Only worktree creation and the tmux attach below are side-effecting,
 		// so they run after this point.
 		layoutRequested := addLayout != "" || addSelectLayout
-		if addFrom != "" && layoutRequested {
+		unreviewedSource := !addBranch
+		if unreviewedSource && layoutRequested {
 			return fmt.Errorf(
-				"--from cannot be combined with --layout/--select-layout; " +
-					"inspect the remote checkout, then run kwt open",
+				"existing branches cannot be combined with --layout/--select-layout; " +
+					"inspect the checkout, then run kwt open",
 			)
 		}
 		launch, err := shouldLaunch(
@@ -167,7 +168,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if addFrom != "" {
+		if unreviewedSource {
 			launch = false
 		}
 		var layout models.Layout
@@ -217,10 +218,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 
 		printAddResult(os.Stdout, branch, expiresAt)
-		if addFrom != "" {
+		if unreviewedSource {
 			_, _ = fmt.Fprintf(
 				os.Stdout,
-				"Review the remote checkout, then run 'kwt open %s' to start its workspace.\n",
+				"Review the existing-branch checkout, then run 'kwt open %s' to start its workspace.\n",
 				worktreePath,
 			)
 		}

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/duration"
 	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
@@ -26,6 +27,11 @@ var (
 	addSelectLayout bool
 	addNoLaunch     bool
 	addFrom         string
+
+	newAddWorkspaceRunner = func(names []string) openWorkspaceRunner {
+		tmuxCommand := tmux.NewTmuxCommandWithStripNames("", names)
+		return tmux.NewWorkspaceRunner(tmuxCommand, names)
+	}
 )
 
 // addCmd represents the add command.
@@ -219,7 +225,13 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		publishFleetBestEffortForCommand(cmd, ctx.Config)
 
 		if launch {
-			return attachWorkspace(info, branch, worktreePath, layout)
+			return attachWorkspace(
+				info,
+				branch,
+				worktreePath,
+				layout,
+				ctx.Config,
+			)
 		}
 		return nil
 	})(cmd, args)
@@ -288,9 +300,14 @@ func prepareLaunch(ctx *CommandContext) (models.Layout, *url.RepositoryInfo, err
 // creating the session first if needed. Called only after prepareLaunch has
 // already validated tmux, resolved the layout, and parsed the repository
 // URL, and after the worktree exists.
-func attachWorkspace(info *url.RepositoryInfo, branch, worktreePath string, layout models.Layout) error {
+func attachWorkspace(
+	info *url.RepositoryInfo,
+	branch, worktreePath string,
+	layout models.Layout,
+	cfg *models.Config,
+) error {
 	session := tmux.WorkspaceSessionName(info, branch, worktreePath)
-	runner := tmux.NewWorkspaceRunner(tmux.NewTmuxCommand(""))
+	runner := newAddWorkspaceRunner(credentials.ProtectedNames(cfg))
 	return runner.EnsureAndAttach(
 		context.Background(), session, worktreePath, layout, os.Getenv("TMUX") != "",
 	)

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -88,6 +88,12 @@ func init() {
 		"Create the worktree without launching a workspace")
 	addCmd.Flags().StringVar(&addFrom, "from", "",
 		"Create a local tracking branch from this remote ref")
+	if err := addCmd.RegisterFlagCompletionFunc(
+		"from",
+		getRemoteBranchCompletions,
+	); err != nil {
+		panic(err)
+	}
 	addCmd.MarkFlagsMutuallyExclusive("layout", "select-layout")
 	addCmd.MarkFlagsMutuallyExclusive("branch", "from", "interactive")
 }

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -201,13 +201,15 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			t := time.Now().Add(expiresDuration)
 			expiresAt = &t
 
-			entry := &registry.WorktreeEntry{
-				Repository: repoURL,
-				Branch:     branch,
-				Path:       worktreePath,
-				IsMain:     false,
-				ExpiresAt:  expiresAt,
+			entry := &registry.WorktreeEntry{}
+			if existing, ok := reg.Get(worktreePath); ok {
+				*entry = *existing
 			}
+			entry.Repository = repoURL
+			entry.Branch = branch
+			entry.Path = worktreePath
+			entry.IsMain = false
+			entry.ExpiresAt = expiresAt
 
 			if err := reg.Register(entry); err != nil {
 				return fmt.Errorf("failed to register worktree: %w", err)

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -42,7 +42,8 @@ If that remote base is unavailable, it falls back to local main, then master,
 then the branch checked out in the primary worktree.
 
 Use --from with an exact remote ref to create a local tracking branch and its
-worktree.`,
+worktree. Remote-source worktrees skip repository setup and workspace launch
+until you inspect the checkout and explicitly open it.`,
 	Example: `  # Create worktree from existing branch
   kwt add feature/new-ui
 
@@ -145,13 +146,23 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		// repository identity failure never leaves a stray worktree behind.
 		// Only worktree creation and the tmux attach below are side-effecting,
 		// so they run after this point.
+		layoutRequested := addLayout != "" || addSelectLayout
+		if addFrom != "" && layoutRequested {
+			return fmt.Errorf(
+				"--from cannot be combined with --layout/--select-layout; " +
+					"inspect the remote checkout, then run kwt open",
+			)
+		}
 		launch, err := shouldLaunch(
 			ctx.Config.Layouts.AutoLaunchOnAdd,
-			addLayout != "" || addSelectLayout,
+			layoutRequested,
 			addNoLaunch,
 		)
 		if err != nil {
 			return err
+		}
+		if addFrom != "" {
+			launch = false
 		}
 		var layout models.Layout
 		var info *url.RepositoryInfo
@@ -198,6 +209,13 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 
 		printAddResult(os.Stdout, branch, expiresAt)
+		if addFrom != "" {
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Review the remote checkout, then run 'kwt open %s' to start its workspace.\n",
+				worktreePath,
+			)
+		}
 		publishFleetBestEffortForCommand(cmd, ctx.Config)
 
 		if launch {

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -25,6 +25,7 @@ var (
 	addLayout       string
 	addSelectLayout bool
 	addNoLaunch     bool
+	addFrom         string
 )
 
 // addCmd represents the add command.
@@ -38,7 +39,10 @@ Use -i flag to interactively select a branch using fuzzy finder.
 
 When -b creates a branch, kwt fetches origin and starts from its default branch.
 If that remote base is unavailable, it falls back to local main, then master,
-then the branch checked out in the primary worktree.`,
+then the branch checked out in the primary worktree.
+
+Use --from with an exact remote ref to create a local tracking branch and its
+worktree.`,
 	Example: `  # Create worktree from existing branch
   kwt add feature/new-ui
 
@@ -47,6 +51,9 @@ then the branch checked out in the primary worktree.`,
 
   # Create new branch and worktree
   kwt add -b feature/api-v2
+
+  # Create a tracking worktree from a remote branch
+  kwt add --from origin/feature/review feature/review
 
   # Interactive branch selection
   kwt add -i
@@ -72,7 +79,10 @@ func init() {
 		"Fuzzy-pick a workspace layout")
 	addCmd.Flags().BoolVar(&addNoLaunch, "no-launch", false,
 		"Create the worktree without launching a workspace")
+	addCmd.Flags().StringVar(&addFrom, "from", "",
+		"Create a local tracking branch from this remote ref")
 	addCmd.MarkFlagsMutuallyExclusive("layout", "select-layout")
+	addCmd.MarkFlagsMutuallyExclusive("branch", "from", "interactive")
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
@@ -85,7 +95,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("cannot specify branch name with -i flag")
 			}
 
-			branches, err := ctx.Git.ListBranches(true)
+			branches, err := ctx.Git.ListAvailableBranches()
 			if err != nil {
 				return fmt.Errorf("failed to list branches: %w", err)
 			}
@@ -97,8 +107,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 			branch = selectedBranch.Name
 			if selectedBranch.IsRemote {
-				branch = selectedBranch.Name[len("origin/"):]
-				addBranch = true
+				addFrom = selectedBranch.Source
 			}
 		} else {
 			if len(args) < 1 {
@@ -153,7 +162,12 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		worktreePath, err := ctx.WorktreeManager.Add(branch, path, addBranch)
+		var worktreePath string
+		if addFrom != "" {
+			worktreePath, err = ctx.WorktreeManager.AddTracking(branch, addFrom, path)
+		} else {
+			worktreePath, err = ctx.WorktreeManager.Add(branch, path, addBranch)
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -219,11 +219,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 		printAddResult(os.Stdout, branch, expiresAt)
 		if unreviewedSource {
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Review the existing-branch checkout, then run 'kwt open %s' to start its workspace.\n",
-				worktreePath,
-			)
+			_, _ = fmt.Fprintln(os.Stdout, existingBranchReviewMessage())
 		}
 		publishFleetBestEffortForCommand(cmd, ctx.Config)
 
@@ -246,6 +242,10 @@ func printAddResult(w io.Writer, branch string, expiresAt *time.Time) {
 	if expiresAt != nil {
 		_, _ = fmt.Fprintf(w, "Worktree expires at %s\n", expiresAt.Format(time.RFC3339))
 	}
+}
+
+func existingBranchReviewMessage() string {
+	return "Review the existing-branch checkout, then run 'kwt open' to select it and start its workspace."
 }
 
 // shouldLaunch implements the add launch-decision rule.

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -18,6 +18,8 @@ import (
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/fleet"
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -200,6 +202,36 @@ func TestPrepareLaunchUsesLocalRepositoryFallback(t *testing.T) {
 	require.NotNil(t, info)
 	assert.Equal(t, filepath.Base(repoPath), info.Repository)
 	assert.True(t, strings.HasPrefix(info.FullPath, "local/"), info.FullPath)
+}
+
+func TestAttachWorkspacePassesConfiguredCredentialName(t *testing.T) {
+	runner := &recordingOpenWorkspaceRunner{}
+	var protectedNames []string
+	oldNewRunner := newAddWorkspaceRunner
+	t.Cleanup(func() { newAddWorkspaceRunner = oldNewRunner })
+	newAddWorkspaceRunner = func(names []string) openWorkspaceRunner {
+		protectedNames = append([]string(nil), names...)
+		return runner
+	}
+	cfg := &models.Config{
+		Fleet: models.FleetConfig{TokenEnv: "Custom_Fleet_Token"},
+	}
+
+	err := attachWorkspace(
+		&url.RepositoryInfo{FullPath: "github.com/acme/widget"},
+		"feature",
+		t.TempDir(),
+		tmux.BlankLayout(),
+		cfg,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, runner.attached)
+	assert.ElementsMatch(
+		t,
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "Custom_Fleet_Token"},
+		protectedNames,
+	)
 }
 
 func putFakeTmuxOnPath(t *testing.T) {

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -82,6 +82,43 @@ func TestAddDoesNotPublishWhenValidationFails(t *testing.T) {
 	assert.Zero(t, calls)
 }
 
+func TestAddFromRemoteBranchCreatesTrackingWorktree(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetAddCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	t.Chdir(repoPath)
+
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	runTUITestGit(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	runTUITestGit(t, repoPath, "remote", "add", "origin", remotePath)
+	runTUITestGit(t, repoPath, "checkout", "-b", "feature/remote")
+	runTUITestGit(t, repoPath, "push", "origin", "feature/remote")
+	runTUITestGit(t, repoPath, "checkout", "main")
+	runTUITestGit(t, repoPath, "branch", "-D", "feature/remote")
+
+	addFrom = "origin/feature/remote"
+	addNoLaunch = true
+	worktreePath := filepath.Join(t.TempDir(), "feature-remote")
+
+	cmd, _, _ := fleetTestCommand()
+	err := runAdd(cmd, []string{"feature/remote", worktreePath})
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"origin/feature/remote",
+		strings.TrimSpace(runTUITestGitOutput(
+			t,
+			worktreePath,
+			"rev-parse",
+			"--abbrev-ref",
+			"@{upstream}",
+		)),
+	)
+}
+
 func TestShouldLaunch(t *testing.T) {
 	cases := []struct {
 		name             string
@@ -166,6 +203,7 @@ func resetAddCommandFlags(t *testing.T) {
 	oldAddLayout := addLayout
 	oldAddSelectLayout := addSelectLayout
 	oldAddNoLaunch := addNoLaunch
+	oldAddFrom := addFrom
 
 	t.Cleanup(func() {
 		addBranch = oldAddBranch
@@ -175,6 +213,7 @@ func resetAddCommandFlags(t *testing.T) {
 		addLayout = oldAddLayout
 		addSelectLayout = oldAddSelectLayout
 		addNoLaunch = oldAddNoLaunch
+		addFrom = oldAddFrom
 	})
 
 	addBranch = false
@@ -184,6 +223,7 @@ func resetAddCommandFlags(t *testing.T) {
 	addLayout = ""
 	addSelectLayout = false
 	addNoLaunch = false
+	addFrom = ""
 }
 
 func initCommandTestConfig(t *testing.T, baseDir string) {

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -130,6 +130,52 @@ func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T
 	assert.NotNil(t, entry.ExpiresAt)
 }
 
+func TestAddFromResolvesRemoteRefAcrossLocalNamespaceCollision(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetAddCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	t.Chdir(repoPath)
+	runTUITestGit(t, repoPath, "remote", "add", "origin", repoPath)
+	runTUITestGit(
+		t,
+		repoPath,
+		"update-ref",
+		"refs/remotes/origin/topic",
+		"HEAD",
+	)
+	runTUITestGit(t, repoPath, "branch", "origin/topic")
+
+	addFrom = "origin/topic"
+	worktreePath := filepath.Join(t.TempDir(), "imported-topic")
+	cmd, _, _ := fleetTestCommand()
+
+	err := runAdd(cmd, []string{"imported-topic", worktreePath})
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"origin",
+		strings.TrimSpace(runTUITestGitOutput(
+			t,
+			repoPath,
+			"config",
+			"branch.imported-topic.remote",
+		)),
+	)
+	assert.Equal(
+		t,
+		"refs/heads/topic",
+		strings.TrimSpace(runTUITestGitOutput(
+			t,
+			repoPath,
+			"config",
+			"branch.imported-topic.merge",
+		)),
+	)
+}
+
 func TestAddExistingLocalBranchDefersWorkspaceLaunchUntilReview(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetAddCommandFlags(t)

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -160,6 +160,14 @@ func TestAddExistingLocalBranchDefersWorkspaceLaunchUntilReview(t *testing.T) {
 	assert.True(t, reg.IsUnreviewedRemoteSource(worktreePath))
 }
 
+func TestExistingBranchReviewMessageUsesStaticPicker(t *testing.T) {
+	assert.Equal(
+		t,
+		"Review the existing-branch checkout, then run 'kwt open' to select it and start its workspace.",
+		existingBranchReviewMessage(),
+	)
+}
+
 func TestAddFromRemoteBranchRejectsImmediateLayoutLaunch(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetAddCommandFlags(t)

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -82,12 +82,14 @@ func TestAddDoesNotPublishWhenValidationFails(t *testing.T) {
 	assert.Zero(t, calls)
 }
 
-func TestAddFromRemoteBranchCreatesTrackingWorktree(t *testing.T) {
+func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetAddCommandFlags(t)
 
 	repoPath := newTUITestRepo(t)
 	initCommandTestConfig(t, t.TempDir())
+	viper.Set("layouts.auto_launch_on_add", true)
+	putFakeTmuxOnPath(t)
 	t.Chdir(repoPath)
 
 	remotePath := filepath.Join(t.TempDir(), "origin.git")
@@ -99,7 +101,6 @@ func TestAddFromRemoteBranchCreatesTrackingWorktree(t *testing.T) {
 	runTUITestGit(t, repoPath, "branch", "-D", "feature/remote")
 
 	addFrom = "origin/feature/remote"
-	addNoLaunch = true
 	worktreePath := filepath.Join(t.TempDir(), "feature-remote")
 
 	cmd, _, _ := fleetTestCommand()
@@ -117,6 +118,26 @@ func TestAddFromRemoteBranchCreatesTrackingWorktree(t *testing.T) {
 			"@{upstream}",
 		)),
 	)
+}
+
+func TestAddFromRemoteBranchRejectsImmediateLayoutLaunch(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetAddCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	t.Chdir(repoPath)
+
+	addFrom = "origin/feature/remote"
+	addLayout = "shell"
+	worktreePath := filepath.Join(t.TempDir(), "feature-remote")
+
+	cmd, _, _ := fleetTestCommand()
+	err := runAdd(cmd, []string{"feature/remote", worktreePath})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inspect the remote checkout")
+	assert.NoDirExists(t, worktreePath)
 }
 
 func TestShouldLaunch(t *testing.T) {

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/fleet"
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/pkg/models"
@@ -103,6 +104,7 @@ func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T
 	runTUITestGit(t, repoPath, "branch", "-D", "feature/remote")
 
 	addFrom = "origin/feature/remote"
+	addExpires = "1h"
 	worktreePath := filepath.Join(t.TempDir(), "feature-remote")
 
 	cmd, _, _ := fleetTestCommand()
@@ -120,6 +122,12 @@ func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T
 			"@{upstream}",
 		)),
 	)
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	entry, ok := reg.Get(worktreePath)
+	require.True(t, ok)
+	assert.True(t, entry.UnreviewedRemoteSource)
+	assert.NotNil(t, entry.ExpiresAt)
 }
 
 func TestAddFromRemoteBranchRejectsImmediateLayoutLaunch(t *testing.T) {

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -130,6 +130,36 @@ func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T
 	assert.NotNil(t, entry.ExpiresAt)
 }
 
+func TestAddExistingLocalBranchDefersWorkspaceLaunchUntilReview(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetAddCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	viper.Set("layouts.auto_launch_on_add", true)
+	putFakeTmuxOnPath(t)
+	runTUITestGit(t, repoPath, "checkout", "-b", "feature/local")
+	runTUITestGit(t, repoPath, "checkout", "main")
+	t.Chdir(repoPath)
+
+	runner := &recordingOpenWorkspaceRunner{}
+	oldNewRunner := newAddWorkspaceRunner
+	t.Cleanup(func() { newAddWorkspaceRunner = oldNewRunner })
+	newAddWorkspaceRunner = func([]string) openWorkspaceRunner {
+		return runner
+	}
+	worktreePath := filepath.Join(t.TempDir(), "feature-local")
+
+	cmd, _, _ := fleetTestCommand()
+	err := runAdd(cmd, []string{"feature/local", worktreePath})
+
+	require.NoError(t, err)
+	assert.False(t, runner.attached)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	assert.True(t, reg.IsUnreviewedRemoteSource(worktreePath))
+}
+
 func TestAddFromRemoteBranchRejectsImmediateLayoutLaunch(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetAddCommandFlags(t)
@@ -146,7 +176,7 @@ func TestAddFromRemoteBranchRejectsImmediateLayoutLaunch(t *testing.T) {
 	err := runAdd(cmd, []string{"feature/remote", worktreePath})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "inspect the remote checkout")
+	assert.Contains(t, err.Error(), "inspect the checkout")
 	assert.NoDirExists(t, worktreePath)
 }
 

--- a/internal/cmd/branches.go
+++ b/internal/cmd/branches.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var branchesJSON bool
+
+var branchesCmd = &cobra.Command{
+	Use:   "branches",
+	Short: "List branches available for a new worktree",
+	Long: `List local and remote branches that are not already checked out.
+
+Remote candidates use the local branch name a worktree will receive while
+retaining the exact remote source ref. Use --json for a stable machine-readable
+surface.`,
+	Args: cobra.NoArgs,
+	RunE: runBranches,
+}
+
+func init() {
+	rootCmd.AddCommand(branchesCmd)
+	branchesCmd.Flags().BoolVar(&branchesJSON, "json", false, "Output in JSON format")
+}
+
+func runBranches(cmd *cobra.Command, _ []string) error {
+	ctx, err := NewGitCommandContext()
+	if err != nil {
+		return err
+	}
+	branches, err := ctx.Git.ListAvailableBranches()
+	if err != nil {
+		return err
+	}
+	if branchesJSON {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(branches)
+	}
+	if len(branches) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no available branches")
+		return nil
+	}
+	for _, branch := range branches {
+		if branch.IsRemote {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", branch.Name, branch.Source)
+		} else {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), branch.Name)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/branches_test.go
+++ b/internal/cmd/branches_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestBranchesJSONListsAvailableCandidates(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	t.Chdir(repoPath)
+	runTUITestGit(t, repoPath, "branch", "feature/ready")
+
+	oldJSON := branchesJSON
+	t.Cleanup(func() { branchesJSON = oldJSON })
+	branchesJSON = true
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	err := runBranches(cmd, nil)
+
+	require.NoError(t, err)
+	var branches []models.Branch
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &branches))
+	require.Len(t, branches, 1)
+	assert.Equal(t, "feature/ready", branches[0].Name)
+	assert.Equal(t, "feature/ready", branches[0].Source)
+}

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -95,8 +95,10 @@ func getRemoteBranchCompletions(
 		if !branch.IsRemote {
 			continue
 		}
-		source := strings.TrimPrefix(branch.Source, "refs/remotes/")
-		if strings.HasPrefix(source, toComplete) {
+		source := branch.Source
+		shortSource := strings.TrimPrefix(source, "refs/remotes/")
+		if strings.HasPrefix(source, toComplete) ||
+			strings.HasPrefix(shortSource, toComplete) {
 			completions = append(
 				completions,
 				fmt.Sprintf("%s\tRemote branch", source),

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -52,7 +52,7 @@ func getBranchCompletions(_ *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	branches, err := g.ListBranches(true)
+	branches, err := g.ListBranches(false)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -60,14 +60,49 @@ func getBranchCompletions(_ *cobra.Command, args []string, toComplete string) ([
 	var completions []string
 	for _, branch := range branches {
 		if strings.HasPrefix(branch.Name, toComplete) {
-			desc := "Local branch"
-			if branch.IsRemote {
-				desc = "Remote branch"
-			}
-			completions = append(completions, fmt.Sprintf("%s\t%s", branch.Name, desc))
+			completions = append(
+				completions,
+				fmt.Sprintf("%s\tLocal branch", branch.Name),
+			)
 		}
 	}
 
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// getRemoteBranchCompletions returns remote sources accepted by --from.
+func getRemoteBranchCompletions(
+	_ *cobra.Command,
+	args []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	g, err := git.NewFromCwd()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	branches, err := g.ListAvailableBranches()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	for _, branch := range branches {
+		if !branch.IsRemote {
+			continue
+		}
+		source := strings.TrimPrefix(branch.Source, "refs/remotes/")
+		if strings.HasPrefix(source, toComplete) {
+			completions = append(
+				completions,
+				fmt.Sprintf("%s\tRemote branch", source),
+			)
+		}
+	}
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -19,6 +19,12 @@ func TestAddBranchCompletionsSeparateLocalAndRemoteSources(t *testing.T) {
 		"refs/remotes/origin/feature/remote-completion",
 		"HEAD",
 	)
+	runTUITestGit(
+		t,
+		repoPath,
+		"branch",
+		"origin/feature/remote-completion",
+	)
 	t.Chdir(repoPath)
 
 	positional, _ := getBranchCompletions(nil, nil, "feature/")
@@ -28,7 +34,7 @@ func TestAddBranchCompletionsSeparateLocalAndRemoteSources(t *testing.T) {
 	assert.NotContains(t, completionValues(positional), "feature/remote-completion")
 	assert.Equal(
 		t,
-		[]string{"origin/feature/remote-completion"},
+		[]string{"refs/remotes/origin/feature/remote-completion"},
 		completionValues(remote),
 	)
 

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddBranchCompletionsSeparateLocalAndRemoteSources(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(t, repoPath, "branch", "feature/local-completion")
+	runTUITestGit(t, repoPath, "remote", "add", "origin", repoPath)
+	runTUITestGit(
+		t,
+		repoPath,
+		"update-ref",
+		"refs/remotes/origin/feature/remote-completion",
+		"HEAD",
+	)
+	t.Chdir(repoPath)
+
+	positional, _ := getBranchCompletions(nil, nil, "feature/")
+	remote, _ := getRemoteBranchCompletions(nil, nil, "origin/")
+
+	assert.Contains(t, completionValues(positional), "feature/local-completion")
+	assert.NotContains(t, completionValues(positional), "feature/remote-completion")
+	assert.Equal(
+		t,
+		[]string{"origin/feature/remote-completion"},
+		completionValues(remote),
+	)
+
+	flagCompletion, ok := addCmd.GetFlagCompletionFunc("from")
+	require.True(t, ok)
+	require.NotNil(t, flagCompletion)
+}
+
+func completionValues(completions []string) []string {
+	values := make([]string, 0, len(completions))
+	for _, completion := range completions {
+		value, _, _ := strings.Cut(completion, "\t")
+		values = append(values, value)
+	}
+	return values
+}

--- a/internal/cmd/fleet.go
+++ b/internal/cmd/fleet.go
@@ -30,11 +30,7 @@ type fleetHubClient interface {
 var (
 	loadFleetConfig         = config.Load
 	newFleetManifestBuilder = func() fleet.ManifestBuildProvider {
-		return fleet.NewManifestBuilder(fleet.ManifestBuilderOptions{
-			ExcludeWorktree: func(path string) (bool, error) {
-				return isUnreviewedRemoteSourcePath(path)
-			},
-		})
+		return fleet.NewManifestBuilder(fleet.ManifestBuilderOptions{})
 	}
 	publishFleetBestEffort = func(ctx context.Context, cfg *models.Config, builder fleet.ManifestBuildProvider, warn *bytes.Buffer) error {
 		return fleet.PublishBestEffort(ctx, cfg, builder, warn)

--- a/internal/cmd/fleet.go
+++ b/internal/cmd/fleet.go
@@ -30,7 +30,15 @@ type fleetHubClient interface {
 var (
 	loadFleetConfig         = config.Load
 	newFleetManifestBuilder = func() fleet.ManifestBuildProvider {
-		return fleet.NewManifestBuilder(fleet.ManifestBuilderOptions{})
+		unreviewed, stateErr := unreviewedRemoteSourcePaths()
+		return fleet.NewManifestBuilder(fleet.ManifestBuilderOptions{
+			ExcludeWorktree: func(path string) (bool, error) {
+				if stateErr != nil {
+					return false, stateErr
+				}
+				return pathSetContains(unreviewed, path), nil
+			},
+		})
 	}
 	publishFleetBestEffort = func(ctx context.Context, cfg *models.Config, builder fleet.ManifestBuildProvider, warn *bytes.Buffer) error {
 		return fleet.PublishBestEffort(ctx, cfg, builder, warn)

--- a/internal/cmd/fleet.go
+++ b/internal/cmd/fleet.go
@@ -30,13 +30,9 @@ type fleetHubClient interface {
 var (
 	loadFleetConfig         = config.Load
 	newFleetManifestBuilder = func() fleet.ManifestBuildProvider {
-		unreviewed, stateErr := unreviewedRemoteSourcePaths()
 		return fleet.NewManifestBuilder(fleet.ManifestBuilderOptions{
 			ExcludeWorktree: func(path string) (bool, error) {
-				if stateErr != nil {
-					return false, stateErr
-				}
-				return pathSetContains(unreviewed, path), nil
+				return isUnreviewedRemoteSourcePath(path)
 			},
 		})
 	}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/tmux"
@@ -19,8 +20,9 @@ var (
 	openSelectLayout bool
 	openStartSession bool
 
-	newOpenWorkspaceRunner = func() openWorkspaceRunner {
-		return tmux.NewWorkspaceRunner(tmux.NewTmuxCommand(""))
+	newOpenWorkspaceRunner = func(names []string) openWorkspaceRunner {
+		tmuxCommand := tmux.NewTmuxCommandWithStripNames("", names)
+		return tmux.NewWorkspaceRunner(tmuxCommand, names)
 	}
 )
 
@@ -271,7 +273,7 @@ func openSelectedWorktree(
 	}
 
 	session := tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path)
-	runner := newOpenWorkspaceRunner()
+	runner := newOpenWorkspaceRunner(credentials.ProtectedNames(ctx.Config))
 	if startSession {
 		return runner.Ensure(commandCtx, session, entry.Path, layout)
 	}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -236,6 +236,9 @@ func openSelectedWorktree(
 	if err := rejectProtectedWorkspaceOpen(commandCtx, entry.Path); err != nil {
 		return err
 	}
+	if err := acknowledgeRemoteSourcePath(entry.Path); err != nil {
+		return err
+	}
 
 	// Only resolve the target repo's default layout (which requires
 	// finding its root and loading, and possibly trust-prompting for, its

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
@@ -179,11 +180,14 @@ func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 	runner := &recordingOpenWorkspaceRunner{}
 	var protectedNames []string
+	var acknowledgedPath string
 	oldNewRunner := newOpenWorkspaceRunner
+	oldAcknowledge := acknowledgeRemoteSourcePath
 	oldLayout := openLayout
 	oldSelectLayout := openSelectLayout
 	t.Cleanup(func() {
 		newOpenWorkspaceRunner = oldNewRunner
+		acknowledgeRemoteSourcePath = oldAcknowledge
 		openLayout = oldLayout
 		openSelectLayout = oldSelectLayout
 	})
@@ -191,8 +195,13 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 		protectedNames = append([]string(nil), names...)
 		return runner
 	}
+	acknowledgeRemoteSourcePath = func(path string) error {
+		acknowledgedPath = path
+		return nil
+	}
 	openLayout = tmux.BlankLayoutName
 	openSelectLayout = false
+	worktreePath := t.TempDir()
 
 	err := openSelectedWorktree(
 		context.Background(),
@@ -200,7 +209,7 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 			Fleet: models.FleetConfig{TokenEnv: "CUSTOM_FLEET_TOKEN"},
 		}},
 		&discovery.GlobalWorktreeEntry{
-			Path:   t.TempDir(),
+			Path:   worktreePath,
 			Branch: "feature",
 			RepositoryInfo: &url.RepositoryInfo{
 				FullPath: "github.com/acme/widget",
@@ -212,6 +221,7 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 	)
 
 	require.NoError(t, err)
+	assert.Equal(t, worktreePath, acknowledgedPath)
 	assert.True(t, runner.ensured)
 	assert.False(t, runner.attached)
 	assert.ElementsMatch(
@@ -219,6 +229,53 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "CUSTOM_FLEET_TOKEN"},
 		protectedNames,
 	)
+}
+
+func TestOpenSelectedWorktreeAcknowledgesPersistedRemoteSource(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	worktreePath := t.TempDir()
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:                   worktreePath,
+		Branch:                 "feature/remote",
+		UnreviewedRemoteSource: true,
+	}))
+
+	runner := &recordingOpenWorkspaceRunner{}
+	oldNewRunner := newOpenWorkspaceRunner
+	oldLayout := openLayout
+	oldSelectLayout := openSelectLayout
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = oldNewRunner
+		openLayout = oldLayout
+		openSelectLayout = oldSelectLayout
+	})
+	newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
+	openLayout = tmux.BlankLayoutName
+	openSelectLayout = false
+
+	err = openSelectedWorktree(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		&discovery.GlobalWorktreeEntry{
+			Path:   worktreePath,
+			Branch: "feature/remote",
+			RepositoryInfo: &url.RepositoryInfo{
+				FullPath: "github.com/acme/widget",
+			},
+		},
+		nil,
+		true,
+		false,
+	)
+
+	require.NoError(t, err)
+	reloaded, err := registry.New()
+	require.NoError(t, err)
+	assert.False(t, reloaded.IsUnreviewedRemoteSource(worktreePath))
+	assert.True(t, runner.ensured)
 }
 
 func TestOpenSelectedWorktreeStartSessionDoesNotPromptForTargetTrust(t *testing.T) {

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -178,6 +178,7 @@ func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 
 func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 	runner := &recordingOpenWorkspaceRunner{}
+	var protectedNames []string
 	oldNewRunner := newOpenWorkspaceRunner
 	oldLayout := openLayout
 	oldSelectLayout := openSelectLayout
@@ -186,13 +187,18 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 		openLayout = oldLayout
 		openSelectLayout = oldSelectLayout
 	})
-	newOpenWorkspaceRunner = func() openWorkspaceRunner { return runner }
+	newOpenWorkspaceRunner = func(names []string) openWorkspaceRunner {
+		protectedNames = append([]string(nil), names...)
+		return runner
+	}
 	openLayout = tmux.BlankLayoutName
 	openSelectLayout = false
 
 	err := openSelectedWorktree(
 		context.Background(),
-		&CommandContext{Config: &models.Config{}},
+		&CommandContext{Config: &models.Config{
+			Fleet: models.FleetConfig{TokenEnv: "CUSTOM_FLEET_TOKEN"},
+		}},
 		&discovery.GlobalWorktreeEntry{
 			Path:   t.TempDir(),
 			Branch: "feature",
@@ -208,6 +214,11 @@ func TestOpenSelectedWorktreeStartsSessionWithoutAttaching(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, runner.ensured)
 	assert.False(t, runner.attached)
+	assert.ElementsMatch(
+		t,
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "CUSTOM_FLEET_TOKEN"},
+		protectedNames,
+	)
 }
 
 func TestOpenSelectedWorktreeStartSessionDoesNotPromptForTargetTrust(t *testing.T) {
@@ -230,7 +241,7 @@ func TestOpenSelectedWorktreeStartSessionDoesNotPromptForTargetTrust(t *testing.
 		openLayout = oldLayout
 		openSelectLayout = oldSelectLayout
 	})
-	newOpenWorkspaceRunner = func() openWorkspaceRunner { return runner }
+	newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
 	openLayout = ""
 	openSelectLayout = false
 

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	gitadapter "go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
@@ -550,7 +551,7 @@ func defaultStartPRWorkspaceSession(
 	if err != nil {
 		return "", err
 	}
-	stripNames := protectedCredentialNames(cfg)
+	stripNames := credentials.ProtectedNames(cfg)
 	socketName := tmux.ProtectedWorkspaceSocketName(
 		workspace.SessionName,
 		workspace.Path,
@@ -614,7 +615,7 @@ func defaultAttachPRWorkspaceSession(
 	if err != nil {
 		return err
 	}
-	stripNames := protectedCredentialNames(cfg)
+	stripNames := credentials.ProtectedNames(cfg)
 	socketName := tmux.ProtectedWorkspaceSocketName(
 		workspace.SessionName,
 		workspace.Path,
@@ -633,24 +634,6 @@ func defaultAttachPRWorkspaceSession(
 		workspace.Path,
 		layout,
 	)
-}
-
-func protectedCredentialNames(cfg *models.Config) []string {
-	names := []string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"}
-	if cfg != nil {
-		names = append(names, cfg.Fleet.TokenEnv)
-	}
-	seen := make(map[string]bool, len(names))
-	protected := make([]string, 0, len(names))
-	for _, name := range names {
-		name = strings.TrimSpace(name)
-		if name == "" || seen[name] {
-			continue
-		}
-		seen[name] = true
-		protected = append(protected, name)
-	}
-	return protected
 }
 
 func defaultNewPRService(

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/tmux"
 	urlutil "go.kenn.io/kwt/internal/url"
@@ -541,7 +542,7 @@ func tryRequireWorkspace(
 
 func TestProtectedCredentialNamesAlwaysIncludeFleetDefaults(t *testing.T) {
 	for _, configured := range []string{"", "CUSTOM_FLEET_TOKEN"} {
-		names := protectedCredentialNames(&models.Config{
+		names := credentials.ProtectedNames(&models.Config{
 			Fleet: models.FleetConfig{TokenEnv: configured},
 		})
 		want := []string{

--- a/internal/cmd/remote_source.go
+++ b/internal/cmd/remote_source.go
@@ -4,51 +4,7 @@ import (
 	"fmt"
 
 	"go.kenn.io/kwt/internal/registry"
-	"go.kenn.io/kwt/internal/utils"
 )
-
-func unreviewedRemoteSourcePaths() (map[string]struct{}, error) {
-	reg, err := registry.New()
-	if err != nil {
-		return nil, fmt.Errorf("open worktree registry: %w", err)
-	}
-	paths := reg.UnreviewedRemoteSourcePaths()
-	result := make(map[string]struct{}, len(paths))
-	for _, path := range paths {
-		result[utils.CanonicalPath(path)] = struct{}{}
-	}
-	return result, nil
-}
-
-func pathSetContains(paths map[string]struct{}, path string) bool {
-	_, ok := paths[utils.CanonicalPath(path)]
-	return ok
-}
-
-func pathSetContainsOrDescendant(
-	paths map[string]struct{},
-	path string,
-) bool {
-	for root := range paths {
-		if utils.IsSameOrChildPath(path, root) {
-			return true
-		}
-	}
-	return false
-}
-
-func isUnreviewedRemoteSourcePath(path string) (bool, error) {
-	reg, err := registry.New()
-	if err != nil {
-		return false, fmt.Errorf("open worktree registry: %w", err)
-	}
-	paths := reg.UnreviewedRemoteSourcePaths()
-	live := make(map[string]struct{}, len(paths))
-	for _, registeredPath := range paths {
-		live[utils.CanonicalPath(registeredPath)] = struct{}{}
-	}
-	return pathSetContains(live, path), nil
-}
 
 var acknowledgeRemoteSourcePath = func(path string) error {
 	reg, err := registry.New()

--- a/internal/cmd/remote_source.go
+++ b/internal/cmd/remote_source.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
+)
+
+func unreviewedRemoteSourcePaths() (map[string]struct{}, error) {
+	reg, err := registry.New()
+	if err != nil {
+		return nil, fmt.Errorf("open worktree registry: %w", err)
+	}
+	paths := reg.UnreviewedRemoteSourcePaths()
+	result := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		result[utils.CanonicalPath(path)] = struct{}{}
+	}
+	return result, nil
+}
+
+func pathSetContains(paths map[string]struct{}, path string) bool {
+	_, ok := paths[utils.CanonicalPath(path)]
+	return ok
+}
+
+var acknowledgeRemoteSourcePath = func(path string) error {
+	reg, err := registry.New()
+	if err != nil {
+		return fmt.Errorf("open worktree registry: %w", err)
+	}
+	if err := reg.AcknowledgeRemoteSource(path); err != nil {
+		return fmt.Errorf("acknowledge remote-source worktree: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/remote_source.go
+++ b/internal/cmd/remote_source.go
@@ -25,6 +25,18 @@ func pathSetContains(paths map[string]struct{}, path string) bool {
 	return ok
 }
 
+func pathSetContainsOrDescendant(
+	paths map[string]struct{},
+	path string,
+) bool {
+	for root := range paths {
+		if utils.IsSameOrChildPath(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
 func isUnreviewedRemoteSourcePath(path string) (bool, error) {
 	reg, err := registry.New()
 	if err != nil {

--- a/internal/cmd/remote_source.go
+++ b/internal/cmd/remote_source.go
@@ -1,18 +1,23 @@
 package cmd
 
 import (
-	"fmt"
-
 	"go.kenn.io/kwt/internal/registry"
 )
 
+var newRemoteSourceRegistry = registry.New
+
 var acknowledgeRemoteSourcePath = func(path string) error {
-	reg, err := registry.New()
+	reg, err := newRemoteSourceRegistry()
 	if err != nil {
-		return fmt.Errorf("open worktree registry: %w", err)
+		// Opening a workspace is the explicit review action. Registry
+		// bookkeeping must not prevent that action for unrelated worktrees.
+		return nil
 	}
-	if err := reg.AcknowledgeRemoteSource(path); err != nil {
-		return fmt.Errorf("acknowledge remote-source worktree: %w", err)
+	if !reg.IsUnreviewedRemoteSource(path) {
+		return nil
 	}
+	// A failed write may leave the marker for a later retry, but the explicit
+	// open remains authoritative and should continue.
+	_ = reg.AcknowledgeRemoteSource(path)
 	return nil
 }

--- a/internal/cmd/remote_source.go
+++ b/internal/cmd/remote_source.go
@@ -25,6 +25,19 @@ func pathSetContains(paths map[string]struct{}, path string) bool {
 	return ok
 }
 
+func isUnreviewedRemoteSourcePath(path string) (bool, error) {
+	reg, err := registry.New()
+	if err != nil {
+		return false, fmt.Errorf("open worktree registry: %w", err)
+	}
+	paths := reg.UnreviewedRemoteSourcePaths()
+	live := make(map[string]struct{}, len(paths))
+	for _, registeredPath := range paths {
+		live[utils.CanonicalPath(registeredPath)] = struct{}{}
+	}
+	return pathSetContains(live, path), nil
+}
+
 var acknowledgeRemoteSourcePath = func(path string) error {
 	reg, err := registry.New()
 	if err != nil {

--- a/internal/cmd/remote_source_test.go
+++ b/internal/cmd/remote_source_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/registry"
+)
+
+func TestAcknowledgeRemoteSourcePathDoesNotBlockOpenWhenRegistryUnavailable(
+	t *testing.T,
+) {
+	previous := newRemoteSourceRegistry
+	t.Cleanup(func() { newRemoteSourceRegistry = previous })
+	newRemoteSourceRegistry = func() (*registry.Registry, error) {
+		return nil, errors.New("registry unavailable")
+	}
+
+	require.NoError(t, acknowledgeRemoteSourcePath("/worktrees/ordinary"))
+}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -224,10 +224,17 @@ func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *u
 		}
 	}
 
+	unreviewed, err := unreviewedRemoteSourcePaths()
+	if err != nil {
+		return nil, err
+	}
 	collector := status.NewStatusCollectorWithOptions(status.StatusCollectorOptions{
 		FetchRemote:    !statusNoFetch,
 		StaleThreshold: time.Duration(statusStaleDays) * 24 * time.Hour,
 		BaseDir:        cfg.Worktree.BaseDir,
+		SkipWorktree: func(path string) bool {
+			return pathSetContains(unreviewed, path)
+		},
 	})
 	return collector.CollectAll(ctx, worktrees)
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -199,9 +200,41 @@ func runWatchLoop(ctx context.Context, refresh func() error, interval time.Durat
 func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *ui.Printer) ([]*models.WorktreeStatus, error) {
 	var worktrees []*models.Worktree
 
+	unreviewed, err := unreviewedRemoteSourcePaths()
+	if err != nil {
+		return nil, err
+	}
+	collector := status.NewStatusCollectorWithOptions(status.StatusCollectorOptions{
+		FetchRemote:    !statusNoFetch,
+		StaleThreshold: time.Duration(statusStaleDays) * 24 * time.Hour,
+		BaseDir:        cfg.Worktree.BaseDir,
+		SkipWorktree: func(path string) bool {
+			return pathSetContainsOrDescendant(unreviewed, path)
+		},
+	})
+	cwd, cwdErr := os.Getwd()
+	if cwdErr == nil && pathSetContainsOrDescendant(unreviewed, cwd) {
+		for path := range unreviewed {
+			if pathSetContainsOrDescendant(
+				map[string]struct{}{path: {}},
+				cwd,
+			) {
+				return collector.CollectAll(ctx, []*models.Worktree{{
+					Path: path,
+				}})
+			}
+		}
+	}
+
 	g, err := git.NewFromCwd()
 	if err != nil || statusGlobal {
-		globalEntries, err := discovery.DiscoverGlobalWorktrees(cfg.Worktree.BaseDir, cfg.Projects)
+		globalEntries, err := discovery.DiscoverGlobalWorktreesFiltered(
+			cfg.Worktree.BaseDir,
+			cfg.Projects,
+			func(path string) bool {
+				return pathSetContainsOrDescendant(unreviewed, path)
+			},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to discover worktrees: %w", err)
 		}
@@ -224,18 +257,6 @@ func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *u
 		}
 	}
 
-	unreviewed, err := unreviewedRemoteSourcePaths()
-	if err != nil {
-		return nil, err
-	}
-	collector := status.NewStatusCollectorWithOptions(status.StatusCollectorOptions{
-		FetchRemote:    !statusNoFetch,
-		StaleThreshold: time.Duration(statusStaleDays) * 24 * time.Hour,
-		BaseDir:        cfg.Worktree.BaseDir,
-		SkipWorktree: func(path string) bool {
-			return pathSetContains(unreviewed, path)
-		},
-	})
 	return collector.CollectAll(ctx, worktrees)
 }
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -200,40 +199,11 @@ func runWatchLoop(ctx context.Context, refresh func() error, interval time.Durat
 func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *ui.Printer) ([]*models.WorktreeStatus, error) {
 	var worktrees []*models.Worktree
 
-	unreviewed, err := unreviewedRemoteSourcePaths()
-	if err != nil {
-		return nil, err
-	}
-	collector := status.NewStatusCollectorWithOptions(status.StatusCollectorOptions{
-		FetchRemote:    !statusNoFetch,
-		StaleThreshold: time.Duration(statusStaleDays) * 24 * time.Hour,
-		BaseDir:        cfg.Worktree.BaseDir,
-		SkipWorktree: func(path string) bool {
-			return pathSetContainsOrDescendant(unreviewed, path)
-		},
-	})
-	cwd, cwdErr := os.Getwd()
-	if cwdErr == nil && pathSetContainsOrDescendant(unreviewed, cwd) {
-		for path := range unreviewed {
-			if pathSetContainsOrDescendant(
-				map[string]struct{}{path: {}},
-				cwd,
-			) {
-				return collector.CollectAll(ctx, []*models.Worktree{{
-					Path: path,
-				}})
-			}
-		}
-	}
-
 	g, err := git.NewFromCwd()
 	if err != nil || statusGlobal {
-		globalEntries, err := discovery.DiscoverGlobalWorktreesFiltered(
+		globalEntries, err := discovery.DiscoverGlobalWorktrees(
 			cfg.Worktree.BaseDir,
 			cfg.Projects,
-			func(path string) bool {
-				return pathSetContainsOrDescendant(unreviewed, path)
-			},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to discover worktrees: %w", err)
@@ -257,6 +227,11 @@ func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *u
 		}
 	}
 
+	collector := status.NewStatusCollectorWithOptions(status.StatusCollectorOptions{
+		FetchRemote:    !statusNoFetch,
+		StaleThreshold: time.Duration(statusStaleDays) * 24 * time.Hour,
+		BaseDir:        cfg.Worktree.BaseDir,
+	})
 	return collector.CollectAll(ctx, worktrees)
 }
 

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/ui"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
@@ -61,6 +63,66 @@ func TestCollectWorktreeStatusesLocalUsesCanonicalLocalRepository(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
 	require.Equal(t, want.FullPath, statuses[0].Repository)
+}
+
+func TestUnreviewedRemoteSourceSkipsAutomaticStatusAndFleetInspection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable fsmonitor hook fixture requires a POSIX shell")
+	}
+	resetStatusTestFlags(t)
+	resetFleetCommandDeps(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	repoDir := t.TempDir()
+	require.NoError(t, cmdStatusTestGit(repoDir, "init", "-b", "main"))
+	require.NoError(t, cmdStatusTestGit(repoDir, "config", "user.name", "Test User"))
+	require.NoError(t, cmdStatusTestGit(repoDir, "config", "user.email", "test@example.com"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, "README.md"),
+		[]byte("# remote\n"),
+		0644,
+	))
+	require.NoError(t, cmdStatusTestGit(repoDir, "add", "."))
+	require.NoError(t, cmdStatusTestGit(repoDir, "commit", "-m", "Initial commit"))
+	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
+	hook := filepath.Join(t.TempDir(), "fsmonitor")
+	require.NoError(t, os.WriteFile(
+		hook,
+		[]byte("#!/bin/sh\nprintf ran > \""+marker+"\"\nprintf '0\\n'\n"),
+		0755,
+	))
+	require.NoError(t, cmdStatusTestGit(repoDir, "config", "core.fsmonitor", hook))
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:                   repoDir,
+		Branch:                 "main",
+		UnreviewedRemoteSource: true,
+	}))
+	t.Chdir(repoDir)
+	statusNoFetch = true
+	cfg := &models.Config{
+		Fleet: models.FleetConfig{HostID: "host-a"},
+		Projects: []models.Project{{
+			Repository: "github.com/acme/widget",
+			Path:       repoDir,
+		}},
+	}
+
+	statuses, err := collectWorktreeStatuses(
+		context.Background(),
+		cfg,
+		ui.New(&models.UIConfig{}),
+	)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+	require.Equal(t, models.WorktreeStatusUnknown, statuses[0].Status)
+	require.NoFileExists(t, marker)
+
+	manifest, err := newFleetManifestBuilder().Build(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Empty(t, manifest.Worktrees)
+	require.NoFileExists(t, marker)
 }
 
 func resetStatusTestFlags(t *testing.T) {

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -65,10 +64,7 @@ func TestCollectWorktreeStatusesLocalUsesCanonicalLocalRepository(t *testing.T) 
 	require.Equal(t, want.FullPath, statuses[0].Repository)
 }
 
-func TestUnreviewedRemoteSourceSkipsAutomaticStatusAndFleetInspection(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("executable fsmonitor hook fixture requires a POSIX shell")
-	}
+func TestImportedWorktreeReceivesAutomaticStatusAndFleetInspection(t *testing.T) {
 	resetStatusTestFlags(t)
 	resetFleetCommandDeps(t)
 	t.Setenv("HOME", t.TempDir())
@@ -84,14 +80,11 @@ func TestUnreviewedRemoteSourceSkipsAutomaticStatusAndFleetInspection(t *testing
 	))
 	require.NoError(t, cmdStatusTestGit(repoDir, "add", "."))
 	require.NoError(t, cmdStatusTestGit(repoDir, "commit", "-m", "Initial commit"))
-	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
-	hook := filepath.Join(t.TempDir(), "fsmonitor")
 	require.NoError(t, os.WriteFile(
-		hook,
-		[]byte("#!/bin/sh\nprintf ran > \""+marker+"\"\nprintf '0\\n'\n"),
-		0755,
+		filepath.Join(repoDir, "README.md"),
+		[]byte("# changed\n"),
+		0644,
 	))
-	require.NoError(t, cmdStatusTestGit(repoDir, "config", "core.fsmonitor", hook))
 	builder := newFleetManifestBuilder()
 	reg, err := registry.New()
 	require.NoError(t, err)
@@ -117,13 +110,13 @@ func TestUnreviewedRemoteSourceSkipsAutomaticStatusAndFleetInspection(t *testing
 	)
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
-	require.Equal(t, models.WorktreeStatusUnknown, statuses[0].Status)
-	require.NoFileExists(t, marker)
+	require.Equal(t, models.WorktreeStatusModified, statuses[0].Status)
+	require.Equal(t, 1, statuses[0].GitStatus.Modified)
 
 	manifest, err := builder.Build(context.Background(), cfg)
 	require.NoError(t, err)
-	require.Empty(t, manifest.Worktrees)
-	require.NoFileExists(t, marker)
+	require.Len(t, manifest.Worktrees, 1)
+	require.Equal(t, 1, manifest.Worktrees[0].Status.Modified)
 }
 
 func resetStatusTestFlags(t *testing.T) {

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -92,6 +92,7 @@ func TestUnreviewedRemoteSourceSkipsAutomaticStatusAndFleetInspection(t *testing
 		0755,
 	))
 	require.NoError(t, cmdStatusTestGit(repoDir, "config", "core.fsmonitor", hook))
+	builder := newFleetManifestBuilder()
 	reg, err := registry.New()
 	require.NoError(t, err)
 	require.NoError(t, reg.Register(&registry.WorktreeEntry{
@@ -119,7 +120,7 @@ func TestUnreviewedRemoteSourceSkipsAutomaticStatusAndFleetInspection(t *testing
 	require.Equal(t, models.WorktreeStatusUnknown, statuses[0].Status)
 	require.NoFileExists(t, marker)
 
-	manifest, err := newFleetManifestBuilder().Build(context.Background(), cfg)
+	manifest, err := builder.Build(context.Background(), cfg)
 	require.NoError(t, err)
 	require.Empty(t, manifest.Worktrees)
 	require.NoFileExists(t, marker)

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -990,28 +990,45 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 			err,
 		)
 		if !branchExisted {
-			if cleanupErr := repo.DeleteBranch(
+			return "", b.rollbackMaterializedBranch(
+				repo,
 				row.Fleet.Branch,
-				true,
-			); cleanupErr != nil {
-				return "", fmt.Errorf(
-					"%w (failed to remove auto-created branch %s; an incomplete worktree may remain: %v)",
-					syncErr,
-					row.Fleet.Branch,
-					cleanupErr,
-				)
-			}
+				syncErr,
+			)
 		}
 		return "", syncErr
 	}
 	if err := b.verifyMaterializedHead(ctx, project.Path, path, row.Fleet); err != nil {
 		if !branchExisted {
-			_ = repo.DeleteBranch(row.Fleet.Branch, true)
+			err = b.rollbackMaterializedBranch(
+				repo,
+				row.Fleet.Branch,
+				err,
+			)
 		}
 		return "", err
 	}
 	publishTUIFleetBestEffort(ctx, b.cfg)
 	return path, nil
+}
+
+func (b *tuiBackend) rollbackMaterializedBranch(
+	repo *git.Git,
+	branch string,
+	materializeErr error,
+) error {
+	if cleanupErr := repo.DeleteBranchIsolated(
+		branch,
+		b.protectedNames,
+	); cleanupErr != nil {
+		return fmt.Errorf(
+			"%w (failed to remove auto-created branch %s; an incomplete worktree may remain: %v)",
+			materializeErr,
+			branch,
+			cleanupErr,
+		)
+	}
+	return materializeErr
 }
 
 func (b *tuiBackend) verifyMaterializedHead(ctx context.Context, repoRoot string, worktreePath string, info *dashboard.FleetInfo) error {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -984,11 +984,25 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 		worktree.AddOptions{SkipSetup: true},
 	)
 	if err != nil {
-		return "", fmt.Errorf(
+		syncErr := fmt.Errorf(
 			"could not sync %s: branch must exist locally or on a fetched remote; push or fetch it first: %w",
 			row.Fleet.Branch,
 			err,
 		)
+		if !branchExisted {
+			if cleanupErr := repo.DeleteBranch(
+				row.Fleet.Branch,
+				true,
+			); cleanupErr != nil {
+				return "", fmt.Errorf(
+					"%w (failed to remove auto-created branch %s; an incomplete worktree may remain: %v)",
+					syncErr,
+					row.Fleet.Branch,
+					cleanupErr,
+				)
+			}
+		}
+		return "", syncErr
 	}
 	if err := b.verifyMaterializedHead(ctx, project.Path, path, row.Fleet); err != nil {
 		if !branchExisted {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -32,27 +32,31 @@ type tuiBackend struct {
 	// mu serializes List and MergeFleet: List mutates cfg (launch project and
 	// workspace registration) while MergeFleet's manifest publish reads it,
 	// and the TUI runs the two as concurrent commands.
-	mu                        sync.Mutex
-	cfg                       *models.Config
-	tmux                      *tmux.TmuxCommand
-	protectedNames            []string
-	launchDir                 string
-	launchProjectRegistered   bool
-	launchWorkspaceRegistered bool
-	discoverGlobalWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverProjectWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverLaunchWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
-	listSessions              func() ([]string, error)
-	ensureAndAttach           func(context.Context, string, string, models.Layout, bool) error
-	registerProject           func(models.Project) error
-	registerWorkspace         func(models.Workspace) (models.Workspace, error)
-	unregisterWorkspace       func(name string) error
-	readFleetState            func(context.Context, *models.Config) (fleet.FleetState, error)
-	loadTargetConfig          func(string, bool) (*models.Config, error)
-	unreviewedWorktreePaths   func() (map[string]struct{}, error)
-	acknowledgeRemoteSource   func(string) error
-	now                       func() time.Time
+	mu                              sync.Mutex
+	cfg                             *models.Config
+	tmux                            *tmux.TmuxCommand
+	protectedNames                  []string
+	launchDir                       string
+	launchProjectRegistered         bool
+	launchWorkspaceRegistered       bool
+	discoverGlobalWorktrees         func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverGlobalWorktreesWithSkip func(
+		string,
+		func(string) bool,
+	) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverProjectWorktrees func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverLaunchWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	collectStatuses          func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
+	listSessions             func() ([]string, error)
+	ensureAndAttach          func(context.Context, string, string, models.Layout, bool) error
+	registerProject          func(models.Project) error
+	registerWorkspace        func(models.Workspace) (models.Workspace, error)
+	unregisterWorkspace      func(name string) error
+	readFleetState           func(context.Context, *models.Config) (fleet.FleetState, error)
+	loadTargetConfig         func(string, bool) (*models.Config, error)
+	unreviewedWorktreePaths  func() (map[string]struct{}, error)
+	acknowledgeRemoteSource  func(string) error
+	now                      func() time.Time
 }
 
 func newTUIBackend(cfg *models.Config) *tuiBackend {
@@ -71,8 +75,15 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		// Registered projects flow into base-dir discovery so a registered
 		// canonical identity wins over a fork origin (the same precedence
 		// applyProjectIdentityFallback applies to per-project discovery).
-		discoverGlobalWorktrees: func(baseDir string) ([]*discovery.GlobalWorktreeEntry, error) {
-			return discovery.DiscoverGlobalWorktrees(baseDir, cfg.Projects)
+		discoverGlobalWorktreesWithSkip: func(
+			baseDir string,
+			skip func(string) bool,
+		) ([]*discovery.GlobalWorktreeEntry, error) {
+			return discovery.DiscoverGlobalWorktreesFiltered(
+				baseDir,
+				cfg.Projects,
+				skip,
+			)
 		},
 		discoverProjectWorktrees: discoverLaunchRepoWorktrees,
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
@@ -105,6 +116,14 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	unreviewed, stateErr := b.unreviewedWorktreePaths()
+	if stateErr != nil {
+		return nil, nil, stateErr
+	}
+	skipUnreviewed := func(path string) bool {
+		return pathSetContainsOrDescendant(unreviewed, path)
+	}
+
 	var (
 		entries           []*discovery.GlobalWorktreeEntry
 		registeredEntries []*discovery.GlobalWorktreeEntry
@@ -118,14 +137,29 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	startup.Add(4)
 	go func() {
 		defer startup.Done()
-		entries, discoveryErr = b.discoverGlobalWorktrees(b.cfg.Worktree.BaseDir)
+		switch {
+		case b.discoverGlobalWorktrees != nil:
+			entries, discoveryErr = b.discoverGlobalWorktrees(
+				b.cfg.Worktree.BaseDir,
+			)
+		case b.discoverGlobalWorktreesWithSkip != nil:
+			entries, discoveryErr = b.discoverGlobalWorktreesWithSkip(
+				b.cfg.Worktree.BaseDir,
+				skipUnreviewed,
+			)
+		}
 	}()
 	go func() {
 		defer startup.Done()
-		registeredEntries = b.discoverRegisteredProjectWorktrees()
+		registeredEntries = b.discoverRegisteredProjectWorktrees(
+			unreviewed,
+		)
 	}()
 	go func() {
 		defer startup.Done()
+		if skipUnreviewed(b.launchDir) {
+			return
+		}
 		launchEntries, launchErr = b.discoverLaunchWorktrees(b.launchDir)
 	}()
 	go func() {
@@ -148,13 +182,13 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	b.registerLaunchProject(launchEntries)
 	b.registerLaunchWorkspace(launchEntries)
 	entries = mergeTUIEntries(entries, launchEntries)
+	entries = mergeTUIEntries(
+		entries,
+		unreviewedTUIEntries(unreviewed, b.cfg.Worktree.BaseDir),
+	)
 
 	var statusByPath map[string]*models.WorktreeStatus
 	if includeStatuses {
-		unreviewed, stateErr := b.unreviewedWorktreePaths()
-		if stateErr != nil {
-			return nil, nil, stateErr
-		}
 		inspectable := make([]*discovery.GlobalWorktreeEntry, 0, len(entries))
 		for _, entry := range entries {
 			if entry != nil && pathSetContains(unreviewed, entry.Path) {
@@ -316,13 +350,16 @@ func localFleetObservation(currentHost string, localRow dashboard.Row, now time.
 	return observation, true
 }
 
-func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWorktreeEntry {
+func (b *tuiBackend) discoverRegisteredProjectWorktrees(
+	unreviewed map[string]struct{},
+) []*discovery.GlobalWorktreeEntry {
 	// Each project discovery spawns git subprocesses; run them concurrently
 	// and merge in config order so results stay deterministic.
 	results := make([][]*discovery.GlobalWorktreeEntry, len(b.cfg.Projects))
 	var wg sync.WaitGroup
 	for i, project := range b.cfg.Projects {
-		if project.Path == "" {
+		if project.Path == "" ||
+			pathSetContainsOrDescendant(unreviewed, project.Path) {
 			continue
 		}
 		wg.Add(1)
@@ -340,6 +377,24 @@ func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWor
 	var entries []*discovery.GlobalWorktreeEntry
 	for _, projectEntries := range results {
 		entries = mergeTUIEntries(entries, projectEntries)
+	}
+	return entries
+}
+
+func unreviewedTUIEntries(
+	unreviewed map[string]struct{},
+	baseDir string,
+) []*discovery.GlobalWorktreeEntry {
+	entries := make([]*discovery.GlobalWorktreeEntry, 0, len(unreviewed))
+	basePaths := map[string]struct{}{baseDir: {}}
+	for worktreePath := range unreviewed {
+		if baseDir == "" ||
+			!pathSetContainsOrDescendant(basePaths, worktreePath) {
+			continue
+		}
+		entries = append(entries, &discovery.GlobalWorktreeEntry{
+			Path: worktreePath,
+		})
 	}
 	return entries
 }

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -32,31 +32,26 @@ type tuiBackend struct {
 	// mu serializes List and MergeFleet: List mutates cfg (launch project and
 	// workspace registration) while MergeFleet's manifest publish reads it,
 	// and the TUI runs the two as concurrent commands.
-	mu                              sync.Mutex
-	cfg                             *models.Config
-	tmux                            *tmux.TmuxCommand
-	protectedNames                  []string
-	launchDir                       string
-	launchProjectRegistered         bool
-	launchWorkspaceRegistered       bool
-	discoverGlobalWorktrees         func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverGlobalWorktreesWithSkip func(
-		string,
-		func(string) bool,
-	) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverProjectWorktrees func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	discoverLaunchWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	collectStatuses          func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
-	listSessions             func() ([]string, error)
-	ensureAndAttach          func(context.Context, string, string, models.Layout, bool) error
-	registerProject          func(models.Project) error
-	registerWorkspace        func(models.Workspace) (models.Workspace, error)
-	unregisterWorkspace      func(name string) error
-	readFleetState           func(context.Context, *models.Config) (fleet.FleetState, error)
-	loadTargetConfig         func(string, bool) (*models.Config, error)
-	unreviewedWorktreePaths  func() (map[string]struct{}, error)
-	acknowledgeRemoteSource  func(string) error
-	now                      func() time.Time
+	mu                        sync.Mutex
+	cfg                       *models.Config
+	tmux                      *tmux.TmuxCommand
+	protectedNames            []string
+	launchDir                 string
+	launchProjectRegistered   bool
+	launchWorkspaceRegistered bool
+	discoverGlobalWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverProjectWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	discoverLaunchWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
+	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
+	listSessions              func() ([]string, error)
+	ensureAndAttach           func(context.Context, string, string, models.Layout, bool) error
+	registerProject           func(models.Project) error
+	registerWorkspace         func(models.Workspace) (models.Workspace, error)
+	unregisterWorkspace       func(name string) error
+	readFleetState            func(context.Context, *models.Config) (fleet.FleetState, error)
+	loadTargetConfig          func(string, bool) (*models.Config, error)
+	acknowledgeRemoteSource   func(string) error
+	now                       func() time.Time
 }
 
 func newTUIBackend(cfg *models.Config) *tuiBackend {
@@ -75,15 +70,8 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		// Registered projects flow into base-dir discovery so a registered
 		// canonical identity wins over a fork origin (the same precedence
 		// applyProjectIdentityFallback applies to per-project discovery).
-		discoverGlobalWorktreesWithSkip: func(
-			baseDir string,
-			skip func(string) bool,
-		) ([]*discovery.GlobalWorktreeEntry, error) {
-			return discovery.DiscoverGlobalWorktreesFiltered(
-				baseDir,
-				cfg.Projects,
-				skip,
-			)
+		discoverGlobalWorktrees: func(baseDir string) ([]*discovery.GlobalWorktreeEntry, error) {
+			return discovery.DiscoverGlobalWorktrees(baseDir, cfg.Projects)
 		},
 		discoverProjectWorktrees: discoverLaunchRepoWorktrees,
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
@@ -98,7 +86,6 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		unregisterWorkspace:     config.UnregisterWorkspace,
 		readFleetState:          readTUIFleetState,
 		loadTargetConfig:        config.LoadForTarget,
-		unreviewedWorktreePaths: unreviewedRemoteSourcePaths,
 		acknowledgeRemoteSource: acknowledgeRemoteSourcePath,
 		now:                     time.Now,
 	}
@@ -116,14 +103,6 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	unreviewed, stateErr := b.unreviewedWorktreePaths()
-	if stateErr != nil {
-		return nil, nil, stateErr
-	}
-	skipUnreviewed := func(path string) bool {
-		return pathSetContainsOrDescendant(unreviewed, path)
-	}
-
 	var (
 		entries           []*discovery.GlobalWorktreeEntry
 		registeredEntries []*discovery.GlobalWorktreeEntry
@@ -137,29 +116,16 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	startup.Add(4)
 	go func() {
 		defer startup.Done()
-		switch {
-		case b.discoverGlobalWorktrees != nil:
-			entries, discoveryErr = b.discoverGlobalWorktrees(
-				b.cfg.Worktree.BaseDir,
-			)
-		case b.discoverGlobalWorktreesWithSkip != nil:
-			entries, discoveryErr = b.discoverGlobalWorktreesWithSkip(
-				b.cfg.Worktree.BaseDir,
-				skipUnreviewed,
-			)
-		}
-	}()
-	go func() {
-		defer startup.Done()
-		registeredEntries = b.discoverRegisteredProjectWorktrees(
-			unreviewed,
+		entries, discoveryErr = b.discoverGlobalWorktrees(
+			b.cfg.Worktree.BaseDir,
 		)
 	}()
 	go func() {
 		defer startup.Done()
-		if skipUnreviewed(b.launchDir) {
-			return
-		}
+		registeredEntries = b.discoverRegisteredProjectWorktrees()
+	}()
+	go func() {
+		defer startup.Done()
 		launchEntries, launchErr = b.discoverLaunchWorktrees(b.launchDir)
 	}()
 	go func() {
@@ -182,24 +148,13 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	b.registerLaunchProject(launchEntries)
 	b.registerLaunchWorkspace(launchEntries)
 	entries = mergeTUIEntries(entries, launchEntries)
-	entries = mergeTUIEntries(
-		entries,
-		unreviewedTUIEntries(unreviewed, b.cfg.Worktree.BaseDir),
-	)
 
 	var statusByPath map[string]*models.WorktreeStatus
 	if includeStatuses {
-		inspectable := make([]*discovery.GlobalWorktreeEntry, 0, len(entries))
-		for _, entry := range entries {
-			if entry != nil && pathSetContains(unreviewed, entry.Path) {
-				continue
-			}
-			inspectable = append(inspectable, entry)
-		}
 		statusByPath, discoveryErr = b.collectStatuses(
 			ctx,
 			b.cfg.Worktree.BaseDir,
-			inspectable,
+			entries,
 		)
 		if discoveryErr != nil {
 			return nil, nil, discoveryErr
@@ -217,9 +172,7 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 		if st == nil {
 			st = unknownStatusForEntry(entry)
 		}
-		row := buildTUIRow(entry, st, liveSessions)
-		row.NeedsReview = pathSetContains(unreviewed, entry.Path)
-		rows = append(rows, row)
+		rows = append(rows, buildTUIRow(entry, st, liveSessions))
 	}
 	rows = append(rows, b.workspaceRows(sessions)...)
 	return rows, nil, nil
@@ -352,16 +305,13 @@ func localFleetObservation(currentHost string, localRow dashboard.Row, now time.
 	return observation, true
 }
 
-func (b *tuiBackend) discoverRegisteredProjectWorktrees(
-	unreviewed map[string]struct{},
-) []*discovery.GlobalWorktreeEntry {
+func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWorktreeEntry {
 	// Each project discovery spawns git subprocesses; run them concurrently
 	// and merge in config order so results stay deterministic.
 	results := make([][]*discovery.GlobalWorktreeEntry, len(b.cfg.Projects))
 	var wg sync.WaitGroup
 	for i, project := range b.cfg.Projects {
-		if project.Path == "" ||
-			pathSetContainsOrDescendant(unreviewed, project.Path) {
+		if project.Path == "" {
 			continue
 		}
 		wg.Add(1)
@@ -379,24 +329,6 @@ func (b *tuiBackend) discoverRegisteredProjectWorktrees(
 	var entries []*discovery.GlobalWorktreeEntry
 	for _, projectEntries := range results {
 		entries = mergeTUIEntries(entries, projectEntries)
-	}
-	return entries
-}
-
-func unreviewedTUIEntries(
-	unreviewed map[string]struct{},
-	baseDir string,
-) []*discovery.GlobalWorktreeEntry {
-	entries := make([]*discovery.GlobalWorktreeEntry, 0, len(unreviewed))
-	basePaths := map[string]struct{}{baseDir: {}}
-	for worktreePath := range unreviewed {
-		if baseDir == "" ||
-			!pathSetContainsOrDescendant(basePaths, worktreePath) {
-			continue
-		}
-		entries = append(entries, &discovery.GlobalWorktreeEntry{
-			Path: worktreePath,
-		})
 	}
 	return entries
 }

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -869,16 +869,37 @@ func (b *tuiBackend) CreateWorktree(
 	ctx context.Context,
 	row dashboard.Row,
 	branch string,
+	source string,
 ) (string, error) {
 	if row.Entry == nil {
 		return "", fmt.Errorf("no worktree selected")
 	}
-	path, err := worktree.New(git.New(row.Entry.Path), b.cfg).Add(branch, "", true)
+	manager := worktree.New(git.New(row.Entry.Path), b.cfg)
+	var path string
+	var err error
+	switch source {
+	case "":
+		path, err = manager.Add(branch, "", true)
+	case branch:
+		path, err = manager.Add(branch, "", false)
+	default:
+		path, err = manager.AddTracking(branch, source, "")
+	}
 	if err != nil {
 		return "", err
 	}
 	publishTUIFleetBestEffort(ctx, b.cfg)
 	return path, nil
+}
+
+func (b *tuiBackend) ListBranches(
+	_ context.Context,
+	row dashboard.Row,
+) ([]models.Branch, error) {
+	if row.Entry == nil {
+		return nil, fmt.Errorf("no worktree selected")
+	}
+	return git.New(row.Entry.Path).ListAvailableBranches()
 }
 
 func (b *tuiBackend) PreviewWorktree(row dashboard.Row, branch string) (dashboard.Row, error) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1018,20 +1018,63 @@ func (b *tuiBackend) verifyMaterializedHead(ctx context.Context, repoRoot string
 	want := strings.TrimSpace(info.RemoteHead)
 	got, err := git.New(worktreePath).RunWithContext(ctx, "rev-parse", "HEAD")
 	if err != nil {
-		_ = worktree.New(git.New(repoRoot), b.cfg).Remove(worktreePath, true)
-		return fmt.Errorf("could not verify synced head for %s; push or fetch it first: %w", info.Branch, err)
+		return b.failMaterializedHeadVerification(
+			repoRoot,
+			worktreePath,
+			fmt.Errorf(
+				"could not verify synced head for %s; push or fetch it first: %w",
+				info.Branch,
+				err,
+			),
+		)
 	}
 	got = strings.TrimSpace(got)
 	if strings.EqualFold(got, want) {
 		return nil
 	}
-	_ = worktree.New(git.New(repoRoot), b.cfg).Remove(worktreePath, true)
-	return fmt.Errorf(
-		"synced %s at %s, but hub reported head %s; push or fetch the reported commit first",
-		info.Branch,
-		shortCommit(got),
-		shortCommit(want),
+	return b.failMaterializedHeadVerification(
+		repoRoot,
+		worktreePath,
+		fmt.Errorf(
+			"synced %s at %s, but hub reported head %s; push or fetch the reported commit first",
+			info.Branch,
+			shortCommit(got),
+			shortCommit(want),
+		),
 	)
+}
+
+func (b *tuiBackend) failMaterializedHeadVerification(
+	repoRoot string,
+	worktreePath string,
+	verificationErr error,
+) error {
+	if err := worktree.New(git.New(repoRoot), b.cfg).Remove(
+		worktreePath,
+		true,
+	); err != nil {
+		return fmt.Errorf(
+			"%w (failed to remove rejected worktree: %v)",
+			verificationErr,
+			err,
+		)
+	}
+	reg, err := registry.New()
+	if err != nil {
+		return fmt.Errorf(
+			"%w (worktree removed, but failed to open registry: %v)",
+			verificationErr,
+			err,
+		)
+	}
+	if err := reg.Unregister(worktreePath); err != nil {
+		return fmt.Errorf(
+			"%w (worktree removed, but failed to unregister it: %v)",
+			verificationErr,
+			err,
+		)
+	}
+	return verificationErr
 }
 
 func localBranchExists(ctx context.Context, g *git.Git, branch string) bool {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -217,7 +217,9 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 		if st == nil {
 			st = unknownStatusForEntry(entry)
 		}
-		rows = append(rows, buildTUIRow(entry, st, liveSessions))
+		row := buildTUIRow(entry, st, liveSessions)
+		row.NeedsReview = pathSetContains(unreviewed, entry.Path)
+		rows = append(rows, row)
 	}
 	rows = append(rows, b.workspaceRows(sessions)...)
 	return rows, nil, nil

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -974,32 +974,42 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 		return "", fmt.Errorf("no local project configured for %s", row.Fleet.ProjectIdentity)
 	}
 	repo := git.New(project.Path)
-	// `git worktree add` auto-creates a local branch from a fetched remote;
-	// remember whether one existed so a failed verification can clean it up.
 	branchExisted := localBranchExists(ctx, repo, row.Fleet.Branch)
-	path, err := worktree.New(repo, b.cfg).AddWithOptions(
-		row.Fleet.Branch,
-		"",
-		false,
-		worktree.AddOptions{SkipSetup: true},
+	manager := worktree.New(repo, b.cfg)
+	var (
+		path          string
+		err           error
+		branchCreated bool
 	)
+	if branchExisted {
+		path, err = manager.AddWithOptions(
+			row.Fleet.Branch,
+			"",
+			false,
+			worktree.AddOptions{SkipSetup: true},
+		)
+	} else {
+		var source string
+		source, err = resolveFetchedRemoteSource(repo, row.Fleet.Branch)
+		if err == nil {
+			path, err = manager.AddTracking(
+				row.Fleet.Branch,
+				source,
+				"",
+			)
+			branchCreated = err == nil
+		}
+	}
 	if err != nil {
 		syncErr := fmt.Errorf(
 			"could not sync %s: branch must exist locally or on a fetched remote; push or fetch it first: %w",
 			row.Fleet.Branch,
 			err,
 		)
-		if !branchExisted {
-			return "", b.rollbackMaterializedBranch(
-				repo,
-				row.Fleet.Branch,
-				syncErr,
-			)
-		}
 		return "", syncErr
 	}
 	if err := b.verifyMaterializedHead(ctx, project.Path, path, row.Fleet); err != nil {
-		if !branchExisted {
+		if branchCreated {
 			err = b.rollbackMaterializedBranch(
 				repo,
 				row.Fleet.Branch,
@@ -1010,6 +1020,33 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 	}
 	publishTUIFleetBestEffort(ctx, b.cfg)
 	return path, nil
+}
+
+func resolveFetchedRemoteSource(repo *git.Git, branch string) (string, error) {
+	branches, err := repo.ListAvailableBranches()
+	if err != nil {
+		return "", fmt.Errorf("list fetched branches: %w", err)
+	}
+	var source string
+	for _, candidate := range branches {
+		if !candidate.IsRemote || candidate.Name != branch {
+			continue
+		}
+		if source != "" {
+			return "", fmt.Errorf(
+				"branch %s matches multiple fetched remotes",
+				branch,
+			)
+		}
+		source = candidate.Source
+	}
+	if source == "" {
+		return "", fmt.Errorf(
+			"branch %s has no matching fetched remote",
+			branch,
+		)
+	}
+	return source, nil
 }
 
 func (b *tuiBackend) rollbackMaterializedBranch(

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -47,6 +47,7 @@ type tuiBackend struct {
 	registerWorkspace         func(models.Workspace) (models.Workspace, error)
 	unregisterWorkspace       func(name string) error
 	readFleetState            func(context.Context, *models.Config) (fleet.FleetState, error)
+	loadTargetConfig          func(string, bool) (*models.Config, error)
 	now                       func() time.Time
 }
 
@@ -76,6 +77,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		registerWorkspace:        config.RegisterWorkspace,
 		unregisterWorkspace:      config.UnregisterWorkspace,
 		readFleetState:           readTUIFleetState,
+		loadTargetConfig:         config.LoadForTarget,
 		now:                      time.Now,
 	}
 }
@@ -874,9 +876,11 @@ func (b *tuiBackend) CreateWorktree(
 	if row.Entry == nil {
 		return "", fmt.Errorf("no worktree selected")
 	}
-	manager := worktree.New(git.New(row.Entry.Path), b.cfg)
+	manager, err := b.worktreeManager(row)
+	if err != nil {
+		return "", err
+	}
 	var path string
-	var err error
 	switch source {
 	case "":
 		path, err = manager.Add(branch, "", true)
@@ -906,7 +910,10 @@ func (b *tuiBackend) PreviewWorktree(row dashboard.Row, branch string) (dashboar
 	if row.Entry == nil {
 		return dashboard.Row{}, fmt.Errorf("no worktree selected")
 	}
-	manager := worktree.New(git.New(row.Entry.Path), b.cfg)
+	manager, err := b.worktreeManager(row)
+	if err != nil {
+		return dashboard.Row{}, err
+	}
 	worktreePath, err := manager.PreparePath("", branch)
 	if err != nil {
 		return dashboard.Row{}, err
@@ -922,6 +929,19 @@ func (b *tuiBackend) PreviewWorktree(row dashboard.Row, branch string) (dashboar
 		Entry:  &entry,
 		Status: unknownStatusForEntry(&entry),
 	}, nil
+}
+
+func (b *tuiBackend) worktreeManager(row dashboard.Row) (*worktree.Manager, error) {
+	repositoryGit := git.New(row.Entry.Path)
+	repoRoot, err := repositoryGit.GetMainRepositoryPath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve selected repository root: %w", err)
+	}
+	cfg, err := b.loadTargetConfig(repoRoot, false)
+	if err != nil {
+		return nil, fmt.Errorf("load selected repository config: %w", err)
+	}
+	return worktree.New(repositoryGit, cfg), nil
 }
 
 func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row) (string, error) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -50,6 +50,8 @@ type tuiBackend struct {
 	unregisterWorkspace       func(name string) error
 	readFleetState            func(context.Context, *models.Config) (fleet.FleetState, error)
 	loadTargetConfig          func(string, bool) (*models.Config, error)
+	unreviewedWorktreePaths   func() (map[string]struct{}, error)
+	acknowledgeRemoteSource   func(string) error
 	now                       func() time.Time
 }
 
@@ -80,12 +82,14 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 			tmuxCmd,
 			protectedNames,
 		).EnsureAndAttach,
-		registerProject:     config.RegisterProject,
-		registerWorkspace:   config.RegisterWorkspace,
-		unregisterWorkspace: config.UnregisterWorkspace,
-		readFleetState:      readTUIFleetState,
-		loadTargetConfig:    config.LoadForTarget,
-		now:                 time.Now,
+		registerProject:         config.RegisterProject,
+		registerWorkspace:       config.RegisterWorkspace,
+		unregisterWorkspace:     config.UnregisterWorkspace,
+		readFleetState:          readTUIFleetState,
+		loadTargetConfig:        config.LoadForTarget,
+		unreviewedWorktreePaths: unreviewedRemoteSourcePaths,
+		acknowledgeRemoteSource: acknowledgeRemoteSourcePath,
+		now:                     time.Now,
 	}
 }
 
@@ -147,7 +151,22 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 
 	var statusByPath map[string]*models.WorktreeStatus
 	if includeStatuses {
-		statusByPath, discoveryErr = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
+		unreviewed, stateErr := b.unreviewedWorktreePaths()
+		if stateErr != nil {
+			return nil, nil, stateErr
+		}
+		inspectable := make([]*discovery.GlobalWorktreeEntry, 0, len(entries))
+		for _, entry := range entries {
+			if entry != nil && pathSetContains(unreviewed, entry.Path) {
+				continue
+			}
+			inspectable = append(inspectable, entry)
+		}
+		statusByPath, discoveryErr = b.collectStatuses(
+			ctx,
+			b.cfg.Worktree.BaseDir,
+			inspectable,
+		)
 		if discoveryErr != nil {
 			return nil, nil, discoveryErr
 		}
@@ -1340,6 +1359,9 @@ func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, lay
 		return fmt.Errorf("no worktree selected")
 	}
 	if err := rejectProtectedWorkspaceOpen(ctx, rowPaneRoot(row)); err != nil {
+		return err
+	}
+	if err := b.acknowledgeRemoteSource(rowPaneRoot(row)); err != nil {
 		return err
 	}
 	sessionName, err := b.sessionName(row)

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/fleet"
 	"go.kenn.io/kwt/internal/git"
@@ -34,6 +35,7 @@ type tuiBackend struct {
 	mu                        sync.Mutex
 	cfg                       *models.Config
 	tmux                      *tmux.TmuxCommand
+	protectedNames            []string
 	launchDir                 string
 	launchProjectRegistered   bool
 	launchWorkspaceRegistered bool
@@ -57,11 +59,13 @@ func newTUIBackend(cfg *models.Config) *tuiBackend {
 }
 
 func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBackend {
-	tmuxCmd := tmux.NewTmuxCommand("")
+	protectedNames := credentials.ProtectedNames(cfg)
+	tmuxCmd := tmux.NewTmuxCommandWithStripNames("", protectedNames)
 	return &tuiBackend{
-		cfg:       cfg,
-		tmux:      tmuxCmd,
-		launchDir: launchDir,
+		cfg:            cfg,
+		tmux:           tmuxCmd,
+		protectedNames: protectedNames,
+		launchDir:      launchDir,
 		// Registered projects flow into base-dir discovery so a registered
 		// canonical identity wins over a fork origin (the same precedence
 		// applyProjectIdentityFallback applies to per-project discovery).
@@ -72,13 +76,16 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
 		collectStatuses:          collectTUIStatuses,
 		listSessions:             tmuxCmd.ListSessions,
-		ensureAndAttach:          tmux.NewWorkspaceRunner(tmuxCmd).EnsureAndAttach,
-		registerProject:          config.RegisterProject,
-		registerWorkspace:        config.RegisterWorkspace,
-		unregisterWorkspace:      config.UnregisterWorkspace,
-		readFleetState:           readTUIFleetState,
-		loadTargetConfig:         config.LoadForTarget,
-		now:                      time.Now,
+		ensureAndAttach: tmux.NewWorkspaceRunner(
+			tmuxCmd,
+			protectedNames,
+		).EnsureAndAttach,
+		registerProject:     config.RegisterProject,
+		registerWorkspace:   config.RegisterWorkspace,
+		unregisterWorkspace: config.UnregisterWorkspace,
+		readFleetState:      readTUIFleetState,
+		loadTargetConfig:    config.LoadForTarget,
+		now:                 time.Now,
 	}
 }
 

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -975,10 +975,13 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 	}
 	repo := git.New(project.Path)
 	branchExisted := localBranchExists(ctx, repo, row.Fleet.Branch)
-	manager := worktree.New(repo, b.cfg)
+	cfg, err := b.loadTargetConfig(project.Path, false)
+	if err != nil {
+		return "", fmt.Errorf("load selected project config: %w", err)
+	}
+	manager := worktree.New(repo, cfg)
 	var (
 		path          string
-		err           error
 		branchCreated bool
 	)
 	if branchExisted {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -411,6 +411,7 @@ func TestTUIBackendListExcludesUnreviewedWorktreeFromStatusCollection(t *testing
 
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
+	assert.True(t, rows[0].NeedsReview)
 	assert.Equal(t, models.WorktreeStatusUnknown, rows[0].Status.Status)
 }
 

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2005,6 +2005,85 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnStaleHead(t *tes
 	))
 }
 
+func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnCheckoutFailure(
+	t *testing.T,
+) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(
+		t,
+		repoPath,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/example/kwt.git",
+	)
+	runTUITestGit(t, repoPath, "checkout", "-b", "feature/broken-remote")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, "missing.txt"),
+		[]byte("unique missing blob\n"),
+		0644,
+	))
+	runTUITestGit(t, repoPath, "add", "missing.txt")
+	runTUITestGit(t, repoPath, "commit", "-m", "Add missing blob")
+	commit := strings.TrimSpace(runTUITestGitOutput(
+		t,
+		repoPath,
+		"rev-parse",
+		"HEAD",
+	))
+	blob := strings.TrimSpace(runTUITestGitOutput(
+		t,
+		repoPath,
+		"rev-parse",
+		"HEAD:missing.txt",
+	))
+	runTUITestGit(t, repoPath, "checkout", "main")
+	runTUITestGit(
+		t,
+		repoPath,
+		"update-ref",
+		"refs/remotes/origin/feature/broken-remote",
+		commit,
+	)
+	runTUITestGit(t, repoPath, "branch", "-D", "feature/broken-remote")
+	require.NoError(t, os.Remove(filepath.Join(
+		repoPath,
+		".git",
+		"objects",
+		blob[:2],
+		blob[2:],
+	)))
+
+	baseDir := filepath.Join(t.TempDir(), "worktrees")
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: baseDir, AutoMkdir: true},
+		Projects: []models.Project{{
+			Repository: "github.com/example/kwt",
+			Name:       "kwt",
+			Path:       repoPath,
+		}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/broken-remote",
+		Branch:          "feature/broken-remote",
+		Hosts:           []string{"host-b"},
+	}}
+
+	path, err := backend.MaterializeWorktree(context.Background(), row)
+
+	require.Error(t, err)
+	assert.Empty(t, path)
+	assert.False(t, tuiTestBranchExists(repoPath, "feature/broken-remote"),
+		"auto-created branch must be removed when checkout fails")
+}
+
 func TestTUIBackendMaterializeWorktreeUnregistersWhenHeadCannotBeRead(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -23,6 +23,7 @@ import (
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/fleet"
 	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
 	dashboard "go.kenn.io/kwt/internal/tui"
 	"go.kenn.io/kwt/internal/url"
@@ -1646,6 +1647,41 @@ func TestTUIBackendCreateWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 	require.NoError(t, err)
 	assert.DirExists(t, path)
 	assert.Equal(t, 1, published)
+}
+
+func TestTUIBackendExistingLocalBranchRemainsUnreviewed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(t, repoPath, "checkout", "-b", "feature/local")
+	runTUITestGit(t, repoPath, "checkout", "main")
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir:   filepath.Join(t.TempDir(), "worktrees"),
+			AutoMkdir: true,
+		},
+	}
+	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		Branch: "main",
+		Path:   repoPath,
+	}}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	backend.loadTargetConfig = func(string, bool) (*models.Config, error) {
+		return cfg, nil
+	}
+
+	path, err := backend.CreateWorktree(
+		context.Background(),
+		row,
+		"feature/local",
+		"feature/local",
+	)
+
+	require.NoError(t, err)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	assert.True(t, reg.IsUnreviewedRemoteSource(path))
 }
 
 func TestTUIBackendWorktreeCreationUsesSelectedRepositoryConfig(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/fleet"
+	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
@@ -1953,6 +1954,11 @@ func TestTUIBackendMaterializeWorktreeRejectsStaleLocalHead(t *testing.T) {
 	assert.NoDirExists(t, filepath.Join(baseDir, "github.com", "example", "kwt", "feature-studio-only"))
 	assert.True(t, tuiTestBranchExists(repoPath, "feature/studio-only"),
 		"pre-existing branch must survive a failed sync")
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	assert.False(t, reg.IsUnreviewedRemoteSource(
+		filepath.Join(baseDir, "github.com", "example", "kwt", "feature-studio-only"),
+	))
 }
 
 func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnStaleHead(t *testing.T) {
@@ -1990,6 +1996,51 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnStaleHead(t *tes
 	assert.Empty(t, path)
 	assert.False(t, tuiTestBranchExists(repoPath, "feature/studio-only"),
 		"auto-created branch must be removed when verification fails")
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	assert.False(t, reg.IsUnreviewedRemoteSource(
+		filepath.Join(baseDir, "github.com", "example", "kwt", "feature-studio-only"),
+	))
+}
+
+func TestTUIBackendMaterializeWorktreeUnregistersWhenHeadCannotBeRead(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(t, repoPath, "remote", "add", "origin", "https://github.com/example/kwt.git")
+	runTUITestGit(t, repoPath, "branch", "feature/studio-only")
+	baseDir := filepath.Join(t.TempDir(), "worktrees")
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: baseDir, AutoMkdir: true},
+	}
+	manager := worktree.New(git.New(repoPath), cfg)
+	worktreePath, err := manager.AddWithOptions(
+		"feature/studio-only",
+		"",
+		false,
+		worktree.AddOptions{SkipSetup: true},
+	)
+	require.NoError(t, err)
+	runTUITestGit(t, worktreePath, "symbolic-ref", "HEAD", "refs/heads/missing")
+
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	err = backend.verifyMaterializedHead(
+		context.Background(),
+		repoPath,
+		worktreePath,
+		&dashboard.FleetInfo{
+			Branch:     "feature/studio-only",
+			RemoteHead: strings.Repeat("b", 40),
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not verify synced head")
+	assert.NoDirExists(t, worktreePath)
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	assert.False(t, reg.IsUnreviewedRemoteSource(worktreePath))
 }
 
 func tuiTestBranchExists(repoPath string, branch string) bool {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1599,7 +1599,7 @@ func TestTUIBackendCreateWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
 
-	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui")
+	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui", "")
 
 	require.NoError(t, err)
 	assert.DirExists(t, path)
@@ -1627,7 +1627,7 @@ func TestTUIBackendCreateWorktreeDoesNotExpandRepositoryLocalTemplate(t *testing
 
 	planned, err := backend.PreviewWorktree(row, "feature/from-tui")
 	require.NoError(t, err)
-	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui")
+	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui", "")
 
 	require.NoError(t, err)
 	assert.NotContains(t, path, secret,

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -26,6 +26,7 @@ import (
 	"go.kenn.io/kwt/internal/tmux"
 	dashboard "go.kenn.io/kwt/internal/tui"
 	"go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -367,6 +368,44 @@ func TestTUIBackendListFastSkipsStatusCollection(t *testing.T) {
 	backend.listSessions = func() ([]string, error) { return nil, nil }
 
 	rows, _, err := backend.ListFast(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, models.WorktreeStatusUnknown, rows[0].Status.Status)
+}
+
+func TestTUIBackendListExcludesUnreviewedWorktreeFromStatusCollection(t *testing.T) {
+	entry := &discovery.GlobalWorktreeEntry{
+		RepositoryInfo: &url.RepositoryInfo{
+			Host: "github.com", Owner: "example", Repository: "kwt",
+		},
+		Branch: "feature/remote",
+		Path:   "/global/github.com/example/kwt/feature-remote",
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: "/global"},
+	}, "")
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return []*discovery.GlobalWorktreeEntry{entry}, nil
+	}
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	backend.unreviewedWorktreePaths = func() (map[string]struct{}, error) {
+		return map[string]struct{}{utils.CanonicalPath(entry.Path): {}}, nil
+	}
+	backend.collectStatuses = func(
+		_ context.Context,
+		_ string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, error) {
+		assert.Empty(t, entries)
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+
+	rows, _, err := backend.List(context.Background())
 
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -2573,6 +2612,43 @@ func TestTUIBackendAttachWorkspaceGuardRejectsEmptyRow(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, "no worktree selected", err.Error())
+}
+
+func TestTUIBackendAttachAcknowledgesRemoteSourceBeforeWorkspaceLaunch(t *testing.T) {
+	workspacePath := t.TempDir()
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	var acknowledged string
+	backend.acknowledgeRemoteSource = func(path string) error {
+		acknowledged = path
+		return nil
+	}
+	launched := false
+	backend.ensureAndAttach = func(
+		context.Context,
+		string,
+		string,
+		models.Layout,
+		bool,
+	) error {
+		launched = true
+		assert.Equal(t, workspacePath, acknowledged)
+		return nil
+	}
+
+	err := backend.attachWorkspace(
+		context.Background(),
+		dashboard.Row{Workspace: &dashboard.WorkspaceInfo{
+			Name: "remote",
+			Path: workspacePath,
+		}},
+		tmux.BlankLayoutName,
+		false,
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, launched)
+	assert.Equal(t, workspacePath, acknowledged)
 }
 
 func TestTUIBackendRefusesProtectedPullRequestWorkspace(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1741,8 +1741,8 @@ func TestTUIBackendCreateWorktreeDoesNotExpandRepositoryLocalTemplate(t *testing
 	cfg := &models.Config{
 		Worktree: models.WorktreeConfig{BaseDir: filepath.Join(t.TempDir(), "worktrees"), AutoMkdir: true},
 		Naming: models.NamingConfig{
-			Template:        `{{printf "%c%s" 36 "KWT_GITHUB_TOKEN"}}/{{.Branch}}`,
-			RepositoryLocal: true,
+			Template:                `{{printf "%c%s" 36 "KWT_GITHUB_TOKEN"}}/{{.Branch}}`,
+			TemplateRepositoryLocal: true,
 		},
 	}
 	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1598,12 +1598,54 @@ func TestTUIBackendCreateWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 		Path:   repoPath,
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	backend.loadTargetConfig = func(string, bool) (*models.Config, error) {
+		return cfg, nil
+	}
 
 	path, err := backend.CreateWorktree(context.Background(), row, "feature/from-tui", "")
 
 	require.NoError(t, err)
 	assert.DirExists(t, path)
 	assert.Equal(t, 1, published)
+}
+
+func TestTUIBackendWorktreeCreationUsesSelectedRepositoryConfig(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(t, repoPath, "remote", "add", "origin", "https://github.com/example/kwt.git")
+	globalBase := filepath.Join(t.TempDir(), "global-worktrees")
+	selectedBase := filepath.Join(t.TempDir(), "selected-worktrees")
+	globalCfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: globalBase, AutoMkdir: true},
+	}
+	selectedCfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: selectedBase, AutoMkdir: true},
+	}
+	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		Branch: "main",
+		Path:   repoPath,
+	}}
+	backend := newTUIBackendWithLaunchDir(globalCfg, "")
+	backend.loadTargetConfig = func(path string, interactive bool) (*models.Config, error) {
+		expectedRoot, err := filepath.EvalSymlinks(repoPath)
+		require.NoError(t, err)
+		assert.Equal(t, expectedRoot, path)
+		assert.False(t, interactive)
+		return selectedCfg, nil
+	}
+
+	planned, err := backend.PreviewWorktree(row, "feature/selected-config")
+	require.NoError(t, err)
+	path, err := backend.CreateWorktree(
+		context.Background(),
+		row,
+		"feature/selected-config",
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, planned.Entry.Path, path)
+	assert.True(t, strings.HasPrefix(path, selectedBase+string(os.PathSeparator)))
+	assert.False(t, strings.HasPrefix(path, globalBase+string(os.PathSeparator)))
 }
 
 func TestTUIBackendCreateWorktreeDoesNotExpandRepositoryLocalTemplate(t *testing.T) {
@@ -1624,6 +1666,9 @@ func TestTUIBackendCreateWorktreeDoesNotExpandRepositoryLocalTemplate(t *testing
 		Path:   repoPath,
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	backend.loadTargetConfig = func(string, bool) (*models.Config, error) {
+		return cfg, nil
+	}
 
 	planned, err := backend.PreviewWorktree(row, "feature/from-tui")
 	require.NoError(t, err)

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1972,6 +1972,18 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnStaleHead(t *tes
 	// Simulate a fetched remote branch with no local counterpart, so
 	// `git worktree add` auto-creates the local branch.
 	runTUITestGit(t, repoPath, "update-ref", "refs/remotes/origin/feature/studio-only", "HEAD")
+	rollbackHookMarker := filepath.Join(t.TempDir(), "rollback-hook-ran")
+	hooksDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hooksDir, "reference-transaction"),
+		fmt.Appendf(
+			nil,
+			"#!/bin/sh\nprintf hook > %q\n",
+			rollbackHookMarker,
+		),
+		0755,
+	))
+	runTUITestGit(t, repoPath, "config", "core.hooksPath", hooksDir)
 	baseDir := filepath.Join(t.TempDir(), "worktrees")
 	cfg := &models.Config{
 		Worktree: models.WorktreeConfig{BaseDir: baseDir, AutoMkdir: true},
@@ -1998,6 +2010,8 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnStaleHead(t *tes
 	assert.Empty(t, path)
 	assert.False(t, tuiTestBranchExists(repoPath, "feature/studio-only"),
 		"auto-created branch must be removed when verification fails")
+	assert.NoFileExists(t, rollbackHookMarker,
+		"fleet branch rollback must not run repository hooks")
 	reg, registryErr := registry.New()
 	require.NoError(t, registryErr)
 	assert.False(t, reg.IsUnreviewedRemoteSource(
@@ -2056,6 +2070,18 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnCheckoutFailure(
 		blob[:2],
 		blob[2:],
 	)))
+	rollbackHookMarker := filepath.Join(t.TempDir(), "rollback-hook-ran")
+	hooksDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hooksDir, "reference-transaction"),
+		fmt.Appendf(
+			nil,
+			"#!/bin/sh\nprintf hook > %q\n",
+			rollbackHookMarker,
+		),
+		0755,
+	))
+	runTUITestGit(t, repoPath, "config", "core.hooksPath", hooksDir)
 
 	baseDir := filepath.Join(t.TempDir(), "worktrees")
 	cfg := &models.Config{
@@ -2082,6 +2108,24 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnCheckoutFailure(
 	assert.Empty(t, path)
 	assert.False(t, tuiTestBranchExists(repoPath, "feature/broken-remote"),
 		"auto-created branch must be removed when checkout fails")
+	assert.NoFileExists(t, rollbackHookMarker,
+		"fleet branch rollback must not run repository hooks")
+}
+
+func TestTUIBackendMaterializeWorktreeReportsBranchRollbackFailure(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+
+	err := backend.rollbackMaterializedBranch(
+		git.New(repoPath),
+		"missing-branch",
+		errors.New("materialization failed"),
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "materialization failed")
+	assert.ErrorContains(t, err, "failed to remove auto-created branch")
+	assert.ErrorContains(t, err, "an incomplete worktree may remain")
 }
 
 func TestTUIBackendMaterializeWorktreeUnregistersWhenHeadCannotBeRead(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -28,7 +28,6 @@ import (
 	"go.kenn.io/kwt/internal/tmux"
 	dashboard "go.kenn.io/kwt/internal/tui"
 	"go.kenn.io/kwt/internal/url"
-	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -376,7 +375,7 @@ func TestTUIBackendListFastSkipsStatusCollection(t *testing.T) {
 	assert.Equal(t, models.WorktreeStatusUnknown, rows[0].Status.Status)
 }
 
-func TestTUIBackendListExcludesUnreviewedWorktreeFromStatusCollection(t *testing.T) {
+func TestTUIBackendListCollectsStatusForImportedWorktree(t *testing.T) {
 	entry := &discovery.GlobalWorktreeEntry{
 		RepositoryInfo: &url.RepositoryInfo{
 			Host: "github.com", Owner: "example", Repository: "kwt",
@@ -394,16 +393,19 @@ func TestTUIBackendListExcludesUnreviewedWorktreeFromStatusCollection(t *testing
 	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
 		return nil, nil
 	}
-	backend.unreviewedWorktreePaths = func() (map[string]struct{}, error) {
-		return map[string]struct{}{utils.CanonicalPath(entry.Path): {}}, nil
-	}
 	backend.collectStatuses = func(
 		_ context.Context,
 		_ string,
 		entries []*discovery.GlobalWorktreeEntry,
 	) (map[string]*models.WorktreeStatus, error) {
-		assert.Empty(t, entries)
-		return nil, nil
+		require.Equal(t, []*discovery.GlobalWorktreeEntry{entry}, entries)
+		return map[string]*models.WorktreeStatus{
+			entry.Path: {
+				Path:   entry.Path,
+				Branch: entry.Branch,
+				Status: models.WorktreeStatusClean,
+			},
+		}, nil
 	}
 	backend.listSessions = func() ([]string, error) { return nil, nil }
 
@@ -411,8 +413,7 @@ func TestTUIBackendListExcludesUnreviewedWorktreeFromStatusCollection(t *testing
 
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.True(t, rows[0].NeedsReview)
-	assert.Equal(t, models.WorktreeStatusUnknown, rows[0].Status.Status)
+	assert.Equal(t, models.WorktreeStatusClean, rows[0].Status.Status)
 }
 
 func TestTUIBackendListFastRunsIndependentDiscoveryConcurrently(t *testing.T) {
@@ -1515,7 +1516,7 @@ func TestTUIBackendAutoRegisteredRelativeRemoteNeverReachesManifest(t *testing.T
 			return nil, nil
 		},
 		DiscoverGlobalWorktrees: func(
-			string, []models.Project, func(string) bool,
+			string, []models.Project,
 		) ([]*discovery.GlobalWorktreeEntry, error) {
 			return nil, nil
 		},
@@ -1526,43 +1527,6 @@ func TestTUIBackendAutoRegisteredRelativeRemoteNeverReachesManifest(t *testing.T
 		assert.NotEqual(t, "cache/team/repo", project.Identity,
 			"a git-derived relative remote must never launder into a published fleet identity")
 	}
-}
-
-func TestTUIBackendLoadsUnreviewedPathsBeforeDiscovery(t *testing.T) {
-	const unreviewedPath = "/worktrees/unreviewed"
-	cfg := &models.Config{
-		Worktree: models.WorktreeConfig{BaseDir: "/worktrees"},
-	}
-	backend := newTUIBackendWithLaunchDir(cfg, unreviewedPath)
-	backend.unreviewedWorktreePaths = func() (map[string]struct{}, error) {
-		return map[string]struct{}{
-			utils.CanonicalPath(unreviewedPath): {},
-		}, nil
-	}
-	globalChecked := false
-	backend.discoverGlobalWorktrees = nil
-	backend.discoverGlobalWorktreesWithSkip = func(
-		_ string,
-		skip func(string) bool,
-	) ([]*discovery.GlobalWorktreeEntry, error) {
-		globalChecked = skip(unreviewedPath)
-		return nil, nil
-	}
-	launchCalled := false
-	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
-		launchCalled = true
-		return nil, nil
-	}
-	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
-		return nil, nil
-	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
-
-	_, _, err := backend.ListFast(context.Background())
-
-	require.NoError(t, err)
-	assert.True(t, globalChecked)
-	assert.False(t, launchCalled)
 }
 
 func TestApplyProjectIdentityFallbackKeepsOriginForPathBackedProjects(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1514,7 +1514,7 @@ func TestTUIBackendAutoRegisteredRelativeRemoteNeverReachesManifest(t *testing.T
 			return nil, nil
 		},
 		DiscoverGlobalWorktrees: func(
-			string, []models.Project,
+			string, []models.Project, func(string) bool,
 		) ([]*discovery.GlobalWorktreeEntry, error) {
 			return nil, nil
 		},
@@ -1525,6 +1525,43 @@ func TestTUIBackendAutoRegisteredRelativeRemoteNeverReachesManifest(t *testing.T
 		assert.NotEqual(t, "cache/team/repo", project.Identity,
 			"a git-derived relative remote must never launder into a published fleet identity")
 	}
+}
+
+func TestTUIBackendLoadsUnreviewedPathsBeforeDiscovery(t *testing.T) {
+	const unreviewedPath = "/worktrees/unreviewed"
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: "/worktrees"},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, unreviewedPath)
+	backend.unreviewedWorktreePaths = func() (map[string]struct{}, error) {
+		return map[string]struct{}{
+			utils.CanonicalPath(unreviewedPath): {},
+		}, nil
+	}
+	globalChecked := false
+	backend.discoverGlobalWorktrees = nil
+	backend.discoverGlobalWorktreesWithSkip = func(
+		_ string,
+		skip func(string) bool,
+	) ([]*discovery.GlobalWorktreeEntry, error) {
+		globalChecked = skip(unreviewedPath)
+		return nil, nil
+	}
+	launchCalled := false
+	backend.discoverLaunchWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		launchCalled = true
+		return nil, nil
+	}
+	backend.discoverProjectWorktrees = func(string) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+
+	_, _, err := backend.ListFast(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, globalChecked)
+	assert.False(t, launchCalled)
 }
 
 func TestApplyProjectIdentityFallbackKeepsOriginForPathBackedProjects(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1945,6 +1945,12 @@ func TestTUIBackendMaterializeWorktreeUsesSelectedProjectConfig(t *testing.T) {
 			BaseDir:   selectedBase,
 			AutoMkdir: true,
 		},
+		Naming: models.NamingConfig{
+			Template: "{{.Branch}}",
+			SanitizeChars: map[string]string{
+				"/": "-",
+			},
+		},
 	}
 	backend := newTUIBackendWithLaunchDir(globalCfg, "")
 	loadedTargetConfig := false

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1920,6 +1920,72 @@ func TestTUIBackendMaterializeWorktreeUsesRegisteredProjectRoot(t *testing.T) {
 	assert.Equal(t, "feature/studio-only", branch)
 }
 
+func TestTUIBackendMaterializeWorktreeTracksRemoteOnlyBranch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(
+		t,
+		repoPath,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/example/kwt.git",
+	)
+	runTUITestGit(
+		t,
+		repoPath,
+		"update-ref",
+		"refs/remotes/origin/feature/remote-only",
+		"HEAD",
+	)
+	baseDir := filepath.Join(t.TempDir(), "worktrees")
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: baseDir, AutoMkdir: true},
+		Projects: []models.Project{{
+			Repository: "github.com/example/kwt",
+			Name:       "kwt",
+			Path:       repoPath,
+		}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/remote-only",
+		Branch:          "feature/remote-only",
+		Hosts:           []string{"host-b"},
+	}}
+
+	path, err := backend.MaterializeWorktree(context.Background(), row)
+
+	require.NoError(t, err)
+	assert.DirExists(t, path)
+	assert.Equal(
+		t,
+		"feature/remote-only",
+		strings.TrimSpace(runTUITestGitOutput(
+			t,
+			path,
+			"branch",
+			"--show-current",
+		)),
+	)
+	assert.Equal(
+		t,
+		"origin/feature/remote-only",
+		strings.TrimSpace(runTUITestGitOutput(
+			t,
+			path,
+			"rev-parse",
+			"--abbrev-ref",
+			"@{upstream}",
+		)),
+	)
+}
+
 func TestTUIBackendMaterializeWorktreeRejectsStaleLocalHead(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2554,6 +2554,18 @@ func TestTUIBackendLayoutNamesBlankOnly(t *testing.T) {
 	assert.Equal(t, []string{"none"}, backend.LayoutNames())
 }
 
+func TestTUIBackendCarriesConfiguredCredentialName(t *testing.T) {
+	backend := newTUIBackend(&models.Config{
+		Fleet: models.FleetConfig{TokenEnv: "Custom_Fleet_Token"},
+	})
+
+	assert.ElementsMatch(
+		t,
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "Custom_Fleet_Token"},
+		backend.protectedNames,
+	)
+}
+
 func TestTUIBackendAttachWorkspaceGuardRejectsEmptyRow(t *testing.T) {
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1661,6 +1661,12 @@ func TestTUIBackendExistingLocalBranchRemainsUnreviewed(t *testing.T) {
 			BaseDir:   filepath.Join(t.TempDir(), "worktrees"),
 			AutoMkdir: true,
 		},
+		Naming: models.NamingConfig{
+			Template: "{{.Branch}}",
+			SanitizeChars: map[string]string{
+				"/": "-",
+			},
+		},
 	}
 	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
 		Branch: "main",

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1902,6 +1902,7 @@ func TestTUIBackendMaterializeWorktreeUsesRegisteredProjectRoot(t *testing.T) {
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",
@@ -1918,6 +1919,56 @@ func TestTUIBackendMaterializeWorktreeUsesRegisteredProjectRoot(t *testing.T) {
 	assert.True(t, strings.HasPrefix(path, baseDir), path)
 	branch := strings.TrimSpace(runTUITestGitOutput(t, path, "branch", "--show-current"))
 	assert.Equal(t, "feature/studio-only", branch)
+}
+
+func TestTUIBackendMaterializeWorktreeUsesSelectedProjectConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	runTUITestGit(t, repoPath, "branch", "feature/selected-config")
+	globalBase := filepath.Join(t.TempDir(), "global-worktrees")
+	selectedBase := filepath.Join(t.TempDir(), "selected-worktrees")
+	globalCfg := &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir:   globalBase,
+			AutoMkdir: true,
+		},
+		Projects: []models.Project{{
+			Repository: "github.com/example/kwt",
+			Name:       "kwt",
+			Path:       repoPath,
+		}},
+	}
+	selectedCfg := &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir:   selectedBase,
+			AutoMkdir: true,
+		},
+	}
+	backend := newTUIBackendWithLaunchDir(globalCfg, "")
+	loadedTargetConfig := false
+	backend.loadTargetConfig = func(path string, interactive bool) (*models.Config, error) {
+		loadedTargetConfig = true
+		assert.Equal(t, repoPath, path)
+		assert.False(t, interactive)
+		return selectedCfg, nil
+	}
+	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
+		ProjectIdentity: "github.com/example/kwt",
+		ProjectName:     "kwt",
+		Kind:            "branch",
+		Ref:             "feature/selected-config",
+		Branch:          "feature/selected-config",
+		Hosts:           []string{"host-b"},
+	}}
+
+	path, err := backend.MaterializeWorktree(context.Background(), row)
+
+	require.NoError(t, err)
+	assert.True(t, loadedTargetConfig)
+	assert.True(t, strings.HasPrefix(path, selectedBase+string(os.PathSeparator)))
+	assert.False(t, strings.HasPrefix(path, globalBase+string(os.PathSeparator)))
 }
 
 func TestTUIBackendMaterializeWorktreeTracksRemoteOnlyBranch(t *testing.T) {
@@ -1950,6 +2001,7 @@ func TestTUIBackendMaterializeWorktreeTracksRemoteOnlyBranch(t *testing.T) {
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",
@@ -2003,6 +2055,7 @@ func TestTUIBackendMaterializeWorktreeRejectsStaleLocalHead(t *testing.T) {
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",
@@ -2060,6 +2113,7 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnStaleHead(t *tes
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",
@@ -2159,6 +2213,7 @@ func TestTUIBackendMaterializeWorktreeDeletesAutoCreatedBranchOnCheckoutFailure(
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",
@@ -2240,6 +2295,12 @@ func tuiTestBranchExists(repoPath string, branch string) bool {
 	return cmd.Run() == nil
 }
 
+func stubTUITargetConfig(backend *tuiBackend, cfg *models.Config) {
+	backend.loadTargetConfig = func(string, bool) (*models.Config, error) {
+		return cfg, nil
+	}
+}
+
 func TestTUIBackendMaterializeWorktreeSkipsRepositorySetupCommands(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("setup command execution requires sh")
@@ -2264,6 +2325,7 @@ func TestTUIBackendMaterializeWorktreeSkipsRepositorySetupCommands(t *testing.T)
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",
@@ -2330,6 +2392,7 @@ func TestTUIBackendMaterializeWorktreeExplainsUnavailableBranch(t *testing.T) {
 		}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUITargetConfig(backend, cfg)
 	row := dashboard.Row{Fleet: &dashboard.FleetInfo{
 		ProjectIdentity: "github.com/example/kwt",
 		ProjectName:     "kwt",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,8 @@ const (
 	configType      = "toml"
 	localConfigName = ".kwt"
 
-	cwdLocalNamingMarker = "kwt.internal.cwd_local_naming"
+	cwdLocalNamingTemplateMarker = "kwt.internal.cwd_local_naming_template"
+	cwdLocalNamingSanitizeMarker = "kwt.internal.cwd_local_naming_sanitize"
 
 	// DefaultNamingTemplate is the starter naming template used for new global configs.
 	DefaultNamingTemplate = "{{.FullPath}}/{{.Branch}}"
@@ -84,7 +85,8 @@ func getLocalConfigPath() string {
 //
 // For repository_settings, merging is done by the `repository` field as the key.
 func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive bool) error {
-	viper.Set(cwdLocalNamingMarker, false)
+	viper.Set(cwdLocalNamingTemplateMarker, false)
+	viper.Set(cwdLocalNamingSanitizeMarker, false)
 	rawPath := getLocalConfigPath()
 	if rawPath == "" {
 		return nil
@@ -141,9 +143,12 @@ func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive boo
 		return fmt.Errorf("resolve local config paths %s: %w", absPath, err)
 	}
 	viper.Set(
-		cwdLocalNamingMarker,
-		localViper.IsSet("naming.template") ||
-			localViper.IsSet("naming.sanitize_chars"),
+		cwdLocalNamingTemplateMarker,
+		localViper.IsSet("naming.template"),
+	)
+	viper.Set(
+		cwdLocalNamingSanitizeMarker,
+		localViper.IsSet("naming.sanitize_chars"),
 	)
 
 	for _, key := range localViper.AllKeys() {
@@ -463,7 +468,8 @@ func LoadForTarget(repoRoot string, interactive bool) (*models.Config, error) {
 	if err := target.MergeConfigMap(viper.AllSettings()); err != nil {
 		return nil, fmt.Errorf("copy global config: %w", err)
 	}
-	repositoryLocalNaming := false
+	repositoryLocalTemplate := false
+	repositoryLocalSanitizeChars := false
 
 	path := filepath.Join(repoRoot, localConfigName+"."+configType)
 	if _, err := os.Lstat(path); err != nil {
@@ -507,8 +513,10 @@ func LoadForTarget(repoRoot string, interactive bool) (*models.Config, error) {
 				if pathErr := resolveTargetLocalPaths(local, repoRoot); pathErr != nil {
 					return nil, fmt.Errorf("resolve target config paths %s: %w", absPath, pathErr)
 				}
-				repositoryLocalNaming = local.IsSet("naming.template") ||
-					local.IsSet("naming.sanitize_chars")
+				repositoryLocalTemplate = local.IsSet("naming.template")
+				repositoryLocalSanitizeChars = local.IsSet(
+					"naming.sanitize_chars",
+				)
 				for _, key := range local.AllKeys() {
 					switch {
 					case key == "repository_settings":
@@ -531,7 +539,9 @@ func LoadForTarget(repoRoot string, interactive bool) (*models.Config, error) {
 	if err := expandConfigPaths(&cfg); err != nil {
 		return nil, err
 	}
-	cfg.Naming.RepositoryLocal = repositoryLocalNaming
+	cfg.Naming.TemplateRepositoryLocal = repositoryLocalTemplate
+	cfg.Naming.SanitizeCharsRepositoryLocal =
+		repositoryLocalSanitizeChars
 	return &cfg, nil
 }
 
@@ -669,7 +679,12 @@ func Load() (*models.Config, error) {
 	if err := expandConfigPaths(&cfg); err != nil {
 		return nil, err
 	}
-	cfg.Naming.RepositoryLocal = viper.GetBool(cwdLocalNamingMarker)
+	cfg.Naming.TemplateRepositoryLocal = viper.GetBool(
+		cwdLocalNamingTemplateMarker,
+	)
+	cfg.Naming.SanitizeCharsRepositoryLocal = viper.GetBool(
+		cwdLocalNamingSanitizeMarker,
+	)
 	return &cfg, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	worktreetemplate "go.kenn.io/kwt/internal/template"
 	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
@@ -563,11 +564,19 @@ func normalizeTargetConfigPath(path string) (string, error) {
 
 func resolveTargetLocalPaths(local *viper.Viper, repoRoot string) error {
 	repoRoot = utils.CanonicalPath(repoRoot)
-	if local.IsSet("naming.template") &&
-		targetPathHasEnvironmentReference(local.GetString("naming.template")) {
-		return fmt.Errorf(
-			"environment variable references are not allowed in repository-local naming templates",
-		)
+	if local.IsSet("naming.template") {
+		hasEnvironmentReference, err :=
+			worktreetemplate.LiteralTextHasEnvironmentReference(
+				local.GetString("naming.template"),
+			)
+		if err != nil {
+			return err
+		}
+		if hasEnvironmentReference {
+			return fmt.Errorf(
+				"environment variable references are not allowed in repository-local naming templates",
+			)
+		}
 	}
 	for _, replacement := range local.GetStringMapString(
 		"naming.sanitize_chars",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ const (
 	configType      = "toml"
 	localConfigName = ".kwt"
 
+	cwdLocalNamingMarker = "kwt.internal.cwd_local_naming"
+
 	// DefaultNamingTemplate is the starter naming template used for new global configs.
 	DefaultNamingTemplate = "{{.FullPath}}/{{.Branch}}"
 
@@ -81,6 +83,7 @@ func getLocalConfigPath() string {
 //
 // For repository_settings, merging is done by the `repository` field as the key.
 func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive bool) error {
+	viper.Set(cwdLocalNamingMarker, false)
 	rawPath := getLocalConfigPath()
 	if rawPath == "" {
 		return nil
@@ -130,6 +133,17 @@ func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive boo
 	if err := localViper.ReadConfig(bytes.NewReader(data)); err != nil {
 		return fmt.Errorf("parse local config %s: %w", absPath, err)
 	}
+	if err := resolveTargetLocalPaths(
+		localViper,
+		filepath.Dir(absPath),
+	); err != nil {
+		return fmt.Errorf("resolve local config paths %s: %w", absPath, err)
+	}
+	viper.Set(
+		cwdLocalNamingMarker,
+		localViper.IsSet("naming.template") ||
+			localViper.IsSet("naming.sanitize_chars"),
+	)
 
 	for _, key := range localViper.AllKeys() {
 		switch {
@@ -646,6 +660,7 @@ func Load() (*models.Config, error) {
 	if err := expandConfigPaths(&cfg); err != nil {
 		return nil, err
 	}
+	cfg.Naming.RepositoryLocal = viper.GetBool(cwdLocalNamingMarker)
 	return &cfg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1487,7 +1487,7 @@ template = "{{$branch := .Branch}}/{{$branch}}"
 	require.NoError(t, mergeLocalConfig(store, trustingPrompter(), true))
 }
 
-func TestMergeLocalConfigMarksNamingAsRepositoryLocal(t *testing.T) {
+func TestMergeLocalConfigTracksTemplateProvenanceSeparately(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
 	absPath, data := writeLocalConfig(
@@ -1512,9 +1512,34 @@ template = "{{.Repository}}/{{.Branch}}"
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if !cfg.Naming.RepositoryLocal {
-		t.Fatal("cwd naming was not marked repository-local")
+	assert.True(t, cfg.Naming.TemplateRepositoryLocal)
+	assert.False(t, cfg.Naming.SanitizeCharsRepositoryLocal)
+}
+
+func TestMergeLocalConfigTracksSanitizationProvenanceSeparately(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("naming.template", "$KWT_GROUP/{{.Branch}}")
+	absPath, data := writeLocalConfig(
+		t,
+		t.TempDir(),
+		[]byte(`
+[naming.sanitize_chars]
+"/" = "-"
+`),
+	)
+	store := &TrustStore{
+		entries: []trustEntry{{
+			Path:   absPath,
+			SHA256: computeSHA256(data),
+		}},
 	}
+
+	require.NoError(t, mergeLocalConfig(store, trustingPrompter(), true))
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.False(t, cfg.Naming.TemplateRepositoryLocal)
+	assert.True(t, cfg.Naming.SanitizeCharsRepositoryLocal)
 }
 
 func TestDefaultLayoutsConfig(t *testing.T) {
@@ -1894,7 +1919,8 @@ template = '{{printf "%c%s" 36 "KWT_GITHUB_TOKEN"}}/{{.Branch}}'
 	cfg, err := LoadForTarget(target, false)
 
 	require.NoError(t, err)
-	assert.True(t, cfg.Naming.RepositoryLocal)
+	assert.True(t, cfg.Naming.TemplateRepositoryLocal)
+	assert.False(t, cfg.Naming.SanitizeCharsRepositoryLocal)
 }
 
 func TestLoadForTargetMergesEquivalentGlobalAndLocalRepositoryPaths(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1466,6 +1466,27 @@ template = "$KWT_GITHUB_TOKEN/{{.Branch}}"
 	}
 }
 
+func TestMergeLocalConfigAllowsTemplateVariablesNamedWithDollar(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	absPath, data := writeLocalConfig(
+		t,
+		t.TempDir(),
+		[]byte(`
+[naming]
+template = "{{$branch := .Branch}}/{{$branch}}"
+`),
+	)
+	store := &TrustStore{
+		entries: []trustEntry{{
+			Path:   absPath,
+			SHA256: computeSHA256(data),
+		}},
+	}
+
+	require.NoError(t, mergeLocalConfig(store, trustingPrompter(), true))
+}
+
 func TestMergeLocalConfigMarksNamingAsRepositoryLocal(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1420,6 +1420,82 @@ copy_files = [".env.evil"]
 	})
 }
 
+func TestMergeLocalConfigRejectsEnvironmentReferencesInNaming(t *testing.T) {
+	tests := []struct {
+		name  string
+		local string
+	}{
+		{
+			name: "template",
+			local: `
+[naming]
+template = "$KWT_GITHUB_TOKEN/{{.Branch}}"
+`,
+		},
+		{
+			name: "replacement",
+			local: `
+[naming.sanitize_chars]
+"/" = "$KWT_GITHUB_TOKEN"
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			absPath, data := writeLocalConfig(
+				t,
+				t.TempDir(),
+				[]byte(tt.local),
+			)
+			store := &TrustStore{
+				entries: []trustEntry{{
+					Path:   absPath,
+					SHA256: computeSHA256(data),
+				}},
+			}
+
+			err := mergeLocalConfig(store, trustingPrompter(), true)
+
+			if err == nil ||
+				!strings.Contains(err.Error(), "environment variable references") {
+				t.Fatalf("mergeLocalConfig() error = %v, want environment rejection", err)
+			}
+		})
+	}
+}
+
+func TestMergeLocalConfigMarksNamingAsRepositoryLocal(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	absPath, data := writeLocalConfig(
+		t,
+		t.TempDir(),
+		[]byte(`
+[naming]
+template = "{{.Repository}}/{{.Branch}}"
+`),
+	)
+	store := &TrustStore{
+		entries: []trustEntry{{
+			Path:   absPath,
+			SHA256: computeSHA256(data),
+		}},
+	}
+
+	if err := mergeLocalConfig(store, trustingPrompter(), true); err != nil {
+		t.Fatalf("mergeLocalConfig() error = %v", err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.Naming.RepositoryLocal {
+		t.Fatal("cwd naming was not marked repository-local")
+	}
+}
+
 func TestDefaultLayoutsConfig(t *testing.T) {
 	// Isolate HOME so Init() reads and writes a throwaway config dir,
 	// never the real ~/.config/kwt (Init calls viper.SafeWriteConfig).

--- a/internal/config/workspace.go
+++ b/internal/config/workspace.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -26,6 +27,9 @@ func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
 	}
 	if !info.IsDir() {
 		return models.Workspace{}, fmt.Errorf("workspace path %s is not a directory", workspace.Path)
+	}
+	if err := tmux.ValidateStartDirectory(path); err != nil {
+		return models.Workspace{}, err
 	}
 	workspace.Path = path
 	if strings.TrimSpace(workspace.Name) == "" {

--- a/internal/config/workspace_test.go
+++ b/internal/config/workspace_test.go
@@ -67,6 +67,17 @@ func TestRegisterWorkspaceRejectsFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a directory")
 }
 
+func TestRegisterWorkspaceRejectsTmuxFormatPath(t *testing.T) {
+	workspaceTestEnv(t)
+	dir := filepath.Join(t.TempDir(), "notes#archive")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	_, err := RegisterWorkspace(models.Workspace{Path: dir})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tmux format syntax")
+}
+
 func TestRegisterWorkspaceWrapsStatErrorWhenParentIsFile(t *testing.T) {
 	workspaceTestEnv(t)
 	file := filepath.Join(t.TempDir(), "notes.txt")

--- a/internal/credentials/environment.go
+++ b/internal/credentials/environment.go
@@ -1,0 +1,52 @@
+// Package credentials centralizes environment-variable names that must not
+// cross into repository-controlled processes.
+package credentials
+
+import (
+	"strings"
+
+	"go.kenn.io/kwt/pkg/models"
+)
+
+// ProtectedNames returns kwt's built-in credential variables plus the
+// configured fleet token variable.
+func ProtectedNames(cfg *models.Config) []string {
+	names := []string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN"}
+	if cfg != nil {
+		names = append(names, cfg.Fleet.TokenEnv)
+	}
+	protected := make([]string, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		folded := strings.ToLower(name)
+		if name == "" || seen[folded] {
+			continue
+		}
+		seen[folded] = true
+		protected = append(protected, name)
+	}
+	return protected
+}
+
+// StripEnvironment removes protected variables case-insensitively. Windows
+// environment names are case-insensitive, and preserving that rule here keeps
+// alternate casing from bypassing checkout isolation.
+func StripEnvironment(env, protectedNames []string) []string {
+	protected := make(map[string]bool, len(protectedNames))
+	for _, name := range protectedNames {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			protected[strings.ToLower(name)] = true
+		}
+	}
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && protected[strings.ToLower(name)] {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -39,6 +39,16 @@ type worktreeCandidate struct {
 // identity wins over a fork origin; see worktree.RepositoryInfoWithProjects);
 // pass nil when no registry is available.
 func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*GlobalWorktreeEntry, error) {
+	return DiscoverGlobalWorktreesFiltered(baseDir, projects, nil)
+}
+
+// DiscoverGlobalWorktreesFiltered finds global worktrees while excluding
+// matching paths before any Git command runs inside them.
+func DiscoverGlobalWorktreesFiltered(
+	baseDir string,
+	projects []models.Project,
+	skipWorktree func(string) bool,
+) ([]*GlobalWorktreeEntry, error) {
 	if baseDir == "" {
 		return nil, fmt.Errorf("base directory not configured")
 	}
@@ -108,7 +118,12 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 		return nil, fmt.Errorf("failed to walk directory: %w", err)
 	}
 
-	return extractWorktreeCandidates(candidates, projects, extractWorktreeInfo), nil
+	return extractWorktreeCandidates(
+		candidates,
+		projects,
+		skipWorktree,
+		extractWorktreeInfo,
+	), nil
 }
 
 // DiscoverWorktree resolves one exact worktree root independently of the
@@ -142,6 +157,7 @@ func DiscoverWorktree(path string, projects []models.Project) (*GlobalWorktreeEn
 func extractWorktreeCandidates(
 	candidates []worktreeCandidate,
 	projects []models.Project,
+	skipWorktree func(string) bool,
 	extract func(string, []models.Project) (*GlobalWorktreeEntry, error),
 ) []*GlobalWorktreeEntry {
 	if len(candidates) == 0 {
@@ -168,6 +184,9 @@ func extractWorktreeCandidates(
 		}()
 	}
 	for index := range candidates {
+		if skipWorktree != nil && skipWorktree(candidates[index].path) {
+			continue
+		}
 		jobs <- index
 	}
 	close(jobs)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -39,16 +39,6 @@ type worktreeCandidate struct {
 // identity wins over a fork origin; see worktree.RepositoryInfoWithProjects);
 // pass nil when no registry is available.
 func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*GlobalWorktreeEntry, error) {
-	return DiscoverGlobalWorktreesFiltered(baseDir, projects, nil)
-}
-
-// DiscoverGlobalWorktreesFiltered finds global worktrees while excluding
-// matching paths before any Git command runs inside them.
-func DiscoverGlobalWorktreesFiltered(
-	baseDir string,
-	projects []models.Project,
-	skipWorktree func(string) bool,
-) ([]*GlobalWorktreeEntry, error) {
 	if baseDir == "" {
 		return nil, fmt.Errorf("base directory not configured")
 	}
@@ -121,7 +111,6 @@ func DiscoverGlobalWorktreesFiltered(
 	return extractWorktreeCandidates(
 		candidates,
 		projects,
-		skipWorktree,
 		extractWorktreeInfo,
 	), nil
 }
@@ -157,7 +146,6 @@ func DiscoverWorktree(path string, projects []models.Project) (*GlobalWorktreeEn
 func extractWorktreeCandidates(
 	candidates []worktreeCandidate,
 	projects []models.Project,
-	skipWorktree func(string) bool,
 	extract func(string, []models.Project) (*GlobalWorktreeEntry, error),
 ) []*GlobalWorktreeEntry {
 	if len(candidates) == 0 {
@@ -184,9 +172,6 @@ func extractWorktreeCandidates(
 		}()
 	}
 	for index := range candidates {
-		if skipWorktree != nil && skipWorktree(candidates[index].path) {
-			continue
-		}
 		jobs <- index
 	}
 	close(jobs)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -427,7 +427,6 @@ func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T
 		done <- extractWorktreeCandidates(
 			candidates,
 			nil,
-			nil,
 			func(path string, _ []models.Project) (*GlobalWorktreeEntry, error) {
 				started <- path
 				<-release
@@ -451,34 +450,6 @@ func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T
 	}
 	if entries[0].Path != candidates[0].path || entries[1].Path != candidates[1].path {
 		t.Fatalf("Candidate order changed: %#v", entries)
-	}
-}
-
-func TestExtractWorktreeCandidatesSkipsBeforeInspection(t *testing.T) {
-	inspected := make(chan string, 1)
-	entries := extractWorktreeCandidates(
-		[]worktreeCandidate{
-			{path: "/worktrees/unreviewed"},
-			{path: "/worktrees/trusted"},
-		},
-		nil,
-		func(path string) bool {
-			return path == "/worktrees/unreviewed"
-		},
-		func(path string, _ []models.Project) (*GlobalWorktreeEntry, error) {
-			inspected <- path
-			return &GlobalWorktreeEntry{Path: path}, nil
-		},
-	)
-	close(inspected)
-
-	if len(entries) != 1 || entries[0].Path != "/worktrees/trusted" {
-		t.Fatalf("entries = %+v, want only trusted worktree", entries)
-	}
-	for path := range inspected {
-		if path == "/worktrees/unreviewed" {
-			t.Fatal("unreviewed worktree was inspected")
-		}
 	}
 }
 

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -427,6 +427,7 @@ func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T
 		done <- extractWorktreeCandidates(
 			candidates,
 			nil,
+			nil,
 			func(path string, _ []models.Project) (*GlobalWorktreeEntry, error) {
 				started <- path
 				<-release
@@ -450,6 +451,34 @@ func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T
 	}
 	if entries[0].Path != candidates[0].path || entries[1].Path != candidates[1].path {
 		t.Fatalf("Candidate order changed: %#v", entries)
+	}
+}
+
+func TestExtractWorktreeCandidatesSkipsBeforeInspection(t *testing.T) {
+	inspected := make(chan string, 1)
+	entries := extractWorktreeCandidates(
+		[]worktreeCandidate{
+			{path: "/worktrees/unreviewed"},
+			{path: "/worktrees/trusted"},
+		},
+		nil,
+		func(path string) bool {
+			return path == "/worktrees/unreviewed"
+		},
+		func(path string, _ []models.Project) (*GlobalWorktreeEntry, error) {
+			inspected <- path
+			return &GlobalWorktreeEntry{Path: path}, nil
+		},
+	)
+	close(inspected)
+
+	if len(entries) != 1 || entries[0].Path != "/worktrees/trusted" {
+		t.Fatalf("entries = %+v, want only trusted worktree", entries)
+	}
+	for path := range inspected {
+		if path == "/worktrees/unreviewed" {
+			t.Fatal("unreviewed worktree was inspected")
+		}
 	}
 }
 

--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -101,16 +101,7 @@ func (f *Finder) SelectBranch(branches []models.Branch) (*models.Branch, error) 
 
 	idx, err := fuzzyfinder.Find(
 		branches,
-		func(i int) string {
-			branch := branches[i]
-			marker := ""
-			if branch.IsCurrent {
-				marker = "* "
-			} else if branch.IsRemote {
-				marker = "→ "
-			}
-			return fmt.Sprintf("%s%s", marker, branch.Name)
-		},
+		f.formatBranchForDisplay(branches),
 		opts...,
 	)
 
@@ -119,6 +110,25 @@ func (f *Finder) SelectBranch(branches []models.Branch) (*models.Branch, error) 
 	}
 
 	return &branches[idx], nil
+}
+
+func (f *Finder) formatBranchForDisplay(
+	branches []models.Branch,
+) func(int) string {
+	return func(i int) string {
+		branch := branches[i]
+		marker := ""
+		if branch.IsCurrent {
+			marker = "* "
+		} else if branch.IsRemote {
+			marker = "→ "
+		}
+		label := strings.TrimSpace(branch.Label)
+		if label == "" {
+			label = branch.Name
+		}
+		return marker + label
+	}
 }
 
 // SelectMultipleWorktrees displays a fuzzy finder for multiple worktree selection.
@@ -339,11 +349,17 @@ func (f *Finder) generateBranchPreview(branch models.Branch, maxLines int) strin
 	preview := []string{
 		fmt.Sprintf("Branch: %s", branch.Name),
 		fmt.Sprintf("Type: %s", branchType),
+	}
+	if branch.Source != "" {
+		preview = append(preview, fmt.Sprintf("Source: %s", branch.Source))
+	}
+	preview = append(
+		preview,
 		fmt.Sprintf("Last commit: %s", truncateMessage(branch.LastCommit.Message, 60)),
 		fmt.Sprintf("Author: %s", branch.LastCommit.Author),
 		fmt.Sprintf("Date: %s", branch.LastCommit.Date.Format("2006-01-02 15:04")),
 		fmt.Sprintf("Hash: %s", truncateHash(branch.LastCommit.Hash)),
-	}
+	)
 
 	return strings.Join(preview[:min(len(preview), maxLines)], "\n")
 }

--- a/internal/finder/finder_test.go
+++ b/internal/finder/finder_test.go
@@ -85,6 +85,36 @@ func TestSelectBranch_EmptyList(t *testing.T) {
 	}
 }
 
+func TestBranchDisplayAndPreviewIncludeRemoteSource(t *testing.T) {
+	branches := []models.Branch{
+		{
+			Name:     "topic",
+			Label:    "topic (origin/topic)",
+			Source:   "refs/remotes/origin/topic",
+			IsRemote: true,
+		},
+		{
+			Name:     "topic",
+			Label:    "topic (upstream/topic)",
+			Source:   "refs/remotes/upstream/topic",
+			IsRemote: true,
+		},
+	}
+	finder := &Finder{}
+	display := finder.formatBranchForDisplay(branches)
+
+	if got := display(0); got != "→ topic (origin/topic)" {
+		t.Fatalf("origin display = %q, want source-qualified label", got)
+	}
+	if got := display(1); got != "→ topic (upstream/topic)" {
+		t.Fatalf("upstream display = %q, want source-qualified label", got)
+	}
+	preview := finder.generateBranchPreview(branches[1], 20)
+	if !strings.Contains(preview, "Source: refs/remotes/upstream/topic") {
+		t.Fatalf("remote preview omitted source:\n%s", preview)
+	}
+}
+
 func TestSelectMultipleWorktrees_EmptyList(t *testing.T) {
 	finder := &Finder{}
 	worktrees := []models.Worktree{}

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.kenn.io/kwt/internal/discovery"
@@ -25,7 +26,9 @@ type ManifestBuilderOptions struct {
 	Now                     func() time.Time
 	Hostname                func() (string, error)
 	DiscoverGlobalWorktrees func(
-		baseDir string, projects []models.Project,
+		baseDir string,
+		projects []models.Project,
+		skipWorktree func(string) bool,
 	) ([]*discovery.GlobalWorktreeEntry, error)
 	ListProjectWorktrees func(ctx context.Context, project models.Project) ([]models.Worktree, error)
 	ExcludeWorktree      func(path string) (bool, error)
@@ -36,7 +39,9 @@ type ManifestBuilder struct {
 	now                     func() time.Time
 	hostname                func() (string, error)
 	discoverGlobalWorktrees func(
-		baseDir string, projects []models.Project,
+		baseDir string,
+		projects []models.Project,
+		skipWorktree func(string) bool,
 	) ([]*discovery.GlobalWorktreeEntry, error)
 	listProjectWorktrees func(ctx context.Context, project models.Project) ([]models.Worktree, error)
 	excludeWorktree      func(path string) (bool, error)
@@ -58,7 +63,8 @@ func NewManifestBuilder(opts ManifestBuilderOptions) *ManifestBuilder {
 		builder.hostname = os.Hostname
 	}
 	if builder.discoverGlobalWorktrees == nil {
-		builder.discoverGlobalWorktrees = discovery.DiscoverGlobalWorktrees
+		builder.discoverGlobalWorktrees =
+			discovery.DiscoverGlobalWorktreesFiltered
 	}
 	if builder.listProjectWorktrees == nil {
 		builder.listProjectWorktrees = func(ctx context.Context, project models.Project) ([]models.Worktree, error) {
@@ -177,6 +183,13 @@ func (b *ManifestBuilder) addConfiguredProject(
 	if !ok {
 		return nil
 	}
+	excluded, err := b.shouldExcludeWorktree(projectPath)
+	if err != nil {
+		return err
+	}
+	if excluded {
+		return nil
+	}
 	project.Path = projectPath
 
 	worktrees, err := b.listProjectWorktrees(ctx, project)
@@ -226,9 +239,35 @@ func (b *ManifestBuilder) addGlobalWorktrees(
 		return nil
 	}
 
-	entries, err := b.discoverGlobalWorktrees(baseDir, cfg.Projects)
+	var (
+		excludeMu  sync.Mutex
+		excludeErr error
+	)
+	skipWorktree := func(path string) bool {
+		excluded, err := b.shouldExcludeWorktree(path)
+		if err != nil {
+			excludeMu.Lock()
+			if excludeErr == nil {
+				excludeErr = err
+			}
+			excludeMu.Unlock()
+			return true
+		}
+		return excluded
+	}
+	entries, err := b.discoverGlobalWorktrees(
+		baseDir,
+		cfg.Projects,
+		skipWorktree,
+	)
 	if err != nil {
 		return fmt.Errorf("discover global worktrees: %w", err)
+	}
+	excludeMu.Lock()
+	err = excludeErr
+	excludeMu.Unlock()
+	if err != nil {
+		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
@@ -285,14 +324,12 @@ func (b *ManifestBuilder) addWorktree(
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	if b.excludeWorktree != nil {
-		excluded, err := b.excludeWorktree(worktree.Path)
-		if err != nil {
-			return false, fmt.Errorf("check worktree inspection state: %w", err)
-		}
-		if excluded {
-			return false, nil
-		}
+	excluded, err := b.shouldExcludeWorktree(worktree.Path)
+	if err != nil {
+		return false, err
+	}
+	if excluded {
+		return false, nil
 	}
 	path, ok := observablePath(worktree.Path)
 	if !ok || hasSeenPath(seenWorktreePaths, path) {
@@ -310,6 +347,19 @@ func (b *ManifestBuilder) addWorktree(
 	seenWorktreePaths[canonicalPathKey(path)] = struct{}{}
 	manifest.Worktrees = append(manifest.Worktrees, row)
 	return true, nil
+}
+
+func (b *ManifestBuilder) shouldExcludeWorktree(
+	path string,
+) (bool, error) {
+	if b.excludeWorktree == nil {
+		return false, nil
+	}
+	excluded, err := b.excludeWorktree(path)
+	if err != nil {
+		return false, fmt.Errorf("check worktree inspection state: %w", err)
+	}
+	return excluded, nil
 }
 
 func buildWorktreeManifest(ctx context.Context, cfg *models.Config, projectIdentity string, worktree models.Worktree) (WorktreeManifest, bool, error) {

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"go.kenn.io/kwt/internal/discovery"
@@ -28,10 +27,8 @@ type ManifestBuilderOptions struct {
 	DiscoverGlobalWorktrees func(
 		baseDir string,
 		projects []models.Project,
-		skipWorktree func(string) bool,
 	) ([]*discovery.GlobalWorktreeEntry, error)
 	ListProjectWorktrees func(ctx context.Context, project models.Project) ([]models.Worktree, error)
-	ExcludeWorktree      func(path string) (bool, error)
 }
 
 // ManifestBuilder builds local advisory fleet manifests.
@@ -41,10 +38,8 @@ type ManifestBuilder struct {
 	discoverGlobalWorktrees func(
 		baseDir string,
 		projects []models.Project,
-		skipWorktree func(string) bool,
 	) ([]*discovery.GlobalWorktreeEntry, error)
 	listProjectWorktrees func(ctx context.Context, project models.Project) ([]models.Worktree, error)
-	excludeWorktree      func(path string) (bool, error)
 }
 
 // NewManifestBuilder creates a manifest builder with optional dependency hooks.
@@ -54,7 +49,6 @@ func NewManifestBuilder(opts ManifestBuilderOptions) *ManifestBuilder {
 		hostname:                opts.Hostname,
 		discoverGlobalWorktrees: opts.DiscoverGlobalWorktrees,
 		listProjectWorktrees:    opts.ListProjectWorktrees,
-		excludeWorktree:         opts.ExcludeWorktree,
 	}
 	if builder.now == nil {
 		builder.now = time.Now
@@ -63,8 +57,7 @@ func NewManifestBuilder(opts ManifestBuilderOptions) *ManifestBuilder {
 		builder.hostname = os.Hostname
 	}
 	if builder.discoverGlobalWorktrees == nil {
-		builder.discoverGlobalWorktrees =
-			discovery.DiscoverGlobalWorktreesFiltered
+		builder.discoverGlobalWorktrees = discovery.DiscoverGlobalWorktrees
 	}
 	if builder.listProjectWorktrees == nil {
 		builder.listProjectWorktrees = func(ctx context.Context, project models.Project) ([]models.Worktree, error) {
@@ -183,13 +176,6 @@ func (b *ManifestBuilder) addConfiguredProject(
 	if !ok {
 		return nil
 	}
-	excluded, err := b.shouldExcludeWorktree(projectPath)
-	if err != nil {
-		return err
-	}
-	if excluded {
-		return nil
-	}
 	project.Path = projectPath
 
 	worktrees, err := b.listProjectWorktrees(ctx, project)
@@ -239,35 +225,12 @@ func (b *ManifestBuilder) addGlobalWorktrees(
 		return nil
 	}
 
-	var (
-		excludeMu  sync.Mutex
-		excludeErr error
-	)
-	skipWorktree := func(path string) bool {
-		excluded, err := b.shouldExcludeWorktree(path)
-		if err != nil {
-			excludeMu.Lock()
-			if excludeErr == nil {
-				excludeErr = err
-			}
-			excludeMu.Unlock()
-			return true
-		}
-		return excluded
-	}
 	entries, err := b.discoverGlobalWorktrees(
 		baseDir,
 		cfg.Projects,
-		skipWorktree,
 	)
 	if err != nil {
 		return fmt.Errorf("discover global worktrees: %w", err)
-	}
-	excludeMu.Lock()
-	err = excludeErr
-	excludeMu.Unlock()
-	if err != nil {
-		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
@@ -324,13 +287,6 @@ func (b *ManifestBuilder) addWorktree(
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	excluded, err := b.shouldExcludeWorktree(worktree.Path)
-	if err != nil {
-		return false, err
-	}
-	if excluded {
-		return false, nil
-	}
 	path, ok := observablePath(worktree.Path)
 	if !ok || hasSeenPath(seenWorktreePaths, path) {
 		return false, nil
@@ -347,19 +303,6 @@ func (b *ManifestBuilder) addWorktree(
 	seenWorktreePaths[canonicalPathKey(path)] = struct{}{}
 	manifest.Worktrees = append(manifest.Worktrees, row)
 	return true, nil
-}
-
-func (b *ManifestBuilder) shouldExcludeWorktree(
-	path string,
-) (bool, error) {
-	if b.excludeWorktree == nil {
-		return false, nil
-	}
-	excluded, err := b.excludeWorktree(path)
-	if err != nil {
-		return false, fmt.Errorf("check worktree inspection state: %w", err)
-	}
-	return excluded, nil
 }
 
 func buildWorktreeManifest(ctx context.Context, cfg *models.Config, projectIdentity string, worktree models.Worktree) (WorktreeManifest, bool, error) {

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -28,6 +28,7 @@ type ManifestBuilderOptions struct {
 		baseDir string, projects []models.Project,
 	) ([]*discovery.GlobalWorktreeEntry, error)
 	ListProjectWorktrees func(ctx context.Context, project models.Project) ([]models.Worktree, error)
+	ExcludeWorktree      func(path string) (bool, error)
 }
 
 // ManifestBuilder builds local advisory fleet manifests.
@@ -38,6 +39,7 @@ type ManifestBuilder struct {
 		baseDir string, projects []models.Project,
 	) ([]*discovery.GlobalWorktreeEntry, error)
 	listProjectWorktrees func(ctx context.Context, project models.Project) ([]models.Worktree, error)
+	excludeWorktree      func(path string) (bool, error)
 }
 
 // NewManifestBuilder creates a manifest builder with optional dependency hooks.
@@ -47,6 +49,7 @@ func NewManifestBuilder(opts ManifestBuilderOptions) *ManifestBuilder {
 		hostname:                opts.Hostname,
 		discoverGlobalWorktrees: opts.DiscoverGlobalWorktrees,
 		listProjectWorktrees:    opts.ListProjectWorktrees,
+		excludeWorktree:         opts.ExcludeWorktree,
 	}
 	if builder.now == nil {
 		builder.now = time.Now
@@ -281,6 +284,15 @@ func (b *ManifestBuilder) addWorktree(
 ) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
+	}
+	if b.excludeWorktree != nil {
+		excluded, err := b.excludeWorktree(worktree.Path)
+		if err != nil {
+			return false, fmt.Errorf("check worktree inspection state: %w", err)
+		}
+		if excluded {
+			return false, nil
+		}
 	}
 	path, ok := observablePath(worktree.Path)
 	if !ok || hasSeenPath(seenWorktreePaths, path) {

--- a/internal/fleet/manifest_test.go
+++ b/internal/fleet/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +42,41 @@ func TestBuildManifestIncludesConfiguredProjectWorktrees(t *testing.T) {
 	assert.Equal(t, fixedTime, manifest.ObservedAt)
 	assert.Contains(t, worktreeRefs(manifest), "branch:feature/fleet")
 	assert.Equal(t, "github.com/kenn-io/kwt", manifest.Projects[0].Identity)
+}
+
+func TestBuildManifestExcludesUnreviewedWorktreeBeforeGitInspection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable fsmonitor hook fixture requires a POSIX shell")
+	}
+	repo := initFleetTestRepo(t, "https://github.com/kenn-io/kwt.git")
+	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
+	hook := filepath.Join(t.TempDir(), "fsmonitor")
+	require.NoError(t, os.WriteFile(
+		hook,
+		[]byte("#!/bin/sh\nprintf ran > \""+marker+"\"\nprintf '0\\n'\n"),
+		0755,
+	))
+	runGit(t, repo, "config", "core.fsmonitor", hook)
+
+	cfg := &models.Config{
+		Fleet: models.FleetConfig{HostID: "host-a"},
+		Projects: []models.Project{{
+			Repository: "github.com/kenn-io/kwt",
+			Name:       "kwt",
+			Path:       repo,
+		}},
+	}
+	manifest, err := NewManifestBuilder(ManifestBuilderOptions{
+		Now:      func() time.Time { return fixedTime },
+		Hostname: func() (string, error) { return "Host-A", nil },
+		ExcludeWorktree: func(string) (bool, error) {
+			return true, nil
+		},
+	}).Build(context.Background(), cfg)
+
+	require.NoError(t, err)
+	assert.Empty(t, manifest.Worktrees)
+	assert.NoFileExists(t, marker)
 }
 
 func TestBuildManifestKeysDetachedWorktreeByHead(t *testing.T) {

--- a/internal/fleet/manifest_test.go
+++ b/internal/fleet/manifest_test.go
@@ -245,7 +245,11 @@ func TestBuildManifestGlobalFallbackPreservesRegisteredIdentity(t *testing.T) {
 		ListProjectWorktrees: func(context.Context, models.Project) ([]models.Worktree, error) {
 			return nil, errors.New("configured listing unavailable")
 		},
-		DiscoverGlobalWorktrees: func(string, []models.Project) ([]*discovery.GlobalWorktreeEntry, error) {
+		DiscoverGlobalWorktrees: func(
+			string,
+			[]models.Project,
+			func(string) bool,
+		) ([]*discovery.GlobalWorktreeEntry, error) {
 			return []*discovery.GlobalWorktreeEntry{{
 				RepositoryURL:  "https://github.com/fork/kwt.git",
 				RepositoryInfo: registered,
@@ -269,6 +273,32 @@ func TestBuildManifestGlobalFallbackPreservesRegisteredIdentity(t *testing.T) {
 	assert.Equal(t, "github.com/kenn-io/kwt", manifest.Projects[0].Identity)
 	require.Len(t, manifest.Worktrees, 1)
 	assert.Equal(t, "github.com/kenn-io/kwt", manifest.Worktrees[0].ProjectIdentity)
+}
+
+func TestBuildManifestExcludesGlobalWorktreeBeforeDiscoveryInspection(t *testing.T) {
+	const unreviewedPath = "/worktrees/unreviewed"
+	checkedBeforeInspection := false
+	manifest, err := NewManifestBuilder(ManifestBuilderOptions{
+		Hostname: func() (string, error) { return "host-a", nil },
+		DiscoverGlobalWorktrees: func(
+			_ string,
+			_ []models.Project,
+			skip func(string) bool,
+		) ([]*discovery.GlobalWorktreeEntry, error) {
+			checkedBeforeInspection = skip(unreviewedPath)
+			return nil, nil
+		},
+		ExcludeWorktree: func(path string) (bool, error) {
+			return path == unreviewedPath, nil
+		},
+	}).Build(context.Background(), &models.Config{
+		Fleet:    models.FleetConfig{HostID: "host-a"},
+		Worktree: models.WorktreeConfig{BaseDir: "/worktrees"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, manifest)
+	assert.True(t, checkedBeforeInspection)
 }
 
 func TestBuildManifestReturnsCanceledContext(t *testing.T) {

--- a/internal/fleet/manifest_test.go
+++ b/internal/fleet/manifest_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -42,41 +41,6 @@ func TestBuildManifestIncludesConfiguredProjectWorktrees(t *testing.T) {
 	assert.Equal(t, fixedTime, manifest.ObservedAt)
 	assert.Contains(t, worktreeRefs(manifest), "branch:feature/fleet")
 	assert.Equal(t, "github.com/kenn-io/kwt", manifest.Projects[0].Identity)
-}
-
-func TestBuildManifestExcludesUnreviewedWorktreeBeforeGitInspection(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("executable fsmonitor hook fixture requires a POSIX shell")
-	}
-	repo := initFleetTestRepo(t, "https://github.com/kenn-io/kwt.git")
-	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
-	hook := filepath.Join(t.TempDir(), "fsmonitor")
-	require.NoError(t, os.WriteFile(
-		hook,
-		[]byte("#!/bin/sh\nprintf ran > \""+marker+"\"\nprintf '0\\n'\n"),
-		0755,
-	))
-	runGit(t, repo, "config", "core.fsmonitor", hook)
-
-	cfg := &models.Config{
-		Fleet: models.FleetConfig{HostID: "host-a"},
-		Projects: []models.Project{{
-			Repository: "github.com/kenn-io/kwt",
-			Name:       "kwt",
-			Path:       repo,
-		}},
-	}
-	manifest, err := NewManifestBuilder(ManifestBuilderOptions{
-		Now:      func() time.Time { return fixedTime },
-		Hostname: func() (string, error) { return "Host-A", nil },
-		ExcludeWorktree: func(string) (bool, error) {
-			return true, nil
-		},
-	}).Build(context.Background(), cfg)
-
-	require.NoError(t, err)
-	assert.Empty(t, manifest.Worktrees)
-	assert.NoFileExists(t, marker)
 }
 
 func TestBuildManifestKeysDetachedWorktreeByHead(t *testing.T) {
@@ -248,7 +212,6 @@ func TestBuildManifestGlobalFallbackPreservesRegisteredIdentity(t *testing.T) {
 		DiscoverGlobalWorktrees: func(
 			string,
 			[]models.Project,
-			func(string) bool,
 		) ([]*discovery.GlobalWorktreeEntry, error) {
 			return []*discovery.GlobalWorktreeEntry{{
 				RepositoryURL:  "https://github.com/fork/kwt.git",
@@ -273,32 +236,6 @@ func TestBuildManifestGlobalFallbackPreservesRegisteredIdentity(t *testing.T) {
 	assert.Equal(t, "github.com/kenn-io/kwt", manifest.Projects[0].Identity)
 	require.Len(t, manifest.Worktrees, 1)
 	assert.Equal(t, "github.com/kenn-io/kwt", manifest.Worktrees[0].ProjectIdentity)
-}
-
-func TestBuildManifestExcludesGlobalWorktreeBeforeDiscoveryInspection(t *testing.T) {
-	const unreviewedPath = "/worktrees/unreviewed"
-	checkedBeforeInspection := false
-	manifest, err := NewManifestBuilder(ManifestBuilderOptions{
-		Hostname: func() (string, error) { return "host-a", nil },
-		DiscoverGlobalWorktrees: func(
-			_ string,
-			_ []models.Project,
-			skip func(string) bool,
-		) ([]*discovery.GlobalWorktreeEntry, error) {
-			checkedBeforeInspection = skip(unreviewedPath)
-			return nil, nil
-		},
-		ExcludeWorktree: func(path string) (bool, error) {
-			return path == unreviewedPath, nil
-		},
-	}).Build(context.Background(), &models.Config{
-		Fleet:    models.FleetConfig{HostID: "host-a"},
-		Worktree: models.WorktreeConfig{BaseDir: "/worktrees"},
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, manifest)
-	assert.True(t, checkedBeforeInspection)
 }
 
 func TestBuildManifestReturnsCanceledContext(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -60,6 +60,31 @@ func (g *Git) run(args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
+// runWithoutKWTCredentials executes a Git operation that may run checkout
+// hooks or filters against untrusted content without exposing kwt tokens.
+func (g *Git) runWithoutKWTCredentials(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if g.workDir != "" {
+		cmd.Dir = g.workDir
+	}
+	cmd.Env = make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && (name == "KWT_GITHUB_TOKEN" || name == "KWT_FLEET_TOKEN") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, entry)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), stderr.String())
+	}
+	return stdout.String(), nil
+}
+
 // runWithContext executes a git command with context support.
 func (g *Git) runWithContext(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"go.kenn.io/kwt/internal/credentials"
 )
 
 // Git provides Git command operations.
@@ -60,21 +62,17 @@ func (g *Git) run(args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-// runWithoutKWTCredentials executes a Git operation that may run checkout
-// hooks or filters against untrusted content without exposing kwt tokens.
-func (g *Git) runWithoutKWTCredentials(args ...string) (string, error) {
+// runWithoutCredentials executes a Git operation that may run against
+// untrusted content without exposing caller-supplied credentials.
+func (g *Git) runWithoutCredentials(
+	protectedNames []string,
+	args ...string,
+) (string, error) {
 	cmd := exec.Command("git", args...)
 	if g.workDir != "" {
 		cmd.Dir = g.workDir
 	}
-	cmd.Env = make([]string, 0, len(os.Environ()))
-	for _, entry := range os.Environ() {
-		name, _, ok := strings.Cut(entry, "=")
-		if ok && (name == "KWT_GITHUB_TOKEN" || name == "KWT_FLEET_TOKEN") {
-			continue
-		}
-		cmd.Env = append(cmd.Env, entry)
-	}
+	cmd.Env = credentials.StripEnvironment(os.Environ(), protectedNames)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 
 // ListBranches returns a list of all branches.
 func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
-	args := []string{"branch", "-v", "--format=%(refname)|%(refname:short)|%(HEAD)|%(committerdate:iso)|%(objectname)|%(subject)|%(authorname)"}
+	args := []string{"branch", "-v", "--format=%(refname)|%(HEAD)|%(committerdate:iso)|%(objectname)|%(subject)|%(authorname)"}
 	if includeRemote {
 		args = append(args, "-a")
 	}
@@ -29,25 +30,35 @@ func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 		}
 
 		parts := strings.Split(line, "|")
-		if len(parts) < 7 {
+		if len(parts) < 6 {
 			continue
 		}
 
 		fullRef := parts[0]
-		name := parts[1]
-		isCurrent := parts[2] == "*"
-		dateStr := parts[3]
-		hash := parts[4]
-		message := parts[5]
-		author := parts[6]
-
-		isRemote := strings.HasPrefix(fullRef, "refs/remotes/")
+		var name, source string
+		var isRemote bool
+		switch {
+		case strings.HasPrefix(fullRef, "refs/heads/"):
+			name = strings.TrimPrefix(fullRef, "refs/heads/")
+			source = name
+		case strings.HasPrefix(fullRef, "refs/remotes/"):
+			name = strings.TrimPrefix(fullRef, "refs/remotes/")
+			source = fullRef
+			isRemote = true
+		default:
+			continue
+		}
+		isCurrent := parts[1] == "*"
+		dateStr := parts[2]
+		hash := parts[3]
+		message := parts[4]
+		author := parts[5]
 
 		date, _ := time.Parse("2006-01-02 15:04:05 -0700", dateStr)
 
 		branches = append(branches, models.Branch{
 			Name:      name,
-			Source:    name,
+			Source:    source,
 			IsCurrent: isCurrent,
 			IsRemote:  isRemote,
 			LastCommit: models.CommitInfo{
@@ -67,6 +78,10 @@ func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 // tracking worktree will use, while Source retains the exact remote ref.
 func (g *Git) ListAvailableBranches() ([]models.Branch, error) {
 	branches, err := g.ListBranches(true)
+	if err != nil {
+		return nil, err
+	}
+	remotes, err := g.remoteNames()
 	if err != nil {
 		return nil, err
 	}
@@ -99,16 +114,47 @@ func (g *Git) ListAvailableBranches() ([]models.Branch, error) {
 		if !branch.IsRemote {
 			continue
 		}
-		remote, name, ok := strings.Cut(branch.Name, "/")
-		if !ok || remote == "" || name == "" || name == "HEAD" ||
+		name, ok := remoteBranchName(branch.Source, remotes)
+		if !ok || name == "HEAD" ||
 			local[name] || checkedOut[name] {
 			continue
 		}
 		branch.Name = name
-		branch.Source = remote + "/" + name
 		available = append(available, branch)
 	}
 	return available, nil
+}
+
+func (g *Git) remoteNames() ([]string, error) {
+	output, err := g.run("remote")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remotes: %w", err)
+	}
+	var remotes []string
+	for remote := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		remote = strings.TrimSpace(remote)
+		if remote != "" {
+			remotes = append(remotes, remote)
+		}
+	}
+	sort.Slice(remotes, func(i, j int) bool {
+		return len(remotes[i]) > len(remotes[j])
+	})
+	return remotes, nil
+}
+
+func remoteBranchName(source string, remotes []string) (string, bool) {
+	const prefix = "refs/remotes/"
+	ref, ok := strings.CutPrefix(source, prefix)
+	if !ok {
+		return "", false
+	}
+	for _, remote := range remotes {
+		if name, found := strings.CutPrefix(ref, remote+"/"); found && name != "" {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // DeleteBranch deletes a branch.

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -87,7 +87,7 @@ func (g *Git) ListAvailableBranches() ([]models.Branch, error) {
 	if err != nil {
 		return nil, err
 	}
-	remotes, err := g.remoteNames()
+	fetchRefspecs, err := g.remoteFetchRefspecs()
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (g *Git) ListAvailableBranches() ([]models.Branch, error) {
 		if !branch.IsRemote {
 			continue
 		}
-		name, ok := remoteBranchName(branch.Source, remotes)
+		name, ok := remoteBranchName(branch.Source, fetchRefspecs)
 		if !ok || name == "HEAD" ||
 			local[name] || checkedOut[name] {
 			continue
@@ -155,18 +155,82 @@ func (g *Git) remoteNames() ([]string, error) {
 	return remotes, nil
 }
 
-func remoteBranchName(source string, remotes []string) (string, bool) {
-	const prefix = "refs/remotes/"
-	ref, ok := strings.CutPrefix(source, prefix)
-	if !ok {
-		return "", false
+type remoteFetchRefspec struct {
+	source      string
+	destination string
+}
+
+func (g *Git) remoteFetchRefspecs() ([]remoteFetchRefspec, error) {
+	remotes, err := g.remoteNames()
+	if err != nil {
+		return nil, err
 	}
+	var refspecs []remoteFetchRefspec
 	for _, remote := range remotes {
-		if name, found := strings.CutPrefix(ref, remote+"/"); found && name != "" {
+		output, configErr := g.run(
+			"config",
+			"--get-all",
+			"remote."+remote+".fetch",
+		)
+		if configErr != nil {
+			continue
+		}
+		for value := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+			value = strings.TrimSpace(value)
+			value = strings.TrimPrefix(value, "+")
+			if value == "" || strings.HasPrefix(value, "^") {
+				continue
+			}
+			source, destination, ok := strings.Cut(value, ":")
+			if !ok || source == "" || destination == "" {
+				continue
+			}
+			refspecs = append(refspecs, remoteFetchRefspec{
+				source:      source,
+				destination: destination,
+			})
+		}
+	}
+	return refspecs, nil
+}
+
+func remoteBranchName(
+	destination string,
+	refspecs []remoteFetchRefspec,
+) (string, bool) {
+	for _, refspec := range refspecs {
+		source, ok := refspec.sourceForDestination(destination)
+		if !ok {
+			continue
+		}
+		name, ok := strings.CutPrefix(source, "refs/heads/")
+		if ok && name != "" {
 			return name, true
 		}
 	}
 	return "", false
+}
+
+func (r remoteFetchRefspec) sourceForDestination(
+	destination string,
+) (string, bool) {
+	star := strings.IndexByte(r.destination, '*')
+	if star < 0 {
+		return r.source, destination == r.destination
+	}
+	if strings.Count(r.destination, "*") != 1 ||
+		strings.Count(r.source, "*") != 1 {
+		return "", false
+	}
+	prefix := r.destination[:star]
+	suffix := r.destination[star+1:]
+	if !strings.HasPrefix(destination, prefix) ||
+		!strings.HasSuffix(destination, suffix) ||
+		len(destination) < len(prefix)+len(suffix) {
+		return "", false
+	}
+	match := destination[len(prefix) : len(destination)-len(suffix)]
+	return strings.Replace(r.source, "*", match, 1), true
 }
 
 // DeleteBranch deletes a branch.

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -62,6 +62,7 @@ func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 
 		branches = append(branches, models.Branch{
 			Name:      name,
+			Label:     name,
 			Source:    source,
 			IsCurrent: isCurrent,
 			IsRemote:  isRemote,
@@ -124,9 +125,15 @@ func (g *Git) ListAvailableBranches() ([]models.Branch, error) {
 			continue
 		}
 		branch.Name = name
+		branch.Label = remoteBranchLabel(name, branch.Source)
 		available = append(available, branch)
 	}
 	return available, nil
+}
+
+func remoteBranchLabel(name string, source string) string {
+	source = strings.TrimPrefix(source, "refs/remotes/")
+	return fmt.Sprintf("%s (%s)", name, source)
 }
 
 func (g *Git) remoteNames() ([]string, error) {

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -11,9 +11,13 @@ import (
 
 // ListBranches returns a list of all branches.
 func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
-	args := []string{"branch", "-v", "--format=%(refname)|%(HEAD)|%(committerdate:iso)|%(objectname)|%(subject)|%(authorname)"}
+	args := []string{
+		"for-each-ref",
+		"--format=%(refname)%00%(HEAD)%00%(committerdate:iso)%00%(objectname)%00%(subject)%00%(authorname)",
+		"refs/heads",
+	}
 	if includeRemote {
-		args = append(args, "-a")
+		args = append(args, "refs/remotes")
 	}
 
 	output, err := g.run(args...)
@@ -22,14 +26,14 @@ func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 	}
 
 	var branches []models.Branch
-	lines := strings.SplitSeq(strings.TrimSpace(output), "\n")
+	lines := strings.SplitSeq(strings.TrimSuffix(output, "\n"), "\n")
 
 	for line := range lines {
 		if line == "" {
 			continue
 		}
 
-		parts := strings.Split(line, "|")
+		parts := strings.Split(line, "\x00")
 		if len(parts) < 6 {
 			continue
 		}

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -182,6 +183,37 @@ func (g *Git) DeleteBranch(branch string, force bool) error {
 		return fmt.Errorf("failed to delete branch %s: %w", branch, err)
 	}
 
+	return nil
+}
+
+// DeleteBranchIsolated force-deletes a branch without exposing protected
+// credentials or allowing repository-configured hooks to run.
+func (g *Git) DeleteBranchIsolated(
+	branch string,
+	protectedNames []string,
+) error {
+	if err := g.validateLocalBranchName(branch, protectedNames); err != nil {
+		return err
+	}
+	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
+	if err != nil {
+		return fmt.Errorf("create empty hooks directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(hooksDir) }()
+
+	isolationArgs, err := g.checkoutIsolationArgs(
+		protectedNames,
+		"",
+		hooksDir,
+	)
+	if err != nil {
+		return err
+	}
+	args := append([]string(nil), isolationArgs...)
+	args = append(args, "branch", "-D", "--", branch)
+	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
+		return fmt.Errorf("failed to delete branch %s: %w", branch, err)
+	}
 	return nil
 }
 

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -10,7 +10,7 @@ import (
 
 // ListBranches returns a list of all branches.
 func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
-	args := []string{"branch", "-v", "--format=%(refname:short)|%(HEAD)|%(committerdate:iso)|%(objectname)|%(subject)|%(authorname)"}
+	args := []string{"branch", "-v", "--format=%(refname)|%(refname:short)|%(HEAD)|%(committerdate:iso)|%(objectname)|%(subject)|%(authorname)"}
 	if includeRemote {
 		args = append(args, "-a")
 	}
@@ -29,26 +29,25 @@ func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 		}
 
 		parts := strings.Split(line, "|")
-		if len(parts) < 6 {
+		if len(parts) < 7 {
 			continue
 		}
 
-		name := parts[0]
-		isCurrent := parts[1] == "*"
-		dateStr := parts[2]
-		hash := parts[3]
-		message := parts[4]
-		author := parts[5]
+		fullRef := parts[0]
+		name := parts[1]
+		isCurrent := parts[2] == "*"
+		dateStr := parts[3]
+		hash := parts[4]
+		message := parts[5]
+		author := parts[6]
 
-		isRemote := strings.HasPrefix(name, "remotes/")
-		if isRemote {
-			name = strings.TrimPrefix(name, "remotes/")
-		}
+		isRemote := strings.HasPrefix(fullRef, "refs/remotes/")
 
 		date, _ := time.Parse("2006-01-02 15:04:05 -0700", dateStr)
 
 		branches = append(branches, models.Branch{
 			Name:      name,
+			Source:    name,
 			IsCurrent: isCurrent,
 			IsRemote:  isRemote,
 			LastCommit: models.CommitInfo{
@@ -61,6 +60,55 @@ func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 	}
 
 	return branches, nil
+}
+
+// ListAvailableBranches returns branches that are not already checked out in
+// any worktree. Remote refs are normalized to the local branch name that a new
+// tracking worktree will use, while Source retains the exact remote ref.
+func (g *Git) ListAvailableBranches() ([]models.Branch, error) {
+	branches, err := g.ListBranches(true)
+	if err != nil {
+		return nil, err
+	}
+	worktrees, err := g.ListWorktrees()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list checked out branches: %w", err)
+	}
+
+	checkedOut := make(map[string]bool, len(worktrees))
+	for _, worktree := range worktrees {
+		if worktree.Branch != "" && worktree.Branch != "HEAD" {
+			checkedOut[worktree.Branch] = true
+		}
+	}
+
+	local := make(map[string]bool)
+	available := make([]models.Branch, 0, len(branches))
+	for _, branch := range branches {
+		if branch.IsRemote {
+			continue
+		}
+		local[branch.Name] = true
+		if checkedOut[branch.Name] {
+			continue
+		}
+		branch.Source = branch.Name
+		available = append(available, branch)
+	}
+	for _, branch := range branches {
+		if !branch.IsRemote {
+			continue
+		}
+		remote, name, ok := strings.Cut(branch.Name, "/")
+		if !ok || remote == "" || name == "" || name == "HEAD" ||
+			local[name] || checkedOut[name] {
+			continue
+		}
+		branch.Name = name
+		branch.Source = remote + "/" + name
+		available = append(available, branch)
+	}
+	return available, nil
 }
 
 // DeleteBranch deletes a branch.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -926,6 +926,41 @@ func TestListAvailableBranchesNormalizesRemoteAndExcludesCheckedOut(t *testing.T
 	}
 }
 
+func TestListAvailableBranchesUsesCustomRemoteFetchRefspec(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
+	gitOutput(t, repo.Path, "config", "--unset-all", "remote.origin.fetch")
+	gitOutput(
+		t,
+		repo.Path,
+		"config",
+		"--add",
+		"remote.origin.fetch",
+		"+refs/heads/*:refs/remotes/pull/*",
+	)
+
+	repo.CreateBranch(t, "custom-fetch")
+	gitOutput(t, repo.Path, "push", "origin", "custom-fetch")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "custom-fetch")
+	gitOutput(t, repo.Path, "fetch", "origin")
+
+	branches, err := New(repo.Path).ListAvailableBranches()
+	require.NoError(t, err)
+
+	for _, branch := range branches {
+		if branch.Source != "refs/remotes/pull/custom-fetch" {
+			continue
+		}
+		assert.Equal(t, "custom-fetch", branch.Name)
+		assert.True(t, branch.IsRemote)
+		return
+	}
+	t.Fatalf("custom-fetch branch not found: %+v", branches)
+}
+
 func TestListAvailableBranchesUsesFullRefsAcrossNamespaceCollisions(t *testing.T) {
 	repo := NewTestRepository(t)
 	remotePath := filepath.Join(t.TempDir(), "upstream.git")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -764,24 +764,31 @@ func TestListAvailableBranchesPreservesDelimiterCharacters(t *testing.T) {
 	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
 	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
 
-	repo.CreateBranch(t, "topic|review")
+	branchName := "topic|review"
+	if runtime.GOOS == "windows" {
+		// NTFS cannot materialize a loose ref containing "|". The commit
+		// subject still exercises NUL-delimited parsing on Windows, while the
+		// ref-name case runs on filesystems that support it.
+		branchName = "topic-review"
+	}
+	repo.CreateBranch(t, branchName)
 	commitTestFile(t, repo.Path, "topic.txt", "topic\n", "Subject | details")
-	gitOutput(t, repo.Path, "push", "origin", "topic|review")
+	gitOutput(t, repo.Path, "push", "origin", branchName)
 	gitOutput(t, repo.Path, "checkout", "main")
-	gitOutput(t, repo.Path, "branch", "-D", "topic|review")
+	gitOutput(t, repo.Path, "branch", "-D", branchName)
 
 	branches, err := New(repo.Path).ListAvailableBranches()
 	if err != nil {
 		t.Fatalf("ListAvailableBranches() error = %v", err)
 	}
 
-	const source = "refs/remotes/origin/topic|review"
+	source := "refs/remotes/origin/" + branchName
 	for _, branch := range branches {
 		if branch.Source != source {
 			continue
 		}
-		if branch.Name != "topic|review" {
-			t.Errorf("branch name = %q, want topic|review", branch.Name)
+		if branch.Name != branchName {
+			t.Errorf("branch name = %q, want %s", branch.Name, branchName)
 		}
 		if branch.LastCommit.Message != "Subject | details" {
 			t.Errorf(

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -126,6 +128,24 @@ func commitTestFile(t *testing.T, dir, name, contents, message string) {
 	}
 	gitOutput(t, dir, "add", name)
 	gitOutput(t, dir, "commit", "-m", message)
+}
+
+func createBranchWithMissingBlob(
+	t *testing.T,
+	repo *TestRepository,
+	branch string,
+) string {
+	t.Helper()
+	repo.CreateBranch(t, branch)
+	commitTestFile(t, repo.Path, "missing.txt", "missing\n", "Missing blob")
+	commit := gitOutput(t, repo.Path, "rev-parse", "HEAD")
+	blob := gitOutput(t, repo.Path, "rev-parse", branch+":missing.txt")
+	gitOutput(t, repo.Path, "checkout", "main")
+	objectPath := filepath.Join(repo.Path, ".git", "objects", blob[:2], blob[2:])
+	if err := os.Remove(objectPath); err != nil {
+		t.Fatalf("remove blob object: %v", err)
+	}
+	return commit
 }
 
 func TestNew(t *testing.T) {
@@ -1263,6 +1283,93 @@ func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
 		if _, err := os.Stat(configuredHookMarker); !os.IsNotExist(err) {
 			t.Errorf("configured hook ran during rollback: stat error = %v", err)
 		}
+	}
+}
+
+func TestAddWorktreeTrackingRejectsOptionLikeBranchName(t *testing.T) {
+	repo := NewTestRepository(t)
+	gitOutput(
+		t,
+		repo.Path,
+		"update-ref",
+		"refs/remotes/origin/-M",
+		"HEAD",
+	)
+
+	worktreePath := filepath.Join(t.TempDir(), "option-like")
+	err := New(repo.Path).AddWorktreeTracking(
+		worktreePath,
+		"-M",
+		"refs/remotes/origin/-M",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid local branch name "-M"`)
+	assert.Equal(t, "main", gitOutput(t, repo.Path, "branch", "--show-current"))
+	assert.NoDirExists(t, worktreePath)
+}
+
+func TestAddWorktreeExistingRemovesWorktreeAfterCheckoutFailure(t *testing.T) {
+	repo := NewTestRepository(t)
+	createBranchWithMissingBlob(t, repo, "broken-local")
+	worktreePath := filepath.Join(t.TempDir(), "broken-local")
+
+	err := New(repo.Path).AddWorktreeExisting(
+		worktreePath,
+		"broken-local",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check out existing-branch worktree")
+	assert.NoDirExists(t, worktreePath)
+	worktrees, listErr := New(repo.Path).ListWorktrees()
+	require.NoError(t, listErr)
+	for _, worktree := range worktrees {
+		assert.NotEqual(t, worktreePath, worktree.Path)
+	}
+}
+
+func TestAddWorktreeTrackingRemovesWorktreeAndBranchAfterCheckoutFailure(
+	t *testing.T,
+) {
+	repo := NewTestRepository(t)
+	commit := createBranchWithMissingBlob(t, repo, "broken-remote")
+	gitOutput(t, repo.Path, "remote", "add", "origin", repo.Path)
+	gitOutput(
+		t,
+		repo.Path,
+		"update-ref",
+		"refs/remotes/origin/broken-remote",
+		commit,
+	)
+	gitOutput(t, repo.Path, "branch", "-D", "broken-remote")
+	worktreePath := filepath.Join(t.TempDir(), "broken-remote")
+
+	err := New(repo.Path).AddWorktreeTracking(
+		worktreePath,
+		"broken-remote",
+		"refs/remotes/origin/broken-remote",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check out worktree tracking")
+	assert.NoDirExists(t, worktreePath)
+	assert.Error(
+		t,
+		repo.run(
+			"show-ref",
+			"--verify",
+			"--quiet",
+			"refs/heads/broken-remote",
+		),
+	)
+	worktrees, listErr := New(repo.Path).ListWorktrees()
+	require.NoError(t, listErr)
+	for _, worktree := range worktrees {
+		assert.NotEqual(t, worktreePath, worktree.Path)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -678,6 +678,82 @@ func TestListBranches(t *testing.T) {
 	})
 }
 
+func TestListAvailableBranchesNormalizesRemoteAndExcludesCheckedOut(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
+
+	repo.CreateBranch(t, "local-ready")
+	gitOutput(t, repo.Path, "checkout", "main")
+	repo.CreateBranch(t, "checked-out")
+	gitOutput(t, repo.Path, "checkout", "main")
+	repo.CreateBranch(t, "remote-only")
+	commitTestFile(t, repo.Path, "remote.txt", "remote\n", "Remote branch")
+	gitOutput(t, repo.Path, "push", "origin", "main", "local-ready", "remote-only")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "remote-only")
+	gitOutput(t, repo.Path, "remote", "set-head", "origin", "-a")
+
+	worktreePath := filepath.Join(t.TempDir(), "checked-out")
+	repo.CreateWorktree(t, worktreePath, "checked-out")
+
+	branches, err := New(repo.Path).ListAvailableBranches()
+	if err != nil {
+		t.Fatalf("ListAvailableBranches() error = %v", err)
+	}
+
+	byName := make(map[string]models.Branch, len(branches))
+	for _, branch := range branches {
+		byName[branch.Name] = branch
+	}
+	if _, ok := byName["main"]; ok {
+		t.Error("current branch was offered as available")
+	}
+	if _, ok := byName["checked-out"]; ok {
+		t.Error("branch checked out in another worktree was offered as available")
+	}
+	if got := byName["local-ready"]; got.IsRemote || got.Source != "local-ready" {
+		t.Errorf("local-ready = %+v, want available local branch", got)
+	}
+	if got := byName["remote-only"]; !got.IsRemote || got.Source != "origin/remote-only" {
+		t.Errorf("remote-only = %+v, want normalized origin branch", got)
+	}
+	if _, ok := byName["HEAD"]; ok {
+		t.Error("remote symbolic HEAD was offered as a branch")
+	}
+}
+
+func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
+
+	repo.CreateBranch(t, "remote-only")
+	commitTestFile(t, repo.Path, "remote.txt", "remote\n", "Remote branch")
+	wantHead := gitOutput(t, repo.Path, "rev-parse", "HEAD")
+	gitOutput(t, repo.Path, "push", "origin", "remote-only")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "remote-only")
+
+	worktreePath := filepath.Join(t.TempDir(), "remote-only")
+	err := New(repo.Path).AddWorktreeTracking(
+		worktreePath,
+		"remote-only",
+		"origin/remote-only",
+	)
+	if err != nil {
+		t.Fatalf("AddWorktreeTracking() error = %v", err)
+	}
+	if got := gitOutput(t, worktreePath, "rev-parse", "HEAD"); got != wantHead {
+		t.Errorf("HEAD = %s, want remote branch %s", got, wantHead)
+	}
+	if got := gitOutput(t, worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"); got != "origin/remote-only" {
+		t.Errorf("upstream = %s, want origin/remote-only", got)
+	}
+}
+
 func TestGetRepositoryName(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -518,6 +518,40 @@ exec "$REAL_GIT" "$@"
 	})
 }
 
+func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "existing-unreviewed")
+	commitTestFile(t, repo.Path, "branch.txt", "branch\n", "Existing branch")
+	gitOutput(t, repo.Path, "checkout", "main")
+
+	hookMarker := filepath.Join(t.TempDir(), "hook-ran")
+	hooksDir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(hooksDir, "post-checkout"),
+		fmt.Appendf(nil, "#!/bin/sh\nprintf hook > %q\n", hookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write checkout hook: %v", err)
+	}
+	gitOutput(t, repo.Path, "config", "core.hooksPath", hooksDir)
+
+	worktreePath := filepath.Join(t.TempDir(), "existing-unreviewed")
+	if err := New(repo.Path).AddWorktreeExisting(
+		worktreePath,
+		"existing-unreviewed",
+		nil,
+	); err != nil {
+		t.Fatalf("AddWorktreeExisting() error = %v", err)
+	}
+
+	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
+		t.Errorf("checkout hook ran against existing branch: stat error = %v", err)
+	}
+	if got := gitOutput(t, worktreePath, "branch", "--show-current"); got != "existing-unreviewed" {
+		t.Errorf("branch = %q, want existing-unreviewed", got)
+	}
+}
+
 func TestRemoveWorktree(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -629,6 +629,32 @@ func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 	}
 }
 
+func TestAddWorktreeExistingPreservesRefsHeadsPrefixInShortName(t *testing.T) {
+	repo := NewTestRepository(t)
+	gitOutput(t, repo.Path, "branch", "topic")
+	gitOutput(
+		t,
+		repo.Path,
+		"update-ref",
+		"refs/heads/refs/heads/topic",
+		"HEAD",
+	)
+	worktreePath := filepath.Join(t.TempDir(), "literal-refs-heads")
+
+	err := New(repo.Path).AddWorktreeExisting(
+		worktreePath,
+		"refs/heads/topic",
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"refs/heads/topic",
+		gitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+}
+
 func TestAddWorktreeExistingDoesNotRecurseIntoSubmodules(t *testing.T) {
 	submodule := NewTestRepository(t)
 	if err := os.WriteFile(

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -758,6 +758,42 @@ func TestListAvailableBranchesUsesFullRefsAcrossNamespaceCollisions(t *testing.T
 	}
 }
 
+func TestListAvailableBranchesPreservesDelimiterCharacters(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
+
+	repo.CreateBranch(t, "topic|review")
+	commitTestFile(t, repo.Path, "topic.txt", "topic\n", "Subject | details")
+	gitOutput(t, repo.Path, "push", "origin", "topic|review")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "topic|review")
+
+	branches, err := New(repo.Path).ListAvailableBranches()
+	if err != nil {
+		t.Fatalf("ListAvailableBranches() error = %v", err)
+	}
+
+	const source = "refs/remotes/origin/topic|review"
+	for _, branch := range branches {
+		if branch.Source != source {
+			continue
+		}
+		if branch.Name != "topic|review" {
+			t.Errorf("branch name = %q, want topic|review", branch.Name)
+		}
+		if branch.LastCommit.Message != "Subject | details" {
+			t.Errorf(
+				"commit subject = %q, want Subject | details",
+				branch.LastCommit.Message,
+			)
+		}
+		return
+	}
+	t.Fatalf("remote branch %s not found: %+v", source, branches)
+}
+
 func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	repo := NewTestRepository(t)
 	remotePath := filepath.Join(t.TempDir(), "origin.git")
@@ -765,6 +801,20 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
 
 	repo.CreateBranch(t, "remote-only")
+	if err := os.WriteFile(
+		filepath.Join(repo.Path, ".gitattributes"),
+		[]byte("remote.txt filter=smudge-attack\nprocess.txt filter=process-attack\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write attributes: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(repo.Path, "process.txt"),
+		[]byte("process content\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write process input: %v", err)
+	}
 	commitTestFile(t, repo.Path, "remote.txt", "remote\n", "Remote branch")
 	wantHead := gitOutput(t, repo.Path, "rev-parse", "HEAD")
 	gitOutput(t, repo.Path, "push", "origin", "remote-only")
@@ -772,6 +822,40 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	gitOutput(t, repo.Path, "branch", "-D", "remote-only")
 	t.Setenv("KWT_GITHUB_TOKEN", "must-not-reach-remote-checkout")
 	t.Setenv("KWT_FLEET_TOKEN", "must-not-reach-remote-checkout")
+	t.Setenv("Custom_Fleet_Token", "must-not-reach-remote-checkout")
+
+	hookMarker := filepath.Join(t.TempDir(), "hook-ran")
+	filterMarker := filepath.Join(t.TempDir(), "filter-ran")
+	processMarker := filepath.Join(t.TempDir(), "process-ran")
+	hooksDir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(hooksDir, "post-checkout"),
+		fmt.Appendf(nil, "#!/bin/sh\nprintf hook > %q\n", hookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write checkout hook: %v", err)
+	}
+	filterDir := t.TempDir()
+	smudgePath := filepath.Join(filterDir, "smudge")
+	if err := os.WriteFile(
+		smudgePath,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf filter > %q\ncat\n", filterMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write smudge filter: %v", err)
+	}
+	processPath := filepath.Join(filterDir, "process")
+	if err := os.WriteFile(
+		processPath,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf process > %q\nexit 1\n", processMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write process filter: %v", err)
+	}
+	gitOutput(t, repo.Path, "config", "core.hooksPath", hooksDir)
+	gitOutput(t, repo.Path, "config", "filter.smudge-attack.smudge", smudgePath)
+	gitOutput(t, repo.Path, "config", "filter.process-attack.process", processPath)
+	gitOutput(t, repo.Path, "config", "filter.process-attack.required", "true")
 
 	if runtime.GOOS != "windows" {
 		realGit, err := exec.LookPath("git")
@@ -781,13 +865,19 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 		wrapperDir := t.TempDir()
 		wrapperPath := filepath.Join(wrapperDir, "git")
 		wrapper := `#!/bin/sh
-if [ "$1" = "branch" ] || { [ "$1" = "worktree" ] && [ "$2" = "add" ]; }; then
-	if [ -n "$KWT_GITHUB_TOKEN" ] || [ -n "$KWT_FLEET_TOKEN" ]; then
-		printf '%s\n' 'kwt credential reached remote-source git command' >&2
-		exit 88
-	fi
+if [ -n "$KWT_GITHUB_TOKEN" ] || [ -n "$KWT_FLEET_TOKEN" ] || [ -n "$Custom_Fleet_Token" ]; then
+	printf '%s\n' 'kwt credential reached remote-source git command' >&2
+	exit 88
 fi
-if [ "$1" = "worktree" ] && [ "$2" = "add" ]; then
+worktree_add=false
+previous=
+for arg in "$@"; do
+	if [ "$previous" = "worktree" ] && [ "$arg" = "add" ]; then
+		worktree_add=true
+	fi
+	previous=$arg
+done
+if $worktree_add; then
 	for arg in "$@"; do
 		if [ "$arg" = "--track" ]; then
 			printf '%s\n' 'error: unknown option track' >&2
@@ -809,7 +899,11 @@ exec "$REAL_GIT" "$@"
 		worktreePath,
 		"remote-only",
 		"origin/remote-only",
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "custom_fleet_token"},
 	)
+	t.Setenv("KWT_GITHUB_TOKEN", "")
+	t.Setenv("KWT_FLEET_TOKEN", "")
+	t.Setenv("Custom_Fleet_Token", "")
 	if err != nil {
 		t.Fatalf("AddWorktreeTracking() error = %v", err)
 	}
@@ -818,6 +912,15 @@ exec "$REAL_GIT" "$@"
 	}
 	if got := gitOutput(t, worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"); got != "origin/remote-only" {
 		t.Errorf("upstream = %s, want origin/remote-only", got)
+	}
+	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
+		t.Errorf("checkout hook ran against remote content: stat error = %v", err)
+	}
+	if _, err := os.Stat(filterMarker); !os.IsNotExist(err) {
+		t.Errorf("smudge filter ran against remote content: stat error = %v", err)
+	}
+	if _, err := os.Stat(processMarker); !os.IsNotExist(err) {
+		t.Errorf("process filter ran against remote content: stat error = %v", err)
 	}
 }
 
@@ -844,6 +947,7 @@ func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
 		occupiedPath,
 		"remote-only",
 		"refs/remotes/origin/remote-only",
+		nil,
 	)
 
 	if err == nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -825,6 +825,7 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	t.Setenv("Custom_Fleet_Token", "must-not-reach-remote-checkout")
 
 	hookMarker := filepath.Join(t.TempDir(), "hook-ran")
+	referenceHookMarker := filepath.Join(t.TempDir(), "reference-hook-ran")
 	filterMarker := filepath.Join(t.TempDir(), "filter-ran")
 	processMarker := filepath.Join(t.TempDir(), "process-ran")
 	hooksDir := t.TempDir()
@@ -834,6 +835,13 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 		0755,
 	); err != nil {
 		t.Fatalf("write checkout hook: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(hooksDir, "reference-transaction"),
+		fmt.Appendf(nil, "#!/bin/sh\nprintf reference > %q\n", referenceHookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write reference transaction hook: %v", err)
 	}
 	filterDir := t.TempDir()
 	smudgePath := filepath.Join(filterDir, "smudge")
@@ -916,6 +924,9 @@ exec "$REAL_GIT" "$@"
 	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
 		t.Errorf("checkout hook ran against remote content: stat error = %v", err)
 	}
+	if _, err := os.Stat(referenceHookMarker); !os.IsNotExist(err) {
+		t.Errorf("reference transaction hook ran during remote creation: stat error = %v", err)
+	}
 	if _, err := os.Stat(filterMarker); !os.IsNotExist(err) {
 		t.Errorf("smudge filter ran against remote content: stat error = %v", err)
 	}
@@ -934,6 +945,16 @@ func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
 	gitOutput(t, repo.Path, "push", "origin", "remote-only")
 	gitOutput(t, repo.Path, "checkout", "main")
 	gitOutput(t, repo.Path, "branch", "-D", "remote-only")
+	referenceHookMarker := filepath.Join(t.TempDir(), "reference-hook-ran")
+	hooksDir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(hooksDir, "reference-transaction"),
+		fmt.Appendf(nil, "#!/bin/sh\nprintf reference > %q\n", referenceHookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write reference transaction hook: %v", err)
+	}
+	gitOutput(t, repo.Path, "config", "core.hooksPath", hooksDir)
 
 	occupiedPath := filepath.Join(t.TempDir(), "occupied")
 	if err := os.MkdirAll(occupiedPath, 0755); err != nil {
@@ -955,6 +976,9 @@ func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
 	}
 	if err := repo.run("show-ref", "--verify", "--quiet", "refs/heads/remote-only"); err == nil {
 		t.Error("local tracking branch remained after worktree creation failed")
+	}
+	if _, err := os.Stat(referenceHookMarker); !os.IsNotExist(err) {
+		t.Errorf("reference transaction hook ran during rollback: stat error = %v", err)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -609,6 +609,70 @@ func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 	}
 }
 
+func TestAddWorktreeExistingDoesNotRecurseIntoSubmodules(t *testing.T) {
+	submodule := NewTestRepository(t)
+	if err := os.WriteFile(
+		filepath.Join(submodule.Path, ".gitattributes"),
+		[]byte("payload.txt filter=submodule-attack\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write submodule attributes: %v", err)
+	}
+	gitOutput(t, submodule.Path, "add", ".gitattributes")
+	commitTestFile(t, submodule.Path, "payload.txt", "payload\n", "Payload")
+
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "existing-unreviewed")
+	gitOutput(
+		t,
+		repo.Path,
+		"-c",
+		"protocol.file.allow=always",
+		"submodule",
+		"add",
+		submodule.Path,
+		"dependency",
+	)
+	gitOutput(t, repo.Path, "commit", "-am", "Add dependency")
+	gitOutput(t, repo.Path, "checkout", "main")
+
+	filterMarker := filepath.Join(t.TempDir(), "submodule-filter-ran")
+	filterCommand := filepath.Join(t.TempDir(), "submodule-filter")
+	if err := os.WriteFile(
+		filterCommand,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf filter > %q\ncat\n", filterMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write submodule filter: %v", err)
+	}
+	gitOutput(
+		t,
+		filepath.Join(repo.Path, "dependency"),
+		"config",
+		"filter.submodule-attack.smudge",
+		filterCommand,
+	)
+	gitOutput(t, repo.Path, "config", "submodule.recurse", "true")
+
+	worktreePath := filepath.Join(t.TempDir(), "existing-unreviewed")
+	if err := New(repo.Path).AddWorktreeExisting(
+		worktreePath,
+		"existing-unreviewed",
+		nil,
+	); err != nil {
+		t.Fatalf("AddWorktreeExisting() error = %v", err)
+	}
+
+	if _, err := os.Stat(filterMarker); !os.IsNotExist(err) {
+		t.Errorf("submodule filter ran before review: stat error = %v", err)
+	}
+	if _, err := os.Stat(
+		filepath.Join(worktreePath, "dependency", "payload.txt"),
+	); !os.IsNotExist(err) {
+		t.Errorf("submodule content materialized before review: stat error = %v", err)
+	}
+}
+
 func TestRemoveWorktree(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)
@@ -846,6 +910,39 @@ func TestListAvailableBranchesUsesFullRefsAcrossNamespaceCollisions(t *testing.T
 	const remoteSource = "refs/remotes/team/upstream/topic"
 	if got := bySource[remoteSource]; got.Name != "topic" || !got.IsRemote {
 		t.Errorf("remote collision branch = %+v, want topic from %s", got, remoteSource)
+	}
+}
+
+func TestListAvailableBranchesLabelsDuplicateRemoteNamesBySource(t *testing.T) {
+	repo := NewTestRepository(t)
+	for _, remote := range []string{"origin", "upstream"} {
+		remotePath := filepath.Join(t.TempDir(), remote+".git")
+		gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+		gitOutput(t, repo.Path, "remote", "add", remote, remotePath)
+	}
+	repo.CreateBranch(t, "topic")
+	commitTestFile(t, repo.Path, "topic.txt", "topic\n", "Topic")
+	gitOutput(t, repo.Path, "push", "origin", "topic")
+	gitOutput(t, repo.Path, "push", "upstream", "topic")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "topic")
+
+	branches, err := New(repo.Path).ListAvailableBranches()
+	if err != nil {
+		t.Fatalf("ListAvailableBranches() error = %v", err)
+	}
+
+	labels := make(map[string]string)
+	for _, branch := range branches {
+		if branch.Name == "topic" {
+			labels[branch.Source] = branch.Label
+		}
+	}
+	if got := labels["refs/remotes/origin/topic"]; got != "topic (origin/topic)" {
+		t.Errorf("origin label = %q, want source-qualified label", got)
+	}
+	if got := labels["refs/remotes/upstream/topic"]; got != "topic (upstream/topic)" {
+		t.Errorf("upstream label = %q, want source-qualified label", got)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -521,10 +521,20 @@ exec "$REAL_GIT" "$@"
 func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 	repo := NewTestRepository(t)
 	repo.CreateBranch(t, "existing-unreviewed")
+	if err := os.WriteFile(
+		filepath.Join(repo.Path, ".gitattributes"),
+		[]byte("branch.txt filter=conditional-attack\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write attributes: %v", err)
+	}
+	gitOutput(t, repo.Path, "add", ".gitattributes")
 	commitTestFile(t, repo.Path, "branch.txt", "branch\n", "Existing branch")
 	gitOutput(t, repo.Path, "checkout", "main")
 
 	hookMarker := filepath.Join(t.TempDir(), "hook-ran")
+	configuredHookMarker := filepath.Join(t.TempDir(), "configured-hook-ran")
+	filterMarker := filepath.Join(t.TempDir(), "conditional-filter-ran")
 	hooksDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(hooksDir, "post-checkout"),
@@ -534,6 +544,39 @@ func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 		t.Fatalf("write checkout hook: %v", err)
 	}
 	gitOutput(t, repo.Path, "config", "core.hooksPath", hooksDir)
+	configuredHook := filepath.Join(t.TempDir(), "configured-hook")
+	if err := os.WriteFile(
+		configuredHook,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf hook > %q\n", configuredHookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write configured hook: %v", err)
+	}
+	gitOutput(t, repo.Path, "config", "hook.configured-attack.command", configuredHook)
+	gitOutput(t, repo.Path, "config", "--add", "hook.configured-attack.event", "post-checkout")
+	gitOutput(t, repo.Path, "config", "--add", "hook.configured-attack.event", "post-index-change")
+	configuredHooksSupported := exec.Command(
+		"git", "-C", repo.Path, "hook", "list", "post-checkout",
+	).Run() == nil
+
+	filterCommand := filepath.Join(t.TempDir(), "conditional-filter")
+	if err := os.WriteFile(
+		filterCommand,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf filter > %q\ncat\n", filterMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write conditional filter: %v", err)
+	}
+	includePath := filepath.Join(t.TempDir(), "onbranch.config")
+	gitOutput(t, repo.Path, "config", "-f", includePath, "filter.conditional-attack.smudge", filterCommand)
+	gitOutput(t, repo.Path, "config", "-f", includePath, "filter.conditional-attack.required", "true")
+	gitOutput(
+		t,
+		repo.Path,
+		"config",
+		"includeIf.onbranch:existing-unreviewed.path",
+		includePath,
+	)
 
 	worktreePath := filepath.Join(t.TempDir(), "existing-unreviewed")
 	if err := New(repo.Path).AddWorktreeExisting(
@@ -546,6 +589,19 @@ func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 
 	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
 		t.Errorf("checkout hook ran against existing branch: stat error = %v", err)
+	}
+	if configuredHooksSupported {
+		if _, err := os.Stat(configuredHookMarker); !os.IsNotExist(err) {
+			t.Errorf("configured hook ran against existing branch: stat error = %v", err)
+		}
+	}
+	if _, err := os.Stat(filterMarker); !os.IsNotExist(err) {
+		t.Errorf("branch-conditional filter ran against existing branch: stat error = %v", err)
+	}
+	if contents, err := os.ReadFile(filepath.Join(worktreePath, "branch.txt")); err != nil {
+		t.Errorf("read checked-out branch file: %v", err)
+	} else if string(contents) != "branch\n" {
+		t.Errorf("branch.txt = %q, want branch content", contents)
 	}
 	if got := gitOutput(t, worktreePath, "branch", "--show-current"); got != "existing-unreviewed" {
 		t.Errorf("branch = %q, want existing-unreviewed", got)
@@ -844,7 +900,11 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	repo.CreateBranch(t, "remote-only")
 	if err := os.WriteFile(
 		filepath.Join(repo.Path, ".gitattributes"),
-		[]byte("remote.txt filter=smudge-attack\nprocess.txt filter=process-attack\n"),
+		[]byte(
+			"remote.txt filter=smudge-attack\n"+
+				"process.txt filter=process-attack\n"+
+				"conditional.txt filter=conditional-attack\n",
+		),
 		0644,
 	); err != nil {
 		t.Fatalf("write attributes: %v", err)
@@ -856,6 +916,14 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	); err != nil {
 		t.Fatalf("write process input: %v", err)
 	}
+	if err := os.WriteFile(
+		filepath.Join(repo.Path, "conditional.txt"),
+		[]byte("conditional content\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write conditional input: %v", err)
+	}
+	gitOutput(t, repo.Path, "add", ".gitattributes", "process.txt", "conditional.txt")
 	commitTestFile(t, repo.Path, "remote.txt", "remote\n", "Remote branch")
 	wantHead := gitOutput(t, repo.Path, "rev-parse", "HEAD")
 	gitOutput(t, repo.Path, "push", "origin", "remote-only")
@@ -867,8 +935,10 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 
 	hookMarker := filepath.Join(t.TempDir(), "hook-ran")
 	referenceHookMarker := filepath.Join(t.TempDir(), "reference-hook-ran")
+	configuredHookMarker := filepath.Join(t.TempDir(), "configured-hook-ran")
 	filterMarker := filepath.Join(t.TempDir(), "filter-ran")
 	processMarker := filepath.Join(t.TempDir(), "process-ran")
+	conditionalFilterMarker := filepath.Join(t.TempDir(), "conditional-filter-ran")
 	hooksDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(hooksDir, "post-checkout"),
@@ -905,6 +975,48 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	gitOutput(t, repo.Path, "config", "filter.smudge-attack.smudge", smudgePath)
 	gitOutput(t, repo.Path, "config", "filter.process-attack.process", processPath)
 	gitOutput(t, repo.Path, "config", "filter.process-attack.required", "true")
+	configuredHook := filepath.Join(t.TempDir(), "configured-hook")
+	if err := os.WriteFile(
+		configuredHook,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf hook > %q\n", configuredHookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write configured hook: %v", err)
+	}
+	gitOutput(t, repo.Path, "config", "hook.configured-attack.command", configuredHook)
+	for _, event := range []string{
+		"post-checkout",
+		"post-index-change",
+		"reference-transaction",
+	} {
+		gitOutput(t, repo.Path, "config", "--add", "hook.configured-attack.event", event)
+	}
+	configuredHooksSupported := exec.Command(
+		"git", "-C", repo.Path, "hook", "list", "post-checkout",
+	).Run() == nil
+
+	conditionalFilter := filepath.Join(t.TempDir(), "conditional-filter")
+	if err := os.WriteFile(
+		conditionalFilter,
+		fmt.Appendf(
+			nil,
+			"#!/bin/sh\nprintf filter > %q\ncat\n",
+			conditionalFilterMarker,
+		),
+		0755,
+	); err != nil {
+		t.Fatalf("write conditional filter: %v", err)
+	}
+	includePath := filepath.Join(t.TempDir(), "gitdir.config")
+	gitOutput(t, repo.Path, "config", "-f", includePath, "filter.conditional-attack.smudge", conditionalFilter)
+	gitOutput(t, repo.Path, "config", "-f", includePath, "filter.conditional-attack.required", "true")
+	gitOutput(
+		t,
+		repo.Path,
+		"config",
+		"includeIf.gitdir:**/worktrees/remote-only.path",
+		includePath,
+	)
 
 	if runtime.GOOS != "windows" {
 		realGit, err := exec.LookPath("git")
@@ -968,11 +1080,24 @@ exec "$REAL_GIT" "$@"
 	if _, err := os.Stat(referenceHookMarker); !os.IsNotExist(err) {
 		t.Errorf("reference transaction hook ran during remote creation: stat error = %v", err)
 	}
+	if configuredHooksSupported {
+		if _, err := os.Stat(configuredHookMarker); !os.IsNotExist(err) {
+			t.Errorf("configured hook ran during remote creation: stat error = %v", err)
+		}
+	}
 	if _, err := os.Stat(filterMarker); !os.IsNotExist(err) {
 		t.Errorf("smudge filter ran against remote content: stat error = %v", err)
 	}
 	if _, err := os.Stat(processMarker); !os.IsNotExist(err) {
 		t.Errorf("process filter ran against remote content: stat error = %v", err)
+	}
+	if _, err := os.Stat(conditionalFilterMarker); !os.IsNotExist(err) {
+		t.Errorf("gitdir-conditional filter ran against remote content: stat error = %v", err)
+	}
+	if contents, err := os.ReadFile(filepath.Join(worktreePath, "conditional.txt")); err != nil {
+		t.Errorf("read checked-out remote file: %v", err)
+	} else if string(contents) != "conditional content\n" {
+		t.Errorf("conditional.txt = %q, want remote content", contents)
 	}
 }
 
@@ -996,6 +1121,20 @@ func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
 		t.Fatalf("write reference transaction hook: %v", err)
 	}
 	gitOutput(t, repo.Path, "config", "core.hooksPath", hooksDir)
+	configuredHookMarker := filepath.Join(t.TempDir(), "configured-hook-ran")
+	configuredHook := filepath.Join(t.TempDir(), "configured-hook")
+	if err := os.WriteFile(
+		configuredHook,
+		fmt.Appendf(nil, "#!/bin/sh\nprintf hook > %q\n", configuredHookMarker),
+		0755,
+	); err != nil {
+		t.Fatalf("write configured hook: %v", err)
+	}
+	gitOutput(t, repo.Path, "config", "hook.configured-attack.command", configuredHook)
+	gitOutput(t, repo.Path, "config", "--add", "hook.configured-attack.event", "reference-transaction")
+	configuredHooksSupported := exec.Command(
+		"git", "-C", repo.Path, "hook", "list", "reference-transaction",
+	).Run() == nil
 
 	occupiedPath := filepath.Join(t.TempDir(), "occupied")
 	if err := os.MkdirAll(occupiedPath, 0755); err != nil {
@@ -1020,6 +1159,11 @@ func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
 	}
 	if _, err := os.Stat(referenceHookMarker); !os.IsNotExist(err) {
 		t.Errorf("reference transaction hook ran during rollback: stat error = %v", err)
+	}
+	if configuredHooksSupported {
+		if _, err := os.Stat(configuredHookMarker); !os.IsNotExist(err) {
+			t.Errorf("configured hook ran during rollback: stat error = %v", err)
+		}
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -716,11 +716,45 @@ func TestListAvailableBranchesNormalizesRemoteAndExcludesCheckedOut(t *testing.T
 	if got := byName["local-ready"]; got.IsRemote || got.Source != "local-ready" {
 		t.Errorf("local-ready = %+v, want available local branch", got)
 	}
-	if got := byName["remote-only"]; !got.IsRemote || got.Source != "origin/remote-only" {
+	if got := byName["remote-only"]; !got.IsRemote ||
+		got.Source != "refs/remotes/origin/remote-only" {
 		t.Errorf("remote-only = %+v, want normalized origin branch", got)
 	}
 	if _, ok := byName["HEAD"]; ok {
 		t.Error("remote symbolic HEAD was offered as a branch")
+	}
+}
+
+func TestListAvailableBranchesUsesFullRefsAcrossNamespaceCollisions(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "upstream.git")
+	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	gitOutput(t, repo.Path, "remote", "add", "team/upstream", remotePath)
+
+	repo.CreateBranch(t, "topic")
+	commitTestFile(t, repo.Path, "topic.txt", "topic\n", "Topic branch")
+	gitOutput(t, repo.Path, "push", "team/upstream", "topic")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "topic")
+	gitOutput(t, repo.Path, "branch", "team/upstream/topic")
+	gitOutput(t, repo.Path, "fetch", "team/upstream")
+
+	branches, err := New(repo.Path).ListAvailableBranches()
+	if err != nil {
+		t.Fatalf("ListAvailableBranches() error = %v", err)
+	}
+
+	bySource := make(map[string]models.Branch, len(branches))
+	for _, branch := range branches {
+		bySource[branch.Source] = branch
+	}
+	if got := bySource["team/upstream/topic"]; got.Name != "team/upstream/topic" ||
+		got.IsRemote {
+		t.Errorf("local collision branch = %+v, want canonical local identity", got)
+	}
+	const remoteSource = "refs/remotes/team/upstream/topic"
+	if got := bySource[remoteSource]; got.Name != "topic" || !got.IsRemote {
+		t.Errorf("remote collision branch = %+v, want topic from %s", got, remoteSource)
 	}
 }
 
@@ -736,6 +770,39 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	gitOutput(t, repo.Path, "push", "origin", "remote-only")
 	gitOutput(t, repo.Path, "checkout", "main")
 	gitOutput(t, repo.Path, "branch", "-D", "remote-only")
+	t.Setenv("KWT_GITHUB_TOKEN", "must-not-reach-remote-checkout")
+	t.Setenv("KWT_FLEET_TOKEN", "must-not-reach-remote-checkout")
+
+	if runtime.GOOS != "windows" {
+		realGit, err := exec.LookPath("git")
+		if err != nil {
+			t.Fatalf("find git executable: %v", err)
+		}
+		wrapperDir := t.TempDir()
+		wrapperPath := filepath.Join(wrapperDir, "git")
+		wrapper := `#!/bin/sh
+if [ "$1" = "branch" ] || { [ "$1" = "worktree" ] && [ "$2" = "add" ]; }; then
+	if [ -n "$KWT_GITHUB_TOKEN" ] || [ -n "$KWT_FLEET_TOKEN" ]; then
+		printf '%s\n' 'kwt credential reached remote-source git command' >&2
+		exit 88
+	fi
+fi
+if [ "$1" = "worktree" ] && [ "$2" = "add" ]; then
+	for arg in "$@"; do
+		if [ "$arg" = "--track" ]; then
+			printf '%s\n' 'error: unknown option track' >&2
+			exit 129
+		fi
+	done
+fi
+exec "$REAL_GIT" "$@"
+`
+		if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+			t.Fatalf("write git compatibility wrapper: %v", err)
+		}
+		t.Setenv("REAL_GIT", realGit)
+		t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
 
 	worktreePath := filepath.Join(t.TempDir(), "remote-only")
 	err := New(repo.Path).AddWorktreeTracking(
@@ -751,6 +818,39 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 	}
 	if got := gitOutput(t, worktreePath, "rev-parse", "--abbrev-ref", "@{upstream}"); got != "origin/remote-only" {
 		t.Errorf("upstream = %s, want origin/remote-only", got)
+	}
+}
+
+func TestAddWorktreeTrackingRollsBackBranchWhenWorktreeFails(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	gitOutput(t, filepath.Dir(remotePath), "init", "--bare", "-b", "main", remotePath)
+	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
+
+	repo.CreateBranch(t, "remote-only")
+	gitOutput(t, repo.Path, "push", "origin", "remote-only")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "remote-only")
+
+	occupiedPath := filepath.Join(t.TempDir(), "occupied")
+	if err := os.MkdirAll(occupiedPath, 0755); err != nil {
+		t.Fatalf("create occupied path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(occupiedPath, "keep"), []byte("keep"), 0644); err != nil {
+		t.Fatalf("write occupied path: %v", err)
+	}
+
+	err := New(repo.Path).AddWorktreeTracking(
+		occupiedPath,
+		"remote-only",
+		"refs/remotes/origin/remote-only",
+	)
+
+	if err == nil {
+		t.Fatal("AddWorktreeTracking() expected an error")
+	}
+	if err := repo.run("show-ref", "--verify", "--quiet", "refs/heads/remote-only"); err == nil {
+		t.Error("local tracking branch remained after worktree creation failed")
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -577,6 +577,7 @@ func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 		"includeIf.onbranch:existing-unreviewed.path",
 		includePath,
 	)
+	gitOutput(t, repo.Path, "config", "core.autocrlf", "true")
 
 	worktreePath := filepath.Join(t.TempDir(), "existing-unreviewed")
 	if err := New(repo.Path).AddWorktreeExisting(
@@ -600,7 +601,7 @@ func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 	}
 	if contents, err := os.ReadFile(filepath.Join(worktreePath, "branch.txt")); err != nil {
 		t.Errorf("read checked-out branch file: %v", err)
-	} else if string(contents) != "branch\n" {
+	} else if strings.ReplaceAll(string(contents), "\r\n", "\n") != "branch\n" {
 		t.Errorf("branch.txt = %q, want branch content", contents)
 	}
 	if got := gitOutput(t, worktreePath, "branch", "--show-current"); got != "existing-unreviewed" {
@@ -1017,6 +1018,7 @@ func TestAddWorktreeTrackingRemoteBranch(t *testing.T) {
 		"includeIf.gitdir:**/worktrees/remote-only.path",
 		includePath,
 	)
+	gitOutput(t, repo.Path, "config", "core.autocrlf", "true")
 
 	if runtime.GOOS != "windows" {
 		realGit, err := exec.LookPath("git")
@@ -1096,7 +1098,7 @@ exec "$REAL_GIT" "$@"
 	}
 	if contents, err := os.ReadFile(filepath.Join(worktreePath, "conditional.txt")); err != nil {
 		t.Errorf("read checked-out remote file: %v", err)
-	} else if string(contents) != "conditional content\n" {
+	} else if strings.ReplaceAll(string(contents), "\r\n", "\n") != "conditional content\n" {
 		t.Errorf("conditional.txt = %q, want remote content", contents)
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1331,6 +1331,44 @@ func TestAddWorktreeExistingRemovesWorktreeAfterCheckoutFailure(t *testing.T) {
 	}
 }
 
+func TestAddWorktreeExistingRejectsRemoteOnlyBranch(t *testing.T) {
+	repo := NewTestRepository(t)
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	gitOutput(
+		t,
+		filepath.Dir(remotePath),
+		"init",
+		"--bare",
+		"-b",
+		"main",
+		remotePath,
+	)
+	gitOutput(t, repo.Path, "remote", "add", "origin", remotePath)
+	repo.CreateBranch(t, "remote-only-local-import")
+	gitOutput(t, repo.Path, "push", "-u", "origin", "remote-only-local-import")
+	gitOutput(t, repo.Path, "checkout", "main")
+	gitOutput(t, repo.Path, "branch", "-D", "remote-only-local-import")
+	worktreePath := filepath.Join(t.TempDir(), "remote-only-local-import")
+
+	err := New(repo.Path).AddWorktreeExisting(
+		worktreePath,
+		"remote-only-local-import",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.NoDirExists(t, worktreePath)
+	assert.Error(
+		t,
+		repo.run(
+			"show-ref",
+			"--verify",
+			"--quiet",
+			"refs/heads/remote-only-local-import",
+		),
+	)
+}
+
 func TestAddWorktreeTrackingRemovesWorktreeAndBranchAfterCheckoutFailure(
 	t *testing.T,
 ) {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -194,6 +194,7 @@ func (g *Git) checkoutIsolationArgs(
 	if workDir != "" {
 		configArgs = append(configArgs, "-C", workDir)
 	}
+	configArgs = append(configArgs, "-c", "submodule.recurse=false")
 	configArgs = append(configArgs, "config", "--null", "--list")
 	output, err := g.runWithoutCredentials(protectedNames, configArgs...)
 	if err != nil {
@@ -239,11 +240,12 @@ func (g *Git) checkoutIsolationArgs(
 	}
 	sort.Strings(driverNames)
 
-	args := make([]string, 0, 4+len(hookNames)*2+len(driverNames)*6)
+	args := make([]string, 0, 6+len(hookNames)*2+len(driverNames)*6)
 	args = append(
 		args,
 		"-c", "core.hooksPath="+hooksDir,
 		"-c", "core.fsmonitor=false",
+		"-c", "submodule.recurse=false",
 	)
 	for _, hook := range hookNames {
 		args = append(args, "-c", "hook."+hook+".enabled=false")
@@ -275,7 +277,7 @@ func (g *Git) checkoutIsolatedWorktree(
 	}
 	args := []string{"-C", path}
 	args = append(args, isolationArgs...)
-	args = append(args, "checkout", "--force")
+	args = append(args, "checkout", "--force", "--no-recurse-submodules")
 	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
 		return err
 	}

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -87,10 +87,14 @@ func (g *Git) AddWorktreeTracking(
 		return fmt.Errorf("create empty hooks directory: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(hooksDir) }()
+	hookIsolation := []string{"-c", "core.hooksPath=" + hooksDir}
 
 	if _, err := g.runWithoutCredentials(
 		protectedNames,
-		"branch", "--track", branch, remoteBranch,
+		append(
+			append([]string(nil), hookIsolation...),
+			"branch", "--track", branch, remoteBranch,
+		)...,
 	); err != nil {
 		return fmt.Errorf(
 			"failed to create branch tracking %s: %w",
@@ -99,7 +103,7 @@ func (g *Git) AddWorktreeTracking(
 		)
 	}
 	worktreeArgs := append(
-		[]string{"-c", "core.hooksPath=" + hooksDir},
+		append([]string(nil), hookIsolation...),
 		isolationArgs...,
 	)
 	worktreeArgs = append(worktreeArgs, "worktree", "add", path, branch)
@@ -109,7 +113,10 @@ func (g *Git) AddWorktreeTracking(
 	); err != nil {
 		if _, rollbackErr := g.runWithoutCredentials(
 			protectedNames,
-			"branch", "-D", branch,
+			append(
+				append([]string(nil), hookIsolation...),
+				"branch", "-D", branch,
+			)...,
 		); rollbackErr != nil {
 			return fmt.Errorf(
 				"failed to add worktree tracking %s: %w (failed to remove branch %s: %v)",

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -74,9 +74,29 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 // AddWorktreeTracking creates a local branch and worktree that track a
 // specific remote branch.
 func (g *Git) AddWorktreeTracking(path, branch, remoteBranch string) error {
-	if _, err := g.run(
-		"worktree", "add", "--track", "-b", branch, path, remoteBranch,
+	if _, err := g.runWithoutKWTCredentials(
+		"branch", "--track", branch, remoteBranch,
 	); err != nil {
+		return fmt.Errorf(
+			"failed to create branch tracking %s: %w",
+			remoteBranch,
+			err,
+		)
+	}
+	if _, err := g.runWithoutKWTCredentials(
+		"worktree", "add", path, branch,
+	); err != nil {
+		if _, rollbackErr := g.runWithoutKWTCredentials(
+			"branch", "-D", branch,
+		); rollbackErr != nil {
+			return fmt.Errorf(
+				"failed to add worktree tracking %s: %w (failed to remove branch %s: %v)",
+				remoteBranch,
+				err,
+				branch,
+				rollbackErr,
+			)
+		}
 		return fmt.Errorf(
 			"failed to add worktree tracking %s: %w",
 			remoteBranch,

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -72,6 +72,32 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 	return nil
 }
 
+// AddWorktreeExisting checks out an existing branch without allowing the
+// checkout to run repository-configured hooks or filters, and without exposing
+// protected credentials to Git.
+func (g *Git) AddWorktreeExisting(
+	path, branch string,
+	protectedNames []string,
+) error {
+	isolationArgs, err := g.remoteCheckoutIsolationArgs(protectedNames)
+	if err != nil {
+		return err
+	}
+	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
+	if err != nil {
+		return fmt.Errorf("create empty hooks directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(hooksDir) }()
+
+	args := []string{"-c", "core.hooksPath=" + hooksDir}
+	args = append(args, isolationArgs...)
+	args = append(args, "worktree", "add", path, branch)
+	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
+		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
+	}
+	return nil
+}
+
 // AddWorktreeTracking creates a local branch and worktree that track a
 // specific remote branch.
 func (g *Git) AddWorktreeTracking(

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -71,6 +71,21 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 	return nil
 }
 
+// AddWorktreeTracking creates a local branch and worktree that track a
+// specific remote branch.
+func (g *Git) AddWorktreeTracking(path, branch, remoteBranch string) error {
+	if _, err := g.run(
+		"worktree", "add", "--track", "-b", branch, path, remoteBranch,
+	); err != nil {
+		return fmt.Errorf(
+			"failed to add worktree tracking %s: %w",
+			remoteBranch,
+			err,
+		)
+	}
+	return nil
+}
+
 func (g *Git) defaultWorktreeBase() (string, error) {
 	remoteBase, remoteErr := g.remoteDefaultWorktreeBase()
 	if remoteErr == nil {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -82,6 +82,7 @@ func (g *Git) AddWorktreeExisting(
 	if err := g.validateLocalBranchName(branch, protectedNames); err != nil {
 		return err
 	}
+	localBranch := strings.TrimPrefix(branch, "refs/heads/")
 	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
 	if err != nil {
 		return fmt.Errorf("create empty hooks directory: %w", err)
@@ -99,13 +100,15 @@ func (g *Git) AddWorktreeExisting(
 	args := append([]string(nil), isolationArgs...)
 	args = append(
 		args,
-		"worktree", "add", "--no-checkout", "--", path, branch,
+		"worktree", "add", "--no-checkout", "--detach",
+		"--", path, "refs/heads/"+localBranch,
 	)
 	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
 		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
+		localBranch,
 		protectedNames,
 		hooksDir,
 	); err != nil {
@@ -193,6 +196,7 @@ func (g *Git) AddWorktreeTracking(
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
+		"",
 		protectedNames,
 		hooksDir,
 	); err != nil {
@@ -337,6 +341,7 @@ func (g *Git) checkoutIsolationArgs(
 
 func (g *Git) checkoutIsolatedWorktree(
 	path string,
+	branch string,
 	protectedNames []string,
 	hooksDir string,
 ) error {
@@ -351,6 +356,9 @@ func (g *Git) checkoutIsolatedWorktree(
 	args := []string{"-C", path}
 	args = append(args, isolationArgs...)
 	args = append(args, "checkout", "--force", "--no-recurse-submodules")
+	if branch != "" {
+		args = append(args, branch, "--")
+	}
 	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
 		return err
 	}

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -82,7 +82,6 @@ func (g *Git) AddWorktreeExisting(
 	if err := g.validateLocalBranchName(branch, protectedNames); err != nil {
 		return err
 	}
-	localBranch := strings.TrimPrefix(branch, "refs/heads/")
 	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
 	if err != nil {
 		return fmt.Errorf("create empty hooks directory: %w", err)
@@ -101,14 +100,14 @@ func (g *Git) AddWorktreeExisting(
 	args = append(
 		args,
 		"worktree", "add", "--no-checkout", "--detach",
-		"--", path, "refs/heads/"+localBranch,
+		"--", path, "refs/heads/"+branch,
 	)
 	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
 		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
-		localBranch,
+		branch,
 		protectedNames,
 		hooksDir,
 	); err != nil {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	gitworktree "go.kenn.io/kit/git/worktree"
@@ -73,8 +74,22 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 
 // AddWorktreeTracking creates a local branch and worktree that track a
 // specific remote branch.
-func (g *Git) AddWorktreeTracking(path, branch, remoteBranch string) error {
-	if _, err := g.runWithoutKWTCredentials(
+func (g *Git) AddWorktreeTracking(
+	path, branch, remoteBranch string,
+	protectedNames []string,
+) error {
+	isolationArgs, err := g.remoteCheckoutIsolationArgs(protectedNames)
+	if err != nil {
+		return err
+	}
+	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
+	if err != nil {
+		return fmt.Errorf("create empty hooks directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(hooksDir) }()
+
+	if _, err := g.runWithoutCredentials(
+		protectedNames,
 		"branch", "--track", branch, remoteBranch,
 	); err != nil {
 		return fmt.Errorf(
@@ -83,10 +98,17 @@ func (g *Git) AddWorktreeTracking(path, branch, remoteBranch string) error {
 			err,
 		)
 	}
-	if _, err := g.runWithoutKWTCredentials(
-		"worktree", "add", path, branch,
+	worktreeArgs := append(
+		[]string{"-c", "core.hooksPath=" + hooksDir},
+		isolationArgs...,
+	)
+	worktreeArgs = append(worktreeArgs, "worktree", "add", path, branch)
+	if _, err := g.runWithoutCredentials(
+		protectedNames,
+		worktreeArgs...,
 	); err != nil {
-		if _, rollbackErr := g.runWithoutKWTCredentials(
+		if _, rollbackErr := g.runWithoutCredentials(
+			protectedNames,
 			"branch", "-D", branch,
 		); rollbackErr != nil {
 			return fmt.Errorf(
@@ -104,6 +126,52 @@ func (g *Git) AddWorktreeTracking(path, branch, remoteBranch string) error {
 		)
 	}
 	return nil
+}
+
+func (g *Git) remoteCheckoutIsolationArgs(
+	protectedNames []string,
+) ([]string, error) {
+	output, err := g.runWithoutCredentials(
+		protectedNames,
+		"config", "--null", "--list",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list configured checkout filters: %w", err)
+	}
+	drivers := make(map[string]bool)
+	for record := range strings.SplitSeq(output, "\x00") {
+		key, _, _ := strings.Cut(record, "\n")
+		key = strings.TrimSpace(key)
+		if !strings.HasPrefix(key, "filter.") {
+			continue
+		}
+		rest := strings.TrimPrefix(key, "filter.")
+		propertyAt := strings.LastIndex(rest, ".")
+		if propertyAt <= 0 {
+			continue
+		}
+		switch rest[propertyAt+1:] {
+		case "smudge", "process", "required":
+			drivers[rest[:propertyAt]] = true
+		}
+	}
+	names := make([]string, 0, len(drivers))
+	for driver := range drivers {
+		names = append(names, driver)
+	}
+	sort.Strings(names)
+
+	args := make([]string, 0, len(names)*6)
+	for _, driver := range names {
+		prefix := "filter." + driver + "."
+		args = append(
+			args,
+			"-c", prefix+"smudge=cat",
+			"-c", prefix+"process=",
+			"-c", prefix+"required=false",
+		)
+	}
+	return args, nil
 }
 
 func (g *Git) defaultWorktreeBase() (string, error) {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -79,6 +79,9 @@ func (g *Git) AddWorktreeExisting(
 	path, branch string,
 	protectedNames []string,
 ) error {
+	if err := g.validateLocalBranchName(branch, protectedNames); err != nil {
+		return err
+	}
 	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
 	if err != nil {
 		return fmt.Errorf("create empty hooks directory: %w", err)
@@ -94,7 +97,10 @@ func (g *Git) AddWorktreeExisting(
 		return err
 	}
 	args := append([]string(nil), isolationArgs...)
-	args = append(args, "worktree", "add", "--no-checkout", path, branch)
+	args = append(
+		args,
+		"worktree", "add", "--no-checkout", "--", path, branch,
+	)
 	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
 		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
 	}
@@ -103,6 +109,17 @@ func (g *Git) AddWorktreeExisting(
 		protectedNames,
 		hooksDir,
 	); err != nil {
+		if cleanupErr := g.removeIsolatedWorktree(
+			path,
+			protectedNames,
+			isolationArgs,
+		); cleanupErr != nil {
+			return fmt.Errorf(
+				"failed to check out existing-branch worktree: %w (failed to remove incomplete worktree: %v)",
+				err,
+				cleanupErr,
+			)
+		}
 		return fmt.Errorf("failed to check out existing-branch worktree: %w", err)
 	}
 	return nil
@@ -114,6 +131,9 @@ func (g *Git) AddWorktreeTracking(
 	path, branch, remoteBranch string,
 	protectedNames []string,
 ) error {
+	if err := g.validateLocalBranchName(branch, protectedNames); err != nil {
+		return err
+	}
 	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
 	if err != nil {
 		return fmt.Errorf("create empty hooks directory: %w", err)
@@ -132,7 +152,7 @@ func (g *Git) AddWorktreeTracking(
 		protectedNames,
 		append(
 			append([]string(nil), isolationArgs...),
-			"branch", "--track", branch, remoteBranch,
+			"branch", "--track", "--", branch, remoteBranch,
 		)...,
 	); err != nil {
 		return fmt.Errorf(
@@ -144,7 +164,7 @@ func (g *Git) AddWorktreeTracking(
 	worktreeArgs := append([]string(nil), isolationArgs...)
 	worktreeArgs = append(
 		worktreeArgs,
-		"worktree", "add", "--no-checkout", path, branch,
+		"worktree", "add", "--no-checkout", "--", path, branch,
 	)
 	if _, err := g.runWithoutCredentials(
 		protectedNames,
@@ -154,7 +174,7 @@ func (g *Git) AddWorktreeTracking(
 			protectedNames,
 			append(
 				append([]string(nil), isolationArgs...),
-				"branch", "-D", branch,
+				"branch", "-D", "--", branch,
 			)...,
 		); rollbackErr != nil {
 			return fmt.Errorf(
@@ -176,11 +196,64 @@ func (g *Git) AddWorktreeTracking(
 		protectedNames,
 		hooksDir,
 	); err != nil {
+		if cleanupErr := g.removeIsolatedWorktree(
+			path,
+			protectedNames,
+			isolationArgs,
+		); cleanupErr != nil {
+			return fmt.Errorf(
+				"failed to check out worktree tracking %s: %w (failed to remove incomplete worktree: %v)",
+				remoteBranch,
+				err,
+				cleanupErr,
+			)
+		}
+		if _, cleanupErr := g.runWithoutCredentials(
+			protectedNames,
+			append(
+				append([]string(nil), isolationArgs...),
+				"branch", "-D", "--", branch,
+			)...,
+		); cleanupErr != nil {
+			return fmt.Errorf(
+				"failed to check out worktree tracking %s: %w (failed to remove branch %s: %v)",
+				remoteBranch,
+				err,
+				branch,
+				cleanupErr,
+			)
+		}
 		return fmt.Errorf(
 			"failed to check out worktree tracking %s: %w",
 			remoteBranch,
 			err,
 		)
+	}
+	return nil
+}
+
+func (g *Git) validateLocalBranchName(
+	branch string,
+	protectedNames []string,
+) error {
+	if _, err := g.runWithoutCredentials(
+		protectedNames,
+		"check-ref-format", "--branch", branch,
+	); err != nil {
+		return fmt.Errorf("invalid local branch name %q: %w", branch, err)
+	}
+	return nil
+}
+
+func (g *Git) removeIsolatedWorktree(
+	path string,
+	protectedNames []string,
+	isolationArgs []string,
+) error {
+	args := append([]string(nil), isolationArgs...)
+	args = append(args, "worktree", "remove", "--force", "--", path)
+	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -79,21 +79,31 @@ func (g *Git) AddWorktreeExisting(
 	path, branch string,
 	protectedNames []string,
 ) error {
-	isolationArgs, err := g.remoteCheckoutIsolationArgs(protectedNames)
-	if err != nil {
-		return err
-	}
 	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
 	if err != nil {
 		return fmt.Errorf("create empty hooks directory: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(hooksDir) }()
 
-	args := []string{"-c", "core.hooksPath=" + hooksDir}
-	args = append(args, isolationArgs...)
-	args = append(args, "worktree", "add", path, branch)
+	isolationArgs, err := g.checkoutIsolationArgs(
+		protectedNames,
+		"",
+		hooksDir,
+	)
+	if err != nil {
+		return err
+	}
+	args := append([]string(nil), isolationArgs...)
+	args = append(args, "worktree", "add", "--no-checkout", path, branch)
 	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
 		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
+	}
+	if err := g.checkoutIsolatedWorktree(
+		path,
+		protectedNames,
+		hooksDir,
+	); err != nil {
+		return fmt.Errorf("failed to check out existing-branch worktree: %w", err)
 	}
 	return nil
 }
@@ -104,21 +114,24 @@ func (g *Git) AddWorktreeTracking(
 	path, branch, remoteBranch string,
 	protectedNames []string,
 ) error {
-	isolationArgs, err := g.remoteCheckoutIsolationArgs(protectedNames)
-	if err != nil {
-		return err
-	}
 	hooksDir, err := os.MkdirTemp("", "kwt-empty-hooks-")
 	if err != nil {
 		return fmt.Errorf("create empty hooks directory: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(hooksDir) }()
-	hookIsolation := []string{"-c", "core.hooksPath=" + hooksDir}
+	isolationArgs, err := g.checkoutIsolationArgs(
+		protectedNames,
+		"",
+		hooksDir,
+	)
+	if err != nil {
+		return err
+	}
 
 	if _, err := g.runWithoutCredentials(
 		protectedNames,
 		append(
-			append([]string(nil), hookIsolation...),
+			append([]string(nil), isolationArgs...),
 			"branch", "--track", branch, remoteBranch,
 		)...,
 	); err != nil {
@@ -128,11 +141,11 @@ func (g *Git) AddWorktreeTracking(
 			err,
 		)
 	}
-	worktreeArgs := append(
-		append([]string(nil), hookIsolation...),
-		isolationArgs...,
+	worktreeArgs := append([]string(nil), isolationArgs...)
+	worktreeArgs = append(
+		worktreeArgs,
+		"worktree", "add", "--no-checkout", path, branch,
 	)
-	worktreeArgs = append(worktreeArgs, "worktree", "add", path, branch)
 	if _, err := g.runWithoutCredentials(
 		protectedNames,
 		worktreeArgs...,
@@ -140,7 +153,7 @@ func (g *Git) AddWorktreeTracking(
 		if _, rollbackErr := g.runWithoutCredentials(
 			protectedNames,
 			append(
-				append([]string(nil), hookIsolation...),
+				append([]string(nil), isolationArgs...),
 				"branch", "-D", branch,
 			)...,
 		); rollbackErr != nil {
@@ -158,44 +171,84 @@ func (g *Git) AddWorktreeTracking(
 			err,
 		)
 	}
+	if err := g.checkoutIsolatedWorktree(
+		path,
+		protectedNames,
+		hooksDir,
+	); err != nil {
+		return fmt.Errorf(
+			"failed to check out worktree tracking %s: %w",
+			remoteBranch,
+			err,
+		)
+	}
 	return nil
 }
 
-func (g *Git) remoteCheckoutIsolationArgs(
+func (g *Git) checkoutIsolationArgs(
 	protectedNames []string,
+	workDir string,
+	hooksDir string,
 ) ([]string, error) {
-	output, err := g.runWithoutCredentials(
-		protectedNames,
-		"config", "--null", "--list",
-	)
+	configArgs := make([]string, 0, 5)
+	if workDir != "" {
+		configArgs = append(configArgs, "-C", workDir)
+	}
+	configArgs = append(configArgs, "config", "--null", "--list")
+	output, err := g.runWithoutCredentials(protectedNames, configArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("list configured checkout filters: %w", err)
+		return nil, fmt.Errorf("list configured checkout isolation: %w", err)
 	}
 	drivers := make(map[string]bool)
+	hooks := make(map[string]bool)
 	for record := range strings.SplitSeq(output, "\x00") {
 		key, _, _ := strings.Cut(record, "\n")
 		key = strings.TrimSpace(key)
-		if !strings.HasPrefix(key, "filter.") {
-			continue
-		}
-		rest := strings.TrimPrefix(key, "filter.")
-		propertyAt := strings.LastIndex(rest, ".")
-		if propertyAt <= 0 {
-			continue
-		}
-		switch rest[propertyAt+1:] {
-		case "smudge", "process", "required":
-			drivers[rest[:propertyAt]] = true
+		lowerKey := strings.ToLower(key)
+		switch {
+		case strings.HasPrefix(lowerKey, "filter."):
+			rest := key[len("filter."):]
+			propertyAt := strings.LastIndex(rest, ".")
+			if propertyAt <= 0 {
+				continue
+			}
+			switch strings.ToLower(rest[propertyAt+1:]) {
+			case "smudge", "process", "required":
+				drivers[rest[:propertyAt]] = true
+			}
+		case strings.HasPrefix(lowerKey, "hook."):
+			rest := key[len("hook."):]
+			propertyAt := strings.LastIndex(rest, ".")
+			if propertyAt <= 0 {
+				continue
+			}
+			switch strings.ToLower(rest[propertyAt+1:]) {
+			case "command", "enabled", "event", "parallel":
+				hooks[rest[:propertyAt]] = true
+			}
 		}
 	}
-	names := make([]string, 0, len(drivers))
+	hookNames := make([]string, 0, len(hooks))
+	for hook := range hooks {
+		hookNames = append(hookNames, hook)
+	}
+	sort.Strings(hookNames)
+	driverNames := make([]string, 0, len(drivers))
 	for driver := range drivers {
-		names = append(names, driver)
+		driverNames = append(driverNames, driver)
 	}
-	sort.Strings(names)
+	sort.Strings(driverNames)
 
-	args := make([]string, 0, len(names)*6)
-	for _, driver := range names {
+	args := make([]string, 0, 4+len(hookNames)*2+len(driverNames)*6)
+	args = append(
+		args,
+		"-c", "core.hooksPath="+hooksDir,
+		"-c", "core.fsmonitor=false",
+	)
+	for _, hook := range hookNames {
+		args = append(args, "-c", "hook."+hook+".enabled=false")
+	}
+	for _, driver := range driverNames {
 		prefix := "filter." + driver + "."
 		args = append(
 			args,
@@ -205,6 +258,28 @@ func (g *Git) remoteCheckoutIsolationArgs(
 		)
 	}
 	return args, nil
+}
+
+func (g *Git) checkoutIsolatedWorktree(
+	path string,
+	protectedNames []string,
+	hooksDir string,
+) error {
+	isolationArgs, err := g.checkoutIsolationArgs(
+		protectedNames,
+		path,
+		hooksDir,
+	)
+	if err != nil {
+		return err
+	}
+	args := []string{"-C", path}
+	args = append(args, isolationArgs...)
+	args = append(args, "checkout", "--force")
+	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (g *Git) defaultWorktreeBase() (string, error) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/gofrs/flock"
 )
 
 // WorktreeEntry represents a registered worktree.
@@ -66,73 +68,131 @@ func New() (*Registry, error) {
 
 // load reads the registry from disk.
 func (r *Registry) load() error {
-	data, err := os.ReadFile(r.path)
+	entries, err := loadEntries(r.path)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.entries = entries
+	r.mu.Unlock()
+	return nil
+}
+
+func loadEntries(path string) (map[string]*WorktreeEntry, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Registry doesn't exist yet, that's OK
-			return nil
+			return make(map[string]*WorktreeEntry), nil
 		}
-		return fmt.Errorf("failed to read registry: %w", err)
+		return nil, fmt.Errorf("failed to read registry: %w", err)
 	}
 
 	if len(data) == 0 {
-		return nil
+		return make(map[string]*WorktreeEntry), nil
 	}
 
 	var entries []*WorktreeEntry
 	if err := json.Unmarshal(data, &entries); err != nil {
-		return fmt.Errorf("failed to unmarshal registry: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal registry: %w", err)
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.entries = make(map[string]*WorktreeEntry)
+	result := make(map[string]*WorktreeEntry, len(entries))
 	for _, entry := range entries {
-		r.entries[entry.Path] = entry
+		result[entry.Path] = entry
 	}
-
-	return nil
+	return result, nil
 }
 
-// save writes the registry to disk.
-func (r *Registry) save() error {
-	r.mu.RLock()
-	entries := make([]*WorktreeEntry, 0, len(r.entries))
-	for _, entry := range r.entries {
+func saveEntries(path string, entriesByPath map[string]*WorktreeEntry) error {
+	entries := make([]*WorktreeEntry, 0, len(entriesByPath))
+	for _, entry := range entriesByPath {
 		entries = append(entries, entry)
 	}
-	r.mu.RUnlock()
 
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal registry: %w", err)
 	}
+	data = append(data, '\n')
 
-	if err := os.WriteFile(r.path, data, 0644); err != nil {
-		return fmt.Errorf("failed to write registry: %w", err)
+	temp, err := os.CreateTemp(filepath.Dir(path), ".registry-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create registry temp file: %w", err)
 	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := temp.Chmod(0644); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("failed to set registry temp permissions: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("failed to write registry temp file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("failed to sync registry temp file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("failed to close registry temp file: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("failed to replace registry: %w", err)
+	}
+	return nil
+}
 
+func (r *Registry) mutate(
+	change func(map[string]*WorktreeEntry) bool,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(r.path), 0755); err != nil {
+		return fmt.Errorf("failed to create registry directory: %w", err)
+	}
+	lock := flock.New(r.path+".lock", flock.SetPermissions(0600))
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("failed to lock registry: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	entries, err := loadEntries(r.path)
+	if err != nil {
+		return err
+	}
+	changed := change(entries)
+	if changed {
+		if err := saveEntries(r.path, entries); err != nil {
+			return err
+		}
+	}
+	r.entries = entries
 	return nil
 }
 
 // Register adds or updates a worktree entry.
 func (r *Registry) Register(entry *WorktreeEntry) error {
-	r.mu.Lock()
-	entry.RegisteredAt = time.Now()
-	r.entries[entry.Path] = entry
-	r.mu.Unlock()
-
-	return r.save()
+	copied := *entry
+	if copied.RegisteredAt.IsZero() {
+		copied.RegisteredAt = time.Now()
+	}
+	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		entries[copied.Path] = &copied
+		return true
+	})
 }
 
 // Unregister removes a worktree entry by path.
 func (r *Registry) Unregister(path string) error {
-	r.mu.Lock()
-	delete(r.entries, path)
-	r.mu.Unlock()
-
-	return r.save()
+	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		if _, ok := entries[path]; !ok {
+			return false
+		}
+		delete(entries, path)
+		return true
+	})
 }
 
 // List returns all registered worktrees.
@@ -168,8 +228,12 @@ func (r *Registry) Get(path string) (*WorktreeEntry, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	entry, ok := r.entries[path]
-	return entry, ok
+	entry, ok := r.entryForPath(path)
+	if !ok {
+		return nil, false
+	}
+	copied := *entry
+	return &copied, true
 }
 
 // IsUnreviewedRemoteSource reports whether path was created from remote
@@ -185,23 +249,29 @@ func (r *Registry) IsUnreviewedRemoteSource(path string) bool {
 // AcknowledgeRemoteSource marks a remote-source worktree as reviewed while
 // preserving any other registry metadata such as its expiration.
 func (r *Registry) AcknowledgeRemoteSource(path string) error {
-	r.mu.Lock()
-	entry, ok := r.entryForPath(path)
-	if !ok || !entry.UnreviewedRemoteSource {
-		r.mu.Unlock()
-		return nil
-	}
-	entry.UnreviewedRemoteSource = false
-	r.mu.Unlock()
-	return r.save()
+	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		entry, ok := entryForPath(entries, path)
+		if !ok || !entry.UnreviewedRemoteSource {
+			return false
+		}
+		entry.UnreviewedRemoteSource = false
+		return true
+	})
 }
 
 func (r *Registry) entryForPath(path string) (*WorktreeEntry, bool) {
-	if entry, ok := r.entries[path]; ok {
+	return entryForPath(r.entries, path)
+}
+
+func entryForPath(
+	entries map[string]*WorktreeEntry,
+	path string,
+) (*WorktreeEntry, bool) {
+	if entry, ok := entries[path]; ok {
 		return entry, true
 	}
 	want := comparableRegistryPath(path)
-	for _, entry := range r.entries {
+	for _, entry := range entries {
 		if comparableRegistryPath(entry.Path) == want {
 			return entry, true
 		}
@@ -251,25 +321,15 @@ func (r *Registry) ListExpired() []*WorktreeEntry {
 
 // Cleanup removes entries that no longer exist on disk.
 func (r *Registry) Cleanup() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	var toRemove []string
-	for path, entry := range r.entries {
-		// Check if the worktree directory still exists
-		gitDir := filepath.Join(path, ".git")
-		if _, err := os.Stat(gitDir); os.IsNotExist(err) {
-			toRemove = append(toRemove, entry.Path)
+	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		changed := false
+		for path := range entries {
+			gitDir := filepath.Join(path, ".git")
+			if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+				delete(entries, path)
+				changed = true
+			}
 		}
-	}
-
-	for _, path := range toRemove {
-		delete(r.entries, path)
-	}
-
-	if len(toRemove) > 0 {
-		return r.save()
-	}
-
-	return nil
+		return changed
+	})
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -179,6 +179,9 @@ func (r *Registry) Register(entry *WorktreeEntry) error {
 		copied.RegisteredAt = time.Now()
 	}
 	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		for _, key := range matchingRegistryKeys(entries, copied.Path) {
+			delete(entries, key)
+		}
 		entries[copied.Path] = &copied
 		return true
 	})
@@ -187,11 +190,11 @@ func (r *Registry) Register(entry *WorktreeEntry) error {
 // Unregister removes a worktree entry by path.
 func (r *Registry) Unregister(path string) error {
 	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
-		if _, ok := entries[path]; !ok {
-			return false
+		keys := matchingRegistryKeys(entries, path)
+		for _, key := range keys {
+			delete(entries, key)
 		}
-		delete(entries, path)
-		return true
+		return len(keys) > 0
 	})
 }
 
@@ -250,12 +253,14 @@ func (r *Registry) IsUnreviewedRemoteSource(path string) bool {
 // preserving any other registry metadata such as its expiration.
 func (r *Registry) AcknowledgeRemoteSource(path string) error {
 	return r.mutate(func(entries map[string]*WorktreeEntry) bool {
-		entry, ok := entryForPath(entries, path)
-		if !ok || !entry.UnreviewedRemoteSource {
-			return false
+		changed := false
+		for _, key := range matchingRegistryKeys(entries, path) {
+			if entries[key].UnreviewedRemoteSource {
+				entries[key].UnreviewedRemoteSource = false
+				changed = true
+			}
 		}
-		entry.UnreviewedRemoteSource = false
-		return true
+		return changed
 	})
 }
 
@@ -277,6 +282,21 @@ func entryForPath(
 		}
 	}
 	return nil, false
+}
+
+func matchingRegistryKeys(
+	entries map[string]*WorktreeEntry,
+	path string,
+) []string {
+	want := comparableRegistryPath(path)
+	keys := make([]string, 0, 1)
+	for key, entry := range entries {
+		if key == path || entry.Path == path ||
+			comparableRegistryPath(entry.Path) == want {
+			keys = append(keys, key)
+		}
+	}
+	return keys
 }
 
 func comparableRegistryPath(path string) string {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -316,21 +316,6 @@ func comparableRegistryPath(path string) string {
 	return filepath.Clean(path)
 }
 
-// UnreviewedRemoteSourcePaths returns the paths that automatic status and
-// fleet collection must not inspect.
-func (r *Registry) UnreviewedRemoteSourcePaths() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	paths := make([]string, 0)
-	for _, entry := range r.entries {
-		if entry.UnreviewedRemoteSource {
-			paths = append(paths, entry.Path)
-		}
-	}
-	return paths
-}
-
 // ListExpired returns all worktrees that have expired.
 func (r *Registry) ListExpired() []*WorktreeEntry {
 	r.mu.RLock()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -116,13 +116,20 @@ func saveEntries(path string, entriesByPath map[string]*WorktreeEntry) error {
 	}
 	data = append(data, '\n')
 
+	mode := os.FileMode(0600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		existing := info.Mode().Perm()
+		if existing&^os.FileMode(0600) == 0 {
+			mode = existing
+		}
+	}
 	temp, err := os.CreateTemp(filepath.Dir(path), ".registry-*.tmp")
 	if err != nil {
 		return fmt.Errorf("failed to create registry temp file: %w", err)
 	}
 	tempPath := temp.Name()
 	defer func() { _ = os.Remove(tempPath) }()
-	if err := temp.Chmod(0644); err != nil {
+	if err := temp.Chmod(mode); err != nil {
 		_ = temp.Close()
 		return fmt.Errorf("failed to set registry temp permissions: %w", err)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -12,13 +12,14 @@ import (
 
 // WorktreeEntry represents a registered worktree.
 type WorktreeEntry struct {
-	Repository   string     `json:"repository"`
-	Branch       string     `json:"branch"`
-	Path         string     `json:"path"`
-	Hash         string     `json:"hash"`
-	IsMain       bool       `json:"is_main"`
-	RegisteredAt time.Time  `json:"registered_at"`
-	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
+	Repository             string     `json:"repository"`
+	Branch                 string     `json:"branch"`
+	Path                   string     `json:"path"`
+	Hash                   string     `json:"hash"`
+	IsMain                 bool       `json:"is_main"`
+	RegisteredAt           time.Time  `json:"registered_at"`
+	ExpiresAt              *time.Time `json:"expires_at,omitempty"`
+	UnreviewedRemoteSource bool       `json:"unreviewed_remote_source,omitempty"`
 }
 
 // IsExpired returns true if the worktree has an expiration date that has passed.
@@ -169,6 +170,68 @@ func (r *Registry) Get(path string) (*WorktreeEntry, bool) {
 
 	entry, ok := r.entries[path]
 	return entry, ok
+}
+
+// IsUnreviewedRemoteSource reports whether path was created from remote
+// content that has not yet been explicitly opened by the user.
+func (r *Registry) IsUnreviewedRemoteSource(path string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.entryForPath(path)
+	return ok && entry.UnreviewedRemoteSource
+}
+
+// AcknowledgeRemoteSource marks a remote-source worktree as reviewed while
+// preserving any other registry metadata such as its expiration.
+func (r *Registry) AcknowledgeRemoteSource(path string) error {
+	r.mu.Lock()
+	entry, ok := r.entryForPath(path)
+	if !ok || !entry.UnreviewedRemoteSource {
+		r.mu.Unlock()
+		return nil
+	}
+	entry.UnreviewedRemoteSource = false
+	r.mu.Unlock()
+	return r.save()
+}
+
+func (r *Registry) entryForPath(path string) (*WorktreeEntry, bool) {
+	if entry, ok := r.entries[path]; ok {
+		return entry, true
+	}
+	want := comparableRegistryPath(path)
+	for _, entry := range r.entries {
+		if comparableRegistryPath(entry.Path) == want {
+			return entry, true
+		}
+	}
+	return nil, false
+}
+
+func comparableRegistryPath(path string) string {
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path)
+}
+
+// UnreviewedRemoteSourcePaths returns the paths that automatic status and
+// fleet collection must not inspect.
+func (r *Registry) UnreviewedRemoteSourcePaths() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	paths := make([]string, 0)
+	for _, entry := range r.entries {
+		if entry.UnreviewedRemoteSource {
+			paths = append(paths, entry.Path)
+		}
+	}
+	return paths
 }
 
 // ListExpired returns all worktrees that have expired.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -212,6 +213,56 @@ func TestRegistryMutationsTreatSymlinkAliasesAsOneWorktree(t *testing.T) {
 	}
 	if got := r.List(); len(got) != 0 {
 		t.Fatalf("List() after unregister = %+v, want empty registry", got)
+	}
+}
+
+func TestRegistryRewriteKeepsFilePrivate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX file permission bits")
+	}
+	path := filepath.Join(t.TempDir(), "registry.json")
+	r := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+
+	if err := r.Register(&WorktreeEntry{
+		Path:       "/worktrees/private",
+		Repository: "https://user:secret@example.com/repo.git",
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat registry: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("new registry mode = %o, want 600", got)
+	}
+
+	if err := os.Chmod(path, 0644); err != nil {
+		t.Fatalf("make legacy registry readable: %v", err)
+	}
+	if err := r.Register(&WorktreeEntry{Path: "/worktrees/second"}); err != nil {
+		t.Fatalf("rewrite legacy registry: %v", err)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rewritten registry: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("rewritten legacy registry mode = %o, want 600", got)
+	}
+
+	if err := os.Chmod(path, 0400); err != nil {
+		t.Fatalf("restrict registry: %v", err)
+	}
+	if err := r.Register(&WorktreeEntry{Path: "/worktrees/third"}); err != nil {
+		t.Fatalf("rewrite restricted registry: %v", err)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat restricted registry: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0400 {
+		t.Fatalf("restricted registry mode = %o, want 400", got)
 	}
 }
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -132,6 +132,42 @@ func TestRegistry_ListExpired(t *testing.T) {
 	}
 }
 
+func TestRegistryAcknowledgesUnreviewedRemoteSourceWithoutLosingExpiration(
+	t *testing.T,
+) {
+	future := time.Now().Add(time.Hour)
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	if err := r.Register(&WorktreeEntry{
+		Path:                   "/worktrees/remote",
+		Branch:                 "feature/remote",
+		ExpiresAt:              &future,
+		UnreviewedRemoteSource: true,
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	if !r.IsUnreviewedRemoteSource("/worktrees/remote") {
+		t.Fatal("remote source was not marked unreviewed")
+	}
+	if err := r.AcknowledgeRemoteSource("/worktrees/remote"); err != nil {
+		t.Fatalf("AcknowledgeRemoteSource() error = %v", err)
+	}
+	if r.IsUnreviewedRemoteSource("/worktrees/remote") {
+		t.Fatal("remote source remained unreviewed after acknowledgement")
+	}
+	entry, ok := r.Get("/worktrees/remote")
+	if !ok || entry.ExpiresAt == nil {
+		t.Fatal("acknowledgement discarded expiration metadata")
+	}
+	if entry.ExpiresAt.Sub(future) > time.Second ||
+		future.Sub(*entry.ExpiresAt) > time.Second {
+		t.Fatalf("expiration = %v, want %v", entry.ExpiresAt, future)
+	}
+}
+
 func TestWorktreeEntry_ExpiresAt_JSONMarshal(t *testing.T) {
 	// Test that ExpiresAt is omitted when nil (backwards compatibility)
 	entry := &WorktreeEntry{

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -165,6 +166,111 @@ func TestRegistryAcknowledgesUnreviewedRemoteSourceWithoutLosingExpiration(
 	if entry.ExpiresAt.Sub(future) > time.Second ||
 		future.Sub(*entry.ExpiresAt) > time.Second {
 		t.Fatalf("expiration = %v, want %v", entry.ExpiresAt, future)
+	}
+}
+
+func TestRegistryConcurrentRegistrationsPreserveBothMarkers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	left := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	right := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	var done sync.WaitGroup
+	done.Add(2)
+
+	register := func(r *Registry, worktreePath string) {
+		defer done.Done()
+		ready.Done()
+		<-start
+		errs <- r.Register(&WorktreeEntry{
+			Path:                   worktreePath,
+			UnreviewedRemoteSource: true,
+		})
+	}
+	go register(left, "/worktrees/left")
+	go register(right, "/worktrees/right")
+	ready.Wait()
+	close(start)
+	done.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+	}
+
+	reloaded := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	if err := reloaded.load(); err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	if !reloaded.IsUnreviewedRemoteSource("/worktrees/left") {
+		t.Error("left registration was lost")
+	}
+	if !reloaded.IsUnreviewedRemoteSource("/worktrees/right") {
+		t.Error("right registration was lost")
+	}
+}
+
+func TestRegistryConcurrentAcknowledgementPreservesOtherMutation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	seed := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	if err := seed.Register(&WorktreeEntry{
+		Path:                   "/worktrees/reviewed",
+		UnreviewedRemoteSource: true,
+	}); err != nil {
+		t.Fatalf("seed Register() error = %v", err)
+	}
+	acknowledger := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	registrar := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	if err := acknowledger.load(); err != nil {
+		t.Fatalf("load acknowledger: %v", err)
+	}
+	if err := registrar.load(); err != nil {
+		t.Fatalf("load registrar: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	var done sync.WaitGroup
+	done.Add(2)
+	go func() {
+		defer done.Done()
+		ready.Done()
+		<-start
+		errs <- acknowledger.AcknowledgeRemoteSource("/worktrees/reviewed")
+	}()
+	go func() {
+		defer done.Done()
+		ready.Done()
+		<-start
+		errs <- registrar.Register(&WorktreeEntry{
+			Path:                   "/worktrees/new",
+			UnreviewedRemoteSource: true,
+		})
+	}()
+	ready.Wait()
+	close(start)
+	done.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("registry mutation error = %v", err)
+		}
+	}
+
+	reloaded := &Registry{entries: make(map[string]*WorktreeEntry), path: path}
+	if err := reloaded.load(); err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	if reloaded.IsUnreviewedRemoteSource("/worktrees/reviewed") {
+		t.Error("acknowledgement was overwritten")
+	}
+	if !reloaded.IsUnreviewedRemoteSource("/worktrees/new") {
+		t.Error("concurrent registration was lost")
 	}
 }
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -169,6 +169,52 @@ func TestRegistryAcknowledgesUnreviewedRemoteSourceWithoutLosingExpiration(
 	}
 }
 
+func TestRegistryMutationsTreatSymlinkAliasesAsOneWorktree(t *testing.T) {
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(worktreePath, 0755); err != nil {
+		t.Fatalf("create worktree path: %v", err)
+	}
+	aliasPath := filepath.Join(root, "worktree-alias")
+	if err := os.Symlink(worktreePath, aliasPath); err != nil {
+		t.Skipf("symbolic links are not supported or allowed: %v", err)
+	}
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(root, "registry.json"),
+	}
+	if err := r.Register(&WorktreeEntry{
+		Path:                   worktreePath,
+		Branch:                 "first",
+		UnreviewedRemoteSource: true,
+	}); err != nil {
+		t.Fatalf("Register(real path) error = %v", err)
+	}
+	if err := r.Register(&WorktreeEntry{
+		Path:                   aliasPath,
+		Branch:                 "latest",
+		UnreviewedRemoteSource: true,
+	}); err != nil {
+		t.Fatalf("Register(alias path) error = %v", err)
+	}
+
+	if got := r.List(); len(got) != 1 || got[0].Branch != "latest" {
+		t.Fatalf("List() = %+v, want one latest alias registration", got)
+	}
+	if err := r.AcknowledgeRemoteSource(worktreePath); err != nil {
+		t.Fatalf("AcknowledgeRemoteSource(real path) error = %v", err)
+	}
+	if r.IsUnreviewedRemoteSource(aliasPath) {
+		t.Fatal("alias remained unreviewed after canonical path acknowledgement")
+	}
+	if err := r.Unregister(worktreePath); err != nil {
+		t.Fatalf("Unregister(real path) error = %v", err)
+	}
+	if got := r.List(); len(got) != 0 {
+		t.Fatalf("List() after unregister = %+v, want empty registry", got)
+	}
+}
+
 func TestRegistryConcurrentRegistrationsPreserveBothMarkers(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "registry.json")
 	left := &Registry{entries: make(map[string]*WorktreeEntry), path: path}

--- a/internal/status/status_collector.go
+++ b/internal/status/status_collector.go
@@ -21,6 +21,7 @@ type StatusCollectorOptions struct {
 	FetchRemote    bool
 	StaleThreshold time.Duration
 	BaseDir        string
+	SkipWorktree   func(path string) bool
 }
 
 // StatusCollector collects status information for worktrees.
@@ -28,6 +29,7 @@ type StatusCollector struct {
 	fetchRemote    bool
 	staleThreshold time.Duration
 	basedir        string
+	skipWorktree   func(path string) bool
 }
 
 // NewStatusCollectorWithOptions creates a new status collector with custom options.
@@ -41,6 +43,7 @@ func NewStatusCollectorWithOptions(opts StatusCollectorOptions) *StatusCollector
 		fetchRemote:    opts.FetchRemote,
 		staleThreshold: opts.StaleThreshold,
 		basedir:        opts.BaseDir,
+		skipWorktree:   opts.SkipWorktree,
 	}
 }
 
@@ -99,8 +102,17 @@ func (c *StatusCollector) CollectAll(ctx context.Context, worktrees []*models.Wo
 }
 
 func (c *StatusCollector) collectOne(ctx context.Context, worktree *models.Worktree) (*models.WorktreeStatus, error) {
-	g := git.New(worktree.Path)
 	repository := strings.TrimSpace(worktree.Repository)
+	if c.skipWorktree != nil && c.skipWorktree(worktree.Path) {
+		return &models.WorktreeStatus{
+			Path:       worktree.Path,
+			Branch:     worktree.Branch,
+			Repository: repository,
+			Status:     models.WorktreeStatusUnknown,
+		}, nil
+	}
+
+	g := git.New(worktree.Path)
 	if repository == "" {
 		repository = c.repositoryIdentity(g, worktree.Path)
 	}

--- a/internal/status/status_collector.go
+++ b/internal/status/status_collector.go
@@ -21,7 +21,6 @@ type StatusCollectorOptions struct {
 	FetchRemote    bool
 	StaleThreshold time.Duration
 	BaseDir        string
-	SkipWorktree   func(path string) bool
 }
 
 // StatusCollector collects status information for worktrees.
@@ -29,7 +28,6 @@ type StatusCollector struct {
 	fetchRemote    bool
 	staleThreshold time.Duration
 	basedir        string
-	skipWorktree   func(path string) bool
 }
 
 // NewStatusCollectorWithOptions creates a new status collector with custom options.
@@ -43,7 +41,6 @@ func NewStatusCollectorWithOptions(opts StatusCollectorOptions) *StatusCollector
 		fetchRemote:    opts.FetchRemote,
 		staleThreshold: opts.StaleThreshold,
 		basedir:        opts.BaseDir,
-		skipWorktree:   opts.SkipWorktree,
 	}
 }
 
@@ -103,15 +100,6 @@ func (c *StatusCollector) CollectAll(ctx context.Context, worktrees []*models.Wo
 
 func (c *StatusCollector) collectOne(ctx context.Context, worktree *models.Worktree) (*models.WorktreeStatus, error) {
 	repository := strings.TrimSpace(worktree.Repository)
-	if c.skipWorktree != nil && c.skipWorktree(worktree.Path) {
-		return &models.WorktreeStatus{
-			Path:       worktree.Path,
-			Branch:     worktree.Branch,
-			Repository: repository,
-			Status:     models.WorktreeStatusUnknown,
-		}, nil
-	}
-
 	g := git.New(worktree.Path)
 	if repository == "" {
 		repository = c.repositoryIdentity(g, worktree.Path)

--- a/internal/status/status_collector_test.go
+++ b/internal/status/status_collector_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,6 +74,46 @@ func TestCollectAllPrefersWorktreeRepository(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
 	assert.Equal(t, "github.com/upstream/repo", statuses[0].Repository)
+}
+
+func TestCollectAllSkipsUnreviewedWorktreeBeforeGitInspection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable fsmonitor hook fixture requires a POSIX shell")
+	}
+	worktreePath := t.TempDir()
+	runStatusTestGit(t, worktreePath, "init", "-b", "main")
+	runStatusTestGit(t, worktreePath, "config", "user.name", "Test User")
+	runStatusTestGit(t, worktreePath, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "README.md"),
+		[]byte("# unreviewed\n"),
+		0644,
+	))
+	runStatusTestGit(t, worktreePath, "add", ".")
+	runStatusTestGit(t, worktreePath, "commit", "-m", "Initial commit")
+	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
+	hook := filepath.Join(t.TempDir(), "fsmonitor")
+	require.NoError(t, os.WriteFile(
+		hook,
+		[]byte("#!/bin/sh\nprintf ran > \""+marker+"\"\nprintf '0\\n'\n"),
+		0755,
+	))
+	runStatusTestGit(t, worktreePath, "config", "core.fsmonitor", hook)
+
+	collector := NewStatusCollectorWithOptions(StatusCollectorOptions{
+		SkipWorktree: func(path string) bool {
+			return filepath.Clean(path) == filepath.Clean(worktreePath)
+		},
+	})
+	statuses, err := collector.CollectAll(context.Background(), []*models.Worktree{{
+		Path:   worktreePath,
+		Branch: "feature/remote",
+	}})
+
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, models.WorktreeStatusUnknown, statuses[0].Status)
+	assert.NoFileExists(t, marker)
 }
 
 // TestCollectAllRelativeDotlessRemoteFallsBackToPathIdentity pins the

--- a/internal/status/status_collector_test.go
+++ b/internal/status/status_collector_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,46 +73,6 @@ func TestCollectAllPrefersWorktreeRepository(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, statuses, 1)
 	assert.Equal(t, "github.com/upstream/repo", statuses[0].Repository)
-}
-
-func TestCollectAllSkipsUnreviewedWorktreeBeforeGitInspection(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("executable fsmonitor hook fixture requires a POSIX shell")
-	}
-	worktreePath := t.TempDir()
-	runStatusTestGit(t, worktreePath, "init", "-b", "main")
-	runStatusTestGit(t, worktreePath, "config", "user.name", "Test User")
-	runStatusTestGit(t, worktreePath, "config", "user.email", "test@example.com")
-	require.NoError(t, os.WriteFile(
-		filepath.Join(worktreePath, "README.md"),
-		[]byte("# unreviewed\n"),
-		0644,
-	))
-	runStatusTestGit(t, worktreePath, "add", ".")
-	runStatusTestGit(t, worktreePath, "commit", "-m", "Initial commit")
-	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
-	hook := filepath.Join(t.TempDir(), "fsmonitor")
-	require.NoError(t, os.WriteFile(
-		hook,
-		[]byte("#!/bin/sh\nprintf ran > \""+marker+"\"\nprintf '0\\n'\n"),
-		0755,
-	))
-	runStatusTestGit(t, worktreePath, "config", "core.fsmonitor", hook)
-
-	collector := NewStatusCollectorWithOptions(StatusCollectorOptions{
-		SkipWorktree: func(path string) bool {
-			return filepath.Clean(path) == filepath.Clean(worktreePath)
-		},
-	})
-	statuses, err := collector.CollectAll(context.Background(), []*models.Worktree{{
-		Path:   worktreePath,
-		Branch: "feature/remote",
-	}})
-
-	require.NoError(t, err)
-	require.Len(t, statuses, 1)
-	assert.Equal(t, models.WorktreeStatusUnknown, statuses[0].Status)
-	assert.NoFileExists(t, marker)
 }
 
 // TestCollectAllRelativeDotlessRemoteFallsBackToPathIdentity pins the

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -31,6 +31,13 @@ type Processor struct {
 	sanitizeChars map[string]string
 }
 
+// EnvironmentOptions selects which naming components inherit environment
+// expansion from global configuration.
+type EnvironmentOptions struct {
+	ExpandTemplate      bool
+	ExpandSanitizeChars bool
+}
+
 // New creates a new template processor.
 func New(templateStr string, sanitizeChars map[string]string) (*Processor, error) {
 	tmpl, err := template.New("worktree").Parse(templateStr)
@@ -51,20 +58,41 @@ func NewWithEnvironment(
 	templateStr string,
 	sanitizeChars map[string]string,
 ) (*Processor, error) {
+	return NewWithEnvironmentOptions(
+		templateStr,
+		sanitizeChars,
+		EnvironmentOptions{
+			ExpandTemplate:      true,
+			ExpandSanitizeChars: true,
+		},
+	)
+}
+
+// NewWithEnvironmentOptions creates a processor with per-component
+// environment-expansion provenance.
+func NewWithEnvironmentOptions(
+	templateStr string,
+	sanitizeChars map[string]string,
+	options EnvironmentOptions,
+) (*Processor, error) {
 	processor, err := New(templateStr, sanitizeChars)
 	if err != nil {
 		return nil, err
 	}
-	for _, tmpl := range processor.template.Templates() {
-		if tmpl.Tree != nil {
-			expandLiteralText(tmpl.Root)
+	if options.ExpandTemplate {
+		for _, tmpl := range processor.template.Templates() {
+			if tmpl.Tree != nil {
+				expandLiteralText(tmpl.Root)
+			}
 		}
 	}
-	expandedSanitizeChars := make(map[string]string, len(sanitizeChars))
-	for old, replacement := range sanitizeChars {
-		expandedSanitizeChars[old] = os.ExpandEnv(replacement)
+	if options.ExpandSanitizeChars {
+		expandedSanitizeChars := make(map[string]string, len(sanitizeChars))
+		for old, replacement := range sanitizeChars {
+			expandedSanitizeChars[old] = os.ExpandEnv(replacement)
+		}
+		processor.sanitizeChars = expandedSanitizeChars
 	}
-	processor.sanitizeChars = expandedSanitizeChars
 	return processor, nil
 }
 

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -68,6 +68,53 @@ func NewWithEnvironment(
 	return processor, nil
 }
 
+// LiteralTextHasEnvironmentReference reports whether environment expansion
+// would affect literal template output. Dollar-prefixed Go template variables
+// inside actions are syntax, not environment references.
+func LiteralTextHasEnvironmentReference(templateStr string) (bool, error) {
+	processor, err := New(templateStr, nil)
+	if err != nil {
+		return false, err
+	}
+	for _, tmpl := range processor.template.Templates() {
+		if tmpl.Tree != nil && literalTextHasEnvironmentReference(tmpl.Root) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func literalTextHasEnvironmentReference(node parse.Node) bool {
+	switch current := node.(type) {
+	case *parse.ListNode:
+		if current == nil {
+			return false
+		}
+		for _, child := range current.Nodes {
+			if literalTextHasEnvironmentReference(child) {
+				return true
+			}
+		}
+	case *parse.TextNode:
+		found := false
+		_ = os.Expand(string(current.Text), func(string) string {
+			found = true
+			return ""
+		})
+		return found
+	case *parse.IfNode:
+		return literalTextHasEnvironmentReference(current.List) ||
+			literalTextHasEnvironmentReference(current.ElseList)
+	case *parse.RangeNode:
+		return literalTextHasEnvironmentReference(current.List) ||
+			literalTextHasEnvironmentReference(current.ElseList)
+	case *parse.WithNode:
+		return literalTextHasEnvironmentReference(current.List) ||
+			literalTextHasEnvironmentReference(current.ElseList)
+	}
+	return false
+}
+
 func expandLiteralText(node parse.Node) {
 	switch current := node.(type) {
 	case *parse.ListNode:

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -4,9 +4,11 @@ package template
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+	"text/template/parse"
 
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
@@ -40,6 +42,53 @@ func New(templateStr string, sanitizeChars map[string]string) (*Processor, error
 		template:      tmpl,
 		sanitizeChars: sanitizeChars,
 	}, nil
+}
+
+// NewWithEnvironment creates a processor for trusted global configuration.
+// Environment references expand only in literal template text and replacement
+// values, never inside template actions or branch-derived data.
+func NewWithEnvironment(
+	templateStr string,
+	sanitizeChars map[string]string,
+) (*Processor, error) {
+	processor, err := New(templateStr, sanitizeChars)
+	if err != nil {
+		return nil, err
+	}
+	for _, tmpl := range processor.template.Templates() {
+		if tmpl.Tree != nil {
+			expandLiteralText(tmpl.Root)
+		}
+	}
+	expandedSanitizeChars := make(map[string]string, len(sanitizeChars))
+	for old, replacement := range sanitizeChars {
+		expandedSanitizeChars[old] = os.ExpandEnv(replacement)
+	}
+	processor.sanitizeChars = expandedSanitizeChars
+	return processor, nil
+}
+
+func expandLiteralText(node parse.Node) {
+	switch current := node.(type) {
+	case *parse.ListNode:
+		if current == nil {
+			return
+		}
+		for _, child := range current.Nodes {
+			expandLiteralText(child)
+		}
+	case *parse.TextNode:
+		current.Text = []byte(os.ExpandEnv(string(current.Text)))
+	case *parse.IfNode:
+		expandLiteralText(current.List)
+		expandLiteralText(current.ElseList)
+	case *parse.RangeNode:
+		expandLiteralText(current.List)
+		expandLiteralText(current.ElseList)
+	case *parse.WithNode:
+		expandLiteralText(current.List)
+		expandLiteralText(current.ElseList)
+	}
 }
 
 // GeneratePath generates a worktree path using the configured template.

--- a/internal/tmux/bootstrap.go
+++ b/internal/tmux/bootstrap.go
@@ -53,6 +53,7 @@ func FirstPanePlaceholderArgv() []string {
 var canonicalStripExact = map[string]bool{
 	"__CFBundleIdentifier": true,
 	"EDITOR":               true,
+	"KWT_FLEET_TOKEN":      true,
 	"KWT_GITHUB_TOKEN":     true,
 	"OLDPWD":               true,
 	"PROMPT":               true,

--- a/internal/tmux/bootstrap_integration_test.go
+++ b/internal/tmux/bootstrap_integration_test.go
@@ -50,7 +50,7 @@ func TestGlobalEnvironmentReadsFreshNamedServer(t *testing.T) {
 	}
 }
 
-func TestWorkspaceOpenDoesNotExpandWorktreePathAsTmuxFormat(t *testing.T) {
+func TestWorkspaceOpenRejectsTmuxFormatPath(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux not found in PATH")
 	}
@@ -73,38 +73,21 @@ func TestWorkspaceOpenDoesNotExpandWorktreePathAsTmuxFormat(t *testing.T) {
 
 	command := NewTmuxCommandForSocketWithStripNames("tmux", socket, nil)
 	runner := NewWorkspaceRunner(command, nil)
-	if err := runner.Ensure(
+	err := runner.Ensure(
 		context.Background(),
 		"kwt-format-test-session",
 		worktreeDir,
 		BlankLayout(),
-	); err != nil {
-		t.Fatalf("open format-bearing worktree: %v", err)
-	}
-	currentPath, err := command.RunCommandOutputContext(
-		context.Background(),
-		"display-message",
-		"-p",
-		"-t",
-		"kwt-format-test-session",
-		"#{pane_current_path}",
 	)
-	if err != nil {
-		t.Fatalf("read format-bearing pane path: %v", err)
+	if err == nil {
+		t.Fatal("opening a format-bearing worktree unexpectedly succeeded")
 	}
-	gotPath, gotErr := filepath.EvalSymlinks(strings.TrimSpace(currentPath))
-	wantPath, wantErr := filepath.EvalSymlinks(worktreeDir)
-	if gotErr != nil || wantErr != nil || gotPath != wantPath {
-		t.Fatalf(
-			"pane path = %q (%v), want literal %q (%v)",
-			gotPath,
-			gotErr,
-			wantPath,
-			wantErr,
-		)
+	if !strings.Contains(err.Error(), "tmux format syntax") {
+		t.Fatalf("open error = %v, want tmux format guidance", err)
 	}
-
-	time.Sleep(500 * time.Millisecond)
+	if command.HasSession("kwt-format-test-session") {
+		t.Fatal("format-bearing worktree created a tmux session")
+	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("tmux expanded the worktree path as a command: %v", err)
 	}

--- a/internal/tmux/bootstrap_integration_test.go
+++ b/internal/tmux/bootstrap_integration_test.go
@@ -50,6 +50,66 @@ func TestGlobalEnvironmentReadsFreshNamedServer(t *testing.T) {
 	}
 }
 
+func TestWorkspaceOpenDoesNotExpandWorktreePathAsTmuxFormat(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not found in PATH")
+	}
+
+	socket := fmt.Sprintf(
+		"kwt-format-test-%d-%d",
+		os.Getpid(),
+		time.Now().UnixNano(),
+	)
+	t.Cleanup(func() { killPrivateTmuxServer(socket) })
+	marker := filepath.Join(t.TempDir(), "tmux-format-executed")
+	t.Setenv("FORMAT_MARKER_PATH", marker)
+	worktreeDir := filepath.Join(
+		t.TempDir(),
+		"#(touch$IFS$FORMAT_MARKER_PATH)-#{HOME}",
+	)
+	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+		t.Fatalf("create format-bearing worktree path: %v", err)
+	}
+
+	command := NewTmuxCommandForSocketWithStripNames("tmux", socket, nil)
+	runner := NewWorkspaceRunner(command, nil)
+	if err := runner.Ensure(
+		context.Background(),
+		"kwt-format-test-session",
+		worktreeDir,
+		BlankLayout(),
+	); err != nil {
+		t.Fatalf("open format-bearing worktree: %v", err)
+	}
+	currentPath, err := command.RunCommandOutputContext(
+		context.Background(),
+		"display-message",
+		"-p",
+		"-t",
+		"kwt-format-test-session",
+		"#{pane_current_path}",
+	)
+	if err != nil {
+		t.Fatalf("read format-bearing pane path: %v", err)
+	}
+	gotPath, gotErr := filepath.EvalSymlinks(strings.TrimSpace(currentPath))
+	wantPath, wantErr := filepath.EvalSymlinks(worktreeDir)
+	if gotErr != nil || wantErr != nil || gotPath != wantPath {
+		t.Fatalf(
+			"pane path = %q (%v), want literal %q (%v)",
+			gotPath,
+			gotErr,
+			wantPath,
+			wantErr,
+		)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("tmux expanded the worktree path as a command: %v", err)
+	}
+}
+
 // TestStripEnvMasksGlobalEnvForSessionOnly exercises the real session
 // bootstrap sequence against a private tmux server and confirms that a
 // variable present in the server-global environment at server-start time is

--- a/internal/tmux/bootstrap_test.go
+++ b/internal/tmux/bootstrap_test.go
@@ -44,6 +44,7 @@ func TestStripEnvNamesSelectsExactAndPrefix(t *testing.T) {
 func TestStripEnvNamesCoversFullCanonicalSet(t *testing.T) {
 	env := []string{
 		"__CFBundleIdentifier=com.example.Terminal",
+		"KWT_FLEET_TOKEN=secret",
 		"KWT_GITHUB_TOKEN=secret",
 		"OLDPWD=/old",
 		"PROMPT=$ ",
@@ -70,6 +71,7 @@ func TestStripEnvNamesCoversFullCanonicalSet(t *testing.T) {
 
 	want := []string{
 		"__CFBundleIdentifier",
+		"KWT_FLEET_TOKEN",
 		"KWT_GITHUB_TOKEN",
 		"OLDPWD",
 		"PROMPT",
@@ -98,7 +100,7 @@ func TestCanonicalStripExactNamesIsSortedAndComplete(t *testing.T) {
 	got := CanonicalStripExactNames()
 
 	want := []string{
-		"EDITOR", "KWT_GITHUB_TOKEN", "OLDPWD", "PROMPT", "PROMPT_COMMAND",
+		"EDITOR", "KWT_FLEET_TOKEN", "KWT_GITHUB_TOKEN", "OLDPWD", "PROMPT", "PROMPT_COMMAND",
 		"PWD", "RPROMPT", "SHLVL", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "VISUAL",
 		"WINDOWID", "_", "__CFBundleIdentifier",
 	}

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -123,7 +123,7 @@ func (r *WorkspaceRunner) EnsureAndAttach(
 func (r *WorkspaceRunner) Ensure(
 	ctx context.Context, session, worktreeDir string, layout models.Layout,
 ) error {
-	if err := validateTmuxStartDirectory(worktreeDir); err != nil {
+	if err := ValidateStartDirectory(worktreeDir); err != nil {
 		return err
 	}
 	sessionExists := r.tmux.HasSession(session)
@@ -157,7 +157,7 @@ func (r *WorkspaceRunner) AttachProtected(
 	if !r.protected {
 		return fmt.Errorf("protected attachment requires a protected workspace runner")
 	}
-	if err := validateTmuxStartDirectory(worktreeDir); err != nil {
+	if err := ValidateStartDirectory(worktreeDir); err != nil {
 		return err
 	}
 	if !r.tmux.HasSession(session) {
@@ -175,7 +175,9 @@ func (r *WorkspaceRunner) AttachProtected(
 	return r.tmux.AttachSessionWithoutEnvironment(ctx, session)
 }
 
-func validateTmuxStartDirectory(worktreeDir string) error {
+// ValidateStartDirectory rejects paths tmux would interpret as format syntax
+// when they are passed as pane and window start directories.
+func ValidateStartDirectory(worktreeDir string) error {
 	if strings.Contains(worktreeDir, "#") {
 		return fmt.Errorf(
 			"workspace path %q contains tmux format syntax ('#'); choose a path without '#'",

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -123,6 +123,9 @@ func (r *WorkspaceRunner) EnsureAndAttach(
 func (r *WorkspaceRunner) Ensure(
 	ctx context.Context, session, worktreeDir string, layout models.Layout,
 ) error {
+	if err := validateTmuxStartDirectory(worktreeDir); err != nil {
+		return err
+	}
 	sessionExists := r.tmux.HasSession(session)
 	if r.protected {
 		if err := r.validateProtectedState(
@@ -154,6 +157,9 @@ func (r *WorkspaceRunner) AttachProtected(
 	if !r.protected {
 		return fmt.Errorf("protected attachment requires a protected workspace runner")
 	}
+	if err := validateTmuxStartDirectory(worktreeDir); err != nil {
+		return err
+	}
 	if !r.tmux.HasSession(session) {
 		return &SessionSafetyError{Reason: fmt.Sprintf(
 			"protected tmux session %q is not running",
@@ -167,6 +173,16 @@ func (r *WorkspaceRunner) AttachProtected(
 		return err
 	}
 	return r.tmux.AttachSessionWithoutEnvironment(ctx, session)
+}
+
+func validateTmuxStartDirectory(worktreeDir string) error {
+	if strings.Contains(worktreeDir, "#") {
+		return fmt.Errorf(
+			"workspace path %q contains tmux format syntax ('#'); choose a path without '#'",
+			worktreeDir,
+		)
+	}
+	return nil
 }
 
 // EnsureAndAttachProtected creates or repairs a protected workspace session

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -245,10 +245,10 @@ func (r *WorkspaceRunner) validateProtectedState(
 func firstMatchingName(names, sensitive []string) (string, bool) {
 	sensitiveSet := make(map[string]bool, len(sensitive))
 	for _, name := range sensitive {
-		sensitiveSet[name] = true
+		sensitiveSet[strings.ToLower(name)] = true
 	}
 	for _, name := range names {
-		if sensitiveSet[name] {
+		if sensitiveSet[strings.ToLower(name)] {
 			return name, true
 		}
 	}

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -72,9 +72,16 @@ func NewProtectedWorkspaceRunner(
 	}
 }
 
-// NewWorkspaceRunner returns a runner backed by the given tmux surface.
-func NewWorkspaceRunner(t workspaceTmux) *WorkspaceRunner {
-	return &WorkspaceRunner{tmux: t}
+// NewWorkspaceRunner returns a runner backed by the given tmux surface while
+// ensuring caller-owned credential variables cannot reach workspace panes.
+func NewWorkspaceRunner(
+	t workspaceTmux,
+	credentialNames []string,
+) *WorkspaceRunner {
+	return &WorkspaceRunner{
+		tmux:            t,
+		extraStripNames: cleanNames(credentialNames),
+	}
 }
 
 func cleanNames(names []string) []string {
@@ -82,10 +89,11 @@ func cleanNames(names []string) []string {
 	seen := make(map[string]bool)
 	for _, name := range names {
 		name = strings.TrimSpace(name)
-		if name == "" || seen[name] {
+		folded := strings.ToLower(name)
+		if name == "" || seen[folded] {
 			continue
 		}
-		seen[name] = true
+		seen[folded] = true
 		cleaned = append(cleaned, name)
 	}
 	return cleaned
@@ -271,14 +279,26 @@ func firstMatchingName(names, sensitive []string) (string, bool) {
 // A show-environment failure on either query falls back to whichever sources
 // remain.
 func (r *WorkspaceRunner) sessionStripNames(session string, sessionExists bool) []string {
-	launcher := StripEnvNames(os.Environ())
+	launcherEnv := os.Environ()
+	launcher := append(
+		StripEnvNames(launcherEnv),
+		matchingProtectedEnvironmentNames(launcherEnv, r.extraStripNames)...,
+	)
 	var serverDerived, sessionDerived []string
 	if output, err := r.tmux.GlobalEnvironment(); err == nil {
-		serverDerived = CanonicalStripNames(ParseServerEnvNames(output))
+		serverNames := ParseServerEnvNames(output)
+		serverDerived = append(
+			CanonicalStripNames(serverNames),
+			matchingProtectedNames(serverNames, r.extraStripNames)...,
+		)
 	}
 	if sessionExists {
 		if output, err := r.tmux.SessionEnvironment(session); err == nil {
-			sessionDerived = CanonicalStripNames(ParseServerEnvNames(output))
+			sessionNames := ParseServerEnvNames(output)
+			sessionDerived = append(
+				CanonicalStripNames(sessionNames),
+				matchingProtectedNames(sessionNames, r.extraStripNames)...,
+			)
 		}
 	}
 	return MergeStripNames(
@@ -288,6 +308,32 @@ func (r *WorkspaceRunner) sessionStripNames(session string, sessionExists bool) 
 		serverDerived,
 		sessionDerived,
 	)
+}
+
+func matchingProtectedEnvironmentNames(
+	env, protectedNames []string,
+) []string {
+	names := make([]string, 0, len(env))
+	for _, entry := range env {
+		if name, _, ok := strings.Cut(entry, "="); ok {
+			names = append(names, name)
+		}
+	}
+	return matchingProtectedNames(names, protectedNames)
+}
+
+func matchingProtectedNames(names, protectedNames []string) []string {
+	protected := make(map[string]bool, len(protectedNames))
+	for _, name := range protectedNames {
+		protected[strings.ToLower(name)] = true
+	}
+	var matched []string
+	for _, name := range names {
+		if protected[strings.ToLower(name)] {
+			matched = append(matched, name)
+		}
+	}
+	return matched
 }
 
 // create spawns the first pane as an inert placeholder (it spawns before the

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -158,7 +158,7 @@ func (m *mockWorkspaceTmux) KillSession(session string) error {
 // capture boundary includes the third (last) pane-creating command.
 func TestEnsureAndAttachCreatesSendsToCapturedIDsAndAttaches(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "even-horizontal", Panes: []string{"codex", "", "vim"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)
@@ -196,7 +196,7 @@ func TestEnsureAndAttachCreatesSendsToCapturedIDsAndAttaches(t *testing.T) {
 
 func TestEnsureCreatesWorkspaceWithoutAttaching(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 
 	err := r.Ensure(
 		context.Background(),
@@ -216,7 +216,7 @@ func TestEnsureAndAttachQueriesServerDefaultShell(t *testing.T) {
 		hasSession:         false,
 		globalDefaultShell: "/opt/homebrew/bin/fish",
 	}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 
 	err := r.EnsureAndAttach(
 		context.Background(), "workspace", "/wt",
@@ -243,7 +243,7 @@ func TestEnsureAndAttachPrefersSessionDefaultShell(t *testing.T) {
 		sessionDefaultShell: "/bin/bash",
 		globalDefaultShell:  "/opt/homebrew/bin/fish",
 	}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 
 	err := r.EnsureAndAttach(
 		context.Background(), "workspace", "/wt",
@@ -487,7 +487,7 @@ func TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing(t *te
 		globalEnv:  "KWT_GITHUB_TOKEN=secret\nSTARSHIP_SESSION_KEY=abc\nHOME=/home/u",
 		sessionEnv: "VSCODE_GIT_IPC_HANDLE=/tmp/ipc\nPATH=/bin",
 	}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "tiled", Panes: []string{"codex"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)
@@ -504,6 +504,29 @@ func TestEnsureAndAttachRepairsExistingSessionBootstrapWithoutConstructing(t *te
 	assert.Empty(t, m.switchedTo)
 }
 
+func TestEnsureAndAttachStripsConfiguredCredentialCaseVariants(t *testing.T) {
+	m := &mockWorkspaceTmux{
+		hasSession: true,
+		globalEnv:  "custom_fleet_token=server-secret",
+		sessionEnv: "Custom_Fleet_Token=session-secret",
+	}
+	r := NewWorkspaceRunner(m, []string{"CUSTOM_FLEET_TOKEN"})
+
+	err := r.EnsureAndAttach(
+		context.Background(),
+		"s",
+		"/wt",
+		models.Layout{Arrange: "tiled", Panes: []string{""}},
+		false,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, m.calls, 1)
+	assert.Contains(t, m.calls[0], "CUSTOM_FLEET_TOKEN")
+	assert.Contains(t, m.calls[0], "custom_fleet_token")
+	assert.Contains(t, m.calls[0], "Custom_Fleet_Token")
+}
+
 // TestEnsureAndAttachRepairSurvivesEnvReadFailures pins the graceful
 // degradation of the strip-name derivation: a show-environment failure on
 // either table drops that source but never fails the attach.
@@ -513,7 +536,7 @@ func TestEnsureAndAttachRepairSurvivesEnvReadFailures(t *testing.T) {
 		globalEnvErr:  errors.New("no server"),
 		sessionEnvErr: errors.New("no session"),
 	}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt",
 		models.Layout{Arrange: "tiled", Panes: []string{""}}, false)
@@ -526,7 +549,7 @@ func TestEnsureAndAttachRepairSurvivesEnvReadFailures(t *testing.T) {
 
 func TestEnsureAndAttachSwitchesClientInsideTmux(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "tiled", Panes: []string{"codex"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, true)
@@ -538,7 +561,7 @@ func TestEnsureAndAttachSwitchesClientInsideTmux(t *testing.T) {
 
 func TestEnsureAndAttachReturnsErrorOnCaptureFailure(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, outputErr: errors.New("boom")}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "tiled", Panes: []string{"codex"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)
@@ -555,7 +578,7 @@ func TestEnsureAndAttachReturnsErrorOnCaptureFailure(t *testing.T) {
 // a subsequent EnsureAndAttach rebuilds instead of attaching to it broken.
 func TestEnsureAndAttachKillsPartialSessionOnCreateFailure(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, failOutputOnCall: 4}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "even-horizontal", Panes: []string{"codex", "vim"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)
@@ -574,7 +597,7 @@ func TestEnsureAndAttachKillsPartialSessionOnCreateFailure(t *testing.T) {
 // killed rather than left half-built.
 func TestEnsureAndAttachKillsPartialSessionOnRespawnFailure(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, failRunOnCall: 2}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "even-horizontal", Panes: []string{"codex", "vim"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)
@@ -597,7 +620,7 @@ func TestEnsureAndAttachKillsPartialSessionOnRespawnFailure(t *testing.T) {
 // BuildPaneCommandSequence branch by the pane-command test below.
 func TestEnsureAndAttachKillsPartialSessionOnLayoutFailure(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, failRunOnCall: 3}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "even-horizontal", Panes: []string{"codex", "vim"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)
@@ -617,7 +640,7 @@ func TestEnsureAndAttachKillsPartialSessionOnLayoutFailure(t *testing.T) {
 // the first-pane respawn, call 3 is select-layout).
 func TestEnsureAndAttachKillsPartialSessionOnPaneCommandFailure(t *testing.T) {
 	m := &mockWorkspaceTmux{hasSession: false, failRunOnCall: 4}
-	r := NewWorkspaceRunner(m)
+	r := NewWorkspaceRunner(m, nil)
 	layout := models.Layout{Arrange: "even-horizontal", Panes: []string{"codex", "vim"}}
 
 	err := r.EnsureAndAttach(context.Background(), "s", "/wt", layout, false)

--- a/internal/tmux/runner_test.go
+++ b/internal/tmux/runner_test.go
@@ -262,7 +262,7 @@ func TestEnsureAndAttachPrefersSessionDefaultShell(t *testing.T) {
 
 func TestProtectedEnsureRejectsSensitiveServerEnvironment(t *testing.T) {
 	m := &mockWorkspaceTmux{
-		globalEnv: "KWT_GITHUB_TOKEN=secret\nKWT_HOME=/tmp/kwt\n",
+		globalEnv: "kwt_github_token=secret\nKWT_HOME=/tmp/kwt\n",
 	}
 	r := NewProtectedWorkspaceRunner(
 		m,
@@ -277,7 +277,7 @@ func TestProtectedEnsureRejectsSensitiveServerEnvironment(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "KWT_GITHUB_TOKEN")
+	assert.Contains(t, err.Error(), "kwt_github_token")
 	assert.Empty(t, m.calls)
 }
 
@@ -308,7 +308,7 @@ func TestProtectedEnsureRejectsSensitiveExistingSession(t *testing.T) {
 	m := &mockWorkspaceTmux{
 		hasSession:       true,
 		globalEnv:        "PATH=/bin\n",
-		sessionEnv:       "CUSTOM_FLEET_TOKEN=secret\n",
+		sessionEnv:       "Custom_Fleet_Token=secret\n",
 		sessionWorkspace: "/wt",
 	}
 	r := NewProtectedWorkspaceRunner(
@@ -324,7 +324,7 @@ func TestProtectedEnsureRejectsSensitiveExistingSession(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CUSTOM_FLEET_TOKEN")
+	assert.Contains(t, err.Error(), "Custom_Fleet_Token")
 	assert.Empty(t, m.calls)
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -68,7 +68,7 @@ func NewTmuxCommandForSocketWithStripNames(
 	extra := make(map[string]bool, len(names))
 	for _, name := range names {
 		if name = strings.TrimSpace(name); name != "" {
-			extra[name] = true
+			extra[strings.ToLower(name)] = true
 		}
 	}
 	return &TmuxCommand{
@@ -400,6 +400,6 @@ func (t *TmuxCommand) stripExtraNames(env []string) []string {
 		return env
 	}
 	return filteredEnviron(env, func(name string) bool {
-		return t.extraStripNames[name]
+		return t.extraStripNames[strings.ToLower(name)]
 	})
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -368,35 +368,9 @@ func (t *TmuxCommand) globalOption(option string) (string, error) {
 // reads them at server start for its default key mode. Call sites that
 // predate context plumbing pass context.Background().
 func (t *TmuxCommand) newCmd(ctx context.Context, args []string) *exec.Cmd {
-	args = escapeTmuxStartDirectories(args)
 	cmd := exec.CommandContext(ctx, t.command, t.socketArgs(args)...)
 	cmd.Env = t.stripExtraNames(SanitizedEnviron(os.Environ()))
 	return cmd
-}
-
-func escapeTmuxStartDirectories(args []string) []string {
-	if len(args) == 0 {
-		return args
-	}
-	switch args[0] {
-	case "new-session",
-		"new-window",
-		"split-window",
-		"respawn-pane",
-		"respawn-window",
-		"run-shell":
-	default:
-		return args
-	}
-
-	escaped := append([]string(nil), args...)
-	for i := 1; i+1 < len(escaped); i++ {
-		if escaped[i] == "-c" {
-			escaped[i+1] = strings.ReplaceAll(escaped[i+1], "#", "##")
-			i++
-		}
-	}
-	return escaped
 }
 
 // newAttachCmd is the exec seam for attach-class commands (attach-session,

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -368,9 +368,35 @@ func (t *TmuxCommand) globalOption(option string) (string, error) {
 // reads them at server start for its default key mode. Call sites that
 // predate context plumbing pass context.Background().
 func (t *TmuxCommand) newCmd(ctx context.Context, args []string) *exec.Cmd {
+	args = escapeTmuxStartDirectories(args)
 	cmd := exec.CommandContext(ctx, t.command, t.socketArgs(args)...)
 	cmd.Env = t.stripExtraNames(SanitizedEnviron(os.Environ()))
 	return cmd
+}
+
+func escapeTmuxStartDirectories(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+	switch args[0] {
+	case "new-session",
+		"new-window",
+		"split-window",
+		"respawn-pane",
+		"respawn-window",
+		"run-shell":
+	default:
+		return args
+	}
+
+	escaped := append([]string(nil), args...)
+	for i := 1; i+1 < len(escaped); i++ {
+		if escaped[i] == "-c" {
+			escaped[i+1] = strings.ReplaceAll(escaped[i+1], "#", "##")
+			i++
+		}
+	}
+	return escaped
 }
 
 // newAttachCmd is the exec seam for attach-class commands (attach-session,

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -50,12 +50,12 @@ func TestNewCmdSanitizesEnvironment(t *testing.T) {
 }
 
 func TestNewCmdStripsConfiguredSensitiveEnvironmentName(t *testing.T) {
-	t.Setenv("CUSTOM_FLEET_TOKEN", "secret")
+	t.Setenv("Custom_Fleet_Token", "secret")
 	t.Setenv("UNRELATED_VAR", "keep-me")
 
 	tc := NewTmuxCommandWithStripNames(
 		"tmux",
-		[]string{"CUSTOM_FLEET_TOKEN"},
+		[]string{"custom_fleet_token"},
 	)
 	cmd := tc.newCmd(
 		context.Background(),
@@ -63,7 +63,7 @@ func TestNewCmdStripsConfiguredSensitiveEnvironmentName(t *testing.T) {
 	)
 
 	for _, entry := range cmd.Env {
-		if hasEnvName(entry, "CUSTOM_FLEET_TOKEN") {
+		if hasEnvName(entry, "Custom_Fleet_Token") {
 			t.Errorf("newCmd().Env leaked configured credential: %v", cmd.Env)
 		}
 	}

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -69,31 +69,6 @@ func TestNewCmdStripsConfiguredSensitiveEnvironmentName(t *testing.T) {
 	}
 }
 
-func TestNewCmdEscapesTmuxFormatsInWorkingDirectory(t *testing.T) {
-	tc := NewTmuxCommand("tmux")
-
-	cmd := tc.newCmd(
-		context.Background(),
-		[]string{
-			"new-session",
-			"-d",
-			"-c",
-			"/work/#(touch$IFS.pwn)",
-		},
-	)
-
-	want := []string{
-		"tmux",
-		"new-session",
-		"-d",
-		"-c",
-		"/work/##(touch$IFS.pwn)",
-	}
-	if !slices.Equal(cmd.Args, want) {
-		t.Fatalf("newCmd args = %v, want %v", cmd.Args, want)
-	}
-}
-
 func TestSocketCommandPrefixesEveryInvocationWithSocketName(t *testing.T) {
 	tc := NewTmuxCommandForSocketWithStripNames(
 		"tmux",

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -69,6 +69,31 @@ func TestNewCmdStripsConfiguredSensitiveEnvironmentName(t *testing.T) {
 	}
 }
 
+func TestNewCmdEscapesTmuxFormatsInWorkingDirectory(t *testing.T) {
+	tc := NewTmuxCommand("tmux")
+
+	cmd := tc.newCmd(
+		context.Background(),
+		[]string{
+			"new-session",
+			"-d",
+			"-c",
+			"/work/#(touch$IFS.pwn)",
+		},
+	)
+
+	want := []string{
+		"tmux",
+		"new-session",
+		"-d",
+		"-c",
+		"/work/##(touch$IFS.pwn)",
+	}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("newCmd args = %v, want %v", cmd.Args, want)
+	}
+}
+
 func TestSocketCommandPrefixesEveryInvocationWithSocketName(t *testing.T) {
 	tc := NewTmuxCommandForSocketWithStripNames(
 		"tmux",

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -74,7 +74,8 @@ type Backend interface {
 	// is a display value only: passing it back as a destination would re-run
 	// path resolution over an already-resolved path.
 	PreviewWorktree(row Row, branch string) (Row, error)
-	CreateWorktree(ctx context.Context, row Row, branch string) (string, error)
+	ListBranches(ctx context.Context, row Row) ([]models.Branch, error)
+	CreateWorktree(ctx context.Context, row Row, branch, source string) (string, error)
 	MaterializeWorktree(ctx context.Context, row Row) (string, error)
 	RemoveWorktree(ctx context.Context, row Row, force bool) error
 	UnregisterWorkspace(row Row) error

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -29,6 +29,7 @@ type Row struct {
 	SessionName string
 	SessionLive bool
 	Creating    bool
+	NeedsReview bool
 }
 
 // WorkspaceInfo is the TUI-facing view of one registered directory workspace.

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -29,7 +29,6 @@ type Row struct {
 	SessionName string
 	SessionLive bool
 	Creating    bool
-	NeedsReview bool
 }
 
 // WorkspaceInfo is the TUI-facing view of one registered directory workspace.

--- a/internal/tui/footer_hints.go
+++ b/internal/tui/footer_hints.go
@@ -24,6 +24,7 @@ func defaultHelpRows(row Row) [][]helpItem {
 		action,
 		{key: "P", desc: "project"},
 		{key: "n", desc: "new"},
+		{key: "b", desc: "branch"},
 		{key: "L", desc: "layout"},
 		{key: "d", desc: "delete"},
 		{key: "K", desc: "kill"},
@@ -46,6 +47,13 @@ func inputHelpRows(mode inputMode) [][]helpItem {
 	switch mode {
 	case inputNewBranch:
 		return [][]helpItem{{
+			{key: "enter", desc: "create"},
+			{key: "esc", desc: "cancel"},
+		}}
+	case inputExistingBranch:
+		return [][]helpItem{{
+			{key: "↑↓", desc: "select"},
+			{key: "type", desc: "narrow"},
 			{key: "enter", desc: "create"},
 			{key: "esc", desc: "cancel"},
 		}}

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -3,49 +3,51 @@ package tui
 import "charm.land/bubbles/v2/key"
 
 type keyMap struct {
-	Up      key.Binding
-	Down    key.Binding
-	Top     key.Binding
-	Bottom  key.Binding
-	Open    key.Binding
-	Layout  key.Binding
-	New     key.Binding
-	Delete  key.Binding
-	Sync    key.Binding
-	Shell   key.Binding
-	Kill    key.Binding
-	Switch  key.Binding
-	Project key.Binding
-	Filter  key.Binding
-	Refresh key.Binding
-	Help    key.Binding
-	Cancel  key.Binding
-	Quit    key.Binding
-	Yes     key.Binding
-	No      key.Binding
+	Up       key.Binding
+	Down     key.Binding
+	Top      key.Binding
+	Bottom   key.Binding
+	Open     key.Binding
+	Layout   key.Binding
+	New      key.Binding
+	Existing key.Binding
+	Delete   key.Binding
+	Sync     key.Binding
+	Shell    key.Binding
+	Kill     key.Binding
+	Switch   key.Binding
+	Project  key.Binding
+	Filter   key.Binding
+	Refresh  key.Binding
+	Help     key.Binding
+	Cancel   key.Binding
+	Quit     key.Binding
+	Yes      key.Binding
+	No       key.Binding
 }
 
 func newKeyMap() keyMap {
 	return keyMap{
-		Up:      key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
-		Down:    key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
-		Top:     key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "top")),
-		Bottom:  key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
-		Open:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("↵", "attach")),
-		Layout:  key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "layout")),
-		New:     key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-		Delete:  key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
-		Sync:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sync")),
-		Shell:   key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "shell")),
-		Kill:    key.NewBinding(key.WithKeys("K"), key.WithHelp("K", "kill-ws")),
-		Switch:  key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "project")),
-		Project: key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "filter")),
-		Filter:  key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
-		Refresh: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
-		Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-		Cancel:  key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
-		Quit:    key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
-		Yes:     key.NewBinding(key.WithKeys("y", "Y"), key.WithHelp("y", "yes")),
-		No:      key.NewBinding(key.WithKeys("n", "N"), key.WithHelp("n", "no")),
+		Up:       key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+		Down:     key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+		Top:      key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "top")),
+		Bottom:   key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
+		Open:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("↵", "attach")),
+		Layout:   key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "layout")),
+		New:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+		Existing: key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "branch")),
+		Delete:   key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+		Sync:     key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sync")),
+		Shell:    key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "shell")),
+		Kill:     key.NewBinding(key.WithKeys("K"), key.WithHelp("K", "kill-ws")),
+		Switch:   key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "project")),
+		Project:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "filter")),
+		Filter:   key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
+		Refresh:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
+		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Cancel:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
+		Quit:     key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+		Yes:      key.NewBinding(key.WithKeys("y", "Y"), key.WithHelp("y", "yes")),
+		No:       key.NewBinding(key.WithKeys("n", "N"), key.WithHelp("n", "no")),
 	}
 }

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -322,6 +322,9 @@ func formatRowChanges(row Row) string {
 	if row.Creating {
 		return "creating…"
 	}
+	if row.NeedsReview {
+		return "review"
+	}
 	if row.Workspace != nil {
 		return "-"
 	}
@@ -403,6 +406,9 @@ func compactFleetDirtySummary(summary string) string {
 
 func formatRowSync(row Row) string {
 	if row.Creating {
+		return "-"
+	}
+	if row.NeedsReview {
 		return "-"
 	}
 	if row.Workspace != nil {

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -322,9 +322,6 @@ func formatRowChanges(row Row) string {
 	if row.Creating {
 		return "creating…"
 	}
-	if row.NeedsReview {
-		return "review"
-	}
 	if row.Workspace != nil {
 		return "-"
 	}
@@ -406,9 +403,6 @@ func compactFleetDirtySummary(summary string) string {
 
 func formatRowSync(row Row) string {
 	if row.Creating {
-		return "-"
-	}
-	if row.NeedsReview {
 		return "-"
 	}
 	if row.Workspace != nil {

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -174,14 +174,6 @@ func TestFormatRowChangesUsesFleetDirtyForRemoteOnlyRows(t *testing.T) {
 	assert.Equal(t, "clean", formatRowChanges(row))
 }
 
-func TestUnreviewedRowExplainsDeferredInspection(t *testing.T) {
-	row := testRow("kwt", "feature", "/w/kwt/feature")
-	row.NeedsReview = true
-
-	assert.Equal(t, "review", formatRowChanges(row))
-	assert.Equal(t, "-", formatRowSync(row))
-}
-
 func TestFormatRowChangesPrefersLocalDirtyCounts(t *testing.T) {
 	row := testRow("kwt", "feature", "/w/kwt/feature")
 	row.Status.Status = models.WorktreeStatusModified

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -174,6 +174,14 @@ func TestFormatRowChangesUsesFleetDirtyForRemoteOnlyRows(t *testing.T) {
 	assert.Equal(t, "clean", formatRowChanges(row))
 }
 
+func TestUnreviewedRowExplainsDeferredInspection(t *testing.T) {
+	row := testRow("kwt", "feature", "/w/kwt/feature")
+	row.NeedsReview = true
+
+	assert.Equal(t, "review", formatRowChanges(row))
+	assert.Equal(t, "-", formatRowSync(row))
+}
+
 func TestFormatRowChangesPrefersLocalDirtyCounts(t *testing.T) {
 	row := testRow("kwt", "feature", "/w/kwt/feature")
 	row.Status.Status = models.WorktreeStatusModified

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1274,8 +1274,12 @@ func (m Model) createWorktreeCmd(row Row, branch, source, pendingPath string) te
 		if err != nil {
 			return actionDoneMsg{err: err, pendingPath: pendingPath}
 		}
+		message := fmt.Sprintf("created %s", branch)
+		if source != "" && source != branch {
+			message = fmt.Sprintf("created %s; review it before attaching", branch)
+		}
 		return actionDoneMsg{
-			message:     fmt.Sprintf("created %s", branch),
+			message:     message,
 			refresh:     true,
 			anchorPath:  path,
 			pendingPath: pendingPath,
@@ -1816,7 +1820,8 @@ func (m Model) renderExistingBranchView() string {
 			}
 			location := "local"
 			if branch.IsRemote {
-				location = "remote · " + branch.Source
+				source := strings.TrimPrefix(branch.Source, "refs/remotes/")
+				location = "remote · " + source
 			}
 			line := fmt.Sprintf("%s %-32s %s", cursor, branch.Name, location)
 			if index == selected {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,6 +21,7 @@ const (
 	inputProjectFilter
 	inputProjectSwitch
 	inputNewBranch
+	inputExistingBranch
 )
 
 type confirmKind int
@@ -59,6 +60,12 @@ type fleetRowsMsg struct {
 	warnings []string
 }
 
+type branchListMsg struct {
+	row      Row
+	branches []models.Branch
+	err      error
+}
+
 type actionDoneMsg struct {
 	message     string
 	err         error
@@ -81,6 +88,10 @@ type Model struct {
 	projectPerspective  string
 	projectFilter       string
 	projectSwitchCursor int
+	branches            []models.Branch
+	branchCursor        int
+	branchRow           Row
+	branchesLoading     bool
 	layouts             []string
 	selectedLayout      string
 	inputMode           inputMode
@@ -174,6 +185,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyFleetRows(msg)
 	case actionDoneMsg:
 		return m.applyActionDone(msg)
+	case branchListMsg:
+		return m.applyBranchList(msg)
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
 	case tea.PasteMsg:
@@ -193,6 +206,8 @@ func (m Model) View() tea.View {
 		b.WriteString(m.renderHelp())
 	} else if m.inputMode == inputProjectSwitch {
 		b.WriteString(m.renderProjectSwitchView())
+	} else if m.inputMode == inputExistingBranch {
+		b.WriteString(m.renderExistingBranchView())
 	} else {
 		b.WriteString(m.renderHeader())
 		b.WriteString("\n\n")
@@ -484,6 +499,21 @@ func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) applyBranchList(msg branchListMsg) (Model, tea.Cmd) {
+	if m.inputMode != inputExistingBranch ||
+		pathIdentity(rowPath(msg.row)) != pathIdentity(rowPath(m.branchRow)) {
+		return m, nil
+	}
+	m.branchesLoading = false
+	if msg.err != nil {
+		m.err = msg.err
+		return m, nil
+	}
+	m.branches = append([]models.Branch(nil), msg.branches...)
+	m.branchCursor = clampCursor(m.branchCursor, len(m.branchOptions()))
+	return m, nil
+}
+
 // dropPendingRow removes an optimistic creation row and supersedes any fleet
 // overlay still in flight. That overlay carries the rows it was dispatched
 // with, so applying it afterwards would put the row back — and with nothing
@@ -634,6 +664,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		return m.cycleLayout()
 	case key.Matches(msg, m.keys.New):
 		return m.startNewBranch()
+	case key.Matches(msg, m.keys.Existing):
+		return m.startExistingBranch()
 	case key.Matches(msg, m.keys.Delete):
 		return m.startDelete()
 	case key.Matches(msg, m.keys.Sync):
@@ -691,6 +723,9 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	if m.inputMode == inputProjectSwitch {
 		return m.handleProjectSwitchKey(msg)
 	}
+	if m.inputMode == inputExistingBranch {
+		return m.handleExistingBranchKey(msg)
+	}
 
 	if key.Matches(msg, m.keys.Cancel) {
 		selectedPath := rowPath(m.selectedRow())
@@ -730,7 +765,7 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 				return m, nil
 			}
 			row := m.selectedRow()
-			return m.startCreateWorktree(row, branch)
+			return m.startCreateWorktree(row, branch, "")
 		case inputFilter:
 			m.inputMode = inputNone
 			m.input.Blur()
@@ -747,7 +782,7 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	return m.updateTextInput(msg)
 }
 
-func (m Model) startCreateWorktree(row Row, branch string) (Model, tea.Cmd) {
+func (m Model) startCreateWorktree(row Row, branch, source string) (Model, tea.Cmd) {
 	planned, err := m.backend.PreviewWorktree(row, branch)
 	if err != nil {
 		m.err = err
@@ -772,7 +807,7 @@ func (m Model) startCreateWorktree(row Row, branch string) (Model, tea.Cmd) {
 	sortRows(m.rows)
 	m.cursor = indexByPath(m.filteredRows(), pendingPath)
 	m.message = fmt.Sprintf("creating %s", branch)
-	return m, m.createWorktreeCmd(row, branch, pendingPath)
+	return m, m.createWorktreeCmd(row, branch, source, pendingPath)
 }
 
 func (m Model) handlePaste(msg tea.PasteMsg) (Model, tea.Cmd) {
@@ -785,6 +820,9 @@ func (m Model) handlePaste(msg tea.PasteMsg) (Model, tea.Cmd) {
 	if m.inputMode == inputProjectSwitch {
 		return m.appendProjectSwitchText(msg.Content), nil
 	}
+	if m.inputMode == inputExistingBranch {
+		return m.appendExistingBranchText(msg.Content), nil
+	}
 	return m.updateTextInput(msg)
 }
 
@@ -792,7 +830,8 @@ func (m Model) shouldForwardToTextInput() bool {
 	return !m.showHelp &&
 		m.confirm.kind == confirmNone &&
 		m.inputMode != inputNone &&
-		m.inputMode != inputProjectSwitch
+		m.inputMode != inputProjectSwitch &&
+		m.inputMode != inputExistingBranch
 }
 
 func (m Model) updateTextInput(msg tea.Msg) (Model, tea.Cmd) {
@@ -840,6 +879,64 @@ func (m Model) handleProjectSwitchKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	}
 
 	return m.appendProjectSwitchText(msg.Key().Text), nil
+}
+
+func (m Model) handleExistingBranchKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
+	switch msg.Key().Code {
+	case tea.KeyEsc:
+		m.inputMode = inputNone
+		m.input.Blur()
+		m.input.SetValue("")
+		m.branches = nil
+		m.branchRow = Row{}
+		m.branchesLoading = false
+		return m, nil
+	case tea.KeyEnter:
+		options := m.branchOptions()
+		if len(options) == 0 {
+			return m, nil
+		}
+		branch := options[clampCursor(m.branchCursor, len(options))]
+		row := m.branchRow
+		m.inputMode = inputNone
+		m.input.Blur()
+		m.input.SetValue("")
+		m.branches = nil
+		m.branchRow = Row{}
+		return m.startCreateWorktree(row, branch.Name, branch.Source)
+	case tea.KeyUp:
+		m.branchCursor = clampCursor(m.branchCursor-1, len(m.branchOptions()))
+		return m, nil
+	case tea.KeyDown:
+		m.branchCursor = clampCursor(m.branchCursor+1, len(m.branchOptions()))
+		return m, nil
+	case tea.KeyBackspace:
+		value := []rune(m.input.Value())
+		if len(value) > 0 {
+			m.input.SetValue(string(value[:len(value)-1]))
+			m.branchCursor = 0
+		}
+		return m, nil
+	}
+	if msg.String() == "ctrl+c" {
+		return m, quitCmd()
+	}
+	return m.appendExistingBranchText(msg.Key().Text), nil
+}
+
+func (m Model) appendExistingBranchText(text string) Model {
+	var b strings.Builder
+	for _, r := range text {
+		if unicode.IsPrint(r) && !unicode.IsControl(r) {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return m
+	}
+	m.input.SetValue(m.input.Value() + b.String())
+	m.branchCursor = 0
+	return m
 }
 
 func (m Model) appendProjectSwitchText(text string) Model {
@@ -960,6 +1057,31 @@ func (m Model) startNewBranch() (Model, tea.Cmd) {
 	m.input.Prompt = fmt.Sprintf("new branch in %s: ", rowRepoName(row))
 	m.input.SetValue("")
 	return m, m.input.Focus()
+}
+
+func (m Model) startExistingBranch() (Model, tea.Cmd) {
+	row := m.selectedRow()
+	if row.Creating {
+		m.message = "worktree is still being created"
+		return m, nil
+	}
+	if row.Workspace != nil {
+		m.message = "not a git worktree"
+		return m, nil
+	}
+	if row.Entry == nil {
+		m.message = "no worktree selected"
+		return m, nil
+	}
+	m.inputMode = inputExistingBranch
+	m.input.Prompt = "Search: "
+	m.input.SetValue("")
+	m.branchRow = row
+	m.branches = nil
+	m.branchCursor = 0
+	m.branchesLoading = true
+	_ = m.input.Focus()
+	return m, m.listBranchesCmd(row)
 }
 
 func (m Model) syncSelected(row Row) (Model, tea.Cmd) {
@@ -1132,9 +1254,21 @@ func (m Model) fleetRowsCmd(ctx context.Context, seq int, rows []Row) tea.Cmd {
 	}
 }
 
-func (m Model) createWorktreeCmd(row Row, branch, pendingPath string) tea.Cmd {
+func (m Model) listBranchesCmd(row Row) tea.Cmd {
 	return func() tea.Msg {
-		path, err := m.backend.CreateWorktree(context.Background(), row, branch)
+		branches, err := m.backend.ListBranches(context.Background(), row)
+		return branchListMsg{row: row, branches: branches, err: err}
+	}
+}
+
+func (m Model) createWorktreeCmd(row Row, branch, source, pendingPath string) tea.Cmd {
+	return func() tea.Msg {
+		path, err := m.backend.CreateWorktree(
+			context.Background(),
+			row,
+			branch,
+			source,
+		)
 		if err != nil {
 			return actionDoneMsg{err: err, pendingPath: pendingPath}
 		}
@@ -1492,6 +1626,29 @@ func (m Model) projectSwitchOptionRows() []projectSwitchOption {
 	return m.projectSwitchOptions()
 }
 
+func (m Model) branchOptions() []models.Branch {
+	query := strings.TrimSpace(strings.ToLower(m.input.Value()))
+	if query == "" {
+		return append([]models.Branch(nil), m.branches...)
+	}
+	tokens := strings.Fields(query)
+	filtered := make([]models.Branch, 0, len(m.branches))
+	for _, branch := range m.branches {
+		haystack := strings.ToLower(branch.Name + " " + branch.Source)
+		matches := true
+		for _, token := range tokens {
+			if !strings.Contains(haystack, token) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			filtered = append(filtered, branch)
+		}
+	}
+	return filtered
+}
+
 func (m Model) projectSwitchOptions() []projectSwitchOption {
 	return m.projectSwitchOptionsForQuery(m.input.Value())
 }
@@ -1606,6 +1763,81 @@ func (m Model) renderProjectSwitchView() string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
+func (m Model) renderExistingBranchView() string {
+	var b strings.Builder
+	b.WriteString("Add existing branch")
+	if name := rowRepoName(m.branchRow); name != "" {
+		b.WriteString(" in ")
+		b.WriteString(name)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(m.input.View())
+	b.WriteString("\n\n")
+
+	options := m.branchOptions()
+	switch {
+	case m.err != nil:
+		b.WriteString(m.theme.error.Render(m.err.Error()))
+		b.WriteString("\n")
+	case m.branchesLoading:
+		b.WriteString(m.theme.dim.Render("  Loading available branches…"))
+		b.WriteString("\n")
+	case len(options) == 0:
+		b.WriteString(m.theme.dim.Render("  No matching available branches"))
+		b.WriteString("\n")
+	default:
+		selected := clampCursor(m.branchCursor, len(options))
+		visibleRows := len(options)
+		if m.height > 0 {
+			footerLines := helpLines(inputHelpRows(inputExistingBranch), m.width)
+			visibleRows = m.height - 6 - footerLines
+			if visibleRows < 1 {
+				visibleRows = 1
+			}
+		}
+		start := 0
+		if visibleRows < len(options) {
+			start = selected - visibleRows/2
+			if start < 0 {
+				start = 0
+			}
+			if start+visibleRows > len(options) {
+				start = len(options) - visibleRows
+			}
+		}
+		end := min(start+visibleRows, len(options))
+		for index := start; index < end; index++ {
+			branch := options[index]
+			cursor := " "
+			if index == selected {
+				cursor = "▸"
+			}
+			location := "local"
+			if branch.IsRemote {
+				location = "remote · " + branch.Source
+			}
+			line := fmt.Sprintf("%s %-32s %s", cursor, branch.Name, location)
+			if index == selected {
+				line = m.theme.cursor.Render(line)
+			}
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		if len(options) > visibleRows {
+			b.WriteString(m.theme.dim.Render(fmt.Sprintf(
+				"[showing %d-%d of %d]",
+				start+1,
+				end,
+				len(options),
+			)))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString(renderHelpTable(inputHelpRows(inputExistingBranch), m.width))
+	return strings.TrimRight(b.String(), "\n")
+}
+
 func (m Model) projectSwitchVisibleRows() int {
 	if m.height <= 0 {
 		return len(m.projectSwitchOptions())
@@ -1654,7 +1886,7 @@ func (m Model) renderHelp() string {
 		"kwt help",
 		"",
 		"↑/k ↓/j move    g/G top/bottom",
-		"enter attach    L layout    n new    d delete    s sync    c shell    K kill workspace",
+		"enter attach    L layout    n new    b branch    d delete    s sync    c shell    K kill workspace",
 		"P project       p filter    / search    r refresh    esc cancel/clear    q quit",
 		"",
 		"Press any key to close help.",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1275,7 +1275,7 @@ func (m Model) createWorktreeCmd(row Row, branch, source, pendingPath string) te
 			return actionDoneMsg{err: err, pendingPath: pendingPath}
 		}
 		message := fmt.Sprintf("created %s", branch)
-		if source != "" && source != branch {
+		if source != "" {
 			message = fmt.Sprintf("created %s; review it before attaching", branch)
 		}
 		return actionDoneMsg{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -935,6 +935,7 @@ func (m Model) appendExistingBranchText(text string) Model {
 		return m
 	}
 	m.input.SetValue(m.input.Value() + b.String())
+	m.input.CursorEnd()
 	m.branchCursor = 0
 	return m
 }
@@ -950,6 +951,7 @@ func (m Model) appendProjectSwitchText(text string) Model {
 		return m
 	}
 	m.input.SetValue(m.input.Value() + b.String())
+	m.input.CursorEnd()
 	m.projectSwitchCursor = clampCursor(0, len(m.projectSwitchOptions()))
 	return m
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -765,7 +765,7 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 				return m, nil
 			}
 			row := m.selectedRow()
-			return m.startCreateWorktree(row, branch, "")
+			return m.startCreateWorktree(row, branch, "", branch)
 		case inputFilter:
 			m.inputMode = inputNone
 			m.input.Blur()
@@ -782,7 +782,15 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	return m.updateTextInput(msg)
 }
 
-func (m Model) startCreateWorktree(row Row, branch, source string) (Model, tea.Cmd) {
+func (m Model) startCreateWorktree(
+	row Row,
+	branch string,
+	source string,
+	display string,
+) (Model, tea.Cmd) {
+	if strings.TrimSpace(display) == "" {
+		display = branch
+	}
 	planned, err := m.backend.PreviewWorktree(row, branch)
 	if err != nil {
 		m.err = err
@@ -801,13 +809,24 @@ func (m Model) startCreateWorktree(row Row, branch, source string) (Model, tea.C
 		}
 		return m, nil
 	}
+	if source != "" && planned.Entry != nil {
+		entry := *planned.Entry
+		entry.Branch = display
+		planned.Entry = &entry
+	}
 	planned.Creating = true
 	m.creating = append(m.creating, pendingPath)
 	m.rows = append(m.rows, planned)
 	sortRows(m.rows)
 	m.cursor = indexByPath(m.filteredRows(), pendingPath)
-	m.message = fmt.Sprintf("creating %s", branch)
-	return m, m.createWorktreeCmd(row, branch, source, pendingPath)
+	m.message = fmt.Sprintf("creating %s", display)
+	return m, m.createWorktreeCmd(
+		row,
+		branch,
+		source,
+		display,
+		pendingPath,
+	)
 }
 
 func (m Model) handlePaste(msg tea.PasteMsg) (Model, tea.Cmd) {
@@ -903,7 +922,12 @@ func (m Model) handleExistingBranchKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		m.input.SetValue("")
 		m.branches = nil
 		m.branchRow = Row{}
-		return m.startCreateWorktree(row, branch.Name, branch.Source)
+		return m.startCreateWorktree(
+			row,
+			branch.Name,
+			branch.Source,
+			branchDisplayLabel(branch),
+		)
 	case tea.KeyUp:
 		m.branchCursor = clampCursor(m.branchCursor-1, len(m.branchOptions()))
 		return m, nil
@@ -1263,7 +1287,13 @@ func (m Model) listBranchesCmd(row Row) tea.Cmd {
 	}
 }
 
-func (m Model) createWorktreeCmd(row Row, branch, source, pendingPath string) tea.Cmd {
+func (m Model) createWorktreeCmd(
+	row Row,
+	branch string,
+	source string,
+	display string,
+	pendingPath string,
+) tea.Cmd {
 	return func() tea.Msg {
 		path, err := m.backend.CreateWorktree(
 			context.Background(),
@@ -1274,9 +1304,12 @@ func (m Model) createWorktreeCmd(row Row, branch, source, pendingPath string) te
 		if err != nil {
 			return actionDoneMsg{err: err, pendingPath: pendingPath}
 		}
-		message := fmt.Sprintf("created %s", branch)
+		message := fmt.Sprintf("created %s", display)
 		if source != "" {
-			message = fmt.Sprintf("created %s; review it before attaching", branch)
+			message = fmt.Sprintf(
+				"created %s; review it before attaching",
+				display,
+			)
 		}
 		return actionDoneMsg{
 			message:     message,
@@ -1640,7 +1673,9 @@ func (m Model) branchOptions() []models.Branch {
 	tokens := strings.Fields(query)
 	filtered := make([]models.Branch, 0, len(m.branches))
 	for _, branch := range m.branches {
-		haystack := strings.ToLower(branch.Name + " " + branch.Source)
+		haystack := strings.ToLower(
+			branch.Name + " " + branch.Label + " " + branch.Source,
+		)
 		matches := true
 		for _, token := range tokens {
 			if !strings.Contains(haystack, token) {
@@ -1818,12 +1853,12 @@ func (m Model) renderExistingBranchView() string {
 			if index == selected {
 				cursor = "▸"
 			}
+			label := branchDisplayLabel(branch)
 			location := "local"
 			if branch.IsRemote {
-				source := strings.TrimPrefix(branch.Source, "refs/remotes/")
-				location = "remote · " + source
+				location = "remote"
 			}
-			line := fmt.Sprintf("%s %-32s %s", cursor, branch.Name, location)
+			line := fmt.Sprintf("%s %-48s %s", cursor, label, location)
 			if index == selected {
 				line = m.theme.cursor.Render(line)
 			}
@@ -1843,6 +1878,19 @@ func (m Model) renderExistingBranchView() string {
 
 	b.WriteString(renderHelpTable(inputHelpRows(inputExistingBranch), m.width))
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func branchDisplayLabel(branch models.Branch) string {
+	if label := strings.TrimSpace(branch.Label); label != "" {
+		return label
+	}
+	if branch.IsRemote {
+		source := strings.TrimPrefix(branch.Source, "refs/remotes/")
+		if source != "" {
+			return fmt.Sprintf("%s (%s)", branch.Name, source)
+		}
+	}
+	return branch.Name
 }
 
 func (m Model) projectSwitchVisibleRows() int {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -759,6 +759,30 @@ func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
 	assert.Equal(t, []string{"refs/remotes/origin/remote-ready"}, backend.createSources)
 }
 
+func TestModelExistingLocalBranchRequiresReviewBeforeAttaching(t *testing.T) {
+	backend := &fakeBackend{
+		createPath: "/w/kwt/local-ready",
+		branches: []models.Branch{{
+			Name:   "local-ready",
+			Source: "local-ready",
+		}},
+	}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+
+	model, loadCmd := updateModel(t, model, press("b"))
+	require.NotNil(t, loadCmd)
+	model, _ = updateModel(t, model, loadCmd())
+	_, createCmd := updateModel(t, model, press("enter"))
+
+	require.NotNil(t, createCmd)
+	result := createCmd()
+	assert.Contains(t, result.(actionDoneMsg).message, "review")
+	assert.Equal(t, []string{"local-ready"}, backend.createSources)
+}
+
 func TestModelShowsNewWorktreeWhileCreateIsInFlight(t *testing.T) {
 	backend := &fakeBackend{createPath: "/w/kwt/feature-fast"}
 	model := NewModel(backend, "/worktrees")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -759,6 +759,46 @@ func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
 	assert.Equal(t, []string{"refs/remotes/origin/remote-ready"}, backend.createSources)
 }
 
+func TestModelExistingBranchPickerPreviewsDuplicateRemoteSource(t *testing.T) {
+	backend := &fakeBackend{
+		createPath: "/w/kwt/topic",
+		branches: []models.Branch{
+			{
+				Name:     "topic",
+				Label:    "topic (origin/topic)",
+				Source:   "refs/remotes/origin/topic",
+				IsRemote: true,
+			},
+			{
+				Name:     "topic",
+				Label:    "topic (upstream/topic)",
+				Source:   "refs/remotes/upstream/topic",
+				IsRemote: true,
+			},
+		},
+	}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+
+	model, loadCmd := updateModel(t, model, press("b"))
+	require.NotNil(t, loadCmd)
+	model, _ = updateModel(t, model, loadCmd())
+	content := stripANSI(viewContent(model))
+	assert.Contains(t, content, "topic (origin/topic)")
+	assert.Contains(t, content, "topic (upstream/topic)")
+
+	model, _ = updateModel(t, model, paste("upstream"))
+	model, createCmd := updateModel(t, model, press("enter"))
+
+	require.NotNil(t, createCmd)
+	require.NotNil(t, model.selectedRow().Entry)
+	assert.Equal(t, "topic (upstream/topic)", model.selectedRow().Entry.Branch)
+	_ = createCmd()
+	assert.Equal(t, []string{"refs/remotes/upstream/topic"}, backend.createSources)
+}
+
 func TestModelExistingLocalBranchRequiresReviewBeforeAttaching(t *testing.T) {
 	backend := &fakeBackend{
 		createPath: "/w/kwt/local-ready",

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -29,11 +29,15 @@ type fakeBackend struct {
 	removeErr       error
 	killErr         error
 	openErr         error
+	branches        []models.Branch
+	branchErr       error
 	fastListCalls   int
 	listCalls       int
+	branchCalls     []string
 	mergeFleetCalls int
 	mergeCtx        context.Context
 	createCalls     []string
+	createSources   []string
 	materializeRows []string
 	removeCalls     []string
 	removeForces    []bool
@@ -58,9 +62,23 @@ func (b *fakeBackend) MergeFleet(ctx context.Context, rows []Row) ([]Row, []stri
 	return append(append([]Row(nil), rows...), b.fleetRows...), b.fleetWarnings
 }
 
-func (b *fakeBackend) CreateWorktree(ctx context.Context, row Row, branch string) (string, error) {
+func (b *fakeBackend) CreateWorktree(
+	ctx context.Context,
+	row Row,
+	branch string,
+	source string,
+) (string, error) {
 	b.createCalls = append(b.createCalls, rowPath(row)+":"+branch)
+	b.createSources = append(b.createSources, source)
 	return b.createPath, b.createErr
+}
+
+func (b *fakeBackend) ListBranches(
+	ctx context.Context,
+	row Row,
+) ([]models.Branch, error) {
+	b.branchCalls = append(b.branchCalls, rowPath(row))
+	return append([]models.Branch(nil), b.branches...), b.branchErr
 }
 
 func (b *fakeBackend) PreviewWorktree(row Row, branch string) (Row, error) {
@@ -697,6 +715,44 @@ func TestModelNewBranchAcceptsPaste(t *testing.T) {
 	require.NotNil(t, cmd)
 	_ = cmd()
 	assert.Equal(t, []string{"/w/kwt/main:feature/pasted"}, backend.createCalls)
+	assert.Equal(t, []string{""}, backend.createSources)
+}
+
+func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
+	backend := &fakeBackend{
+		createPath: "/w/kwt/remote-ready",
+		branches: []models.Branch{
+			{Name: "local-ready", Source: "local-ready"},
+			{
+				Name:     "remote-ready",
+				Source:   "origin/remote-ready",
+				IsRemote: true,
+			},
+		},
+	}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
+		testRow("kwt", "main", "/w/kwt/main"),
+	}})
+
+	model, loadCmd := updateModel(t, model, press("b"))
+	require.NotNil(t, loadCmd)
+	model, _ = updateModel(t, model, loadCmd())
+
+	content := stripANSI(viewContent(model))
+	assert.Contains(t, content, "local-ready")
+	assert.Contains(t, content, "remote-ready")
+	assert.Contains(t, content, "origin/remote-ready")
+
+	for _, value := range []string{"r", "e", "m", "o", "t", "e"} {
+		model, _ = updateModel(t, model, press(value))
+	}
+	_, createCmd := updateModel(t, model, press("enter"))
+
+	require.NotNil(t, createCmd)
+	_ = createCmd()
+	assert.Equal(t, []string{"/w/kwt/main:remote-ready"}, backend.createCalls)
+	assert.Equal(t, []string{"origin/remote-ready"}, backend.createSources)
 }
 
 func TestModelShowsNewWorktreeWhileCreateIsInFlight(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -726,7 +726,7 @@ func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
 			{Name: "local-ready", Source: "local-ready"},
 			{
 				Name:     "remote-ready",
-				Source:   "origin/remote-ready",
+				Source:   "refs/remotes/origin/remote-ready",
 				IsRemote: true,
 			},
 		},
@@ -744,6 +744,7 @@ func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
 	assert.Contains(t, content, "local-ready")
 	assert.Contains(t, content, "remote-ready")
 	assert.Contains(t, content, "origin/remote-ready")
+	assert.NotContains(t, content, "refs/remotes/")
 
 	for _, value := range []string{"r", "e", "m", "o", "t", "e"} {
 		model, _ = updateModel(t, model, press(value))
@@ -752,9 +753,10 @@ func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
 	_, createCmd := updateModel(t, model, press("enter"))
 
 	require.NotNil(t, createCmd)
-	_ = createCmd()
+	result := createCmd()
+	assert.Contains(t, result.(actionDoneMsg).message, "review")
 	assert.Equal(t, []string{"/w/kwt/main:remote-ready"}, backend.createCalls)
-	assert.Equal(t, []string{"origin/remote-ready"}, backend.createSources)
+	assert.Equal(t, []string{"refs/remotes/origin/remote-ready"}, backend.createSources)
 }
 
 func TestModelShowsNewWorktreeWhileCreateIsInFlight(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -668,6 +668,7 @@ func TestModelProjectPerspectiveCancelKeepsCurrentProject(t *testing.T) {
 	model, _ = updateModel(t, model, press("P"))
 	model, _ = updateModel(t, model, press("k"))
 	model, _ = updateModel(t, model, press("a"))
+	assert.Equal(t, len("ka"), model.input.Position())
 	model, _ = updateModel(t, model, press("esc"))
 
 	assert.Equal(t, "kwt", model.projectPerspective)
@@ -747,6 +748,7 @@ func TestModelExistingBranchPickerCreatesSelectedRemote(t *testing.T) {
 	for _, value := range []string{"r", "e", "m", "o", "t", "e"} {
 		model, _ = updateModel(t, model, press(value))
 	}
+	assert.Equal(t, len("remote"), model.input.Position())
 	_, createCmd := updateModel(t, model, press("enter"))
 
 	require.NotNil(t, createCmd)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -132,13 +132,11 @@ func (m *Manager) addUnreviewedSource(
 		return "", fmt.Errorf("open remote-source state: %w", err)
 	}
 	previous, existed := state.Get(path)
-	entry := &registry.WorktreeEntry{}
-	if existed {
-		*entry = *previous
+	entry := &registry.WorktreeEntry{
+		Branch:                 branch,
+		Path:                   path,
+		UnreviewedRemoteSource: true,
 	}
-	entry.Branch = branch
-	entry.Path = path
-	entry.UnreviewedRemoteSource = true
 	if err := state.Register(entry); err != nil {
 		return "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -18,6 +18,7 @@ import (
 type GitInterface interface {
 	ListWorktrees() ([]models.Worktree, error)
 	AddWorktree(path, branch string, createBranch bool) error
+	AddWorktreeTracking(path, branch, remoteBranch string) error
 	AddWorktreeFromBase(path, branch, baseBranch string) error
 	RemoveWorktree(path string, force bool) error
 	DeleteBranch(branch string, force bool) error
@@ -66,6 +67,21 @@ func (m *Manager) AddWithOptions(branch string, customPath string, createBranch 
 	if !opts.SkipSetup {
 		m.runPostWorktreeSetup(branch, path)
 	}
+	return path, nil
+}
+
+// AddTracking creates a worktree on a local branch that tracks remoteBranch.
+func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, error) {
+	path, err := m.preparePath(customPath, branch, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if err := m.git.AddWorktreeTracking(path, branch, remoteBranch); err != nil {
+		return "", err
+	}
+
+	m.runPostWorktreeSetup(branch, path)
 	return path, nil
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"go.kenn.io/kwt/internal/credentials"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/template"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
@@ -35,8 +36,14 @@ type GitInterface interface {
 
 // Manager handles worktree operations.
 type Manager struct {
-	git    GitInterface
-	config *models.Config
+	git                   GitInterface
+	config                *models.Config
+	openRemoteSourceState func() (remoteSourceState, error)
+}
+
+type remoteSourceState interface {
+	Register(*registry.WorktreeEntry) error
+	Unregister(string) error
 }
 
 // AddOptions controls optional behavior for creating a worktree.
@@ -49,6 +56,9 @@ func New(g GitInterface, config *models.Config) *Manager {
 	return &Manager{
 		git:    g,
 		config: config,
+		openRemoteSourceState: func() (remoteSourceState, error) {
+			return registry.New()
+		},
 	}
 }
 
@@ -83,12 +93,25 @@ func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, 
 		return "", err
 	}
 
+	state, err := m.openRemoteSourceState()
+	if err != nil {
+		return "", fmt.Errorf("open remote-source state: %w", err)
+	}
+	if err := state.Register(&registry.WorktreeEntry{
+		Branch:                 branch,
+		Path:                   path,
+		UnreviewedRemoteSource: true,
+	}); err != nil {
+		return "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
+	}
+
 	if err := m.git.AddWorktreeTracking(
 		path,
 		branch,
 		remoteBranch,
 		credentials.ProtectedNames(m.config),
 	); err != nil {
+		_ = state.Unregister(path)
 		return "", err
 	}
 
@@ -237,7 +260,7 @@ func (m *Manager) preparePath(
 		path = generatedPath
 	}
 
-	if !generated || !m.config.Naming.RepositoryLocal {
+	if !generated {
 		expandedPath, err := utils.ExpandPath(path)
 		if err != nil {
 			return "", fmt.Errorf("failed to expand path: %w", err)
@@ -282,11 +305,20 @@ func (m *Manager) generateWorktreePathForRepository(
 			baseDir = setting.BaseDir
 		}
 	}
+	namingTemplate := m.config.Naming.Template
+	if !m.config.Naming.RepositoryLocal {
+		expandedBaseDir, err := utils.ExpandPath(baseDir)
+		if err != nil {
+			return "", fmt.Errorf("failed to expand worktree base: %w", err)
+		}
+		baseDir = expandedBaseDir
+		namingTemplate = os.ExpandEnv(namingTemplate)
+	}
 
 	// Use template if configured, otherwise fall back to default URL hierarchy
-	if m.config.Naming.Template != "" {
+	if namingTemplate != "" {
 		// Create template processor
-		processor, err := template.New(m.config.Naming.Template, m.config.Naming.SanitizeChars)
+		processor, err := template.New(namingTemplate, m.config.Naming.SanitizeChars)
 		if err != nil {
 			// Fall back to default hierarchy if template is invalid
 			return url.GenerateWorktreePath(baseDir, repoInfo, branch), nil

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -360,13 +360,24 @@ func (m *Manager) generateWorktreePathForRepository(
 			return "", fmt.Errorf("failed to expand worktree base: %w", err)
 		}
 		baseDir = expandedBaseDir
-		namingTemplate = os.ExpandEnv(namingTemplate)
 	}
 
 	// Use template if configured, otherwise fall back to default URL hierarchy
 	if namingTemplate != "" {
 		// Create template processor
-		processor, err := template.New(namingTemplate, m.config.Naming.SanitizeChars)
+		var processor *template.Processor
+		var err error
+		if m.config.Naming.RepositoryLocal {
+			processor, err = template.New(
+				namingTemplate,
+				m.config.Naming.SanitizeChars,
+			)
+		} else {
+			processor, err = template.NewWithEnvironment(
+				namingTemplate,
+				m.config.Naming.SanitizeChars,
+			)
+		}
 		if err != nil {
 			// Fall back to default hierarchy if template is invalid
 			return url.GenerateWorktreePath(baseDir, repoInfo, branch), nil

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -71,6 +71,8 @@ func (m *Manager) AddWithOptions(branch string, customPath string, createBranch 
 }
 
 // AddTracking creates a worktree on a local branch that tracks remoteBranch.
+// Repository setup is intentionally deferred: the remote checkout is
+// untrusted until the user has reviewed it.
 func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, error) {
 	path, err := m.preparePath(customPath, branch, nil)
 	if err != nil {
@@ -81,7 +83,6 @@ func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, 
 		return "", err
 	}
 
-	m.runPostWorktreeSetup(branch, path)
 	return path, nil
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -354,30 +354,25 @@ func (m *Manager) generateWorktreePathForRepository(
 		}
 	}
 	namingTemplate := m.config.Naming.Template
-	if !m.config.Naming.RepositoryLocal {
-		expandedBaseDir, err := utils.ExpandPath(baseDir)
-		if err != nil {
-			return "", fmt.Errorf("failed to expand worktree base: %w", err)
-		}
-		baseDir = expandedBaseDir
+	expandedBaseDir, err := utils.ExpandPath(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand worktree base: %w", err)
 	}
+	baseDir = expandedBaseDir
 
 	// Use template if configured, otherwise fall back to default URL hierarchy
 	if namingTemplate != "" {
 		// Create template processor
-		var processor *template.Processor
-		var err error
-		if m.config.Naming.RepositoryLocal {
-			processor, err = template.New(
-				namingTemplate,
-				m.config.Naming.SanitizeChars,
-			)
-		} else {
-			processor, err = template.NewWithEnvironment(
-				namingTemplate,
-				m.config.Naming.SanitizeChars,
-			)
+		naming := m.config.Naming
+		environmentOptions := template.EnvironmentOptions{
+			ExpandTemplate:      !naming.TemplateRepositoryLocal,
+			ExpandSanitizeChars: !naming.SanitizeCharsRepositoryLocal,
 		}
+		processor, err := template.NewWithEnvironmentOptions(
+			namingTemplate,
+			naming.SanitizeChars,
+			environmentOptions,
+		)
 		if err != nil {
 			// Fall back to default hierarchy if template is invalid
 			return url.GenerateWorktreePath(baseDir, repoInfo, branch), nil

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -11,6 +11,7 @@ import (
 	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/template"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
@@ -312,6 +313,10 @@ func (m *Manager) preparePath(
 			return "", fmt.Errorf("failed to expand path: %w", err)
 		}
 		path = expandedPath
+	}
+
+	if err := tmux.ValidateStartDirectory(path); err != nil {
+		return "", err
 	}
 
 	if m.config.Worktree.AutoMkdir {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -339,6 +339,7 @@ func (m *Manager) generateWorktreePathForRepository(
 			return "", err
 		}
 	}
+	branch = encodeBranchForWorktreePath(branch)
 
 	// Determine effective base directory: per-repo setting overrides global
 	baseDir := m.config.Worktree.BaseDir
@@ -390,6 +391,10 @@ func (m *Manager) generateWorktreePathForRepository(
 	// Fall back to default URL hierarchy
 	path := url.GenerateWorktreePath(baseDir, repoInfo, branch)
 	return path, ensurePathWithinBase(baseDir, path)
+}
+
+func encodeBranchForWorktreePath(branch string) string {
+	return strings.NewReplacer("%", "%25", "#", "%23").Replace(branch)
 }
 
 func (m *Manager) repositoryInfo() (*url.RepositoryInfo, error) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -20,6 +20,7 @@ import (
 type GitInterface interface {
 	ListWorktrees() ([]models.Worktree, error)
 	AddWorktree(path, branch string, createBranch bool) error
+	AddWorktreeExisting(path, branch string, protectedNames []string) error
 	AddWorktreeTracking(
 		path, branch, remoteBranch string,
 		protectedNames []string,
@@ -44,6 +45,7 @@ type Manager struct {
 type remoteSourceState interface {
 	Register(*registry.WorktreeEntry) error
 	Unregister(string) error
+	Get(string) (*registry.WorktreeEntry, bool)
 }
 
 // AddOptions controls optional behavior for creating a worktree.
@@ -69,6 +71,10 @@ func (m *Manager) Add(branch string, customPath string, createBranch bool) (stri
 
 // AddWithOptions creates a new worktree and returns the path of the created worktree.
 func (m *Manager) AddWithOptions(branch string, customPath string, createBranch bool, opts AddOptions) (string, error) {
+	if !createBranch {
+		return m.addExisting(branch, customPath)
+	}
+
 	path, err := m.preparePath(customPath, branch, nil)
 	if err != nil {
 		return "", err
@@ -84,6 +90,20 @@ func (m *Manager) AddWithOptions(branch string, customPath string, createBranch 
 	return path, nil
 }
 
+func (m *Manager) addExisting(branch, customPath string) (string, error) {
+	path, err := m.preparePath(customPath, branch, nil)
+	if err != nil {
+		return "", err
+	}
+	return m.addUnreviewedSource(path, branch, func() error {
+		return m.git.AddWorktreeExisting(
+			path,
+			branch,
+			credentials.ProtectedNames(m.config),
+		)
+	})
+}
+
 // AddTracking creates a worktree on a local branch that tracks remoteBranch.
 // Repository setup is intentionally deferred: the remote checkout is
 // untrusted until the user has reviewed it.
@@ -93,25 +113,53 @@ func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, 
 		return "", err
 	}
 
+	return m.addUnreviewedSource(path, branch, func() error {
+		return m.git.AddWorktreeTracking(
+			path,
+			branch,
+			remoteBranch,
+			credentials.ProtectedNames(m.config),
+		)
+	})
+}
+
+func (m *Manager) addUnreviewedSource(
+	path, branch string,
+	add func() error,
+) (string, error) {
 	state, err := m.openRemoteSourceState()
 	if err != nil {
 		return "", fmt.Errorf("open remote-source state: %w", err)
 	}
-	if err := state.Register(&registry.WorktreeEntry{
-		Branch:                 branch,
-		Path:                   path,
-		UnreviewedRemoteSource: true,
-	}); err != nil {
+	previous, existed := state.Get(path)
+	entry := &registry.WorktreeEntry{}
+	if existed {
+		*entry = *previous
+	}
+	entry.Branch = branch
+	entry.Path = path
+	entry.UnreviewedRemoteSource = true
+	if err := state.Register(entry); err != nil {
 		return "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
 	}
 
-	if err := m.git.AddWorktreeTracking(
-		path,
-		branch,
-		remoteBranch,
-		credentials.ProtectedNames(m.config),
-	); err != nil {
-		_ = state.Unregister(path)
+	if err := add(); err != nil {
+		var restoreErr error
+		switch {
+		case existed:
+			restoreErr = state.Register(previous)
+		default:
+			if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+				restoreErr = state.Unregister(path)
+			}
+		}
+		if restoreErr != nil {
+			return "", fmt.Errorf(
+				"%w (failed to restore remote-source state: %v)",
+				err,
+				restoreErr,
+			)
+		}
 		return "", err
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/template"
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
@@ -18,7 +19,10 @@ import (
 type GitInterface interface {
 	ListWorktrees() ([]models.Worktree, error)
 	AddWorktree(path, branch string, createBranch bool) error
-	AddWorktreeTracking(path, branch, remoteBranch string) error
+	AddWorktreeTracking(
+		path, branch, remoteBranch string,
+		protectedNames []string,
+	) error
 	AddWorktreeFromBase(path, branch, baseBranch string) error
 	RemoveWorktree(path string, force bool) error
 	DeleteBranch(branch string, force bool) error
@@ -79,7 +83,12 @@ func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, 
 		return "", err
 	}
 
-	if err := m.git.AddWorktreeTracking(path, branch, remoteBranch); err != nil {
+	if err := m.git.AddWorktreeTracking(
+		path,
+		branch,
+		remoteBranch,
+		credentials.ProtectedNames(m.config),
+	); err != nil {
 		return "", err
 	}
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -28,6 +28,7 @@ type mockGit struct {
 	deleteBranchError error
 	recentCommits     []models.CommitInfo
 	mainRepoPathError error
+	trackingSource    string
 }
 
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
@@ -41,6 +42,18 @@ func (m *mockGit) AddWorktree(path, branch string, createBranch bool) error {
 	if m.addError != nil {
 		return m.addError
 	}
+	m.worktrees = append(m.worktrees, models.Worktree{
+		Path:   path,
+		Branch: branch,
+	})
+	return nil
+}
+
+func (m *mockGit) AddWorktreeTracking(path, branch, remoteBranch string) error {
+	if m.addError != nil {
+		return m.addError
+	}
+	m.trackingSource = remoteBranch
 	m.worktrees = append(m.worktrees, models.Worktree{
 		Path:   path,
 		Branch: branch,
@@ -185,6 +198,29 @@ func TestManagerAdd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
+	baseDir := t.TempDir()
+	mockG := &mockGit{}
+	manager := New(mockG, &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir:   baseDir,
+			AutoMkdir: true,
+		},
+	})
+
+	path, err := manager.AddTracking(
+		"feature/remote",
+		"origin/feature/remote",
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(baseDir, "github.com", "test-user", "test-repo", "feature-remote"), path)
+	require.Len(t, mockG.worktrees, 1)
+	assert.Equal(t, "feature/remote", mockG.worktrees[0].Branch)
+	assert.Equal(t, "origin/feature/remote", mockG.trackingSource)
 }
 
 func TestManagerRemove(t *testing.T) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ type mockGit struct {
 	recentCommits     []models.CommitInfo
 	mainRepoPathError error
 	trackingSource    string
+	existingSource    string
 	protectedNames    []string
 }
 
@@ -49,6 +51,17 @@ func (m *mockRemoteSourceState) Register(entry *registry.WorktreeEntry) error {
 func (m *mockRemoteSourceState) Unregister(path string) error {
 	delete(m.entries, path)
 	return nil
+}
+
+func (m *mockRemoteSourceState) Get(
+	path string,
+) (*registry.WorktreeEntry, bool) {
+	entry, ok := m.entries[path]
+	if !ok {
+		return nil, false
+	}
+	copied := *entry
+	return &copied, true
 }
 
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
@@ -77,6 +90,22 @@ func (m *mockGit) AddWorktreeTracking(
 		return m.addError
 	}
 	m.trackingSource = remoteBranch
+	m.protectedNames = append([]string(nil), protectedNames...)
+	m.worktrees = append(m.worktrees, models.Worktree{
+		Path:   path,
+		Branch: branch,
+	})
+	return nil
+}
+
+func (m *mockGit) AddWorktreeExisting(
+	path, branch string,
+	protectedNames []string,
+) error {
+	if m.addError != nil {
+		return m.addError
+	}
+	m.existingSource = branch
 	m.protectedNames = append([]string(nil), protectedNames...)
 	m.worktrees = append(m.worktrees, models.Worktree{
 		Path:   path,
@@ -272,6 +301,99 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 	assert.True(t, state.entries[worktreePath].UnreviewedRemoteSource)
 	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
 	assert.NoFileExists(t, filepath.Join(worktreePath, "setup-ran"))
+}
+
+func TestManagerAddExistingMarksSourceUnreviewedAndSkipsSetup(t *testing.T) {
+	baseDir := t.TempDir()
+	repoDir := t.TempDir()
+	worktreePath := filepath.Join(baseDir, "local-worktree")
+	require.NoError(t, os.MkdirAll(worktreePath, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, "copy-me"),
+		[]byte("trusted config, untrusted branch"),
+		0644,
+	))
+	mockG := &mockGit{repoPath: repoDir}
+	state := &mockRemoteSourceState{}
+	manager := New(mockG, &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir:   baseDir,
+			AutoMkdir: true,
+		},
+		RepositorySettings: []models.RepositorySetting{{
+			Repository: repoDir,
+			CopyFiles:  []string{"copy-me"},
+		}},
+		Fleet: models.FleetConfig{TokenEnv: "Custom_Fleet_Token"},
+	})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	path, err := manager.Add("feature/local", worktreePath, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, worktreePath, path)
+	assert.Equal(t, "feature/local", mockG.existingSource)
+	assert.ElementsMatch(
+		t,
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "Custom_Fleet_Token"},
+		mockG.protectedNames,
+	)
+	require.Contains(t, state.entries, worktreePath)
+	assert.True(t, state.entries[worktreePath].UnreviewedRemoteSource)
+	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
+}
+
+func TestManagerAddTrackingRestoresExistingMarkerAfterGitFailure(t *testing.T) {
+	worktreePath := t.TempDir()
+	future := time.Now().Add(time.Hour)
+	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
+		worktreePath: {
+			Path:                   worktreePath,
+			Branch:                 "feature/existing",
+			Repository:             "github.com/acme/widget",
+			ExpiresAt:              &future,
+			UnreviewedRemoteSource: true,
+		},
+	}}
+	manager := New(&mockGit{addError: errors.New("already checked out")}, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	_, err := manager.AddTracking(
+		"feature/existing",
+		"refs/remotes/origin/feature/existing",
+		worktreePath,
+	)
+
+	require.Error(t, err)
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok, "failed repeated add must retain the safety marker")
+	assert.True(t, entry.UnreviewedRemoteSource)
+	assert.Equal(t, "github.com/acme/widget", entry.Repository)
+	assert.Equal(t, &future, entry.ExpiresAt)
+}
+
+func TestManagerAddTrackingRetainsMarkerWhenFailedCheckoutPathExists(t *testing.T) {
+	worktreePath := t.TempDir()
+	state := &mockRemoteSourceState{}
+	manager := New(&mockGit{addError: errors.New("checkout failed")}, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	_, err := manager.AddTracking(
+		"feature/partial",
+		"refs/remotes/origin/feature/partial",
+		worktreePath,
+	)
+
+	require.Error(t, err)
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok, "a possibly materialized checkout must remain isolated")
+	assert.True(t, entry.UnreviewedRemoteSource)
 }
 
 func TestManagerAddTrackingDoesNotExpandRemoteBranchEnvironmentReferences(
@@ -1107,7 +1229,7 @@ func TestManagerAdd_ConfigurableSetupIntegration(t *testing.T) {
 	mockG := &mockGit{repoPath: repoDir}
 	m := New(mockG, cfg)
 
-	_, err = m.Add("feature/test", filepath.Join(worktreeDir, "wt1"), false)
+	_, err = m.Add("feature/test", filepath.Join(worktreeDir, "wt1"), true)
 	if err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -1150,7 +1272,7 @@ func TestManagerAdd_SetupFromWorktreeContext(t *testing.T) {
 	mockG := &mockGit{repoPath: repoDir}
 	m := New(mockG, cfg)
 
-	_, err = m.Add("feature/wt-test", filepath.Join(worktreeDir, "wt1"), false)
+	_, err = m.Add("feature/wt-test", filepath.Join(worktreeDir, "wt1"), true)
 	if err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	configpkg "go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -30,6 +31,24 @@ type mockGit struct {
 	mainRepoPathError error
 	trackingSource    string
 	protectedNames    []string
+}
+
+type mockRemoteSourceState struct {
+	entries map[string]*registry.WorktreeEntry
+}
+
+func (m *mockRemoteSourceState) Register(entry *registry.WorktreeEntry) error {
+	if m.entries == nil {
+		m.entries = make(map[string]*registry.WorktreeEntry)
+	}
+	copied := *entry
+	m.entries[entry.Path] = &copied
+	return nil
+}
+
+func (m *mockRemoteSourceState) Unregister(path string) error {
+	delete(m.entries, path)
+	return nil
 }
 
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
@@ -216,6 +235,7 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 		0644,
 	))
 	mockG := &mockGit{repoPath: repoDir}
+	state := &mockRemoteSourceState{}
 	manager := New(mockG, &models.Config{
 		Worktree: models.WorktreeConfig{
 			BaseDir:   baseDir,
@@ -228,6 +248,9 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 		}},
 		Fleet: models.FleetConfig{TokenEnv: "Custom_Fleet_Token"},
 	})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
 
 	path, err := manager.AddTracking(
 		"feature/remote",
@@ -245,8 +268,38 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "Custom_Fleet_Token"},
 		mockG.protectedNames,
 	)
+	require.Contains(t, state.entries, worktreePath)
+	assert.True(t, state.entries[worktreePath].UnreviewedRemoteSource)
 	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
 	assert.NoFileExists(t, filepath.Join(worktreePath, "setup-ran"))
+}
+
+func TestManagerAddTrackingDoesNotExpandRemoteBranchEnvironmentReferences(
+	t *testing.T,
+) {
+	trustedBase := t.TempDir()
+	t.Setenv("KWT_TEST_WORKTREE_BASE", trustedBase)
+	t.Setenv("KWT_GITHUB_TOKEN", "credential-must-not-appear-in-path")
+	mockG := &mockGit{repoURL: "https://github.com/acme/widget.git"}
+	manager := New(mockG, &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir: "$KWT_TEST_WORKTREE_BASE",
+		},
+		Naming: models.NamingConfig{Template: "{{.Branch}}"},
+	})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return &mockRemoteSourceState{}, nil
+	}
+
+	path, err := manager.AddTracking(
+		"$KWT_GITHUB_TOKEN",
+		"refs/remotes/origin/$KWT_GITHUB_TOKEN",
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(trustedBase, "$KWT_GITHUB_TOKEN"), path)
+	assert.NotContains(t, path, "credential-must-not-appear-in-path")
 }
 
 func TestManagerRemove(t *testing.T) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -850,6 +850,31 @@ func TestGenerateWorktreePathDefaultTemplatePreservesNestedRemoteNamespace(t *te
 	}
 }
 
+func TestGenerateWorktreePathEncodesTmuxFormatCharacters(t *testing.T) {
+	baseDir := t.TempDir()
+	manager := New(&mockGit{
+		repoURL: "https://github.com/acme/widget.git",
+	}, &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: baseDir},
+		Naming: models.NamingConfig{
+			Template:      "{{.Branch}}",
+			SanitizeChars: map[string]string{"/": "-"},
+		},
+	})
+
+	path, err := manager.generateWorktreePath(
+		"feature/%23/#(touch$IFS.pwn)",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		filepath.Join(baseDir, "feature-%2523-%23(touch$IFS.pwn)"),
+		path,
+	)
+	assert.NotContains(t, path, "#")
+}
+
 // TestRepositoryInfoFromGitCanonicalResolver pins the single canonical
 // resolver every identity-reporting surface routes through: an origin URL wins,
 // a no-remote repository falls back to the "local/..." identity, and a

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -202,25 +202,40 @@ func TestManagerAdd(t *testing.T) {
 
 func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 	baseDir := t.TempDir()
-	mockG := &mockGit{}
+	repoDir := t.TempDir()
+	worktreePath := filepath.Join(baseDir, "remote-worktree")
+	require.NoError(t, os.MkdirAll(worktreePath, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, "copy-me"),
+		[]byte("untrusted"),
+		0644,
+	))
+	mockG := &mockGit{repoPath: repoDir}
 	manager := New(mockG, &models.Config{
 		Worktree: models.WorktreeConfig{
 			BaseDir:   baseDir,
 			AutoMkdir: true,
 		},
+		RepositorySettings: []models.RepositorySetting{{
+			Repository:    repoDir,
+			CopyFiles:     []string{"copy-me"},
+			SetupCommands: []string{"touch setup-ran"},
+		}},
 	})
 
 	path, err := manager.AddTracking(
 		"feature/remote",
 		"origin/feature/remote",
-		"",
+		worktreePath,
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(baseDir, "github.com", "test-user", "test-repo", "feature-remote"), path)
+	assert.Equal(t, worktreePath, path)
 	require.Len(t, mockG.worktrees, 1)
 	assert.Equal(t, "feature/remote", mockG.worktrees[0].Branch)
 	assert.Equal(t, "origin/feature/remote", mockG.trackingSource)
+	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
+	assert.NoFileExists(t, filepath.Join(worktreePath, "setup-ran"))
 }
 
 func TestManagerRemove(t *testing.T) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -376,6 +376,38 @@ func TestManagerAddTrackingRestoresExistingMarkerAfterGitFailure(t *testing.T) {
 	assert.Equal(t, &future, entry.ExpiresAt)
 }
 
+func TestManagerAddTrackingReplacesStaleMetadataAfterSuccess(t *testing.T) {
+	worktreePath := t.TempDir()
+	expired := time.Now().Add(-time.Hour)
+	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
+		worktreePath: {
+			Path:                   worktreePath,
+			Branch:                 "feature/stale",
+			Repository:             "github.com/acme/old",
+			ExpiresAt:              &expired,
+			UnreviewedRemoteSource: true,
+		},
+	}}
+	manager := New(&mockGit{}, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	_, err := manager.AddTracking(
+		"feature/reused",
+		"refs/remotes/origin/feature/reused",
+		worktreePath,
+	)
+
+	require.NoError(t, err)
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok)
+	assert.Equal(t, "feature/reused", entry.Branch)
+	assert.Empty(t, entry.Repository)
+	assert.Nil(t, entry.ExpiresAt)
+	assert.True(t, entry.UnreviewedRemoteSource)
+}
+
 func TestManagerAddTrackingRetainsMarkerWhenFailedCheckoutPathExists(t *testing.T) {
 	worktreePath := t.TempDir()
 	state := &mockRemoteSourceState{}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -552,6 +552,8 @@ func TestManagerValidateWorktreePath(t *testing.T) {
 }
 
 func TestGenerateWorktreePath(t *testing.T) {
+	defaultBaseDir := filepath.Join(t.TempDir(), "base")
+	perRepoBaseDir := filepath.Join(t.TempDir(), "per-repo-base")
 	tests := []struct {
 		name               string
 		branch             string
@@ -561,7 +563,7 @@ func TestGenerateWorktreePath(t *testing.T) {
 		repositorySettings []models.RepositorySetting
 		mainRepoPathError  error
 		wantErr            bool
-		wantBaseDir        string // if non-empty, overrides "/base" in expected path
+		wantBaseDir        string
 	}{
 		{
 			name:       "BasicTemplate",
@@ -587,10 +589,10 @@ func TestGenerateWorktreePath(t *testing.T) {
 			repoName: "myrepo",
 			repoPath: "/mock/repo/path",
 			repositorySettings: []models.RepositorySetting{
-				{Repository: "/mock/repo/path", BaseDir: "/per-repo-base"},
+				{Repository: "/mock/repo/path", BaseDir: perRepoBaseDir},
 			},
 			wantSuffix:  "github.com/test-user/test-repo/feature-test",
-			wantBaseDir: "/per-repo-base",
+			wantBaseDir: perRepoBaseDir,
 		},
 		{
 			name:     "PerRepoBaseDirEmpty",
@@ -608,7 +610,7 @@ func TestGenerateWorktreePath(t *testing.T) {
 			repoName:          "myrepo",
 			mainRepoPathError: errors.New("git error"),
 			repositorySettings: []models.RepositorySetting{
-				{Repository: "/mock/repo/path", BaseDir: "/per-repo-base"},
+				{Repository: "/mock/repo/path", BaseDir: perRepoBaseDir},
 			},
 			wantErr: true,
 		},
@@ -624,7 +626,7 @@ func TestGenerateWorktreePath(t *testing.T) {
 
 			config := &models.Config{
 				Worktree: models.WorktreeConfig{
-					BaseDir: "/base",
+					BaseDir: defaultBaseDir,
 				},
 				RepositorySettings: tt.repositorySettings,
 			}
@@ -642,7 +644,7 @@ func TestGenerateWorktreePath(t *testing.T) {
 				t.Fatalf("generateWorktreePath() error = %v", err)
 			}
 
-			baseDir := "/base"
+			baseDir := defaultBaseDir
 			if tt.wantBaseDir != "" {
 				baseDir = tt.wantBaseDir
 			}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1150,8 +1150,8 @@ func TestPreparePathDoesNotExpandRepositoryLocalTemplateOutput(t *testing.T) {
 		&models.Config{
 			Worktree: models.WorktreeConfig{BaseDir: baseDir},
 			Naming: models.NamingConfig{
-				Template:        `{{printf "%c%s" 36 "KWT_GITHUB_TOKEN"}}/{{.Branch}}`,
-				RepositoryLocal: true,
+				Template:                `{{printf "%c%s" 36 "KWT_GITHUB_TOKEN"}}/{{.Branch}}`,
+				TemplateRepositoryLocal: true,
 			},
 		},
 	)
@@ -1209,6 +1209,39 @@ func TestPreparePathExpandsGlobalSanitizationReplacements(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(baseDir, "feature__widgets"), path)
+}
+
+func TestPreparePathExpandsNamingComponentsByProvenance(t *testing.T) {
+	t.Setenv("KWT_WORKTREE_GROUP", "trusted-group")
+	t.Setenv("KWT_BRANCH_SEPARATOR", "__")
+	baseDir := t.TempDir()
+	manager := New(
+		&mockGit{repoURL: "https://github.com/acme/widget.git"},
+		&models.Config{
+			Worktree: models.WorktreeConfig{BaseDir: baseDir},
+			Naming: models.NamingConfig{
+				Template:                     "$KWT_WORKTREE_GROUP/{{.Branch}}",
+				TemplateRepositoryLocal:      false,
+				SanitizeCharsRepositoryLocal: true,
+				SanitizeChars: map[string]string{
+					"/": "$KWT_BRANCH_SEPARATOR",
+				},
+			},
+		},
+	)
+
+	path, err := manager.PreparePath("", "feature/widgets")
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		filepath.Join(
+			baseDir,
+			"trusted-group",
+			"feature$KWT_BRANCH_SEPARATORwidgets",
+		),
+		path,
+	)
 }
 
 func TestGenerateWorktreePathRejectsSymlinkEscapeFromBaseDir(t *testing.T) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -29,6 +29,7 @@ type mockGit struct {
 	recentCommits     []models.CommitInfo
 	mainRepoPathError error
 	trackingSource    string
+	protectedNames    []string
 }
 
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
@@ -49,11 +50,15 @@ func (m *mockGit) AddWorktree(path, branch string, createBranch bool) error {
 	return nil
 }
 
-func (m *mockGit) AddWorktreeTracking(path, branch, remoteBranch string) error {
+func (m *mockGit) AddWorktreeTracking(
+	path, branch, remoteBranch string,
+	protectedNames []string,
+) error {
 	if m.addError != nil {
 		return m.addError
 	}
 	m.trackingSource = remoteBranch
+	m.protectedNames = append([]string(nil), protectedNames...)
 	m.worktrees = append(m.worktrees, models.Worktree{
 		Path:   path,
 		Branch: branch,
@@ -221,6 +226,7 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 			CopyFiles:     []string{"copy-me"},
 			SetupCommands: []string{"touch setup-ran"},
 		}},
+		Fleet: models.FleetConfig{TokenEnv: "Custom_Fleet_Token"},
 	})
 
 	path, err := manager.AddTracking(
@@ -234,6 +240,11 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 	require.Len(t, mockG.worktrees, 1)
 	assert.Equal(t, "feature/remote", mockG.worktrees[0].Branch)
 	assert.Equal(t, "origin/feature/remote", mockG.trackingSource)
+	assert.ElementsMatch(
+		t,
+		[]string{"KWT_GITHUB_TOKEN", "KWT_FLEET_TOKEN", "Custom_Fleet_Token"},
+		mockG.protectedNames,
+	)
 	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
 	assert.NoFileExists(t, filepath.Join(worktreePath, "setup-ran"))
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1163,6 +1163,54 @@ func TestPreparePathDoesNotExpandRepositoryLocalTemplateOutput(t *testing.T) {
 	assert.Contains(t, path, "$KWT_GITHUB_TOKEN")
 }
 
+func TestPreparePathExpandsOnlyLiteralTextInGlobalTemplate(t *testing.T) {
+	t.Setenv("KWT_WORKTREE_GROUP", "trusted-group")
+	baseDir := t.TempDir()
+	manager := New(
+		&mockGit{repoURL: "https://github.com/acme/widget.git"},
+		&models.Config{
+			Worktree: models.WorktreeConfig{BaseDir: baseDir},
+			Naming: models.NamingConfig{
+				Template: `$KWT_WORKTREE_GROUP/{{$branch := .Branch}}{{$branch}}`,
+				SanitizeChars: map[string]string{
+					"/": "-",
+				},
+			},
+		},
+	)
+
+	path, err := manager.PreparePath("", "feature/widgets")
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		filepath.Join(baseDir, "trusted-group", "feature-widgets"),
+		path,
+	)
+}
+
+func TestPreparePathExpandsGlobalSanitizationReplacements(t *testing.T) {
+	t.Setenv("KWT_BRANCH_SEPARATOR", "__")
+	baseDir := t.TempDir()
+	manager := New(
+		&mockGit{repoURL: "https://github.com/acme/widget.git"},
+		&models.Config{
+			Worktree: models.WorktreeConfig{BaseDir: baseDir},
+			Naming: models.NamingConfig{
+				Template: "{{.Branch}}",
+				SanitizeChars: map[string]string{
+					"/": "$KWT_BRANCH_SEPARATOR",
+				},
+			},
+		},
+	)
+
+	path, err := manager.PreparePath("", "feature/widgets")
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(baseDir, "feature__widgets"), path)
+}
+
 func TestGenerateWorktreePathRejectsSymlinkEscapeFromBaseDir(t *testing.T) {
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "base")

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1220,6 +1220,23 @@ func TestPreparePathDoesNotExpandRepositoryLocalTemplateOutput(t *testing.T) {
 	assert.Contains(t, path, "$KWT_GITHUB_TOKEN")
 }
 
+func TestAddRejectsTmuxFormatPathBeforeMutation(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "uncreated")
+	worktreePath := filepath.Join(parent, "feature#widgets")
+	repositoryGit := &mockGit{}
+	manager := New(repositoryGit, &models.Config{
+		Worktree: models.WorktreeConfig{AutoMkdir: true},
+	})
+
+	path, err := manager.Add("feature/widgets", worktreePath, true)
+
+	require.Error(t, err)
+	assert.Empty(t, path)
+	assert.Contains(t, err.Error(), "tmux format syntax")
+	assert.Empty(t, repositoryGit.worktrees)
+	assert.NoDirExists(t, parent)
+}
+
 func TestPreparePathExpandsOnlyLiteralTextInGlobalTemplate(t *testing.T) {
 	t.Setenv("KWT_WORKTREE_GROUP", "trusted-group")
 	baseDir := t.TempDir()

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -19,6 +19,7 @@ type Worktree struct {
 // Branch represents a Git branch with its metadata.
 type Branch struct {
 	Name       string     `json:"name"`        // Branch name
+	Source     string     `json:"source"`      // Local branch or remote ref used to create a worktree
 	IsCurrent  bool       `json:"is_current"`  // Whether this is the current branch
 	IsRemote   bool       `json:"is_remote"`   // Whether this is a remote branch
 	LastCommit CommitInfo `json:"last_commit"` // Information about the last commit

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -19,6 +19,7 @@ type Worktree struct {
 // Branch represents a Git branch with its metadata.
 type Branch struct {
 	Name       string     `json:"name"`        // Branch name
+	Label      string     `json:"label"`       // Source-qualified display label
 	Source     string     `json:"source"`      // Local branch or remote ref used to create a worktree
 	IsCurrent  bool       `json:"is_current"`  // Whether this is the current branch
 	IsRemote   bool       `json:"is_remote"`   // Whether this is a remote branch

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -127,9 +127,10 @@ type UIConfig struct {
 
 // NamingConfig contains directory naming and template configuration options.
 type NamingConfig struct {
-	Template        string            `mapstructure:"template"`            // Directory name template
-	SanitizeChars   map[string]string `mapstructure:"sanitize_chars"`      // Character replacement for branch names
-	RepositoryLocal bool              `mapstructure:"-" toml:"-" json:"-"` // Generated paths include repository-local naming input
+	Template                     string            `mapstructure:"template"`            // Directory name template
+	SanitizeChars                map[string]string `mapstructure:"sanitize_chars"`      // Character replacement for branch names
+	TemplateRepositoryLocal      bool              `mapstructure:"-" toml:"-" json:"-"` // Template came from repository-local config
+	SanitizeCharsRepositoryLocal bool              `mapstructure:"-" toml:"-" json:"-"` // Replacements came from repository-local config
 }
 
 // WorktreeStatus represents the current status of a worktree.


### PR DESCRIPTION
Creating a worktree from an existing branch currently requires users to know whether it is local or remote, and the interactive flow loses the selected remote ref. That makes a routine review or continuation workflow error-prone and leaves API consumers without an authoritative branch inventory.

This establishes one normalized contract for branches that are not already checked out while retaining the exact source ref required for remote tracking. The dashboard can now search and select existing branches with `b`, the CLI can create a tracking worktree with `kwt add --from`, and external clients can consume `kwt branches --json`. New-branch creation remains a separate action, so selecting an existing branch cannot silently start from the default base.

Validation:
- `make check`
- `make build`
- `make docs-build`
- pre-push lint and formatting gates