### PR TITLE
Make worktree removal conditional on creation identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Test First: Write a failing test before implementation, then make it pass, then refactor. Do not add production code without a failing test that requires it.
 - No Unrequested GitHub Comments: Do not comment on GitHub issues or pull requests unless the user explicitly instructs you to post a comment.
 - No CI Polling: Do not poll GitHub or the `gh` API to watch jobs or workflow status unless the user explicitly instructs you to do so.
+- No Navel-Gazing Validation Sections: Do not add a `Validation` section to a PR description for routine tests, builds, lint, formatting, or CI. Include one only when the validation was unusual, potentially surprising, manual, or otherwise important for reviewers to understand.
 - No Bash Content-Assertion Tests: Do not add shell tests that only grep scripts, workflows, or config files for implementation text. Prefer exercising behavior directly or documenting a manual check.
 - Documentation should move with behavior changes when practical: CLI flags, config keys, workflows, and user-facing contracts should be updated with the code.
 - Keep changes focused. Do not refactor unrelated code or rewrite user changes while completing a task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,4 +28,5 @@ contract. The short version:
 - Close only verified work: `kata close <ref> --done --message "<scope + verification>" --commit <sha>`.
 - If work is incomplete, label `needs-review` and comment what remains rather than closing.
 - Never `kata delete` or `kata purge` without explicit user authorization.
+
 <!-- END KATA -->

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -104,6 +104,13 @@ tools](#attaching-from-other-tools) before using `new-session`.
 and direct the user through `kwt pr attach`.
 `created_at` is populated in both local and `-g` mode.
 
+## `kwt remove`
+
+`--if-created-at <timestamp>` makes a single-worktree removal conditional on
+the `created_at` value returned by `kwt list --json`. Kwt compares that identity
+and removes the worktree while holding the repository's worktree-mutation lock,
+so automation cannot delete a replacement checkout created at the same path.
+
 ## `kwt projects`
 
 `--json` emits an array of the registered project repositories (`{repository,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -90,9 +90,10 @@ Protected pull-request imports remain restricted to `kwt pr attach`.
 ## `kwt list`
 
 `--json` emits an array of objects with `path`, `branch`, `commit_hash`, `is_main`,
-`created_at` (worktree directory mtime), `repository` (the `host/owner/name`
-slug, or a `local/<path>` fallback for a repository without a usable remote —
-see below), and `session_name` (the tmux workspace session name kwt attaches to).
+`created_at` (worktree directory mtime), `generation` (the durable identity for
+conditional removal), `repository` (the `host/owner/name` slug, or a
+`local/<path>` fallback for a repository without a usable remote — see below),
+and `session_name` (the tmux workspace session name kwt attaches to).
 An imported pull-request worktree additionally includes `tmux_socket_name` for
 its protected workspace-specific server. To converge on the same session, run
 `kwt open <path> --start-session` before an ordinary attach-only client, or
@@ -102,14 +103,16 @@ protected attach policy. See [Attaching from other
 tools](#attaching-from-other-tools) before using `new-session`.
 `kwt open` and dashboard open actions refuse protected pull-request imports
 and direct the user through `kwt pr attach`.
-`created_at` is populated in both local and `-g` mode.
+`created_at` and `generation` are populated in both local and `-g` mode.
 
 ## `kwt remove`
 
-`--if-created-at <timestamp>` makes a single-worktree removal conditional on
-the `created_at` value returned by `kwt list --json`. Kwt compares that identity
-and removes the worktree while holding the repository's worktree-mutation lock,
-so automation cannot delete a replacement checkout created at the same path.
+`--if-generation <id>` makes a single-worktree removal conditional on the
+`generation` value returned by `kwt list --json`. Kwt stores this random
+identity in the worktree's Git administrative directory and compares it while
+holding the repository's worktree-mutation lock, so automation cannot delete a
+replacement checkout created at the same path. Ordinary directory changes do
+not alter the generation.
 
 ## `kwt projects`
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -295,37 +295,28 @@ func registerWorktreeExpiration(
 	branch string,
 	expiresAt *time.Time,
 ) error {
-	observed, _ := reg.Get(worktreePath)
-	if observed != nil && observed.CreationToken != "" {
-		return fmt.Errorf(
-			"worktree creation in progress for %s",
-			worktreePath,
-		)
-	}
-	entry := &registry.WorktreeEntry{}
-	if observed != nil {
-		*entry = *observed
-	}
-	entry.Repository = repository
-	entry.Branch = branch
-	entry.Path = worktreePath
-	entry.IsMain = false
-	entry.ExpiresAt = expiresAt
-	entry.Generation = generation
-
 	return g.WithWorktreeGeneration(
 		worktreePath,
 		generation,
 		func() error {
-			replaced, err := reg.CompareAndSwap(
+			updated, err := reg.SetExpirationIfGeneration(
 				worktreePath,
-				observed,
-				entry,
+				generation,
+				repository,
+				branch,
+				expiresAt,
 			)
 			if err != nil {
 				return err
 			}
-			if !replaced {
+			if !updated {
+				if observed, ok := reg.Get(worktreePath); ok &&
+					observed.CreationToken != "" {
+					return fmt.Errorf(
+						"worktree creation in progress for %s",
+						worktreePath,
+					)
+				}
 				return fmt.Errorf(
 					"registry ownership changed for %s",
 					worktreePath,

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/duration"
+	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
@@ -253,18 +254,15 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			t := time.Now().Add(expiresDuration)
 			expiresAt = &t
 
-			entry := &registry.WorktreeEntry{}
-			if existing, ok := reg.Get(worktreePath); ok {
-				*entry = *existing
-			}
-			entry.Repository = repoURL
-			entry.Branch = branch
-			entry.Path = worktreePath
-			entry.IsMain = false
-			entry.ExpiresAt = expiresAt
-			entry.Generation = worktreeGeneration
-
-			if err := reg.Register(entry); err != nil {
+			if err := registerWorktreeExpiration(
+				ctx.Git,
+				reg,
+				worktreePath,
+				worktreeGeneration,
+				repoURL,
+				branch,
+				expiresAt,
+			); err != nil {
 				return fmt.Errorf("failed to register worktree: %w", err)
 			}
 		}
@@ -286,6 +284,50 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	})(cmd, args)
+}
+
+func registerWorktreeExpiration(
+	g *git.Git,
+	reg *registry.Registry,
+	worktreePath string,
+	generation string,
+	repository string,
+	branch string,
+	expiresAt *time.Time,
+) error {
+	observed, _ := reg.Get(worktreePath)
+	entry := &registry.WorktreeEntry{}
+	if observed != nil {
+		*entry = *observed
+	}
+	entry.Repository = repository
+	entry.Branch = branch
+	entry.Path = worktreePath
+	entry.IsMain = false
+	entry.ExpiresAt = expiresAt
+	entry.Generation = generation
+
+	return g.WithWorktreeGeneration(
+		worktreePath,
+		generation,
+		func() error {
+			replaced, err := reg.CompareAndSwap(
+				worktreePath,
+				observed,
+				entry,
+			)
+			if err != nil {
+				return err
+			}
+			if !replaced {
+				return fmt.Errorf(
+					"registry ownership changed for %s",
+					worktreePath,
+				)
+			}
+			return nil
+		},
+	)
 }
 
 func resolveRemoteBranchSource(

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -296,6 +296,12 @@ func registerWorktreeExpiration(
 	expiresAt *time.Time,
 ) error {
 	observed, _ := reg.Get(worktreePath)
+	if observed != nil && observed.CreationToken != "" {
+		return fmt.Errorf(
+			"worktree creation in progress for %s",
+			worktreePath,
+		)
+	}
 	entry := &registry.WorktreeEntry{}
 	if observed != nil {
 		*entry = *observed

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -190,7 +190,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		var worktreePath string
+		var (
+			worktreePath       string
+			worktreeGeneration string
+		)
 		if remoteSource != "" {
 			branches, listErr := ctx.Git.ListBranches(true)
 			if listErr != nil {
@@ -203,13 +206,36 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			worktreePath, err = ctx.WorktreeManager.AddTracking(
-				branch,
-				remoteSource,
-				path,
-			)
+			if addExpires != "" {
+				worktreePath, worktreeGeneration, err =
+					ctx.WorktreeManager.AddTrackingWithGeneration(
+						branch,
+						remoteSource,
+						path,
+					)
+			} else {
+				worktreePath, err = ctx.WorktreeManager.AddTracking(
+					branch,
+					remoteSource,
+					path,
+				)
+			}
 		} else {
-			worktreePath, err = ctx.WorktreeManager.Add(branch, path, addBranch)
+			if addExpires != "" {
+				worktreePath, worktreeGeneration, err =
+					ctx.WorktreeManager.AddWithGeneration(
+						branch,
+						path,
+						addBranch,
+						worktree.AddOptions{},
+					)
+			} else {
+				worktreePath, err = ctx.WorktreeManager.Add(
+					branch,
+					path,
+					addBranch,
+				)
+			}
 		}
 		if err != nil {
 			return err
@@ -236,6 +262,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			entry.Path = worktreePath
 			entry.IsMain = false
 			entry.ExpiresAt = expiresAt
+			entry.Generation = worktreeGeneration
 
 			if err := reg.Register(entry); err != nil {
 				return fmt.Errorf("failed to register worktree: %w", err)

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -198,6 +198,49 @@ func TestRegisterWorktreeExpirationRejectsRecreatedWorktree(t *testing.T) {
 	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
 }
 
+func TestRegisterWorktreeExpirationRejectsProvisionalCreation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "creating-worktree")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"feature/creating",
+		worktreePath,
+	)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:          worktreePath,
+		Branch:        "feature/creating",
+		CreationToken: "active-creation",
+	}))
+	expiresAt := time.Now().Add(time.Hour)
+
+	err = registerWorktreeExpiration(
+		git.New(repoPath),
+		reg,
+		worktreePath,
+		generation,
+		"https://github.com/example/repository.git",
+		"feature/creating",
+		&expiresAt,
+	)
+
+	require.ErrorContains(t, err, "worktree creation in progress")
+	entry, ok := reg.Get(worktreePath)
+	require.True(t, ok)
+	assert.Equal(t, "active-creation", entry.CreationToken)
+	assert.Empty(t, entry.Generation)
+	assert.Nil(t, entry.ExpiresAt)
+}
+
 func TestAddFromResolvesRemoteRefAcrossLocalNamespaceCollision(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetAddCommandFlags(t)

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -198,6 +198,45 @@ func TestRegisterWorktreeExpirationRejectsRecreatedWorktree(t *testing.T) {
 	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
 }
 
+func TestRegisterWorktreeExpirationCreatesOrdinaryWorktreeEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "ordinary-worktree")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"feature/ordinary",
+		worktreePath,
+	)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	expiresAt := time.Now().Add(time.Hour)
+
+	err = registerWorktreeExpiration(
+		git.New(repoPath),
+		reg,
+		worktreePath,
+		generation,
+		"https://github.com/example/repository.git",
+		"feature/ordinary",
+		&expiresAt,
+	)
+
+	require.NoError(t, err)
+	entry, ok := reg.Get(worktreePath)
+	require.True(t, ok)
+	assert.Equal(t, generation, entry.Generation)
+	assert.Equal(t, "feature/ordinary", entry.Branch)
+	require.NotNil(t, entry.ExpiresAt)
+	assert.True(t, entry.ExpiresAt.Equal(expiresAt))
+}
+
 func TestRegisterWorktreeExpirationRejectsProvisionalCreation(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -128,6 +128,7 @@ func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T
 	require.True(t, ok)
 	assert.True(t, entry.UnreviewedRemoteSource)
 	assert.NotNil(t, entry.ExpiresAt)
+	assert.NotEmpty(t, entry.Generation)
 }
 
 func TestAddFromResolvesRemoteRefAcrossLocalNamespaceCollision(t *testing.T) {

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -129,6 +130,72 @@ func TestAddFromRemoteBranchCreatesTrackingWorktreeWithoutLaunching(t *testing.T
 	assert.True(t, entry.UnreviewedRemoteSource)
 	assert.NotNil(t, entry.ExpiresAt)
 	assert.NotEmpty(t, entry.Generation)
+}
+
+func TestRegisterWorktreeExpirationRejectsRecreatedWorktree(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "reused-worktree")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"feature/original",
+		worktreePath,
+	)
+	originalGeneration := tuiTestWorktreeGeneration(
+		t,
+		repoPath,
+		worktreePath,
+	)
+	runTUITestGit(t, repoPath, "worktree", "remove", "--force", worktreePath)
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"feature/replacement",
+		worktreePath,
+	)
+	replacementGeneration := tuiTestWorktreeGeneration(
+		t,
+		repoPath,
+		worktreePath,
+	)
+
+	reg, err := registry.New()
+	require.NoError(t, err)
+	replacementExpiry := time.Now().Add(2 * time.Hour)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:       worktreePath,
+		Branch:     "feature/replacement",
+		Generation: replacementGeneration,
+		ExpiresAt:  &replacementExpiry,
+	}))
+	staleExpiry := time.Now().Add(time.Hour)
+
+	err = registerWorktreeExpiration(
+		git.New(repoPath),
+		reg,
+		worktreePath,
+		originalGeneration,
+		"https://github.com/example/original.git",
+		"feature/original",
+		&staleExpiry,
+	)
+
+	require.Error(t, err)
+	entry, ok := reg.Get(worktreePath)
+	require.True(t, ok)
+	assert.Equal(t, "feature/replacement", entry.Branch)
+	assert.Equal(t, replacementGeneration, entry.Generation)
+	require.NotNil(t, entry.ExpiresAt)
+	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
 }
 
 func TestAddFromResolvesRemoteRefAcrossLocalNamespaceCollision(t *testing.T) {

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -26,7 +26,8 @@ var pruneCmd = &cobra.Command{
 This command removes administrative files from .git/worktrees for worktrees
 whose working directories have been deleted from the filesystem.
 
-With --expired flag, removes worktrees that have passed their expiration date.`,
+With --expired, a live worktree is removed only when its recorded generation
+still matches. Legacy expiration records without a generation are skipped.`,
 	Example: `  # Clean up stale worktree information
   kwt prune
 
@@ -110,6 +111,22 @@ func runPruneExpired(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
+		if err := git.ValidateWorktreeGeneration(entry.Generation); err != nil {
+			if pruneDryRun {
+				fmt.Printf(
+					"Would skip (missing worktree generation): %s\n",
+					entry.Path,
+				)
+			} else {
+				fmt.Printf(
+					"Skipping (missing worktree generation): %s\n",
+					entry.Path,
+				)
+			}
+			skipped++
+			continue
+		}
+
 		// Check for uncommitted changes unless --force
 		if !pruneForce {
 			dirty, err := isWorktreeDirty(entry.Path)
@@ -137,7 +154,11 @@ func runPruneExpired(cmd *cobra.Command, args []string) error {
 
 		// Remove the worktree using git
 		g := git.New(entry.Path)
-		if err := g.RemoveWorktree(entry.Path, pruneForce, ""); err != nil {
+		if err := g.RemoveWorktree(
+			entry.Path,
+			pruneForce,
+			entry.Generation,
+		); err != nil {
 			fmt.Printf("Failed to remove worktree %s: %v\n", entry.Path, err)
 			skipped++
 			continue

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -100,8 +100,20 @@ func runPruneExpired(cmd *cobra.Command, args []string) error {
 				removed++
 				continue
 			}
-			if err := reg.Unregister(entry.Path); err != nil {
+			unregistered, err := reg.UnregisterIfGeneration(
+				entry.Path,
+				entry.Generation,
+			)
+			if err != nil {
 				fmt.Printf("Warning: failed to unregister %s: %v\n", entry.Path, err)
+				skipped++
+				continue
+			}
+			if !unregistered {
+				fmt.Printf(
+					"Skipping (registry generation changed): %s\n",
+					entry.Path,
+				)
 				skipped++
 				continue
 			}
@@ -166,7 +178,10 @@ func runPruneExpired(cmd *cobra.Command, args []string) error {
 		changed++
 
 		// Unregister from registry
-		if err := reg.Unregister(entry.Path); err != nil {
+		if _, err := reg.UnregisterIfGeneration(
+			entry.Path,
+			entry.Generation,
+		); err != nil {
 			fmt.Printf("Warning: failed to unregister %s: %v\n", entry.Path, err)
 		}
 

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -137,7 +137,7 @@ func runPruneExpired(cmd *cobra.Command, args []string) error {
 
 		// Remove the worktree using git
 		g := git.New(entry.Path)
-		if err := g.RemoveWorktree(entry.Path, pruneForce); err != nil {
+		if err := g.RemoveWorktree(entry.Path, pruneForce, nil); err != nil {
 			fmt.Printf("Failed to remove worktree %s: %v\n", entry.Path, err)
 			skipped++
 			continue

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -137,7 +137,7 @@ func runPruneExpired(cmd *cobra.Command, args []string) error {
 
 		// Remove the worktree using git
 		g := git.New(entry.Path)
-		if err := g.RemoveWorktree(entry.Path, pruneForce, nil); err != nil {
+		if err := g.RemoveWorktree(entry.Path, pruneForce, ""); err != nil {
 			fmt.Printf("Failed to remove worktree %s: %v\n", entry.Path, err)
 			skipped++
 			continue

--- a/internal/cmd/prune_test.go
+++ b/internal/cmd/prune_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -119,6 +120,136 @@ func TestPruneExpiredDoesNotPublishOnDryRun(t *testing.T) {
 	require.NoError(t, err)
 	_, exists := reg.Get(expiredPath)
 	assert.True(t, exists)
+}
+
+func TestPruneExpiredPreservesLiveWorktreeWithoutGeneration(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "legacy-expired")
+	runTUITestGit(t, repoPath, "branch", "feature/legacy-expired")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		worktreePath,
+		"feature/legacy-expired",
+	)
+	registerExpiredWorktree(t, worktreePath)
+	pruneExpired = true
+	pruneForce = true
+
+	cmd, _, _ := fleetTestCommand()
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err)
+	assert.DirExists(t, worktreePath)
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	_, exists := reg.Get(worktreePath)
+	assert.True(t, exists)
+}
+
+func TestPruneExpiredPreservesReplacementGeneration(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "expired-replacement")
+	runTUITestGit(t, repoPath, "branch", "feature/expired-original")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		worktreePath,
+		"feature/expired-original",
+	)
+	originalGeneration, generationErr := git.New(repoPath).WorktreeGeneration(
+		worktreePath,
+	)
+	require.NoError(t, generationErr)
+	expiredAt := time.Now().Add(-time.Hour)
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Repository: "repo",
+		Branch:     "feature/expired-original",
+		Path:       worktreePath,
+		ExpiresAt:  &expiredAt,
+		Generation: originalGeneration,
+	}))
+
+	runTUITestGit(t, repoPath, "worktree", "remove", "--force", worktreePath)
+	runTUITestGit(t, repoPath, "branch", "feature/expired-replacement")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		worktreePath,
+		"feature/expired-replacement",
+	)
+	pruneExpired = true
+	pruneForce = true
+
+	cmd, _, _ := fleetTestCommand()
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err)
+	assert.DirExists(t, worktreePath)
+	reloaded, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	_, exists := reloaded.Get(worktreePath)
+	assert.True(t, exists)
+}
+
+func TestPruneExpiredRemovesMatchingGeneration(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "expired-matching")
+	runTUITestGit(t, repoPath, "branch", "feature/expired-matching")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		worktreePath,
+		"feature/expired-matching",
+	)
+	generation, generationErr := git.New(repoPath).WorktreeGeneration(
+		worktreePath,
+	)
+	require.NoError(t, generationErr)
+	expiredAt := time.Now().Add(-time.Hour)
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Repository: "repo",
+		Branch:     "feature/expired-matching",
+		Path:       worktreePath,
+		ExpiresAt:  &expiredAt,
+		Generation: generation,
+	}))
+	pruneExpired = true
+	pruneForce = true
+
+	cmd, _, _ := fleetTestCommand()
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err)
+	assert.NoDirExists(t, worktreePath)
+	reloaded, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	_, exists := reloaded.Get(worktreePath)
+	assert.False(t, exists)
 }
 
 func resetPruneCommandFlags(t *testing.T) {

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -215,7 +215,7 @@ func removeLocalWorktree(
 
 	removed := 0
 	for _, wt := range toRemove {
-		registryPath := registeredWorktreePath(wt.Path)
+		registryRecord := registeredWorktreeForRemoval(wt.Path)
 		if deleteBranch {
 			if err := ctx.WorktreeManager.RemoveWithBranch(
 				wt.Path,
@@ -227,7 +227,7 @@ func removeLocalWorktree(
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
-					unregisterWorktreePath(registryPath, wt.Generation)
+					unregisterWorktreeRecord(registryRecord)
 				}
 				if generationCondition.specified {
 					return removed, err
@@ -247,7 +247,7 @@ func removeLocalWorktree(
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
-					unregisterWorktreePath(registryPath, wt.Generation)
+					unregisterWorktreeRecord(registryRecord)
 				}
 				if generationCondition.specified {
 					return removed, err
@@ -260,7 +260,7 @@ func removeLocalWorktree(
 		removed++
 
 		// Clean up registry entry after successful removal
-		unregisterWorktreePath(registryPath, wt.Generation)
+		unregisterWorktreeRecord(registryRecord)
 	}
 
 	return removed, nil
@@ -386,7 +386,7 @@ func removeGlobalWorktree(
 	// Remove each worktree by changing to its repository directory
 	removed := 0
 	for _, entry := range toRemove {
-		registryPath := registeredWorktreePath(entry.Path)
+		registryRecord := registeredWorktreeForRemoval(entry.Path)
 		// Change to the repository directory to run git commands
 		originalDir, err := os.Getwd()
 		if err != nil {
@@ -424,7 +424,7 @@ func removeGlobalWorktree(
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
-					unregisterWorktreePath(registryPath, entry.Generation)
+					unregisterWorktreeRecord(registryRecord)
 				}
 				if generationCondition.specified {
 					_ = os.Chdir(originalDir)
@@ -446,7 +446,7 @@ func removeGlobalWorktree(
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
-					unregisterWorktreePath(registryPath, entry.Generation)
+					unregisterWorktreeRecord(registryRecord)
 				}
 				if generationCondition.specified {
 					_ = os.Chdir(originalDir)
@@ -472,7 +472,7 @@ func removeGlobalWorktree(
 		}
 
 		// Clean up registry entry after successful removal
-		unregisterWorktreePath(registryPath, entry.Generation)
+		unregisterWorktreeRecord(registryRecord)
 		removed++
 
 		// Change back to original directory
@@ -552,20 +552,36 @@ func worktreePathRemoved(path string) bool {
 	return os.IsNotExist(err)
 }
 
-func registeredWorktreePath(path string) string {
+type removalRegistryRecord struct {
+	path       string
+	generation string
+	present    bool
+}
+
+func registeredWorktreeForRemoval(path string) removalRegistryRecord {
 	reg, err := registry.New()
 	if err != nil {
-		return path
+		return removalRegistryRecord{}
 	}
 	entry, ok := reg.Get(path)
 	if !ok {
-		return path
+		return removalRegistryRecord{}
 	}
-	return entry.Path
+	return removalRegistryRecord{
+		path:       entry.Path,
+		generation: entry.Generation,
+		present:    true,
+	}
 }
 
-func unregisterWorktreePath(path string, generation string) {
+func unregisterWorktreeRecord(record removalRegistryRecord) {
+	if !record.present {
+		return
+	}
 	if reg, err := registry.New(); err == nil {
-		_, _ = reg.UnregisterIfGeneration(path, generation)
+		_, _ = reg.UnregisterIfGeneration(
+			record.path,
+			record.generation,
+		)
 	}
 }

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/discovery"
@@ -18,6 +19,7 @@ var (
 	removeForce       bool
 	removeDryRun      bool
 	removeGlobal      bool
+	removeIfCreatedAt string
 	deleteBranch      bool
 	forceDeleteBranch bool
 )
@@ -73,6 +75,7 @@ func init() {
 	removeCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Force delete even if dirty")
 	removeCmd.Flags().BoolVarP(&removeDryRun, "dry-run", "d", false, "Show deletion targets only")
 	removeCmd.Flags().BoolVarP(&removeGlobal, "global", "g", false, "Remove from any worktree in the configured base directory")
+	removeCmd.Flags().StringVar(&removeIfCreatedAt, "if-created-at", "", "Remove only if the worktree creation identity matches")
 	removeCmd.Flags().BoolVarP(&deleteBranch, "delete-branch", "b", false, "Also delete the branch after removing worktree")
 	removeCmd.Flags().BoolVar(&forceDeleteBranch, "force-delete-branch", false, "Force delete the branch even if not merged")
 }
@@ -112,6 +115,10 @@ func runRemove(cmd *cobra.Command, args []string) error {
 }
 
 func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
+	expectedCreatedAt, err := parseRemoveCreationIdentity()
+	if err != nil {
+		return 0, err
+	}
 	worktrees, err := ctx.WorktreeManager.List()
 	if err != nil {
 		return 0, fmt.Errorf("failed to list worktrees: %w", err)
@@ -169,11 +176,26 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 		return 0, nil
 	}
+	if expectedCreatedAt != nil && len(toRemove) != 1 {
+		return 0, fmt.Errorf(
+			"--if-created-at requires exactly one worktree",
+		)
+	}
 
 	removed := 0
 	for _, wt := range toRemove {
 		if deleteBranch {
-			if err := ctx.WorktreeManager.RemoveWithBranch(wt.Path, wt.Branch, removeForce, deleteBranch, forceDeleteBranch); err != nil {
+			if err := ctx.WorktreeManager.RemoveWithBranch(
+				wt.Path,
+				wt.Branch,
+				removeForce,
+				deleteBranch,
+				forceDeleteBranch,
+				expectedCreatedAt,
+			); err != nil {
+				if expectedCreatedAt != nil {
+					return 0, err
+				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
 				if worktreePathRemoved(wt.Path) {
 					removed++
@@ -186,7 +208,14 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 				ctx.Printer.PrintSuccess(fmt.Sprintf("Deleted branch: %s", wt.Branch))
 			}
 		} else {
-			if err := ctx.WorktreeManager.Remove(wt.Path, removeForce); err != nil {
+			if err := ctx.WorktreeManager.Remove(
+				wt.Path,
+				removeForce,
+				expectedCreatedAt,
+			); err != nil {
+				if expectedCreatedAt != nil {
+					return 0, err
+				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
 				if worktreePathRemoved(wt.Path) {
 					removed++
@@ -216,6 +245,10 @@ func filterNonMainWorktrees(worktrees []models.Worktree) []models.Worktree {
 }
 
 func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
+	expectedCreatedAt, err := parseRemoveCreationIdentity()
+	if err != nil {
+		return 0, err
+	}
 	entries, err := discovery.DiscoverGlobalWorktrees(ctx.Config.Worktree.BaseDir, ctx.Config.Projects)
 	if err != nil {
 		return 0, fmt.Errorf("failed to discover worktrees: %w", err)
@@ -330,6 +363,11 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 		return 0, nil
 	}
+	if expectedCreatedAt != nil && len(toRemove) != 1 {
+		return 0, fmt.Errorf(
+			"--if-created-at requires exactly one worktree",
+		)
+	}
 
 	// Remove each worktree by changing to its repository directory
 	removed := 0
@@ -361,7 +399,18 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 		wm := worktree.New(g, ctx.Config)
 
 		if deleteBranch {
-			if err := wm.RemoveWithBranch(entry.Path, entry.Branch, removeForce, deleteBranch, forceDeleteBranch); err != nil {
+			if err := wm.RemoveWithBranch(
+				entry.Path,
+				entry.Branch,
+				removeForce,
+				deleteBranch,
+				forceDeleteBranch,
+				expectedCreatedAt,
+			); err != nil {
+				if expectedCreatedAt != nil {
+					_ = os.Chdir(originalDir)
+					return 0, err
+				}
 				repoName := "unknown"
 				if entry.RepositoryInfo != nil {
 					repoName = entry.RepositoryInfo.Repository
@@ -375,7 +424,15 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 				continue
 			}
 		} else {
-			if err := wm.Remove(entry.Path, removeForce); err != nil {
+			if err := wm.Remove(
+				entry.Path,
+				removeForce,
+				expectedCreatedAt,
+			); err != nil {
+				if expectedCreatedAt != nil {
+					_ = os.Chdir(originalDir)
+					return 0, err
+				}
 				repoName := "unknown"
 				if entry.RepositoryInfo != nil {
 					repoName = entry.RepositoryInfo.Repository
@@ -408,6 +465,20 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 	}
 
 	return removed, nil
+}
+
+func parseRemoveCreationIdentity() (*time.Time, error) {
+	if removeIfCreatedAt == "" {
+		return nil, nil
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, removeIfCreatedAt)
+	if err != nil || createdAt.IsZero() {
+		return nil, fmt.Errorf(
+			"invalid --if-created-at value %q",
+			removeIfCreatedAt,
+		)
+	}
+	return &createdAt, nil
 }
 
 func worktreePathRemoved(path string) bool {

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	pathpkg "path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -10,6 +12,7 @@ import (
 	"go.kenn.io/kwt/internal/finder"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -261,25 +264,7 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 	var toRemove []*discovery.GlobalWorktreeEntry
 
 	if len(args) > 0 {
-		// Pattern matching
-		pattern := strings.ToLower(args[0])
-		var matches []*discovery.GlobalWorktreeEntry
-
-		for _, entry := range nonMainEntries {
-			branchLower := strings.ToLower(entry.Branch)
-			var repoName string
-			if entry.RepositoryInfo != nil {
-				repoName = strings.ToLower(entry.RepositoryInfo.Repository)
-			}
-
-			// Match against branch name, path, repo name, or repo:branch pattern
-			if strings.Contains(branchLower, pattern) ||
-				strings.Contains(strings.ToLower(entry.Path), pattern) ||
-				strings.Contains(repoName, pattern) ||
-				strings.Contains(repoName+":"+branchLower, pattern) {
-				matches = append(matches, entry)
-			}
-		}
+		matches := matchGlobalRemovalEntries(nonMainEntries, args[0])
 
 		if len(matches) == 0 {
 			return 0, fmt.Errorf("no worktree matches pattern: %s", args[0])
@@ -454,6 +439,66 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 	}
 
 	return removed, nil
+}
+
+func matchGlobalRemovalEntries(
+	entries []*discovery.GlobalWorktreeEntry,
+	pattern string,
+) []*discovery.GlobalWorktreeEntry {
+	if patternPath, ok := globalRemovalPathKey(pattern); ok {
+		var exactPathMatches []*discovery.GlobalWorktreeEntry
+		for _, entry := range entries {
+			entryPath, entryOK := globalRemovalPathKey(entry.Path)
+			if entryOK && entryPath == patternPath {
+				exactPathMatches = append(exactPathMatches, entry)
+			}
+		}
+		if len(exactPathMatches) > 0 {
+			return exactPathMatches
+		}
+	}
+
+	lowerPattern := strings.ToLower(
+		strings.ReplaceAll(filepath.ToSlash(pattern), `\`, "/"),
+	)
+	var matches []*discovery.GlobalWorktreeEntry
+	for _, entry := range entries {
+		branchLower := strings.ToLower(entry.Branch)
+		pathLower := strings.ToLower(
+			strings.ReplaceAll(filepath.ToSlash(entry.Path), `\`, "/"),
+		)
+		var repoName string
+		if entry.RepositoryInfo != nil {
+			repoName = strings.ToLower(entry.RepositoryInfo.Repository)
+		}
+
+		if strings.Contains(branchLower, lowerPattern) ||
+			strings.Contains(pathLower, lowerPattern) ||
+			strings.Contains(repoName, lowerPattern) ||
+			strings.Contains(repoName+":"+branchLower, lowerPattern) {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+func globalRemovalPathKey(rawPath string) (string, bool) {
+	windowsPath := (len(rawPath) >= 2 && rawPath[1] == ':') ||
+		strings.HasPrefix(rawPath, `\\`) ||
+		strings.HasPrefix(rawPath, "//")
+	if !filepath.IsAbs(rawPath) && !windowsPath {
+		return "", false
+	}
+	if filepath.IsAbs(rawPath) {
+		rawPath = utils.CanonicalPath(rawPath)
+	}
+	key := pathpkg.Clean(
+		strings.ReplaceAll(filepath.ToSlash(rawPath), `\`, "/"),
+	)
+	if windowsPath {
+		key = strings.ToLower(key)
+	}
+	return key, true
 }
 
 func worktreePathRemoved(path string) bool {

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	pathpkg "path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -498,15 +499,11 @@ func matchGlobalRemovalEntries(
 		}
 	}
 
-	lowerPattern := strings.ToLower(
-		strings.ReplaceAll(filepath.ToSlash(pattern), `\`, "/"),
-	)
+	lowerPattern := globalRemovalSearchKey(pattern)
 	var matches []*discovery.GlobalWorktreeEntry
 	for _, entry := range entries {
 		branchLower := strings.ToLower(entry.Branch)
-		pathLower := strings.ToLower(
-			strings.ReplaceAll(filepath.ToSlash(entry.Path), `\`, "/"),
-		)
+		pathLower := globalRemovalSearchKey(entry.Path)
 		var repoName string
 		if entry.RepositoryInfo != nil {
 			repoName = strings.ToLower(entry.RepositoryInfo.Repository)
@@ -523,22 +520,31 @@ func matchGlobalRemovalEntries(
 }
 
 func globalRemovalPathKey(rawPath string) (string, bool) {
-	windowsPath := (len(rawPath) >= 2 && rawPath[1] == ':') ||
-		strings.HasPrefix(rawPath, `\\`) ||
-		strings.HasPrefix(rawPath, "//")
+	windowsPath := windowsStyleRemovalPath(rawPath)
 	if !filepath.IsAbs(rawPath) && !windowsPath {
 		return "", false
 	}
-	if filepath.IsAbs(rawPath) {
-		rawPath = utils.CanonicalPath(rawPath)
+	if !windowsPath {
+		return utils.PathKey(rawPath), true
 	}
 	key := pathpkg.Clean(
 		strings.ReplaceAll(filepath.ToSlash(rawPath), `\`, "/"),
 	)
-	if windowsPath {
-		key = strings.ToLower(key)
+	return strings.ToLower(key), true
+}
+
+func globalRemovalSearchKey(rawPath string) string {
+	key := filepath.ToSlash(rawPath)
+	if runtime.GOOS == "windows" || windowsStyleRemovalPath(rawPath) {
+		key = strings.ReplaceAll(key, `\`, "/")
 	}
-	return key, true
+	return strings.ToLower(key)
+}
+
+func windowsStyleRemovalPath(rawPath string) bool {
+	return (len(rawPath) >= 2 && rawPath[1] == ':') ||
+		strings.HasPrefix(rawPath, `\\`) ||
+		strings.HasPrefix(rawPath, "//")
 }
 
 func worktreePathRemoved(path string) bool {

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -26,6 +26,11 @@ var (
 	forceDeleteBranch  bool
 )
 
+type removalGenerationCondition struct {
+	generation string
+	specified  bool
+}
+
 // removeCmd represents the remove command.
 var removeCmd = &cobra.Command{
 	Use:     "remove [pattern]",
@@ -83,6 +88,10 @@ func init() {
 }
 
 func runRemove(cmd *cobra.Command, args []string) error {
+	generationCondition, err := requestedRemovalGeneration(cmd)
+	if err != nil {
+		return err
+	}
 	return ExecuteWithArgs(false, func(ctx *CommandContext, cmd *cobra.Command, args []string) error {
 		// Try to get git context, but don't fail if we're not in a git repo
 		gitCtx, gitErr := NewGitCommandContext()
@@ -93,14 +102,22 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		return ctx.WithGlobalLocalSupport(
 			removeGlobal,
 			func(ctx *CommandContext) error {
-				removed, err := removeLocalWorktree(ctx, args)
+				removed, err := removeLocalWorktree(
+					ctx,
+					args,
+					generationCondition,
+				)
 				if removed > 0 {
 					publishFleetBestEffortForCommand(cmd, ctx.Config)
 				}
 				return err
 			},
 			func(ctx *CommandContext) error {
-				removed, err := removeGlobalWorktree(ctx, args)
+				removed, err := removeGlobalWorktree(
+					ctx,
+					args,
+					generationCondition,
+				)
 				if removed > 0 {
 					publishFleetBestEffortForCommand(cmd, ctx.Config)
 				}
@@ -110,8 +127,28 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	})(cmd, args)
 }
 
-func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
-	expectedGeneration := removeIfGeneration
+func requestedRemovalGeneration(
+	cmd *cobra.Command,
+) (removalGenerationCondition, error) {
+	if !cmd.Flags().Changed("if-generation") {
+		return removalGenerationCondition{}, nil
+	}
+	if err := git.ValidateWorktreeGeneration(removeIfGeneration); err != nil {
+		return removalGenerationCondition{}, fmt.Errorf(
+			"--if-generation must be a 32-character hexadecimal value",
+		)
+	}
+	return removalGenerationCondition{
+		generation: removeIfGeneration,
+		specified:  true,
+	}, nil
+}
+
+func removeLocalWorktree(
+	ctx *CommandContext,
+	args []string,
+	generationCondition removalGenerationCondition,
+) (int, error) {
 	worktrees, err := ctx.WorktreeManager.List()
 	if err != nil {
 		return 0, fmt.Errorf("failed to list worktrees: %w", err)
@@ -169,7 +206,7 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 		return 0, nil
 	}
-	if expectedGeneration != "" && len(toRemove) != 1 {
+	if generationCondition.specified && len(toRemove) != 1 {
 		return 0, fmt.Errorf(
 			"--if-generation requires exactly one worktree",
 		)
@@ -185,13 +222,13 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 				removeForce,
 				deleteBranch,
 				forceDeleteBranch,
-				expectedGeneration,
+				generationCondition.generation,
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedGeneration != "" {
+				if generationCondition.specified {
 					return removed, err
 				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
@@ -205,13 +242,13 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 			if err := ctx.WorktreeManager.Remove(
 				wt.Path,
 				removeForce,
-				expectedGeneration,
+				generationCondition.generation,
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedGeneration != "" {
+				if generationCondition.specified {
 					return removed, err
 				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
@@ -238,8 +275,11 @@ func filterNonMainWorktrees(worktrees []models.Worktree) []models.Worktree {
 	return filtered
 }
 
-func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
-	expectedGeneration := removeIfGeneration
+func removeGlobalWorktree(
+	ctx *CommandContext,
+	args []string,
+	generationCondition removalGenerationCondition,
+) (int, error) {
 	entries, err := discovery.DiscoverGlobalWorktrees(ctx.Config.Worktree.BaseDir, ctx.Config.Projects)
 	if err != nil {
 		return 0, fmt.Errorf("failed to discover worktrees: %w", err)
@@ -336,7 +376,7 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 		return 0, nil
 	}
-	if expectedGeneration != "" && len(toRemove) != 1 {
+	if generationCondition.specified && len(toRemove) != 1 {
 		return 0, fmt.Errorf(
 			"--if-generation requires exactly one worktree",
 		)
@@ -379,13 +419,13 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 				removeForce,
 				deleteBranch,
 				forceDeleteBranch,
-				expectedGeneration,
+				generationCondition.generation,
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedGeneration != "" {
+				if generationCondition.specified {
 					_ = os.Chdir(originalDir)
 					return removed, err
 				}
@@ -401,13 +441,13 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 			if err := wm.Remove(
 				entry.Path,
 				removeForce,
-				expectedGeneration,
+				generationCondition.generation,
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedGeneration != "" {
+				if generationCondition.specified {
 					_ = os.Chdir(originalDir)
 					return removed, err
 				}

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -226,7 +226,7 @@ func removeLocalWorktree(
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
-					unregisterWorktreePath(registryPath)
+					unregisterWorktreePath(registryPath, wt.Generation)
 				}
 				if generationCondition.specified {
 					return removed, err
@@ -246,7 +246,7 @@ func removeLocalWorktree(
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
-					unregisterWorktreePath(registryPath)
+					unregisterWorktreePath(registryPath, wt.Generation)
 				}
 				if generationCondition.specified {
 					return removed, err
@@ -259,7 +259,7 @@ func removeLocalWorktree(
 		removed++
 
 		// Clean up registry entry after successful removal
-		unregisterWorktreePath(registryPath)
+		unregisterWorktreePath(registryPath, wt.Generation)
 	}
 
 	return removed, nil
@@ -423,7 +423,7 @@ func removeGlobalWorktree(
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
-					unregisterWorktreePath(registryPath)
+					unregisterWorktreePath(registryPath, entry.Generation)
 				}
 				if generationCondition.specified {
 					_ = os.Chdir(originalDir)
@@ -445,7 +445,7 @@ func removeGlobalWorktree(
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
-					unregisterWorktreePath(registryPath)
+					unregisterWorktreePath(registryPath, entry.Generation)
 				}
 				if generationCondition.specified {
 					_ = os.Chdir(originalDir)
@@ -471,7 +471,7 @@ func removeGlobalWorktree(
 		}
 
 		// Clean up registry entry after successful removal
-		unregisterWorktreePath(registryPath)
+		unregisterWorktreePath(registryPath, entry.Generation)
 		removed++
 
 		// Change back to original directory
@@ -558,8 +558,8 @@ func registeredWorktreePath(path string) string {
 	return entry.Path
 }
 
-func unregisterWorktreePath(path string) {
+func unregisterWorktreePath(path string, generation string) {
 	if reg, err := registry.New(); err == nil {
-		_ = reg.Unregister(path)
+		_, _ = reg.UnregisterIfGeneration(path, generation)
 	}
 }

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/discovery"
@@ -16,12 +15,12 @@ import (
 )
 
 var (
-	removeForce       bool
-	removeDryRun      bool
-	removeGlobal      bool
-	removeIfCreatedAt string
-	deleteBranch      bool
-	forceDeleteBranch bool
+	removeForce        bool
+	removeDryRun       bool
+	removeGlobal       bool
+	removeIfGeneration string
+	deleteBranch       bool
+	forceDeleteBranch  bool
 )
 
 // removeCmd represents the remove command.
@@ -75,7 +74,7 @@ func init() {
 	removeCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Force delete even if dirty")
 	removeCmd.Flags().BoolVarP(&removeDryRun, "dry-run", "d", false, "Show deletion targets only")
 	removeCmd.Flags().BoolVarP(&removeGlobal, "global", "g", false, "Remove from any worktree in the configured base directory")
-	removeCmd.Flags().StringVar(&removeIfCreatedAt, "if-created-at", "", "Remove only if the worktree creation identity matches")
+	removeCmd.Flags().StringVar(&removeIfGeneration, "if-generation", "", "Remove only if the worktree generation matches")
 	removeCmd.Flags().BoolVarP(&deleteBranch, "delete-branch", "b", false, "Also delete the branch after removing worktree")
 	removeCmd.Flags().BoolVar(&forceDeleteBranch, "force-delete-branch", false, "Force delete the branch even if not merged")
 }
@@ -109,10 +108,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 }
 
 func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
-	expectedCreatedAt, err := parseRemoveCreationIdentity()
-	if err != nil {
-		return 0, err
-	}
+	expectedGeneration := removeIfGeneration
 	worktrees, err := ctx.WorktreeManager.List()
 	if err != nil {
 		return 0, fmt.Errorf("failed to list worktrees: %w", err)
@@ -170,9 +166,9 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 		return 0, nil
 	}
-	if expectedCreatedAt != nil && len(toRemove) != 1 {
+	if expectedGeneration != "" && len(toRemove) != 1 {
 		return 0, fmt.Errorf(
-			"--if-created-at requires exactly one worktree",
+			"--if-generation requires exactly one worktree",
 		)
 	}
 
@@ -186,13 +182,13 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 				removeForce,
 				deleteBranch,
 				forceDeleteBranch,
-				expectedCreatedAt,
+				expectedGeneration,
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedCreatedAt != nil {
+				if expectedGeneration != "" {
 					return removed, err
 				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
@@ -206,13 +202,13 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 			if err := ctx.WorktreeManager.Remove(
 				wt.Path,
 				removeForce,
-				expectedCreatedAt,
+				expectedGeneration,
 			); err != nil {
 				if worktreePathRemoved(wt.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedCreatedAt != nil {
+				if expectedGeneration != "" {
 					return removed, err
 				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
@@ -240,10 +236,7 @@ func filterNonMainWorktrees(worktrees []models.Worktree) []models.Worktree {
 }
 
 func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
-	expectedCreatedAt, err := parseRemoveCreationIdentity()
-	if err != nil {
-		return 0, err
-	}
+	expectedGeneration := removeIfGeneration
 	entries, err := discovery.DiscoverGlobalWorktrees(ctx.Config.Worktree.BaseDir, ctx.Config.Projects)
 	if err != nil {
 		return 0, fmt.Errorf("failed to discover worktrees: %w", err)
@@ -358,9 +351,9 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 		return 0, nil
 	}
-	if expectedCreatedAt != nil && len(toRemove) != 1 {
+	if expectedGeneration != "" && len(toRemove) != 1 {
 		return 0, fmt.Errorf(
-			"--if-created-at requires exactly one worktree",
+			"--if-generation requires exactly one worktree",
 		)
 	}
 
@@ -401,13 +394,13 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 				removeForce,
 				deleteBranch,
 				forceDeleteBranch,
-				expectedCreatedAt,
+				expectedGeneration,
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedCreatedAt != nil {
+				if expectedGeneration != "" {
 					_ = os.Chdir(originalDir)
 					return removed, err
 				}
@@ -423,13 +416,13 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 			if err := wm.Remove(
 				entry.Path,
 				removeForce,
-				expectedCreatedAt,
+				expectedGeneration,
 			); err != nil {
 				if worktreePathRemoved(entry.Path) {
 					removed++
 					unregisterWorktreePath(registryPath)
 				}
-				if expectedCreatedAt != nil {
+				if expectedGeneration != "" {
 					_ = os.Chdir(originalDir)
 					return removed, err
 				}
@@ -461,20 +454,6 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 	}
 
 	return removed, nil
-}
-
-func parseRemoveCreationIdentity() (*time.Time, error) {
-	if removeIfCreatedAt == "" {
-		return nil, nil
-	}
-	createdAt, err := time.Parse(time.RFC3339Nano, removeIfCreatedAt)
-	if err != nil || createdAt.IsZero() {
-		return nil, fmt.Errorf(
-			"invalid --if-created-at value %q",
-			removeIfCreatedAt,
-		)
-	}
-	return &createdAt, nil
 }
 
 func worktreePathRemoved(path string) bool {

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -92,23 +92,17 @@ func runRemove(cmd *cobra.Command, args []string) error {
 			removeGlobal,
 			func(ctx *CommandContext) error {
 				removed, err := removeLocalWorktree(ctx, args)
-				if err != nil {
-					return err
-				}
 				if removed > 0 {
 					publishFleetBestEffortForCommand(cmd, ctx.Config)
 				}
-				return nil
+				return err
 			},
 			func(ctx *CommandContext) error {
 				removed, err := removeGlobalWorktree(ctx, args)
-				if err != nil {
-					return err
-				}
 				if removed > 0 {
 					publishFleetBestEffortForCommand(cmd, ctx.Config)
 				}
-				return nil
+				return err
 			},
 		)
 	})(cmd, args)
@@ -184,6 +178,7 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 
 	removed := 0
 	for _, wt := range toRemove {
+		registryPath := registeredWorktreePath(wt.Path)
 		if deleteBranch {
 			if err := ctx.WorktreeManager.RemoveWithBranch(
 				wt.Path,
@@ -193,14 +188,14 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 				forceDeleteBranch,
 				expectedCreatedAt,
 			); err != nil {
-				if expectedCreatedAt != nil {
-					return 0, err
-				}
-				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
 				if worktreePathRemoved(wt.Path) {
 					removed++
-					unregisterWorktreePath(wt.Path)
+					unregisterWorktreePath(registryPath)
 				}
+				if expectedCreatedAt != nil {
+					return removed, err
+				}
+				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
 				continue
 			}
 			ctx.Printer.PrintSuccess(fmt.Sprintf("Removed worktree: %s", wt.Branch))
@@ -213,14 +208,14 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 				removeForce,
 				expectedCreatedAt,
 			); err != nil {
-				if expectedCreatedAt != nil {
-					return 0, err
-				}
-				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
 				if worktreePathRemoved(wt.Path) {
 					removed++
-					unregisterWorktreePath(wt.Path)
+					unregisterWorktreePath(registryPath)
 				}
+				if expectedCreatedAt != nil {
+					return removed, err
+				}
+				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s: %v", wt.Branch, err))
 				continue
 			}
 			ctx.Printer.PrintSuccess(fmt.Sprintf("Removed worktree: %s", wt.Branch))
@@ -228,7 +223,7 @@ func removeLocalWorktree(ctx *CommandContext, args []string) (int, error) {
 		removed++
 
 		// Clean up registry entry after successful removal
-		unregisterWorktreePath(wt.Path)
+		unregisterWorktreePath(registryPath)
 	}
 
 	return removed, nil
@@ -372,6 +367,7 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 	// Remove each worktree by changing to its repository directory
 	removed := 0
 	for _, entry := range toRemove {
+		registryPath := registeredWorktreePath(entry.Path)
 		// Change to the repository directory to run git commands
 		originalDir, err := os.Getwd()
 		if err != nil {
@@ -407,19 +403,19 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 				forceDeleteBranch,
 				expectedCreatedAt,
 			); err != nil {
+				if worktreePathRemoved(entry.Path) {
+					removed++
+					unregisterWorktreePath(registryPath)
+				}
 				if expectedCreatedAt != nil {
 					_ = os.Chdir(originalDir)
-					return 0, err
+					return removed, err
 				}
 				repoName := "unknown"
 				if entry.RepositoryInfo != nil {
 					repoName = entry.RepositoryInfo.Repository
 				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s:%s: %v", repoName, entry.Branch, err))
-				if worktreePathRemoved(entry.Path) {
-					removed++
-					unregisterWorktreePath(entry.Path)
-				}
 				_ = os.Chdir(originalDir)
 				continue
 			}
@@ -429,19 +425,19 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 				removeForce,
 				expectedCreatedAt,
 			); err != nil {
+				if worktreePathRemoved(entry.Path) {
+					removed++
+					unregisterWorktreePath(registryPath)
+				}
 				if expectedCreatedAt != nil {
 					_ = os.Chdir(originalDir)
-					return 0, err
+					return removed, err
 				}
 				repoName := "unknown"
 				if entry.RepositoryInfo != nil {
 					repoName = entry.RepositoryInfo.Repository
 				}
 				ctx.Printer.PrintError(fmt.Errorf("failed to remove %s:%s: %v", repoName, entry.Branch, err))
-				if worktreePathRemoved(entry.Path) {
-					removed++
-					unregisterWorktreePath(entry.Path)
-				}
 				_ = os.Chdir(originalDir)
 				continue
 			}
@@ -457,7 +453,7 @@ func removeGlobalWorktree(ctx *CommandContext, args []string) (int, error) {
 		}
 
 		// Clean up registry entry after successful removal
-		unregisterWorktreePath(entry.Path)
+		unregisterWorktreePath(registryPath)
 		removed++
 
 		// Change back to original directory
@@ -484,6 +480,18 @@ func parseRemoveCreationIdentity() (*time.Time, error) {
 func worktreePathRemoved(path string) bool {
 	_, err := os.Stat(path)
 	return os.IsNotExist(err)
+}
+
+func registeredWorktreePath(path string) string {
+	reg, err := registry.New()
+	if err != nil {
+		return path
+	}
+	entry, ok := reg.Get(path)
+	if !ok {
+		return path
+	}
+	return entry.Path
 }
 
 func unregisterWorktreePath(path string) {

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -135,6 +136,15 @@ func TestRemoveLocalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing.
 	require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "change.txt"), []byte("change"), 0644))
 	runTUITestGit(t, worktreePath, "add", ".")
 	runTUITestGit(t, worktreePath, "commit", "-m", "unmerged worktree commit")
+	info, err := os.Stat(worktreePath)
+	require.NoError(t, err)
+	removeIfCreatedAt = info.ModTime().Format(time.RFC3339Nano)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:   worktreePath,
+		Branch: "task7/remove-local-branch-delete-fails",
+	}))
 
 	var calls int
 	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
@@ -143,11 +153,15 @@ func TestRemoveLocalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing.
 	}
 
 	cmd, _, _ := fleetTestCommand()
-	err := runRemove(cmd, []string{"task7/remove-local-branch-delete-fails"})
+	err = runRemove(cmd, []string{"task7/remove-local-branch-delete-fails"})
 
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "worktree removed but failed to delete branch")
 	assert.Equal(t, 1, calls)
 	assert.NoDirExists(t, worktreePath)
+	refreshedRegistry, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	_, registered := refreshedRegistry.Get(worktreePath)
+	assert.False(t, registered)
 }
 
 func TestRemoveGlobalPublishesOnceAfterSuccessfulRemoval(t *testing.T) {
@@ -246,6 +260,15 @@ func TestRemoveGlobalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing
 	require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "change.txt"), []byte("change"), 0644))
 	runTUITestGit(t, worktreePath, "add", ".")
 	runTUITestGit(t, worktreePath, "commit", "-m", "unmerged worktree commit")
+	info, err := os.Stat(worktreePath)
+	require.NoError(t, err)
+	removeIfCreatedAt = info.ModTime().Format(time.RFC3339Nano)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:   worktreePath,
+		Branch: "task7/remove-global-branch-delete-fails",
+	}))
 
 	var calls int
 	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
@@ -254,11 +277,15 @@ func TestRemoveGlobalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing
 	}
 
 	cmd, _, _ := fleetTestCommand()
-	err := runRemove(cmd, []string{"task7/remove-global-branch-delete-fails"})
+	err = runRemove(cmd, []string{"task7/remove-global-branch-delete-fails"})
 
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "worktree removed but failed to delete branch")
 	assert.Equal(t, 1, calls)
 	assert.NoDirExists(t, worktreePath)
+	refreshedRegistry, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	_, registered := refreshedRegistry.Get(worktreePath)
+	assert.False(t, registered)
 }
 
 func resetRemoveCommandFlags(t *testing.T) {

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,41 @@ func TestRemoveLocalPublishesOnceAfterSuccessfulRemoval(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
+}
+
+func TestRemoveLocalRejectsRecreatedWorktree(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetRemoveCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	t.Chdir(repoPath)
+
+	worktreePath := filepath.Join(t.TempDir(), "remove-replacement")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"task7/remove-replacement",
+		worktreePath,
+	)
+	info, err := os.Stat(worktreePath)
+	require.NoError(t, err)
+	removeIfCreatedAt = info.ModTime().Format(time.RFC3339Nano)
+	replacementTime := info.ModTime().Add(time.Second)
+	require.NoError(t, os.Chtimes(
+		worktreePath,
+		replacementTime,
+		replacementTime,
+	))
+
+	cmd, _, _ := fleetTestCommand()
+	err = runRemove(cmd, []string{worktreePath})
+
+	require.ErrorContains(t, err, "creation identity changed")
+	assert.DirExists(t, worktreePath)
 }
 
 func TestRemoveLocalDoesNotPublishOnDryRun(t *testing.T) {
@@ -231,6 +267,7 @@ func resetRemoveCommandFlags(t *testing.T) {
 	oldRemoveForce := removeForce
 	oldRemoveDryRun := removeDryRun
 	oldRemoveGlobal := removeGlobal
+	oldRemoveIfCreatedAt := removeIfCreatedAt
 	oldDeleteBranch := deleteBranch
 	oldForceDeleteBranch := forceDeleteBranch
 
@@ -238,6 +275,7 @@ func resetRemoveCommandFlags(t *testing.T) {
 		removeForce = oldRemoveForce
 		removeDryRun = oldRemoveDryRun
 		removeGlobal = oldRemoveGlobal
+		removeIfCreatedAt = oldRemoveIfCreatedAt
 		deleteBranch = oldDeleteBranch
 		forceDeleteBranch = oldForceDeleteBranch
 	})
@@ -245,6 +283,7 @@ func resetRemoveCommandFlags(t *testing.T) {
 	removeForce = false
 	removeDryRun = false
 	removeGlobal = false
+	removeIfCreatedAt = ""
 	deleteBranch = false
 	forceDeleteBranch = false
 }

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -187,8 +187,9 @@ func TestRemoveLocalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing.
 	reg, err := registry.New()
 	require.NoError(t, err)
 	require.NoError(t, reg.Register(&registry.WorktreeEntry{
-		Path:   worktreePath,
-		Branch: "task7/remove-local-branch-delete-fails",
+		Path:       worktreePath,
+		Branch:     "task7/remove-local-branch-delete-fails",
+		Generation: removeIfGeneration,
 	}))
 
 	var calls int
@@ -349,8 +350,9 @@ func TestRemoveGlobalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing
 	reg, err := registry.New()
 	require.NoError(t, err)
 	require.NoError(t, reg.Register(&registry.WorktreeEntry{
-		Path:   worktreePath,
-		Branch: "task7/remove-global-branch-delete-fails",
+		Path:       worktreePath,
+		Branch:     "task7/remove-global-branch-delete-fails",
+		Generation: removeIfGeneration,
 	}))
 
 	var calls int

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -38,6 +38,41 @@ func TestRemoveLocalPublishesOnceAfterSuccessfulRemoval(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+func TestRemoveLocalUnregistersLegacyEntry(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetRemoveCommandFlags(t)
+
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	t.Chdir(repoPath)
+	worktreePath := filepath.Join(t.TempDir(), "remove-local-legacy")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"task7/remove-local-legacy",
+		worktreePath,
+	)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:                   worktreePath,
+		Branch:                 "task7/remove-local-legacy",
+		UnreviewedRemoteSource: true,
+	}))
+
+	cmd, _, _ := fleetTestCommand()
+	err = runRemove(cmd, []string{"task7/remove-local-legacy"})
+
+	require.NoError(t, err)
+	refreshedRegistry, err := registry.New()
+	require.NoError(t, err)
+	_, registered := refreshedRegistry.Get(worktreePath)
+	assert.False(t, registered)
+}
+
 func TestRemoveLocalRejectsRecreatedWorktree(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetRemoveCommandFlags(t)

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -69,10 +69,54 @@ func TestRemoveLocalRejectsRecreatedWorktree(t *testing.T) {
 	)
 
 	cmd, _, _ := fleetTestCommand()
+	setRemoveGenerationFlag(t, cmd, removeIfGeneration)
 	err := runRemove(cmd, []string{worktreePath})
 
 	require.ErrorContains(t, err, "generation changed")
 	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveRejectsExplicitInvalidGeneration(t *testing.T) {
+	tests := []struct {
+		name       string
+		generation string
+	}{
+		{name: "empty", generation: ""},
+		{name: "malformed", generation: "not-a-generation"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFleetCommandDeps(t)
+			resetRemoveCommandFlags(t)
+
+			repoPath := newTUITestRepo(t)
+			initCommandTestConfig(t, t.TempDir())
+			t.Chdir(repoPath)
+			worktreePath := filepath.Join(t.TempDir(), "remove-invalid")
+			runTUITestGit(
+				t,
+				repoPath,
+				"worktree",
+				"add",
+				"-b",
+				"task7/remove-invalid",
+				worktreePath,
+			)
+
+			cmd, _, _ := fleetTestCommand()
+			setRemoveGenerationFlag(t, cmd, tt.generation)
+
+			err := runRemove(cmd, []string{worktreePath})
+
+			require.ErrorContains(
+				t,
+				err,
+				"--if-generation must be a 32-character hexadecimal value",
+			)
+			assert.DirExists(t, worktreePath)
+		})
+	}
 }
 
 func TestRemoveLocalDoesNotPublishOnDryRun(t *testing.T) {
@@ -154,6 +198,7 @@ func TestRemoveLocalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing.
 	}
 
 	cmd, _, _ := fleetTestCommand()
+	setRemoveGenerationFlag(t, cmd, removeIfGeneration)
 	err = runRemove(cmd, []string{"task7/remove-local-branch-delete-fails"})
 
 	require.ErrorContains(t, err, "worktree removed but failed to delete branch")
@@ -192,18 +237,19 @@ func TestRemoveGlobalPublishesOnceAfterSuccessfulRemoval(t *testing.T) {
 }
 
 func TestMatchGlobalRemovalEntriesPrefersExactPath(t *testing.T) {
+	exactPath := filepath.Join(t.TempDir(), "foo")
 	exact := &discovery.GlobalWorktreeEntry{
-		Path:   "/work/foo",
+		Path:   exactPath,
 		Branch: "task/foo",
 	}
 	prefix := &discovery.GlobalWorktreeEntry{
-		Path:   "/work/foo-old",
+		Path:   exactPath + "-old",
 		Branch: "task/foo-old",
 	}
 
 	matches := matchGlobalRemovalEntries(
 		[]*discovery.GlobalWorktreeEntry{exact, prefix},
-		"/work/foo",
+		exactPath,
 	)
 
 	require.Len(t, matches, 1)
@@ -314,6 +360,7 @@ func TestRemoveGlobalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing
 	}
 
 	cmd, _, _ := fleetTestCommand()
+	setRemoveGenerationFlag(t, cmd, removeIfGeneration)
 	err = runRemove(cmd, []string{"task7/remove-global-branch-delete-fails"})
 
 	require.ErrorContains(t, err, "worktree removed but failed to delete branch")
@@ -350,4 +397,14 @@ func resetRemoveCommandFlags(t *testing.T) {
 	removeIfGeneration = ""
 	deleteBranch = false
 	forceDeleteBranch = false
+}
+
+func setRemoveGenerationFlag(
+	t *testing.T,
+	cmd *cobra.Command,
+	generation string,
+) {
+	t.Helper()
+	cmd.Flags().StringVar(&removeIfGeneration, "if-generation", "", "")
+	require.NoError(t, cmd.Flags().Set("if-generation", generation))
 }

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -55,20 +54,23 @@ func TestRemoveLocalRejectsRecreatedWorktree(t *testing.T) {
 		"task7/remove-replacement",
 		worktreePath,
 	)
-	info, err := os.Stat(worktreePath)
-	require.NoError(t, err)
-	removeIfCreatedAt = info.ModTime().Format(time.RFC3339Nano)
-	replacementTime := info.ModTime().Add(time.Second)
-	require.NoError(t, os.Chtimes(
+	removeIfGeneration = tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	runTUITestGit(t, repoPath, "worktree", "remove", worktreePath)
+	runTUITestGit(t, repoPath, "branch", "-D", "task7/remove-replacement")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"task7/remove-replacement",
 		worktreePath,
-		replacementTime,
-		replacementTime,
-	))
+	)
 
 	cmd, _, _ := fleetTestCommand()
-	err = runRemove(cmd, []string{worktreePath})
+	err := runRemove(cmd, []string{worktreePath})
 
-	require.ErrorContains(t, err, "creation identity changed")
+	require.ErrorContains(t, err, "generation changed")
 	assert.DirExists(t, worktreePath)
 }
 
@@ -136,9 +138,7 @@ func TestRemoveLocalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing.
 	require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "change.txt"), []byte("change"), 0644))
 	runTUITestGit(t, worktreePath, "add", ".")
 	runTUITestGit(t, worktreePath, "commit", "-m", "unmerged worktree commit")
-	info, err := os.Stat(worktreePath)
-	require.NoError(t, err)
-	removeIfCreatedAt = info.ModTime().Format(time.RFC3339Nano)
+	removeIfGeneration = tuiTestWorktreeGeneration(t, repoPath, worktreePath)
 	reg, err := registry.New()
 	require.NoError(t, err)
 	require.NoError(t, reg.Register(&registry.WorktreeEntry{
@@ -260,9 +260,7 @@ func TestRemoveGlobalPublishesWhenWorktreeRemovedButBranchDeleteFails(t *testing
 	require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "change.txt"), []byte("change"), 0644))
 	runTUITestGit(t, worktreePath, "add", ".")
 	runTUITestGit(t, worktreePath, "commit", "-m", "unmerged worktree commit")
-	info, err := os.Stat(worktreePath)
-	require.NoError(t, err)
-	removeIfCreatedAt = info.ModTime().Format(time.RFC3339Nano)
+	removeIfGeneration = tuiTestWorktreeGeneration(t, repoPath, worktreePath)
 	reg, err := registry.New()
 	require.NoError(t, err)
 	require.NoError(t, reg.Register(&registry.WorktreeEntry{
@@ -294,7 +292,7 @@ func resetRemoveCommandFlags(t *testing.T) {
 	oldRemoveForce := removeForce
 	oldRemoveDryRun := removeDryRun
 	oldRemoveGlobal := removeGlobal
-	oldRemoveIfCreatedAt := removeIfCreatedAt
+	oldRemoveIfGeneration := removeIfGeneration
 	oldDeleteBranch := deleteBranch
 	oldForceDeleteBranch := forceDeleteBranch
 
@@ -302,7 +300,7 @@ func resetRemoveCommandFlags(t *testing.T) {
 		removeForce = oldRemoveForce
 		removeDryRun = oldRemoveDryRun
 		removeGlobal = oldRemoveGlobal
-		removeIfCreatedAt = oldRemoveIfCreatedAt
+		removeIfGeneration = oldRemoveIfGeneration
 		deleteBranch = oldDeleteBranch
 		forceDeleteBranch = oldForceDeleteBranch
 	})
@@ -310,7 +308,7 @@ func resetRemoveCommandFlags(t *testing.T) {
 	removeForce = false
 	removeDryRun = false
 	removeGlobal = false
-	removeIfCreatedAt = ""
+	removeIfGeneration = ""
 	deleteBranch = false
 	forceDeleteBranch = false
 }

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -188,6 +189,44 @@ func TestRemoveGlobalPublishesOnceAfterSuccessfulRemoval(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
+}
+
+func TestMatchGlobalRemovalEntriesPrefersExactPath(t *testing.T) {
+	exact := &discovery.GlobalWorktreeEntry{
+		Path:   "/work/foo",
+		Branch: "task/foo",
+	}
+	prefix := &discovery.GlobalWorktreeEntry{
+		Path:   "/work/foo-old",
+		Branch: "task/foo-old",
+	}
+
+	matches := matchGlobalRemovalEntries(
+		[]*discovery.GlobalWorktreeEntry{exact, prefix},
+		"/work/foo",
+	)
+
+	require.Len(t, matches, 1)
+	assert.Same(t, exact, matches[0])
+}
+
+func TestMatchGlobalRemovalEntriesNormalizesWindowsSeparators(t *testing.T) {
+	exact := &discovery.GlobalWorktreeEntry{
+		Path:   `C:/work/foo`,
+		Branch: "task/foo",
+	}
+	prefix := &discovery.GlobalWorktreeEntry{
+		Path:   `C:/work/foo-old`,
+		Branch: "task/foo-old",
+	}
+
+	matches := matchGlobalRemovalEntries(
+		[]*discovery.GlobalWorktreeEntry{exact, prefix},
+		`C:\work\foo`,
+	)
+
+	require.Len(t, matches, 1)
+	assert.Same(t, exact, matches[0])
 }
 
 func TestRemoveGlobalDoesNotPublishOnDryRun(t *testing.T) {

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -274,6 +275,29 @@ func TestMatchGlobalRemovalEntriesNormalizesWindowsSeparators(t *testing.T) {
 
 	require.Len(t, matches, 1)
 	assert.Same(t, exact, matches[0])
+}
+
+func TestMatchGlobalRemovalEntriesPreservesUnixLiteralBackslash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("backslash is a path separator on Windows")
+	}
+	baseDir := t.TempDir()
+	literal := &discovery.GlobalWorktreeEntry{
+		Path:   filepath.Join(baseDir, `foo\bar`),
+		Branch: "literal-backslash",
+	}
+	slashed := &discovery.GlobalWorktreeEntry{
+		Path:   filepath.Join(baseDir, "foo", "bar"),
+		Branch: "slash-separated",
+	}
+
+	matches := matchGlobalRemovalEntries(
+		[]*discovery.GlobalWorktreeEntry{literal, slashed},
+		literal.Path,
+	)
+
+	require.Len(t, matches, 1)
+	assert.Same(t, literal, matches[0])
 }
 
 func TestRemoveGlobalDoesNotPublishOnDryRun(t *testing.T) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -583,6 +583,8 @@ func discoverLaunchRepoWorktrees(launchDir string) ([]*discovery.GlobalWorktreeE
 			Path:           wt.Path,
 			CommitHash:     wt.CommitHash,
 			IsMain:         wt.IsMain,
+			CreatedAt:      wt.CreatedAt,
+			Generation:     wt.Generation,
 		})
 	}
 	return entries, nil

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1258,6 +1258,7 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 	if strings.TrimSpace(generation) == "" {
 		return fmt.Errorf("worktree generation unavailable; refresh before removing")
 	}
+	registryRecord := registeredWorktreeForRemoval(row.Entry.Path)
 
 	repoRoot, err := b.repositoryRootForRow(row)
 	if err != nil {
@@ -1276,12 +1277,7 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 		return err
 	}
 
-	if reg, err := registry.New(); err == nil {
-		_, _ = reg.UnregisterIfGeneration(
-			row.Entry.Path,
-			generation,
-		)
-	}
+	unregisterWorktreeRecord(registryRecord)
 
 	publishTUIFleetBestEffort(ctx, b.cfg)
 

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1351,16 +1351,20 @@ func (b *tuiBackend) validateRepositoryRootForRow(
 		}
 	}
 
-	repositoryURL, err := git.New(repoRoot).GetRepositoryURL()
+	var projects []models.Project
+	if b.cfg != nil {
+		projects = b.cfg.Projects
+	}
+	liveInfo, err := worktree.RepositoryInfoWithProjects(
+		git.New(repoRoot),
+		projects,
+	)
 	if err == nil {
-		liveInfo, parseErr := url.ParseRepositoryURL(repositoryURL)
-		if parseErr == nil {
-			for _, candidate := range rowRepositoryIdentityCandidates(
-				row.Entry.RepositoryInfo,
-			) {
-				if sameRepositoryIdentity(liveInfo.FullPath, candidate) {
-					return nil
-				}
+		for _, candidate := range rowRepositoryIdentityCandidates(
+			row.Entry.RepositoryInfo,
+		) {
+			if sameRepositoryIdentity(liveInfo.FullPath, candidate) {
+				return nil
 			}
 		}
 	}

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1169,7 +1169,10 @@ func (b *tuiBackend) failMaterializedHeadVerification(
 			err,
 		)
 	}
-	if err := reg.Unregister(worktreePath); err != nil {
+	if _, err := reg.UnregisterIfGeneration(
+		worktreePath,
+		worktreeGeneration,
+	); err != nil {
 		return fmt.Errorf(
 			"%w (worktree removed, but failed to unregister it: %v)",
 			verificationErr,
@@ -1274,7 +1277,10 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 	}
 
 	if reg, err := registry.New(); err == nil {
-		_ = reg.Unregister(row.Entry.Path)
+		_, _ = reg.UnregisterIfGeneration(
+			row.Entry.Path,
+			generation,
+		)
 	}
 
 	publishTUIFleetBestEffort(ctx, b.cfg)
@@ -1292,6 +1298,12 @@ func (b *tuiBackend) repositoryRootForRow(row dashboard.Row) (string, error) {
 
 	repoRoot, err := git.New(row.Entry.Path).GetMainRepositoryPath()
 	if err == nil {
+		if identityErr := b.validateRepositoryRootForRow(
+			repoRoot,
+			row,
+		); identityErr != nil {
+			return "", identityErr
+		}
 		return repoRoot, nil
 	}
 	directErr := err
@@ -1303,12 +1315,59 @@ func (b *tuiBackend) repositoryRootForRow(row dashboard.Row) (string, error) {
 			}
 			repoRoot, err := git.New(project.Path).GetMainRepositoryPath()
 			if err == nil {
+				if identityErr := b.validateRepositoryRootForRow(
+					repoRoot,
+					row,
+				); identityErr != nil {
+					return "", identityErr
+				}
 				return repoRoot, nil
 			}
 		}
 	}
 
 	return "", fmt.Errorf("failed to find repository root: %w", directErr)
+}
+
+func (b *tuiBackend) validateRepositoryRootForRow(
+	repoRoot string,
+	row dashboard.Row,
+) error {
+	if row.Entry == nil || len(rowRepositoryIdentityCandidates(
+		row.Entry.RepositoryInfo,
+	)) == 0 {
+		return nil
+	}
+	if b.cfg != nil {
+		for _, project := range b.cfg.Projects {
+			if !projectMatchesRow(project, row) {
+				continue
+			}
+			projectRoot, err := git.New(project.Path).GetMainRepositoryPath()
+			if err == nil &&
+				utils.PathKey(projectRoot) == utils.PathKey(repoRoot) {
+				return nil
+			}
+		}
+	}
+
+	repositoryURL, err := git.New(repoRoot).GetRepositoryURL()
+	if err == nil {
+		liveInfo, parseErr := url.ParseRepositoryURL(repositoryURL)
+		if parseErr == nil {
+			for _, candidate := range rowRepositoryIdentityCandidates(
+				row.Entry.RepositoryInfo,
+			) {
+				if sameRepositoryIdentity(liveInfo.FullPath, candidate) {
+					return nil
+				}
+			}
+		}
+	}
+	return fmt.Errorf(
+		"repository identity changed for %s; refresh before removing",
+		row.Entry.Path,
+	)
 }
 
 func projectMatchesRow(project models.Project, row dashboard.Row) bool {
@@ -1488,7 +1547,7 @@ func samePath(a string, b string) bool {
 }
 
 func cleanComparablePath(path string) string {
-	return utils.CanonicalPath(path)
+	return utils.PathKey(path)
 }
 
 func (b *tuiBackend) KillSession(row dashboard.Row) error {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -108,6 +109,7 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 		launchEntries     []*discovery.GlobalWorktreeEntry
 		sessions          []string
 		discoveryErr      error
+		registeredErr     error
 		launchErr         error
 		sessionsErr       error
 		startup           sync.WaitGroup
@@ -121,7 +123,8 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	}()
 	go func() {
 		defer startup.Done()
-		registeredEntries = b.discoverRegisteredProjectWorktrees()
+		registeredEntries, registeredErr =
+			b.discoverRegisteredProjectWorktrees()
 	}()
 	go func() {
 		defer startup.Done()
@@ -135,6 +138,12 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 
 	if discoveryErr != nil {
 		return nil, nil, fmt.Errorf("failed to discover worktrees: %w", discoveryErr)
+	}
+	if registeredErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to discover registered project worktrees: %w",
+			registeredErr,
+		)
 	}
 	if launchErr != nil {
 		return nil, nil, fmt.Errorf("failed to discover launch repository worktrees: %w", launchErr)
@@ -304,10 +313,14 @@ func localFleetObservation(currentHost string, localRow dashboard.Row, now time.
 	return observation, true
 }
 
-func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWorktreeEntry {
+func (b *tuiBackend) discoverRegisteredProjectWorktrees() (
+	[]*discovery.GlobalWorktreeEntry,
+	error,
+) {
 	// Each project discovery spawns git subprocesses; run them concurrently
 	// and merge in config order so results stay deterministic.
 	results := make([][]*discovery.GlobalWorktreeEntry, len(b.cfg.Projects))
+	projectErrors := make([]error, len(b.cfg.Projects))
 	var wg sync.WaitGroup
 	for i, project := range b.cfg.Projects {
 		if project.Path == "" {
@@ -318,6 +331,9 @@ func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWor
 			defer wg.Done()
 			projectEntries, err := b.discoverProjectWorktrees(project.Path)
 			if err != nil {
+				if git.IsIncompleteInventory(err) {
+					projectErrors[i] = err
+				}
 				return
 			}
 			results[i] = applyProjectIdentityFallback(projectEntries, project)
@@ -329,7 +345,7 @@ func (b *tuiBackend) discoverRegisteredProjectWorktrees() []*discovery.GlobalWor
 	for _, projectEntries := range results {
 		entries = mergeTUIEntries(entries, projectEntries)
 	}
-	return entries
+	return entries, errors.Join(projectErrors...)
 }
 
 // registerLaunchProject persists the launch repository at most once per TUI
@@ -554,6 +570,9 @@ func discoverLaunchRepoWorktrees(launchDir string) ([]*discovery.GlobalWorktreeE
 	g := git.New(launchDir)
 	worktrees, err := g.ListWorktrees()
 	if err != nil {
+		if git.IsIncompleteInventory(err) {
+			return nil, err
+		}
 		return nil, nil
 	}
 

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -1414,130 +1413,11 @@ func (b *tuiBackend) removeWorktreeFromRoot(
 	force bool,
 	generation string,
 ) error {
-	err := worktree.New(git.New(repoRoot), b.cfg).Remove(
-		worktreePath,
-		force,
-		generation,
-	)
-	if err == nil || !isWorktreeValidationError(err) {
-		return err
-	}
-
-	if repairErr := repairLinkedWorktreeGitFile(repoRoot, worktreePath); repairErr != nil {
-		return fmt.Errorf("%w (failed to repair worktree metadata: %v)", err, repairErr)
-	}
 	return worktree.New(git.New(repoRoot), b.cfg).Remove(
 		worktreePath,
 		force,
 		generation,
 	)
-}
-
-func isWorktreeValidationError(err error) bool {
-	if err == nil {
-		return false
-	}
-	text := err.Error()
-	return strings.Contains(text, "validation failed, cannot remove working tree") &&
-		strings.Contains(text, ".git")
-}
-
-func repairLinkedWorktreeGitFile(repoRoot string, worktreePath string) error {
-	gitFilePath := filepath.Join(worktreePath, ".git")
-	info, err := os.Lstat(gitFilePath)
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("%s is a symbolic link", gitFilePath)
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("%s is not a regular file", gitFilePath)
-	}
-
-	adminDir, err := findLinkedWorktreeAdminDir(repoRoot, worktreePath)
-	if err != nil {
-		return err
-	}
-
-	mode := info.Mode().Perm()
-	if mode == 0 {
-		mode = 0644
-	}
-	return writeReplacementFile(gitFilePath, []byte("gitdir: "+adminDir+"\n"), mode)
-}
-
-func writeReplacementFile(path string, data []byte, mode os.FileMode) (err error) {
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".git.repair-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	removeTmp := true
-	defer func() {
-		if removeTmp {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if err := tmp.Chmod(mode); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	n, err := tmp.Write(data)
-	if err == nil && n != len(data) {
-		err = io.ErrShortWrite
-	}
-	if closeErr := tmp.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return err
-	}
-	removeTmp = false
-	return nil
-}
-
-func findLinkedWorktreeAdminDir(repoRoot string, worktreePath string) (string, error) {
-	commonDir, err := git.New(repoRoot).RunCommand("rev-parse", "--git-common-dir")
-	if err != nil {
-		return "", err
-	}
-	commonDir = strings.TrimSpace(commonDir)
-	if !filepath.IsAbs(commonDir) {
-		commonDir = filepath.Join(repoRoot, commonDir)
-	}
-
-	worktreesDir := filepath.Join(commonDir, "worktrees")
-	entries, err := os.ReadDir(worktreesDir)
-	if err != nil {
-		return "", err
-	}
-
-	wantGitFile := filepath.Join(worktreePath, ".git")
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		adminDir := filepath.Join(worktreesDir, entry.Name())
-		gitdirPath := filepath.Join(adminDir, "gitdir")
-		data, err := os.ReadFile(gitdirPath)
-		if err != nil {
-			continue
-		}
-		gotGitFile := strings.TrimSpace(string(data))
-		if !filepath.IsAbs(gotGitFile) {
-			gotGitFile = filepath.Join(adminDir, gotGitFile)
-		}
-		if samePath(gotGitFile, wantGitFile) {
-			return adminDir, nil
-		}
-	}
-
-	return "", fmt.Errorf("no worktree admin dir found for %s", worktreePath)
 }
 
 func samePath(a string, b string) bool {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1128,6 +1128,7 @@ func (b *tuiBackend) failMaterializedHeadVerification(
 	if err := worktree.New(git.New(repoRoot), b.cfg).Remove(
 		worktreePath,
 		true,
+		nil,
 	); err != nil {
 		return fmt.Errorf(
 			"%w (failed to remove rejected worktree: %v)",
@@ -1315,7 +1316,11 @@ func rowRepositoryIdentityCandidates(info *url.RepositoryInfo) []string {
 }
 
 func (b *tuiBackend) removeWorktreeFromRoot(repoRoot string, worktreePath string, force bool) error {
-	err := worktree.New(git.New(repoRoot), b.cfg).Remove(worktreePath, force)
+	err := worktree.New(git.New(repoRoot), b.cfg).Remove(
+		worktreePath,
+		force,
+		nil,
+	)
 	if err == nil || !isWorktreeValidationError(err) {
 		return err
 	}
@@ -1323,7 +1328,11 @@ func (b *tuiBackend) removeWorktreeFromRoot(repoRoot string, worktreePath string
 	if repairErr := repairLinkedWorktreeGitFile(repoRoot, worktreePath); repairErr != nil {
 		return fmt.Errorf("%w (failed to repair worktree metadata: %v)", err, repairErr)
 	}
-	return worktree.New(git.New(repoRoot), b.cfg).Remove(worktreePath, force)
+	return worktree.New(git.New(repoRoot), b.cfg).Remove(
+		worktreePath,
+		force,
+		nil,
+	)
 }
 
 func isWorktreeValidationError(err error) bool {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -956,6 +956,7 @@ func (b *tuiBackend) PreviewWorktree(row dashboard.Row, branch string) (dashboar
 	entry.CommitHash = ""
 	entry.IsMain = false
 	entry.CreatedAt = time.Time{}
+	entry.Generation = ""
 	return dashboard.Row{
 		Entry:  &entry,
 		Status: unknownStatusForEntry(&entry),
@@ -1128,7 +1129,7 @@ func (b *tuiBackend) failMaterializedHeadVerification(
 	if err := worktree.New(git.New(repoRoot), b.cfg).Remove(
 		worktreePath,
 		true,
-		nil,
+		"",
 	); err != nil {
 		return fmt.Errorf(
 			"%w (failed to remove rejected worktree: %v)",
@@ -1226,12 +1227,21 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 	if row.Entry.IsMain {
 		return fmt.Errorf("refusing to remove a main worktree")
 	}
+	generation := row.Entry.Generation
+	if strings.TrimSpace(generation) == "" {
+		return fmt.Errorf("worktree generation unavailable; refresh before removing")
+	}
 
 	repoRoot, err := b.repositoryRootForRow(row)
 	if err != nil {
 		return err
 	}
-	if err := b.removeWorktreeFromRoot(repoRoot, row.Entry.Path, force); err != nil {
+	if err := b.removeWorktreeFromRoot(
+		repoRoot,
+		row.Entry.Path,
+		force,
+		generation,
+	); err != nil {
 		if strings.Contains(err.Error(), "contains modified or untracked files") ||
 			strings.Contains(err.Error(), "has local changes") {
 			return fmt.Errorf("worktree has uncommitted changes")
@@ -1315,11 +1325,16 @@ func rowRepositoryIdentityCandidates(info *url.RepositoryInfo) []string {
 	return candidates
 }
 
-func (b *tuiBackend) removeWorktreeFromRoot(repoRoot string, worktreePath string, force bool) error {
+func (b *tuiBackend) removeWorktreeFromRoot(
+	repoRoot string,
+	worktreePath string,
+	force bool,
+	generation string,
+) error {
 	err := worktree.New(git.New(repoRoot), b.cfg).Remove(
 		worktreePath,
 		force,
-		nil,
+		generation,
 	)
 	if err == nil || !isWorktreeValidationError(err) {
 		return err
@@ -1331,7 +1346,7 @@ func (b *tuiBackend) removeWorktreeFromRoot(repoRoot string, worktreePath string
 	return worktree.New(git.New(repoRoot), b.cfg).Remove(
 		worktreePath,
 		force,
-		nil,
+		generation,
 	)
 }
 

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1000,11 +1000,12 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 	}
 	manager := worktree.New(repo, cfg)
 	var (
-		path          string
-		branchCreated bool
+		path               string
+		worktreeGeneration string
+		branchCreated      bool
 	)
 	if branchExisted {
-		path, err = manager.AddWithOptions(
+		path, worktreeGeneration, err = manager.AddWithGeneration(
 			row.Fleet.Branch,
 			"",
 			false,
@@ -1014,7 +1015,7 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 		var source string
 		source, err = resolveFetchedRemoteSource(repo, row.Fleet.Branch)
 		if err == nil {
-			path, err = manager.AddTracking(
+			path, worktreeGeneration, err = manager.AddTrackingWithGeneration(
 				row.Fleet.Branch,
 				source,
 				"",
@@ -1030,7 +1031,13 @@ func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row)
 		)
 		return "", syncErr
 	}
-	if err := b.verifyMaterializedHead(ctx, project.Path, path, row.Fleet); err != nil {
+	if err := b.verifyMaterializedHead(
+		ctx,
+		project.Path,
+		path,
+		worktreeGeneration,
+		row.Fleet,
+	); err != nil {
 		if branchCreated {
 			err = b.rollbackMaterializedBranch(
 				repo,
@@ -1090,7 +1097,13 @@ func (b *tuiBackend) rollbackMaterializedBranch(
 	return materializeErr
 }
 
-func (b *tuiBackend) verifyMaterializedHead(ctx context.Context, repoRoot string, worktreePath string, info *dashboard.FleetInfo) error {
+func (b *tuiBackend) verifyMaterializedHead(
+	ctx context.Context,
+	repoRoot string,
+	worktreePath string,
+	worktreeGeneration string,
+	info *dashboard.FleetInfo,
+) error {
 	if info == nil || strings.TrimSpace(info.RemoteHead) == "" {
 		return nil
 	}
@@ -1100,6 +1113,7 @@ func (b *tuiBackend) verifyMaterializedHead(ctx context.Context, repoRoot string
 		return b.failMaterializedHeadVerification(
 			repoRoot,
 			worktreePath,
+			worktreeGeneration,
 			fmt.Errorf(
 				"could not verify synced head for %s; push or fetch it first: %w",
 				info.Branch,
@@ -1114,6 +1128,7 @@ func (b *tuiBackend) verifyMaterializedHead(ctx context.Context, repoRoot string
 	return b.failMaterializedHeadVerification(
 		repoRoot,
 		worktreePath,
+		worktreeGeneration,
 		fmt.Errorf(
 			"synced %s at %s, but hub reported head %s; push or fetch the reported commit first",
 			info.Branch,
@@ -1126,12 +1141,19 @@ func (b *tuiBackend) verifyMaterializedHead(ctx context.Context, repoRoot string
 func (b *tuiBackend) failMaterializedHeadVerification(
 	repoRoot string,
 	worktreePath string,
+	worktreeGeneration string,
 	verificationErr error,
 ) error {
+	if err := git.ValidateWorktreeGeneration(worktreeGeneration); err != nil {
+		return fmt.Errorf(
+			"%w (rejected worktree preserved because its generation is unavailable)",
+			verificationErr,
+		)
+	}
 	if err := worktree.New(git.New(repoRoot), b.cfg).Remove(
 		worktreePath,
 		true,
-		"",
+		worktreeGeneration,
 	); err != nil {
 		return fmt.Errorf(
 			"%w (failed to remove rejected worktree: %v)",

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2783,7 +2783,7 @@ func TestTUIBackendRemoveWorktreeRejectsBrokenGitFile(t *testing.T) {
 
 	require.Error(t, err)
 	output := runTUITestGitOutput(t, repoPath, "worktree", "list", "--porcelain")
-	assert.Contains(t, output, worktreePath)
+	assert.Contains(t, output, "branch refs/heads/codex/broken")
 	assert.DirExists(t, worktreePath)
 }
 

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -523,6 +523,46 @@ func TestTUIBackendListIncludesRegisteredProjectWorktrees(t *testing.T) {
 	})
 }
 
+func TestTUIBackendListPropagatesIncompleteRegisteredProjectInventory(
+	t *testing.T,
+) {
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: "/global"},
+		Projects: []models.Project{{
+			Repository: "github.com/example/tools",
+			Path:       "/repos/tools",
+		}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "")
+	stubTUIProjectRegistration(backend)
+	backend.discoverGlobalWorktrees = func(
+		string,
+	) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	incomplete := &git.IncompleteInventoryError{
+		Path: "/repos/tools",
+		Err:  errors.New("generation is unreadable"),
+	}
+	backend.discoverProjectWorktrees = func(
+		string,
+	) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, incomplete
+	}
+	backend.discoverLaunchWorktrees = func(
+		string,
+	) ([]*discovery.GlobalWorktreeEntry, error) {
+		return nil, nil
+	}
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+
+	rows, _, err := backend.ListFast(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, incomplete)
+	assert.Nil(t, rows)
+}
+
 func TestDashboardFleetInfoSummarizesPrimaryObservations(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -28,6 +28,7 @@ import (
 	"go.kenn.io/kwt/internal/tmux"
 	dashboard "go.kenn.io/kwt/internal/tui"
 	"go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -1670,6 +1671,7 @@ func TestTUIBackendRemoveWorktreeFallsBackToRegisteredProjectRoot(t *testing.T) 
 	repoPath := newTUITestRepo(t)
 	worktreePath := filepath.Join(t.TempDir(), "stale-worktree")
 	runTUITestGit(t, repoPath, "worktree", "add", "-b", "codex/stale", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
 	require.NoError(t, os.RemoveAll(worktreePath))
 
 	cfg := &models.Config{
@@ -1688,8 +1690,9 @@ func TestTUIBackendRemoveWorktreeFallsBackToRegisteredProjectRoot(t *testing.T) 
 			Repository: "service-api",
 			FullPath:   "github.com/example/service-api",
 		},
-		Branch: "codex/stale",
-		Path:   worktreePath,
+		Branch:     "codex/stale",
+		Path:       worktreePath,
+		Generation: generation,
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
 
@@ -1890,6 +1893,11 @@ func TestTUIBackendRemoveWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 		},
 		Branch: "codex/removable",
 		Path:   worktreePath,
+		Generation: tuiTestWorktreeGeneration(
+			t,
+			repoPath,
+			worktreePath,
+		),
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
 
@@ -1897,6 +1905,47 @@ func TestTUIBackendRemoveWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, published)
+}
+
+func TestTUIBackendRemoveWorktreeRejectsReplacementGeneration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "replacement-worktree")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "codex/original", worktreePath)
+	worktrees, err := git.New(repoPath).ListWorktrees()
+	require.NoError(t, err)
+	var originalGeneration string
+	for _, worktree := range worktrees {
+		if utils.CanonicalPath(worktree.Path) == utils.CanonicalPath(worktreePath) {
+			originalGeneration = worktree.Generation
+		}
+	}
+	require.NotEmpty(t, originalGeneration)
+
+	runTUITestGit(t, repoPath, "worktree", "remove", worktreePath)
+	runTUITestGit(t, repoPath, "branch", "-D", "codex/original")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "codex/replacement", worktreePath)
+	replacementGeneration := tuiTestWorktreeGeneration(
+		t,
+		repoPath,
+		worktreePath,
+	)
+	require.NotEqual(t, originalGeneration, replacementGeneration)
+	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		Branch:     "codex/original",
+		Path:       worktreePath,
+		Generation: originalGeneration,
+	}}
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
+	}, "")
+
+	err = backend.RemoveWorktree(context.Background(), row, true)
+
+	require.ErrorContains(t, err, "generation changed")
+	assert.DirExists(t, worktreePath)
 }
 
 func TestTUIBackendRemoveWorktreeDirtyErrorDoesNotSuggestCLIForce(t *testing.T) {
@@ -1925,6 +1974,11 @@ func TestTUIBackendRemoveWorktreeDirtyErrorDoesNotSuggestCLIForce(t *testing.T) 
 		},
 		Branch: "codex/dirty",
 		Path:   worktreePath,
+		Generation: tuiTestWorktreeGeneration(
+			t,
+			repoPath,
+			worktreePath,
+		),
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
 
@@ -1962,6 +2016,11 @@ func TestTUIBackendForceRemoveDeletesDirtyWorktree(t *testing.T) {
 		},
 		Branch: "codex/dirty",
 		Path:   worktreePath,
+		Generation: tuiTestWorktreeGeneration(
+			t,
+			repoPath,
+			worktreePath,
+		),
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
 
@@ -2509,6 +2568,7 @@ func TestTUIBackendRemoveWorktreeRepairsBrokenGitFile(t *testing.T) {
 	repoPath := newTUITestRepo(t)
 	worktreePath := filepath.Join(t.TempDir(), "broken-worktree")
 	runTUITestGit(t, repoPath, "worktree", "add", "-b", "codex/broken", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(worktreePath, ".git"),
 		[]byte("gitdir: /missing/repo/.git/worktrees/broken-worktree\n"),
@@ -2531,8 +2591,9 @@ func TestTUIBackendRemoveWorktreeRepairsBrokenGitFile(t *testing.T) {
 			Repository: "service-api",
 			FullPath:   "github.com/example/service-api",
 		},
-		Branch: "codex/broken",
-		Path:   worktreePath,
+		Branch:     "codex/broken",
+		Path:       worktreePath,
+		Generation: generation,
 	}}
 	backend := newTUIBackendWithLaunchDir(cfg, "")
 
@@ -2738,6 +2799,25 @@ func runTUITestGitOutput(t *testing.T, dir string, args ...string) string {
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s failed:\n%s", strings.Join(args, " "), output))
 	return string(output)
+}
+
+func tuiTestWorktreeGeneration(
+	t *testing.T,
+	repoPath string,
+	worktreePath string,
+) string {
+	t.Helper()
+	worktrees, err := git.New(repoPath).ListWorktrees()
+	require.NoError(t, err)
+	for _, worktree := range worktrees {
+		if utils.CanonicalPath(worktree.Path) ==
+			utils.CanonicalPath(worktreePath) {
+			require.NotEmpty(t, worktree.Generation)
+			return worktree.Generation
+		}
+	}
+	t.Fatalf("worktree %s not found", worktreePath)
+	return ""
 }
 
 func stubTUIProjectRegistration(backend *tuiBackend) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1988,6 +1988,49 @@ func TestTUIBackendRejectsRepositoryRootFromDifferentIdentity(t *testing.T) {
 	assert.ErrorContains(t, err, "repository identity changed")
 }
 
+func TestTUIBackendAcceptsDiscoveryLocalRepositoryIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin func(*testing.T, string)
+	}{
+		{name: "without origin"},
+		{
+			name: "filesystem origin",
+			origin: func(t *testing.T, repoPath string) {
+				runTUITestGit(
+					t,
+					repoPath,
+					"remote",
+					"add",
+					"origin",
+					filepath.Join(t.TempDir(), "upstream.git"),
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoPath := newTUITestRepo(t)
+			if tt.origin != nil {
+				tt.origin(t, repoPath)
+			}
+			repoInfo, err := worktree.RepositoryInfoFromLocalPath(repoPath)
+			require.NoError(t, err)
+			backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+			row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+				Path:           repoPath,
+				RepositoryInfo: repoInfo,
+			}}
+
+			root, err := backend.repositoryRootForRow(row)
+
+			require.NoError(t, err)
+			assert.True(t, samePath(repoPath, root))
+		})
+	}
+}
+
 func TestTUIBackendRemoveWorktreeDirtyErrorDoesNotSuggestCLIForce(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2749,6 +2749,54 @@ func TestDiscoverLaunchRepoWorktreesListsLocalOnlyRepository(t *testing.T) {
 	assert.Equal(t, filepath.Base(repoPath), entries[0].RepositoryInfo.Repository)
 }
 
+func TestTUIBackendRemovesLaunchWorktreeOutsideGlobalBase(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "outside-global-base")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"feature/outside",
+		worktreePath,
+	)
+	cfg := &models.Config{
+		Worktree: models.WorktreeConfig{
+			BaseDir: filepath.Join(t.TempDir(), "global"),
+		},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, repoPath)
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.registerProject = func(models.Project) error { return nil }
+	backend.registerWorkspace = func(
+		workspace models.Workspace,
+	) (models.Workspace, error) {
+		return workspace, nil
+	}
+
+	rows, _, err := backend.ListFast(context.Background())
+	require.NoError(t, err)
+	var row dashboard.Row
+	for _, candidate := range rows {
+		if candidate.Entry != nil &&
+			samePath(candidate.Entry.Path, worktreePath) {
+			row = candidate
+			break
+		}
+	}
+	require.NotNil(t, row.Entry)
+	require.NotEmpty(t, row.Entry.Generation)
+
+	err = backend.RemoveWorktree(context.Background(), row, false)
+
+	require.NoError(t, err)
+	assert.NoDirExists(t, worktreePath)
+}
+
 // TestDiscoverLaunchRepoWorktreesRejectsRelativeDotlessRemote pins the
 // remote-provenance gate on launch discovery: a relative dotless filesystem
 // remote must not surface as a shareable identity. The entry retains the raw

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1907,6 +1907,50 @@ func TestTUIBackendRemoveWorktreePublishesAfterSuccessfulMutation(t *testing.T) 
 	assert.Equal(t, 1, published)
 }
 
+func TestTUIBackendRemoveWorktreeUnregistersLegacyEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "legacy-registry-worktree")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		"-b",
+		"codex/legacy-registry",
+		worktreePath,
+	)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(&registry.WorktreeEntry{
+		Path:                   worktreePath,
+		Branch:                 "codex/legacy-registry",
+		UnreviewedRemoteSource: true,
+	}))
+	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		Branch: "codex/legacy-registry",
+		Path:   worktreePath,
+		Generation: tuiTestWorktreeGeneration(
+			t,
+			repoPath,
+			worktreePath,
+		),
+	}}
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
+	}, "")
+
+	err = backend.RemoveWorktree(context.Background(), row, false)
+
+	require.NoError(t, err)
+	refreshedRegistry, err := registry.New()
+	require.NoError(t, err)
+	_, registered := refreshedRegistry.Get(worktreePath)
+	assert.False(t, registered)
+}
+
 func TestTUIBackendRemoveWorktreeRejectsReplacementGeneration(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2743,7 +2743,7 @@ func TestTUIBackendMaterializeWorktreeExplainsUnavailableBranch(t *testing.T) {
 	assert.Contains(t, err.Error(), "push or fetch it first")
 }
 
-func TestTUIBackendRemoveWorktreeRepairsBrokenGitFile(t *testing.T) {
+func TestTUIBackendRemoveWorktreeRejectsBrokenGitFile(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
@@ -2781,61 +2781,42 @@ func TestTUIBackendRemoveWorktreeRepairsBrokenGitFile(t *testing.T) {
 
 	err := backend.RemoveWorktree(context.Background(), row, false)
 
-	require.NoError(t, err)
+	require.Error(t, err)
 	output := runTUITestGitOutput(t, repoPath, "worktree", "list", "--porcelain")
-	assert.NotContains(t, output, worktreePath)
-	assert.NoDirExists(t, worktreePath)
+	assert.Contains(t, output, worktreePath)
+	assert.DirExists(t, worktreePath)
 }
 
-func TestRepairLinkedWorktreeGitFileRejectsSymlink(t *testing.T) {
-	repoPath := newTUITestRepo(t)
-	worktreePath := filepath.Join(t.TempDir(), "symlink-worktree")
-	runTUITestGit(t, repoPath, "worktree", "add", "-b", "codex/symlink", worktreePath)
+func TestTUIBackendRemoveWorktreePreservesCrossRepositoryReplacementWithBrokenGitFile(
+	t *testing.T,
+) {
+	repoA := newTUITestRepo(t)
+	repoB := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "replaced-worktree")
+	runTUITestGit(t, repoA, "worktree", "add", "-b", "codex/original", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoA, worktreePath)
 
-	victimPath := filepath.Join(t.TempDir(), "victim")
-	const victimContents = "do not replace me\n"
-	require.NoError(t, os.WriteFile(victimPath, []byte(victimContents), 0644))
+	require.NoError(t, os.RemoveAll(worktreePath))
+	runTUITestGit(t, repoB, "worktree", "add", "-b", "codex/replacement", worktreePath)
+	const sentinel = "repository B must survive\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "replacement.txt"),
+		[]byte(sentinel),
+		0644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, ".git"),
+		[]byte("gitdir: /missing/repository-b/worktree\n"),
+		0644,
+	))
 
-	gitFilePath := filepath.Join(worktreePath, ".git")
-	require.NoError(t, os.Remove(gitFilePath))
-	if err := os.Symlink(victimPath, gitFilePath); err != nil {
-		t.Skipf("symbolic links are not supported or allowed on this filesystem: %v", err)
-	}
-
-	err := repairLinkedWorktreeGitFile(repoPath, worktreePath)
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	err := backend.removeWorktreeFromRoot(repoA, worktreePath, true, generation)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "symbolic link")
-	data, readErr := os.ReadFile(victimPath)
+	data, readErr := os.ReadFile(filepath.Join(worktreePath, "replacement.txt"))
 	require.NoError(t, readErr)
-	assert.Equal(t, victimContents, string(data))
-}
-
-func TestRepairLinkedWorktreeGitFileReplacesHardLinkWithoutClobberingTarget(t *testing.T) {
-	repoPath := newTUITestRepo(t)
-	worktreePath := filepath.Join(t.TempDir(), "hardlink-worktree")
-	runTUITestGit(t, repoPath, "worktree", "add", "-b", "codex/hardlink", worktreePath)
-
-	victimPath := filepath.Join(t.TempDir(), "victim")
-	const victimContents = "do not replace me\n"
-	require.NoError(t, os.WriteFile(victimPath, []byte(victimContents), 0644))
-
-	gitFilePath := filepath.Join(worktreePath, ".git")
-	require.NoError(t, os.Remove(gitFilePath))
-	if err := os.Link(victimPath, gitFilePath); err != nil {
-		t.Skipf("hard links are not supported on this filesystem: %v", err)
-	}
-
-	err := repairLinkedWorktreeGitFile(repoPath, worktreePath)
-
-	require.NoError(t, err)
-	victimData, readErr := os.ReadFile(victimPath)
-	require.NoError(t, readErr)
-	assert.Equal(t, victimContents, string(victimData))
-	gitData, readErr := os.ReadFile(gitFilePath)
-	require.NoError(t, readErr)
-	assert.Contains(t, string(gitData), "gitdir: ")
-	assert.NotEqual(t, string(gitData), string(victimData))
+	assert.Equal(t, sentinel, string(data))
 }
 
 func TestTUIBackendResolveLayoutFallsBackToRegisteredProjectRoot(t *testing.T) {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2426,6 +2426,7 @@ func TestTUIBackendMaterializeWorktreeUnregistersWhenHeadCannotBeRead(t *testing
 		context.Background(),
 		repoPath,
 		worktreePath,
+		tuiTestWorktreeGeneration(t, repoPath, worktreePath),
 		&dashboard.FleetInfo{
 			Branch:     "feature/studio-only",
 			RemoteHead: strings.Repeat("b", 40),
@@ -2438,6 +2439,60 @@ func TestTUIBackendMaterializeWorktreeUnregistersWhenHeadCannotBeRead(t *testing
 	reg, registryErr := registry.New()
 	require.NoError(t, registryErr)
 	assert.False(t, reg.IsUnreviewedRemoteSource(worktreePath))
+}
+
+func TestTUIBackendMaterializationCleanupPreservesReplacementWorktree(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "materialized")
+	runTUITestGit(t, repoPath, "branch", "feature/materialized")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		worktreePath,
+		"feature/materialized",
+	)
+	originalGeneration := tuiTestWorktreeGeneration(
+		t,
+		repoPath,
+		worktreePath,
+	)
+	runTUITestGit(t, repoPath, "worktree", "remove", "--force", worktreePath)
+	runTUITestGit(t, repoPath, "branch", "feature/replacement")
+	runTUITestGit(
+		t,
+		repoPath,
+		"worktree",
+		"add",
+		worktreePath,
+		"feature/replacement",
+	)
+
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	err := backend.failMaterializedHeadVerification(
+		repoPath,
+		worktreePath,
+		originalGeneration,
+		errors.New("stale materialized head"),
+	)
+
+	require.Error(t, err)
+	assert.DirExists(t, worktreePath)
+	assert.Equal(
+		t,
+		"feature/replacement",
+		strings.TrimSpace(runTUITestGitOutput(
+			t,
+			worktreePath,
+			"rev-parse",
+			"--abbrev-ref",
+			"HEAD",
+		)),
+	)
 }
 
 func tuiTestBranchExists(repoPath string, branch string) bool {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1948,6 +1948,46 @@ func TestTUIBackendRemoveWorktreeRejectsReplacementGeneration(t *testing.T) {
 	assert.DirExists(t, worktreePath)
 }
 
+func TestTUIBackendRejectsRepositoryRootFromDifferentIdentity(t *testing.T) {
+	repoA := newTUITestRepo(t)
+	repoB := newTUITestRepo(t)
+	runTUITestGit(
+		t,
+		repoA,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/example/repo-a.git",
+	)
+	runTUITestGit(
+		t,
+		repoB,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/example/repo-b.git",
+	)
+	repoAInfo, err := url.ParseRepositoryURL(
+		"https://github.com/example/repo-a.git",
+	)
+	require.NoError(t, err)
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Projects: []models.Project{{
+			Repository: "github.com/example/repo-a",
+			Path:       repoA,
+		}},
+	}, "")
+	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
+		Path:           repoB,
+		RepositoryInfo: repoAInfo,
+	}}
+
+	_, err = backend.repositoryRootForRow(row)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "repository identity changed")
+}
+
 func TestTUIBackendRemoveWorktreeDirtyErrorDoesNotSuggestCLIForce(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -194,16 +194,20 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 	repositoryGit := git.New(worktreePath)
 	g := worktree.NewCachedIdentityGit(repositoryGit)
 
-	// Get current branch
-	branch, err := getCurrentBranch(worktreePath)
+	worktrees, err := repositoryGit.ListWorktrees()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get current branch: %w", err)
+		return nil, fmt.Errorf("failed to list repository worktrees: %w", err)
 	}
-
-	// Get commit hash
-	commitHash, err := getCurrentCommitHash(worktreePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get commit hash: %w", err)
+	var snapshot *models.Worktree
+	canonicalPath := utils.CanonicalPath(worktreePath)
+	for i := range worktrees {
+		if utils.CanonicalPath(worktrees[i].Path) == canonicalPath {
+			snapshot = &worktrees[i]
+			break
+		}
+	}
+	if snapshot == nil {
+		return nil, fmt.Errorf("worktree disappeared during discovery")
 	}
 
 	repoURL := ""
@@ -218,20 +222,15 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 	// error; a worktree without resolvable identity still lists.
 	repoInfo, _ := worktree.RepositoryInfoWithProjects(g, projects)
 
-	var createdAt time.Time
-	if info, statErr := os.Stat(worktreePath); statErr == nil {
-		createdAt = info.ModTime()
-	}
-	generation, _ := repositoryGit.WorktreeGeneration(worktreePath)
-
 	return &GlobalWorktreeEntry{
 		RepositoryURL:  repoURL,
 		RepositoryInfo: repoInfo,
-		Branch:         branch,
-		Path:           worktreePath,
-		CommitHash:     commitHash,
-		CreatedAt:      createdAt,
-		Generation:     generation,
+		Branch:         snapshot.Branch,
+		Path:           snapshot.Path,
+		CommitHash:     snapshot.CommitHash,
+		IsMain:         snapshot.IsMain,
+		CreatedAt:      snapshot.CreatedAt,
+		Generation:     snapshot.Generation,
 	}, nil
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -109,10 +109,17 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 		return nil, fmt.Errorf("failed to walk directory: %w", err)
 	}
 
+	snapshots := snapshotCandidateWorktrees(candidates)
 	return extractWorktreeCandidates(
 		candidates,
 		projects,
-		extractWorktreeInfo,
+		func(path string, projects []models.Project) (*GlobalWorktreeEntry, error) {
+			snapshot, ok := snapshots[utils.CanonicalPath(path)]
+			if !ok {
+				return nil, fmt.Errorf("worktree disappeared during discovery")
+			}
+			return extractWorktreeInfoFromSnapshot(path, projects, snapshot)
+		},
 	), nil
 }
 
@@ -187,13 +194,57 @@ func extractWorktreeCandidates(
 	return entries
 }
 
+func snapshotCandidateWorktrees(
+	candidates []worktreeCandidate,
+) map[string]models.Worktree {
+	repositories := make(map[string]string)
+	for _, candidate := range candidates {
+		mainRoot, err := git.New(candidate.path).GetMainRepositoryPath()
+		if err != nil {
+			continue
+		}
+		repositories[utils.CanonicalPath(mainRoot)] = mainRoot
+	}
+
+	snapshots := make(map[string]models.Worktree)
+	if len(repositories) == 0 {
+		return snapshots
+	}
+
+	const maxWorkers = 16
+	workerCount := min(len(repositories), maxWorkers)
+	jobs := make(chan string)
+	var snapshotsMu sync.Mutex
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for repositoryRoot := range jobs {
+				worktrees, err := git.New(repositoryRoot).ListWorktrees()
+				if err != nil {
+					continue
+				}
+				snapshotsMu.Lock()
+				for _, snapshot := range worktrees {
+					snapshots[utils.CanonicalPath(snapshot.Path)] = snapshot
+				}
+				snapshotsMu.Unlock()
+			}
+		}()
+	}
+	for _, repositoryRoot := range repositories {
+		jobs <- repositoryRoot
+	}
+	close(jobs)
+	workers.Wait()
+
+	return snapshots
+}
+
 // extractWorktreeInfo extracts worktree information from a worktree directory.
 func extractWorktreeInfo(worktreePath string, projects []models.Project) (*GlobalWorktreeEntry, error) {
-	// The cached wrapper keeps the entry's recorded remote URL and the
-	// resolver's own reads to one subprocess per call kind.
 	repositoryGit := git.New(worktreePath)
-	g := worktree.NewCachedIdentityGit(repositoryGit)
-
 	worktrees, err := repositoryGit.ListWorktrees()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list repository worktrees: %w", err)
@@ -209,7 +260,17 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 	if snapshot == nil {
 		return nil, fmt.Errorf("worktree disappeared during discovery")
 	}
+	return extractWorktreeInfoFromSnapshot(worktreePath, projects, *snapshot)
+}
 
+func extractWorktreeInfoFromSnapshot(
+	worktreePath string,
+	projects []models.Project,
+	snapshot models.Worktree,
+) (*GlobalWorktreeEntry, error) {
+	// The cached wrapper keeps the entry's recorded remote URL and the
+	// resolver's own reads to one subprocess per call kind.
+	g := worktree.NewCachedIdentityGit(git.New(worktreePath))
 	repoURL := ""
 	if gotURL, err := g.GetRepositoryURL(); err == nil {
 		repoURL = gotURL

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -2,6 +2,7 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -109,7 +110,10 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 		return nil, fmt.Errorf("failed to walk directory: %w", err)
 	}
 
-	snapshots := snapshotCandidateWorktrees(candidates)
+	snapshots, err := snapshotCandidateWorktrees(candidates)
+	if err != nil {
+		return nil, err
+	}
 	return extractWorktreeCandidates(
 		candidates,
 		projects,
@@ -196,7 +200,7 @@ func extractWorktreeCandidates(
 
 func snapshotCandidateWorktrees(
 	candidates []worktreeCandidate,
-) map[string]models.Worktree {
+) (map[string]models.Worktree, error) {
 	repositories := make(map[string]string)
 	for _, candidate := range candidates {
 		mainRoot, err := git.New(candidate.path).GetMainRepositoryPath()
@@ -208,13 +212,14 @@ func snapshotCandidateWorktrees(
 
 	snapshots := make(map[string]models.Worktree)
 	if len(repositories) == 0 {
-		return snapshots
+		return snapshots, nil
 	}
 
 	const maxWorkers = 16
 	workerCount := min(len(repositories), maxWorkers)
 	jobs := make(chan string)
 	var snapshotsMu sync.Mutex
+	var snapshotErrors []error
 	var workers sync.WaitGroup
 	workers.Add(workerCount)
 	for range workerCount {
@@ -223,6 +228,16 @@ func snapshotCandidateWorktrees(
 			for repositoryRoot := range jobs {
 				worktrees, err := git.New(repositoryRoot).ListWorktrees()
 				if err != nil {
+					snapshotsMu.Lock()
+					snapshotErrors = append(
+						snapshotErrors,
+						fmt.Errorf(
+							"snapshot repository %s: %w",
+							repositoryRoot,
+							err,
+						),
+					)
+					snapshotsMu.Unlock()
 					continue
 				}
 				snapshotsMu.Lock()
@@ -239,7 +254,7 @@ func snapshotCandidateWorktrees(
 	close(jobs)
 	workers.Wait()
 
-	return snapshots
+	return snapshots, errors.Join(snapshotErrors...)
 }
 
 // extractWorktreeInfo extracts worktree information from a worktree directory.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -26,6 +26,7 @@ type GlobalWorktreeEntry struct {
 	CommitHash     string
 	IsMain         bool
 	CreatedAt      time.Time // Worktree directory modification time
+	Generation     string    // Durable worktree registration identity
 }
 
 type worktreeCandidate struct {
@@ -190,7 +191,8 @@ func extractWorktreeCandidates(
 func extractWorktreeInfo(worktreePath string, projects []models.Project) (*GlobalWorktreeEntry, error) {
 	// The cached wrapper keeps the entry's recorded remote URL and the
 	// resolver's own reads to one subprocess per call kind.
-	g := worktree.NewCachedIdentityGit(git.New(worktreePath))
+	repositoryGit := git.New(worktreePath)
+	g := worktree.NewCachedIdentityGit(repositoryGit)
 
 	// Get current branch
 	branch, err := getCurrentBranch(worktreePath)
@@ -220,6 +222,7 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 	if info, statErr := os.Stat(worktreePath); statErr == nil {
 		createdAt = info.ModTime()
 	}
+	generation, _ := repositoryGit.WorktreeGeneration(worktreePath)
 
 	return &GlobalWorktreeEntry{
 		RepositoryURL:  repoURL,
@@ -228,6 +231,7 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 		Path:           worktreePath,
 		CommitHash:     commitHash,
 		CreatedAt:      createdAt,
+		Generation:     generation,
 	}, nil
 }
 
@@ -284,6 +288,7 @@ func (e *GlobalWorktreeEntry) Model() models.Worktree {
 		CommitHash: e.CommitHash,
 		IsMain:     e.IsMain,
 		CreatedAt:  e.CreatedAt,
+		Generation: e.Generation,
 	}
 	if e.RepositoryInfo != nil {
 		m.Repository = e.RepositoryInfo.FullPath

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -114,7 +114,7 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 		candidates,
 		projects,
 		func(path string, projects []models.Project) (*GlobalWorktreeEntry, error) {
-			snapshot, ok := snapshots[utils.CanonicalPath(path)]
+			snapshot, ok := snapshots[utils.PathKey(path)]
 			if !ok {
 				return nil, fmt.Errorf("worktree disappeared during discovery")
 			}
@@ -137,7 +137,7 @@ func DiscoverWorktree(path string, projects []models.Project) (*GlobalWorktreeEn
 	if err != nil {
 		return nil, fmt.Errorf("failed to find worktree root: %w", err)
 	}
-	if utils.CanonicalPath(root) != utils.CanonicalPath(expanded) {
+	if utils.PathKey(root) != utils.PathKey(expanded) {
 		return nil, fmt.Errorf("path is not a worktree root")
 	}
 	entry, err := extractWorktreeInfo(root, projects)
@@ -146,7 +146,7 @@ func DiscoverWorktree(path string, projects []models.Project) (*GlobalWorktreeEn
 	}
 	if mainRoot, mainErr := repositoryGit.GetMainRepositoryPath(); mainErr == nil {
 		entry.IsMain =
-			utils.CanonicalPath(mainRoot) == utils.CanonicalPath(root)
+			utils.PathKey(mainRoot) == utils.PathKey(root)
 	}
 	return entry, nil
 }
@@ -203,7 +203,7 @@ func snapshotCandidateWorktrees(
 		if err != nil {
 			continue
 		}
-		repositories[utils.CanonicalPath(mainRoot)] = mainRoot
+		repositories[utils.PathKey(mainRoot)] = mainRoot
 	}
 
 	snapshots := make(map[string]models.Worktree)
@@ -227,7 +227,7 @@ func snapshotCandidateWorktrees(
 				}
 				snapshotsMu.Lock()
 				for _, snapshot := range worktrees {
-					snapshots[utils.CanonicalPath(snapshot.Path)] = snapshot
+					snapshots[utils.PathKey(snapshot.Path)] = snapshot
 				}
 				snapshotsMu.Unlock()
 			}
@@ -250,9 +250,9 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 		return nil, fmt.Errorf("failed to list repository worktrees: %w", err)
 	}
 	var snapshot *models.Worktree
-	canonicalPath := utils.CanonicalPath(worktreePath)
+	canonicalPath := utils.PathKey(worktreePath)
 	for i := range worktrees {
-		if utils.CanonicalPath(worktrees[i].Path) == canonicalPath {
+		if utils.PathKey(worktrees[i].Path) == canonicalPath {
 			snapshot = &worktrees[i]
 			break
 		}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -382,12 +382,11 @@ func TestDiscoverGlobalWorktreesReportsRepositorySnapshotFailure(t *testing.T) {
 	gitDir := strings.TrimSpace(
 		strings.TrimPrefix(strings.TrimSpace(string(dotGit)), "gitdir: "),
 	)
-	if err := os.WriteFile(
+	if err := os.Mkdir(
 		filepath.Join(gitDir, "kwt-generation"),
-		[]byte("invalid\n"),
-		0o600,
+		0o700,
 	); err != nil {
-		t.Fatalf("corrupt worktree generation: %v", err)
+		t.Fatalf("block worktree generation initialization: %v", err)
 	}
 
 	entries, err := DiscoverGlobalWorktrees(baseDir, nil)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -367,6 +367,39 @@ func TestDiscoverGlobalWorktrees_MainAndLinkedWorktrees(t *testing.T) {
 	}
 }
 
+func TestDiscoverGlobalWorktreesReportsRepositorySnapshotFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	repoDir := filepath.Join(baseDir, "repo", "main")
+	repo := initRepoAt(t, repoDir, "https://github.com/user/repo.git")
+	repo.CreateBranch(t, "feature")
+	worktreeDir := filepath.Join(baseDir, "repo", "feature")
+	repo.CreateWorktree(t, worktreeDir, "feature")
+
+	dotGit, err := os.ReadFile(filepath.Join(worktreeDir, ".git"))
+	if err != nil {
+		t.Fatalf("read linked worktree .git file: %v", err)
+	}
+	gitDir := strings.TrimSpace(
+		strings.TrimPrefix(strings.TrimSpace(string(dotGit)), "gitdir: "),
+	)
+	if err := os.WriteFile(
+		filepath.Join(gitDir, "kwt-generation"),
+		[]byte("invalid\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("corrupt worktree generation: %v", err)
+	}
+
+	entries, err := DiscoverGlobalWorktrees(baseDir, nil)
+
+	if err == nil {
+		t.Fatalf(
+			"DiscoverGlobalWorktrees() entries = %v, want snapshot error",
+			entries,
+		)
+	}
+}
+
 func TestDiscoverGlobalWorktreesListsEachRepositoryOnce(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a POSIX shell wrapper")

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -3,7 +3,9 @@ package discovery
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -362,6 +364,60 @@ func TestDiscoverGlobalWorktrees_MainAndLinkedWorktrees(t *testing.T) {
 	}
 	if linkedCount != 1 {
 		t.Errorf("Expected 1 linked worktree, got %d", linkedCount)
+	}
+}
+
+func TestDiscoverGlobalWorktreesListsEachRepositoryOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell wrapper")
+	}
+
+	baseDir := t.TempDir()
+	repoDir := filepath.Join(baseDir, "github.com", "user", "repo", "main")
+	repo := initRepoAt(t, repoDir, "https://github.com/user/repo.git")
+	for _, branch := range []string{"feature-a", "feature-b"} {
+		repo.CreateBranch(t, branch)
+		repo.CreateWorktree(
+			t,
+			filepath.Join(baseDir, "github.com", "user", "repo", branch),
+			branch,
+		)
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find git executable: %v", err)
+	}
+	countPath := filepath.Join(t.TempDir(), "worktree-list-count")
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	wrapper := `#!/bin/sh
+if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
+	printf '1\n' >> "$WORKTREE_LIST_COUNT"
+fi
+exec "$REAL_GIT" "$@"
+`
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+		t.Fatalf("write git wrapper: %v", err)
+	}
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("WORKTREE_LIST_COUNT", countPath)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	entries, err := DiscoverGlobalWorktrees(baseDir, nil)
+
+	if err != nil {
+		t.Fatalf("DiscoverGlobalWorktrees() error = %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("Expected 3 entries, got %d", len(entries))
+	}
+	count, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read worktree list count: %v", err)
+	}
+	if got := strings.Count(string(count), "\n"); got != 1 {
+		t.Fatalf("git worktree list calls = %d, want 1", got)
 	}
 }
 

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -180,7 +180,7 @@ func (b *ManifestBuilder) addConfiguredProject(
 
 	worktrees, err := b.listProjectWorktrees(ctx, project)
 	if err != nil {
-		if isContextError(err) {
+		if isContextError(err) || git.IsIncompleteInventory(err) {
 			return err
 		}
 		return nil

--- a/internal/fleet/manifest_test.go
+++ b/internal/fleet/manifest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/internal/git"
 	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -272,6 +273,36 @@ func TestBuildManifestPropagatesCanceledProjectWorktreeListing(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Nil(t, manifest)
+}
+
+func TestBuildManifestPropagatesIncompleteProjectInventory(t *testing.T) {
+	repo := initFleetTestRepo(t, "https://github.com/kenn-io/kwt.git")
+	incomplete := &git.IncompleteInventoryError{
+		Path: repo,
+		Err:  errors.New("generation is unreadable"),
+	}
+
+	manifest, err := NewManifestBuilder(ManifestBuilderOptions{
+		Now:      func() time.Time { return fixedTime },
+		Hostname: func() (string, error) { return "Host-A", nil },
+		ListProjectWorktrees: func(
+			context.Context,
+			models.Project,
+		) ([]models.Worktree, error) {
+			return nil, incomplete
+		},
+	}).Build(context.Background(), &models.Config{
+		Fleet: models.FleetConfig{HostID: "host-a"},
+		Projects: []models.Project{{
+			Repository: "github.com/kenn-io/kwt",
+			Name:       "kwt",
+			Path:       repo,
+		}},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, incomplete)
 	assert.Nil(t, manifest)
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -729,7 +729,7 @@ func TestRemoveWorktree(t *testing.T) {
 	repo.CreateWorktree(t, worktreePath, "to-remove")
 
 	// Remove the worktree
-	err := g.RemoveWorktree(worktreePath, false)
+	err := g.RemoveWorktree(worktreePath, false, nil)
 	if err != nil {
 		t.Fatalf("RemoveWorktree() error = %v", err)
 	}
@@ -741,6 +741,29 @@ func TestRemoveWorktree(t *testing.T) {
 			t.Error("Worktree still exists in list after removal")
 		}
 	}
+}
+
+func TestRemoveWorktreeRejectsChangedCreationIdentity(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "replacement")
+	worktreePath := filepath.Join(t.TempDir(), "replacement")
+	repo.CreateWorktree(t, worktreePath, "replacement")
+
+	info, err := os.Stat(worktreePath)
+	require.NoError(t, err)
+	expected := info.ModTime()
+	replacementTime := expected.Add(time.Second)
+	require.NoError(t, os.Chtimes(
+		worktreePath,
+		replacementTime,
+		replacementTime,
+	))
+
+	err = g.RemoveWorktree(worktreePath, false, &expected)
+
+	require.ErrorContains(t, err, "creation identity changed")
+	assert.DirExists(t, worktreePath)
 }
 
 func TestRemoveWorktreeCleansDirectoryAfterGitDeregistersWorktree(t *testing.T) {
@@ -775,7 +798,7 @@ exec "$REAL_GIT" "$@"
 	t.Setenv("REAL_GIT", realGit)
 	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	err = New(worktreePath).RemoveWorktree(worktreePath, false)
+	err = New(worktreePath).RemoveWorktree(worktreePath, false, nil)
 
 	if err != nil {
 		t.Fatalf("RemoveWorktree() error = %v", err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/utils"
@@ -776,6 +777,84 @@ func TestListWorktreesKeepsGenerationStableWhenDirectoryChanges(t *testing.T) {
 		}
 	}
 	t.Fatal("worktree missing after ordinary directory change")
+}
+
+func TestListWorktreesWaitsForConcurrentWorktreeReplacement(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "original")
+	worktreePath := filepath.Join(t.TempDir(), "replacement")
+	repo.CreateWorktree(t, worktreePath, "original")
+	before, err := g.ListWorktrees()
+	require.NoError(t, err)
+	var originalGeneration string
+	for _, worktree := range before {
+		if utils.CanonicalPath(worktree.Path) ==
+			utils.CanonicalPath(worktreePath) {
+			originalGeneration = worktree.Generation
+		}
+	}
+	require.NotEmpty(t, originalGeneration)
+
+	lock := flock.New(
+		filepath.Join(repo.Path, ".git", "kwt-worktree.lock"),
+		flock.SetPermissions(0600),
+	)
+	require.NoError(t, lock.Lock())
+	t.Cleanup(func() { _ = lock.Unlock() })
+
+	result := make(chan []models.Worktree, 1)
+	listErr := make(chan error, 1)
+	go func() {
+		worktrees, err := g.ListWorktrees()
+		if err != nil {
+			listErr <- err
+			return
+		}
+		result <- worktrees
+	}()
+
+	select {
+	case err := <-listErr:
+		require.NoError(t, err)
+	case <-result:
+		t.Fatal("worktree listing completed while replacement lock was held")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	gitOutput(t, repo.Path, "worktree", "remove", worktreePath)
+	gitOutput(t, repo.Path, "branch", "-D", "original")
+	gitOutput(
+		t,
+		repo.Path,
+		"worktree",
+		"add",
+		"-b",
+		"replacement",
+		worktreePath,
+	)
+	require.NoError(t, lock.Unlock())
+
+	select {
+	case err := <-listErr:
+		require.NoError(t, err)
+	case worktrees := <-result:
+		for _, worktree := range worktrees {
+			if utils.CanonicalPath(worktree.Path) ==
+				utils.CanonicalPath(worktreePath) {
+				assert.Equal(t, "replacement", worktree.Branch)
+				assert.NotEqual(
+					t,
+					originalGeneration,
+					worktree.Generation,
+				)
+				return
+			}
+		}
+		t.Fatal("replacement worktree missing from locked snapshot")
+	case <-time.After(5 * time.Second):
+		t.Fatal("worktree listing did not resume after replacement")
+	}
 }
 
 func TestRemoveWorktreeRejectsChangedGeneration(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1053,6 +1053,26 @@ func TestWorktreeGenerationRecoversFromRelativeAdministrativeGitDir(
 	assert.Equal(t, generation, recovered)
 }
 
+func TestWorktreeGenerationRecoversInterruptedInitialization(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "interrupted-generation")
+	worktreePath := filepath.Join(t.TempDir(), "interrupted-generation")
+	repo.CreateWorktree(t, worktreePath, "interrupted-generation")
+	adminDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	generationPath := filepath.Join(adminDir, "kwt-generation")
+	require.NoError(t, os.WriteFile(generationPath, []byte("partial"), 0o600))
+
+	generation, err := g.WorktreeGeneration(worktreePath)
+
+	require.NoError(t, err)
+	require.NoError(t, ValidateWorktreeGeneration(generation))
+	data, err := os.ReadFile(generationPath)
+	require.NoError(t, err)
+	assert.Equal(t, generation, strings.TrimSpace(string(data)))
+}
+
 func TestListWorktreesReportsGenerationInitializationFailure(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)
@@ -1903,6 +1923,28 @@ func TestAddWorktreeTrackingReusesMatchingOrphanBranch(t *testing.T) {
 			"@{upstream}",
 		),
 	)
+}
+
+func TestAddWorktreeExistingRefusesGenerationlessRegisteredWorktree(
+	t *testing.T,
+) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "legacy-existing")
+	worktreePath := filepath.Join(t.TempDir(), "legacy-existing")
+	repo.CreateWorktree(t, worktreePath, "legacy-existing")
+	keepPath := filepath.Join(worktreePath, "keep")
+	require.NoError(t, os.WriteFile(keepPath, []byte("preserve me"), 0o600))
+
+	err := New(repo.Path).AddWorktreeExisting(
+		worktreePath,
+		"legacy-existing",
+		nil,
+	)
+
+	require.ErrorContains(t, err, "already registered without a generation")
+	data, readErr := os.ReadFile(keepPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "preserve me", string(data))
 }
 
 func TestAddWorktreeExistingRemovesWorktreeAfterCheckoutFailure(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1925,6 +1925,45 @@ func TestAddWorktreeTrackingReusesMatchingOrphanBranch(t *testing.T) {
 	)
 }
 
+func TestAddWorktreeTrackingRejectsDivergentOrphanBranch(t *testing.T) {
+	repo := NewTestRepository(t)
+	gitOutput(t, repo.Path, "remote", "add", "origin", repo.Path)
+	gitOutput(
+		t,
+		repo.Path,
+		"update-ref",
+		"refs/remotes/origin/diverged",
+		"HEAD",
+	)
+	gitOutput(
+		t,
+		repo.Path,
+		"branch",
+		"--track",
+		"diverged",
+		"refs/remotes/origin/diverged",
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo.Path, "local-only"),
+		[]byte("different content"),
+		0o600,
+	))
+	gitOutput(t, repo.Path, "add", "local-only")
+	gitOutput(t, repo.Path, "commit", "-m", "advance local branch source")
+	gitOutput(t, repo.Path, "update-ref", "refs/heads/diverged", "HEAD")
+	worktreePath := filepath.Join(t.TempDir(), "diverged")
+
+	err := New(repo.Path).AddWorktreeTracking(
+		worktreePath,
+		"diverged",
+		"refs/remotes/origin/diverged",
+		nil,
+	)
+
+	require.ErrorContains(t, err, "points to a different commit")
+	assert.NoDirExists(t, worktreePath)
+}
+
 func TestAddWorktreeExistingRefusesGenerationlessRegisteredWorktree(
 	t *testing.T,
 ) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1017,6 +1017,42 @@ func TestListWorktreesDoesNotAdoptGenerationFromAnotherRepository(t *testing.T) 
 	require.ErrorContains(t, err, "belongs to a different repository")
 }
 
+func TestWorktreeGenerationRecoversFromRelativeAdministrativeGitDir(
+	t *testing.T,
+) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "relative-admin-gitdir")
+	worktreePath := filepath.Join(t.TempDir(), "relative-admin-gitdir")
+	repo.CreateWorktree(t, worktreePath, "relative-admin-gitdir")
+	generation, err := g.WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	adminDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	relativeDotGit, err := filepath.Rel(
+		adminDir,
+		filepath.Join(worktreePath, ".git"),
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(adminDir, "gitdir"),
+		[]byte(relativeDotGit+"\n"),
+		0o600,
+	))
+	require.NoError(t, os.Remove(filepath.Join(worktreePath, ".git")))
+	unrelatedCWD := filepath.Join(
+		t.TempDir(),
+		strings.Repeat("unrelated/", 20),
+	)
+	require.NoError(t, os.MkdirAll(unrelatedCWD, 0o755))
+	t.Chdir(unrelatedCWD)
+
+	recovered, err := g.WorktreeGeneration(worktreePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, generation, recovered)
+}
+
 func TestListWorktreesReportsGenerationInitializationFailure(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -987,6 +987,24 @@ func TestListWorktreesKeepsGenerationStableWhenDirectoryChanges(t *testing.T) {
 	t.Fatal("worktree missing after ordinary directory change")
 }
 
+func TestListWorktreesReportsGenerationInitializationFailure(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "broken-generation")
+	worktreePath := filepath.Join(t.TempDir(), "broken-generation")
+	repo.CreateWorktree(t, worktreePath, "broken-generation")
+	adminDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(
+		filepath.Join(adminDir, "kwt-generation"),
+		0700,
+	))
+
+	_, err = g.ListWorktrees()
+
+	require.ErrorContains(t, err, "worktree generation")
+}
+
 func TestListWorktreesWaitsForConcurrentWorktreeReplacement(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1148,6 +1148,52 @@ exec "$REAL_GIT" "$@"
 	}
 }
 
+func TestConditionalRemoveWorktreePreservesDirectoryAfterGitDeregistersWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell wrapper")
+	}
+
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "partially-removed-conditionally")
+	worktreePath := filepath.Join(t.TempDir(), "remove-wt")
+	repo.CreateWorktree(t, worktreePath, "partially-removed-conditionally")
+
+	g := New(worktreePath)
+	worktrees, err := g.ListWorktrees()
+	require.NoError(t, err)
+	var generation string
+	for _, worktree := range worktrees {
+		if utils.CanonicalPath(worktree.Path) == utils.CanonicalPath(worktreePath) {
+			generation = worktree.Generation
+			break
+		}
+	}
+	require.NotEmpty(t, generation)
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	wrapper := `#!/bin/sh
+if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then
+	"$REAL_GIT" "$@" || exit $?
+	mkdir -p "$3"
+	printf 'replacement created during removal\n' > "$3/replacement"
+	printf "error: failed to delete '%s': Directory not empty\n" "$3" >&2
+	exit 1
+fi
+exec "$REAL_GIT" "$@"
+`
+	require.NoError(t, os.WriteFile(wrapperPath, []byte(wrapper), 0755))
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err = g.RemoveWorktree(worktreePath, false, generation)
+
+	require.ErrorContains(t, err, "failed to remove worktree")
+	assert.FileExists(t, filepath.Join(worktreePath, "replacement"))
+}
+
 func TestPruneWorktrees(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1289,6 +1289,23 @@ func TestPruneWorktrees(t *testing.T) {
 	}
 }
 
+func TestPruneWorktreesRejectsActiveCreationReservation(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	reservation, err := g.reserveWorktreeCreation(
+		filepath.Join(t.TempDir(), "creating-worktree"),
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, reservation.release())
+	})
+
+	err = g.PruneWorktrees()
+
+	require.ErrorContains(t, err, "worktree creation in progress")
+}
+
 func TestListBranches(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -729,7 +730,7 @@ func TestRemoveWorktree(t *testing.T) {
 	repo.CreateWorktree(t, worktreePath, "to-remove")
 
 	// Remove the worktree
-	err := g.RemoveWorktree(worktreePath, false, nil)
+	err := g.RemoveWorktree(worktreePath, false, "")
 	if err != nil {
 		t.Fatalf("RemoveWorktree() error = %v", err)
 	}
@@ -743,26 +744,60 @@ func TestRemoveWorktree(t *testing.T) {
 	}
 }
 
-func TestRemoveWorktreeRejectsChangedCreationIdentity(t *testing.T) {
+func TestListWorktreesKeepsGenerationStableWhenDirectoryChanges(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "stable-generation")
+	worktreePath := filepath.Join(t.TempDir(), "stable-generation")
+	repo.CreateWorktree(t, worktreePath, "stable-generation")
+
+	before, err := g.ListWorktrees()
+	require.NoError(t, err)
+	var generation string
+	for _, worktree := range before {
+		if utils.CanonicalPath(worktree.Path) == utils.CanonicalPath(worktreePath) {
+			generation = worktree.Generation
+		}
+	}
+	require.NotEmpty(t, generation)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "ordinary-change"),
+		[]byte("content"),
+		0644,
+	))
+
+	after, err := g.ListWorktrees()
+	require.NoError(t, err)
+	for _, worktree := range after {
+		if utils.CanonicalPath(worktree.Path) == utils.CanonicalPath(worktreePath) {
+			assert.Equal(t, generation, worktree.Generation)
+			return
+		}
+	}
+	t.Fatal("worktree missing after ordinary directory change")
+}
+
+func TestRemoveWorktreeRejectsChangedGeneration(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)
 	repo.CreateBranch(t, "replacement")
 	worktreePath := filepath.Join(t.TempDir(), "replacement")
 	repo.CreateWorktree(t, worktreePath, "replacement")
 
-	info, err := os.Stat(worktreePath)
+	worktrees, err := g.ListWorktrees()
 	require.NoError(t, err)
-	expected := info.ModTime()
-	replacementTime := expected.Add(time.Second)
-	require.NoError(t, os.Chtimes(
-		worktreePath,
-		replacementTime,
-		replacementTime,
-	))
+	var generation string
+	for _, worktree := range worktrees {
+		if utils.CanonicalPath(worktree.Path) == utils.CanonicalPath(worktreePath) {
+			generation = worktree.Generation
+		}
+	}
+	require.NotEmpty(t, generation)
 
-	err = g.RemoveWorktree(worktreePath, false, &expected)
+	err = g.RemoveWorktree(worktreePath, false, "replacement-generation")
 
-	require.ErrorContains(t, err, "creation identity changed")
+	require.ErrorContains(t, err, "generation changed")
 	assert.DirExists(t, worktreePath)
 }
 
@@ -798,7 +833,7 @@ exec "$REAL_GIT" "$@"
 	t.Setenv("REAL_GIT", realGit)
 	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	err = New(worktreePath).RemoveWorktree(worktreePath, false, nil)
+	err = New(worktreePath).RemoveWorktree(worktreePath, false, "")
 
 	if err != nil {
 		t.Fatalf("RemoveWorktree() error = %v", err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -547,7 +547,25 @@ func TestHookReentrantWorktreeList(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := New(os.Getenv("KWT_TEST_HOOK_REPO")).ListWorktrees()
+		worktrees, err := New(
+			os.Getenv("KWT_TEST_HOOK_REPO"),
+		).ListWorktrees()
+		reservedPath := os.Getenv("KWT_TEST_HOOK_WORKTREE")
+		for _, worktree := range worktrees {
+			if utils.CanonicalPath(worktree.Path) ==
+				utils.CanonicalPath(reservedPath) {
+				err = fmt.Errorf(
+					"in-progress worktree was visible during checkout",
+				)
+			}
+		}
+		if _, generationErr := New(
+			os.Getenv("KWT_TEST_HOOK_REPO"),
+		).readWorktreeGeneration(reservedPath); generationErr == nil {
+			err = fmt.Errorf(
+				"in-progress worktree generation was initialized during listing",
+			)
+		}
 		done <- err
 	}()
 
@@ -599,8 +617,133 @@ func TestHookCapableWorktreeAddsAllowHookToListWorktrees(t *testing.T) {
 			t.Setenv("KWT_TEST_HOOK_REPO", repo.Path)
 
 			worktreePath := filepath.Join(t.TempDir(), "hook-worktree")
+			t.Setenv("KWT_TEST_HOOK_WORKTREE", worktreePath)
 			require.NoError(t, tt.add(New(repo.Path), worktreePath))
 			assert.DirExists(t, worktreePath)
+		})
+	}
+}
+
+func TestWorktreeCreationReservationHidesAndProtectsCheckout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test hook uses a POSIX shell")
+	}
+
+	repo := NewTestRepository(t)
+	startedPath := filepath.Join(t.TempDir(), "hook-started")
+	releasePath := filepath.Join(t.TempDir(), "hook-release")
+	hookPath := filepath.Join(repo.Path, ".git", "hooks", "post-checkout")
+	hook := `#!/bin/sh
+touch "$KWT_TEST_HOOK_STARTED"
+while [ ! -f "$KWT_TEST_HOOK_RELEASE" ]; do
+	sleep 0.01
+done
+`
+	require.NoError(t, os.WriteFile(hookPath, []byte(hook), 0755))
+	t.Setenv("KWT_TEST_HOOK_STARTED", startedPath)
+	t.Setenv("KWT_TEST_HOOK_RELEASE", releasePath)
+	t.Cleanup(func() {
+		_ = os.WriteFile(releasePath, nil, 0644)
+	})
+
+	g := New(repo.Path)
+	worktreePath := filepath.Join(t.TempDir(), "reserved-worktree")
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- g.AddWorktree(worktreePath, "reserved-worktree", true)
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(startedPath)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	worktrees, err := g.ListWorktrees()
+	require.NoError(t, err)
+	for _, worktree := range worktrees {
+		assert.NotEqual(
+			t,
+			utils.CanonicalPath(worktreePath),
+			utils.CanonicalPath(worktree.Path),
+		)
+	}
+	require.ErrorContains(
+		t,
+		g.RemoveWorktree(worktreePath, false, ""),
+		"creation in progress",
+	)
+	assert.DirExists(t, worktreePath)
+
+	require.NoError(t, os.WriteFile(releasePath, nil, 0644))
+	require.NoError(t, <-addErr)
+}
+
+func TestHookCapableWorktreeAddRecoversGenerationInitializationFailure(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test hook uses POSIX permissions")
+	}
+
+	tests := []struct {
+		name string
+		add  func(*Git, string) error
+	}{
+		{
+			name: "default base",
+			add: func(g *Git, path string) error {
+				return g.AddWorktree(path, "recover-default-base", true)
+			},
+		},
+		{
+			name: "explicit base",
+			add: func(g *Git, path string) error {
+				return g.AddWorktreeFromBase(
+					path,
+					"recover-explicit-base",
+					"main",
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewTestRepository(t)
+			lockPath := filepath.Join(
+				repo.Path,
+				".git",
+				"kwt-worktree.lock",
+			)
+			require.NoError(t, os.WriteFile(lockPath, nil, 0600))
+			t.Cleanup(func() { _ = os.Chmod(lockPath, 0600) })
+			hookPath := filepath.Join(
+				repo.Path,
+				".git",
+				"hooks",
+				"post-checkout",
+			)
+			hook := `#!/bin/sh
+chmod 000 "$KWT_TEST_MUTATION_LOCK"
+`
+			require.NoError(t, os.WriteFile(hookPath, []byte(hook), 0755))
+			t.Setenv("KWT_TEST_MUTATION_LOCK", lockPath)
+
+			worktreePath := filepath.Join(t.TempDir(), "worktree")
+			require.NoError(t, tt.add(New(repo.Path), worktreePath))
+			assert.DirExists(t, worktreePath)
+
+			require.NoError(t, os.Chmod(lockPath, 0600))
+			worktrees, err := New(repo.Path).ListWorktrees()
+			require.NoError(t, err)
+			for _, worktree := range worktrees {
+				if utils.CanonicalPath(worktree.Path) ==
+					utils.CanonicalPath(worktreePath) {
+					assert.NotEmpty(t, worktree.Generation)
+					return
+				}
+			}
+			t.Fatal("created worktree missing after generation retry")
 		})
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -987,6 +987,36 @@ func TestListWorktreesKeepsGenerationStableWhenDirectoryChanges(t *testing.T) {
 	t.Fatal("worktree missing after ordinary directory change")
 }
 
+func TestListWorktreesDoesNotAdoptGenerationFromAnotherRepository(t *testing.T) {
+	repoA := NewTestRepository(t)
+	repoB := NewTestRepository(t)
+	repoA.CreateBranch(t, "repo-a-worktree")
+	repoB.CreateBranch(t, "repo-b-worktree")
+	worktreePath := filepath.Join(t.TempDir(), "reused-worktree")
+	repoA.CreateWorktree(t, worktreePath, "repo-a-worktree")
+
+	before, err := New(repoA.Path).ListWorktrees()
+	require.NoError(t, err)
+	var repoAGeneration string
+	for _, worktree := range before {
+		if utils.PathKey(worktree.Path) == utils.PathKey(worktreePath) {
+			repoAGeneration = worktree.Generation
+			break
+		}
+	}
+	require.NotEmpty(t, repoAGeneration)
+
+	require.NoError(t, os.RemoveAll(worktreePath))
+	repoB.CreateWorktree(t, worktreePath, "repo-b-worktree")
+	repoBGeneration, err := New(repoB.Path).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	require.NotEqual(t, repoAGeneration, repoBGeneration)
+
+	_, err = New(repoA.Path).ListWorktrees()
+
+	require.ErrorContains(t, err, "belongs to a different repository")
+}
+
 func TestListWorktreesReportsGenerationInitializationFailure(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -540,6 +540,71 @@ exec "$REAL_GIT" "$@"
 	})
 }
 
+func TestHookReentrantWorktreeList(t *testing.T) {
+	if os.Getenv("KWT_TEST_HOOK_REENTRANT_LIST") != "1" {
+		t.Skip("helper process")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := New(os.Getenv("KWT_TEST_HOOK_REPO")).ListWorktrees()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		fmt.Fprintln(os.Stderr, "hook could not re-enter kwt worktree listing")
+		os.Exit(2)
+	}
+}
+
+func TestHookCapableWorktreeAddsAllowHookToListWorktrees(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test hook uses a POSIX shell")
+	}
+
+	tests := []struct {
+		name string
+		add  func(*Git, string) error
+	}{
+		{
+			name: "default base",
+			add: func(g *Git, path string) error {
+				return g.AddWorktree(path, "hook-default-base", true)
+			},
+		},
+		{
+			name: "explicit base",
+			add: func(g *Git, path string) error {
+				return g.AddWorktreeFromBase(path, "hook-explicit-base", "main")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewTestRepository(t)
+			hooksDir := filepath.Join(repo.Path, ".git", "hooks")
+			hookPath := filepath.Join(hooksDir, "post-checkout")
+			hook := `#!/bin/sh
+"$KWT_TEST_BINARY" -test.run=^TestHookReentrantWorktreeList$
+`
+			require.NoError(t, os.WriteFile(hookPath, []byte(hook), 0755))
+			t.Setenv("KWT_TEST_BINARY", os.Args[0])
+			t.Setenv("KWT_TEST_HOOK_REENTRANT_LIST", "1")
+			t.Setenv("KWT_TEST_HOOK_REPO", repo.Path)
+
+			worktreePath := filepath.Join(t.TempDir(), "hook-worktree")
+			require.NoError(t, tt.add(New(repo.Path), worktreePath))
+			assert.DirExists(t, worktreePath)
+		})
+	}
+}
+
 func TestAddWorktreeExistingDisablesCheckoutHooks(t *testing.T) {
 	repo := NewTestRepository(t)
 	repo.CreateBranch(t, "existing-unreviewed")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1863,6 +1863,48 @@ func TestAddWorktreeTrackingRejectsOptionLikeBranchName(t *testing.T) {
 	assert.NoDirExists(t, worktreePath)
 }
 
+func TestAddWorktreeTrackingReusesMatchingOrphanBranch(t *testing.T) {
+	repo := NewTestRepository(t)
+	gitOutput(t, repo.Path, "remote", "add", "origin", repo.Path)
+	gitOutput(
+		t,
+		repo.Path,
+		"update-ref",
+		"refs/remotes/origin/orphaned",
+		"HEAD",
+	)
+	gitOutput(
+		t,
+		repo.Path,
+		"branch",
+		"--track",
+		"orphaned",
+		"refs/remotes/origin/orphaned",
+	)
+	worktreePath := filepath.Join(t.TempDir(), "orphaned")
+
+	err := New(repo.Path).AddWorktreeTracking(
+		worktreePath,
+		"orphaned",
+		"refs/remotes/origin/orphaned",
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.DirExists(t, worktreePath)
+	assert.Equal(
+		t,
+		"origin/orphaned",
+		gitOutput(
+			t,
+			worktreePath,
+			"rev-parse",
+			"--abbrev-ref",
+			"@{upstream}",
+		),
+	)
+}
+
 func TestAddWorktreeExistingRemovesWorktreeAfterCheckoutFailure(t *testing.T) {
 	repo := NewTestRepository(t)
 	createBranchWithMissingBlob(t, repo, "broken-local")

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -1071,8 +1071,13 @@ func (g *Git) hasRegisteredWorktree(canonicalPath string) (bool, error) {
 
 // PruneWorktrees removes worktree information for deleted directories.
 func (g *Git) PruneWorktrees() error {
-	if _, err := g.run("worktree", "prune"); err != nil {
-		return fmt.Errorf("failed to prune worktrees: %w", err)
-	}
-	return nil
+	return g.withWorktreeMutationLock(nil, func() error {
+		if err := g.rejectActiveWorktreeCreation(nil); err != nil {
+			return err
+		}
+		if _, err := g.run("worktree", "prune"); err != nil {
+			return fmt.Errorf("failed to prune worktrees: %w", err)
+		}
+		return nil
+	})
 }

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -803,11 +803,25 @@ func ValidateWorktreeGeneration(generation string) error {
 }
 
 func (g *Git) worktreeGitDir(path string) (string, error) {
+	commonDir, commonDirErr := g.worktreeCommonDir(nil)
+	if commonDirErr != nil {
+		return "", fmt.Errorf(
+			"resolve worktree Git directory: %w",
+			commonDirErr,
+		)
+	}
+
 	dotGitPath := filepath.Join(path, ".git")
 	info, err := os.Stat(dotGitPath)
 	if err == nil {
 		if info.IsDir() {
-			return dotGitPath, nil
+			if utils.PathKey(dotGitPath) == utils.PathKey(commonDir) {
+				return commonDir, nil
+			}
+			return "", fmt.Errorf(
+				"resolve worktree Git directory: %s belongs to a different repository",
+				path,
+			)
 		}
 		data, readErr := os.ReadFile(dotGitPath)
 		if readErr == nil {
@@ -822,24 +836,18 @@ func (g *Git) worktreeGitDir(path string) (string, error) {
 				gitDir = filepath.Clean(gitDir)
 				if gitDirInfo, statErr := os.Stat(gitDir); statErr == nil &&
 					gitDirInfo.IsDir() {
-					return gitDir, nil
+					if worktreeGitDirBelongsToCommon(gitDir, commonDir) {
+						return gitDir, nil
+					}
+					return "", fmt.Errorf(
+						"resolve worktree Git directory: %s belongs to a different repository",
+						path,
+					)
 				}
 			}
 		}
 	}
 
-	commonDirOutput, commonDirErr := g.run("rev-parse", "--git-common-dir")
-	if commonDirErr != nil {
-		return "", fmt.Errorf(
-			"resolve worktree Git directory: %w",
-			commonDirErr,
-		)
-	}
-	commonDir := strings.TrimSpace(commonDirOutput)
-	if !filepath.IsAbs(commonDir) {
-		commonDir = filepath.Join(g.workDir, commonDir)
-	}
-	commonDir = filepath.Clean(commonDir)
 	entries, readDirErr := os.ReadDir(filepath.Join(commonDir, "worktrees"))
 	if readDirErr != nil {
 		return "", fmt.Errorf("resolve worktree Git directory: %w", readDirErr)
@@ -863,14 +871,22 @@ func (g *Git) worktreeGitDir(path string) (string, error) {
 	return "", fmt.Errorf("resolve worktree Git directory: worktree not found")
 }
 
+func worktreeGitDirBelongsToCommon(gitDir string, commonDir string) bool {
+	if utils.PathKey(gitDir) == utils.PathKey(commonDir) {
+		return true
+	}
+	return utils.PathKey(filepath.Dir(gitDir)) ==
+		utils.PathKey(filepath.Join(commonDir, "worktrees"))
+}
+
 func comparableWorktreePath(path string) string {
 	if _, err := os.Stat(path); err == nil {
-		return utils.CanonicalPath(path)
+		return utils.PathKey(path)
 	}
-	return filepath.Join(
+	return utils.PathKey(filepath.Join(
 		utils.CanonicalPath(filepath.Dir(path)),
 		filepath.Base(path),
-	)
+	))
 }
 
 func (g *Git) reserveWorktreeCreation(

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -285,23 +285,20 @@ func (g *Git) addWorktreeExisting(
 	if err != nil {
 		return err
 	}
-	resume, err := g.registeredWorktreeNeedsCheckout(
+	if err := g.rejectRegisteredWorktreeDestination(
 		path,
 		protectedNames,
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
-	if !resume {
-		args := append([]string(nil), isolationArgs...)
-		args = append(
-			args,
-			"worktree", "add", "--no-checkout", "--detach",
-			"--", path, "refs/heads/"+branch,
-		)
-		if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
-			return fmt.Errorf("failed to add existing-branch worktree: %w", err)
-		}
+	args := append([]string(nil), isolationArgs...)
+	args = append(
+		args,
+		"worktree", "add", "--no-checkout", "--detach",
+		"--", path, "refs/heads/"+branch,
+	)
+	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
+		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
@@ -412,11 +409,10 @@ func (g *Git) addWorktreeTracking(
 		return err
 	}
 
-	resume, err := g.registeredWorktreeNeedsCheckout(
+	if err := g.rejectRegisteredWorktreeDestination(
 		path,
 		protectedNames,
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 	reusedBranch, err := g.reusableTrackingBranch(
@@ -445,44 +441,42 @@ func (g *Git) addWorktreeTracking(
 		}
 		createdBranch = true
 	}
-	if !resume {
-		worktreeArgs := append([]string(nil), isolationArgs...)
-		worktreeArgs = append(
-			worktreeArgs,
-			"worktree", "add", "--no-checkout", "--", path, branch,
-		)
-		if _, err := g.runWithoutCredentials(
-			protectedNames,
-			worktreeArgs...,
-		); err != nil {
-			if !createdBranch {
-				return fmt.Errorf(
-					"failed to add worktree tracking %s: %w",
-					remoteBranch,
-					err,
-				)
-			}
-			if _, rollbackErr := g.runWithoutCredentials(
-				protectedNames,
-				append(
-					append([]string(nil), isolationArgs...),
-					"branch", "-D", "--", branch,
-				)...,
-			); rollbackErr != nil {
-				return fmt.Errorf(
-					"failed to add worktree tracking %s: %w (failed to remove branch %s: %v)",
-					remoteBranch,
-					err,
-					branch,
-					rollbackErr,
-				)
-			}
+	worktreeArgs := append([]string(nil), isolationArgs...)
+	worktreeArgs = append(
+		worktreeArgs,
+		"worktree", "add", "--no-checkout", "--", path, branch,
+	)
+	if _, err := g.runWithoutCredentials(
+		protectedNames,
+		worktreeArgs...,
+	); err != nil {
+		if !createdBranch {
 			return fmt.Errorf(
 				"failed to add worktree tracking %s: %w",
 				remoteBranch,
 				err,
 			)
 		}
+		if _, rollbackErr := g.runWithoutCredentials(
+			protectedNames,
+			append(
+				append([]string(nil), isolationArgs...),
+				"branch", "-D", "--", branch,
+			)...,
+		); rollbackErr != nil {
+			return fmt.Errorf(
+				"failed to add worktree tracking %s: %w (failed to remove branch %s: %v)",
+				remoteBranch,
+				err,
+				branch,
+				rollbackErr,
+			)
+		}
+		return fmt.Errorf(
+			"failed to add worktree tracking %s: %w",
+			remoteBranch,
+			err,
+		)
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
@@ -528,10 +522,10 @@ func (g *Git) addWorktreeTracking(
 	return nil
 }
 
-func (g *Git) registeredWorktreeNeedsCheckout(
+func (g *Git) rejectRegisteredWorktreeDestination(
 	path string,
 	protectedNames []string,
-) (bool, error) {
+) error {
 	output, err := g.runWithoutCredentials(
 		protectedNames,
 		"worktree",
@@ -539,28 +533,22 @@ func (g *Git) registeredWorktreeNeedsCheckout(
 		"--porcelain",
 	)
 	if err != nil {
-		return false, err
+		return err
 	}
 	want := comparableWorktreePath(path)
-	registered := false
 	for _, entry := range gitworktree.ParsePorcelain(output) {
-		if comparableWorktreePath(entry.Path) == want {
-			registered = true
-			break
+		if comparableWorktreePath(entry.Path) != want {
+			continue
 		}
-	}
-	if !registered {
-		return false, nil
-	}
-	if _, err := g.readWorktreeGeneration(path); err == nil {
-		return false, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return false, &IncompleteInventoryError{
-			Path: path,
-			Err:  err,
+		if _, generationErr := g.readWorktreeGeneration(path); generationErr != nil {
+			return fmt.Errorf(
+				"worktree %s is already registered without a generation; refusing to replace it",
+				path,
+			)
 		}
+		return fmt.Errorf("worktree %s is already registered", path)
 	}
-	return true, nil
+	return nil
 }
 
 func (g *Git) reusableTrackingBranch(
@@ -930,32 +918,36 @@ func (g *Git) WorktreeGeneration(path string) (string, error) {
 		return "", err
 	}
 	generationPath := filepath.Join(gitDir, "kwt-generation")
-	file, err := os.OpenFile(
-		generationPath,
-		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
-		0600,
-	)
+	file, err := os.CreateTemp(gitDir, ".kwt-generation-")
 	if err != nil {
-		if os.IsExist(err) {
-			return g.readWorktreeGeneration(path)
-		}
-		return "", fmt.Errorf("persist worktree identity: %w", err)
+		return "", fmt.Errorf("create worktree identity temporary file: %w", err)
+	}
+	tempPath := file.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return "", fmt.Errorf("secure worktree identity: %w", err)
 	}
 	if _, err := fmt.Fprintln(file, generation); err != nil {
 		_ = file.Close()
-		_ = os.Remove(generationPath)
 		return "", fmt.Errorf("persist worktree identity: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return "", fmt.Errorf("sync worktree identity: %w", err)
 	}
 	if err := file.Close(); err != nil {
-		_ = os.Remove(generationPath)
 		return "", fmt.Errorf("persist worktree identity: %w", err)
 	}
-	return generation, nil
+	if err := os.Rename(tempPath, generationPath); err != nil {
+		return "", fmt.Errorf("install worktree identity: %w", err)
+	}
+	return g.readWorktreeGeneration(path)
 }
 
 // ReadWorktreeGeneration returns an existing durable identity without
-// initializing one. Recovery uses absence as evidence that checkout did not
-// complete its kwt creation boundary.
+// initializing one. Recovery can finalize a present identity without making
+// a generation-less registered worktree eligible for checkout or cleanup.
 func (g *Git) ReadWorktreeGeneration(path string) (string, error) {
 	return g.readWorktreeGeneration(path)
 }

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -3,6 +3,7 @@ package git
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,28 @@ type worktreeCreationReservation struct {
 
 type worktreeCreatedError struct {
 	err error
+}
+
+// IncompleteInventoryError reports a repository whose worktree inventory
+// cannot be observed completely enough to publish or replace cached state.
+type IncompleteInventoryError struct {
+	Path string
+	Err  error
+}
+
+func (e *IncompleteInventoryError) Error() string {
+	return fmt.Sprintf("incomplete worktree inventory at %s: %v", e.Path, e.Err)
+}
+
+func (e *IncompleteInventoryError) Unwrap() error {
+	return e.Err
+}
+
+// IsIncompleteInventory reports whether err represents an incomplete
+// repository worktree snapshot.
+func IsIncompleteInventory(err error) bool {
+	var incomplete *IncompleteInventoryError
+	return errors.As(err, &incomplete)
 }
 
 func (e *worktreeCreatedError) Error() string {
@@ -91,11 +114,13 @@ func (g *Git) listWorktrees(excludedPath string) ([]models.Worktree, error) {
 		}
 		generation, generationErr := g.WorktreeGeneration(worktree.Path)
 		if generationErr != nil {
-			return nil, fmt.Errorf(
-				"initialize worktree generation for %s: %w",
-				worktree.Path,
-				generationErr,
-			)
+			return nil, &IncompleteInventoryError{
+				Path: worktree.Path,
+				Err: fmt.Errorf(
+					"initialize worktree generation: %w",
+					generationErr,
+				),
+			}
 		}
 		worktree.Generation = generation
 		worktrees = append(worktrees, worktree)
@@ -260,14 +285,23 @@ func (g *Git) addWorktreeExisting(
 	if err != nil {
 		return err
 	}
-	args := append([]string(nil), isolationArgs...)
-	args = append(
-		args,
-		"worktree", "add", "--no-checkout", "--detach",
-		"--", path, "refs/heads/"+branch,
+	resume, err := g.registeredWorktreeNeedsCheckout(
+		path,
+		protectedNames,
 	)
-	if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
-		return fmt.Errorf("failed to add existing-branch worktree: %w", err)
+	if err != nil {
+		return err
+	}
+	if !resume {
+		args := append([]string(nil), isolationArgs...)
+		args = append(
+			args,
+			"worktree", "add", "--no-checkout", "--detach",
+			"--", path, "refs/heads/"+branch,
+		)
+		if _, err := g.runWithoutCredentials(protectedNames, args...); err != nil {
+			return fmt.Errorf("failed to add existing-branch worktree: %w", err)
+		}
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
@@ -378,48 +412,77 @@ func (g *Git) addWorktreeTracking(
 		return err
 	}
 
-	if _, err := g.runWithoutCredentials(
+	resume, err := g.registeredWorktreeNeedsCheckout(
+		path,
 		protectedNames,
-		append(
-			append([]string(nil), isolationArgs...),
-			"branch", "--track", "--", branch, remoteBranch,
-		)...,
-	); err != nil {
-		return fmt.Errorf(
-			"failed to create branch tracking %s: %w",
-			remoteBranch,
-			err,
-		)
-	}
-	worktreeArgs := append([]string(nil), isolationArgs...)
-	worktreeArgs = append(
-		worktreeArgs,
-		"worktree", "add", "--no-checkout", "--", path, branch,
 	)
-	if _, err := g.runWithoutCredentials(
+	if err != nil {
+		return err
+	}
+	reusedBranch, err := g.reusableTrackingBranch(
+		branch,
+		remoteBranch,
 		protectedNames,
-		worktreeArgs...,
-	); err != nil {
-		if _, rollbackErr := g.runWithoutCredentials(
+		isolationArgs,
+	)
+	if err != nil {
+		return err
+	}
+	createdBranch := false
+	if !reusedBranch {
+		if _, err := g.runWithoutCredentials(
 			protectedNames,
 			append(
 				append([]string(nil), isolationArgs...),
-				"branch", "-D", "--", branch,
+				"branch", "--track", "--", branch, remoteBranch,
 			)...,
-		); rollbackErr != nil {
+		); err != nil {
 			return fmt.Errorf(
-				"failed to add worktree tracking %s: %w (failed to remove branch %s: %v)",
+				"failed to create branch tracking %s: %w",
 				remoteBranch,
 				err,
-				branch,
-				rollbackErr,
 			)
 		}
-		return fmt.Errorf(
-			"failed to add worktree tracking %s: %w",
-			remoteBranch,
-			err,
+		createdBranch = true
+	}
+	if !resume {
+		worktreeArgs := append([]string(nil), isolationArgs...)
+		worktreeArgs = append(
+			worktreeArgs,
+			"worktree", "add", "--no-checkout", "--", path, branch,
 		)
+		if _, err := g.runWithoutCredentials(
+			protectedNames,
+			worktreeArgs...,
+		); err != nil {
+			if !createdBranch {
+				return fmt.Errorf(
+					"failed to add worktree tracking %s: %w",
+					remoteBranch,
+					err,
+				)
+			}
+			if _, rollbackErr := g.runWithoutCredentials(
+				protectedNames,
+				append(
+					append([]string(nil), isolationArgs...),
+					"branch", "-D", "--", branch,
+				)...,
+			); rollbackErr != nil {
+				return fmt.Errorf(
+					"failed to add worktree tracking %s: %w (failed to remove branch %s: %v)",
+					remoteBranch,
+					err,
+					branch,
+					rollbackErr,
+				)
+			}
+			return fmt.Errorf(
+				"failed to add worktree tracking %s: %w",
+				remoteBranch,
+				err,
+			)
+		}
 	}
 	if err := g.checkoutIsolatedWorktree(
 		path,
@@ -439,20 +502,22 @@ func (g *Git) addWorktreeTracking(
 				cleanupErr,
 			))
 		}
-		if _, cleanupErr := g.runWithoutCredentials(
-			protectedNames,
-			append(
-				append([]string(nil), isolationArgs...),
-				"branch", "-D", "--", branch,
-			)...,
-		); cleanupErr != nil {
-			return fmt.Errorf(
-				"failed to check out worktree tracking %s: %w (failed to remove branch %s: %v)",
-				remoteBranch,
-				err,
-				branch,
-				cleanupErr,
-			)
+		if createdBranch {
+			if _, cleanupErr := g.runWithoutCredentials(
+				protectedNames,
+				append(
+					append([]string(nil), isolationArgs...),
+					"branch", "-D", "--", branch,
+				)...,
+			); cleanupErr != nil {
+				return fmt.Errorf(
+					"failed to check out worktree tracking %s: %w (failed to remove branch %s: %v)",
+					remoteBranch,
+					err,
+					branch,
+					cleanupErr,
+				)
+			}
 		}
 		return fmt.Errorf(
 			"failed to check out worktree tracking %s: %w",
@@ -461,6 +526,82 @@ func (g *Git) addWorktreeTracking(
 		)
 	}
 	return nil
+}
+
+func (g *Git) registeredWorktreeNeedsCheckout(
+	path string,
+	protectedNames []string,
+) (bool, error) {
+	output, err := g.runWithoutCredentials(
+		protectedNames,
+		"worktree",
+		"list",
+		"--porcelain",
+	)
+	if err != nil {
+		return false, err
+	}
+	want := comparableWorktreePath(path)
+	registered := false
+	for _, entry := range gitworktree.ParsePorcelain(output) {
+		if comparableWorktreePath(entry.Path) == want {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		return false, nil
+	}
+	if _, err := g.readWorktreeGeneration(path); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, &IncompleteInventoryError{
+			Path: path,
+			Err:  err,
+		}
+	}
+	return true, nil
+}
+
+func (g *Git) reusableTrackingBranch(
+	branch string,
+	remoteBranch string,
+	protectedNames []string,
+	isolationArgs []string,
+) (bool, error) {
+	fullBranch := "refs/heads/" + branch
+	args := append([]string(nil), isolationArgs...)
+	args = append(
+		args,
+		"for-each-ref",
+		"--format=%(refname)%00%(upstream)",
+		"--count=1",
+		"--",
+		fullBranch,
+	)
+	output, err := g.runWithoutCredentials(protectedNames, args...)
+	if err != nil {
+		return false, fmt.Errorf("inspect local tracking branch: %w", err)
+	}
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return false, nil
+	}
+	parts := strings.SplitN(output, "\x00", 2)
+	if len(parts) != 2 || parts[0] != fullBranch {
+		return false, fmt.Errorf("inspect local tracking branch: invalid response")
+	}
+	expectedSource := remoteBranch
+	if !strings.HasPrefix(expectedSource, "refs/") {
+		expectedSource = "refs/remotes/" + expectedSource
+	}
+	if parts[1] != expectedSource {
+		return false, fmt.Errorf(
+			"local branch %s already exists with a different upstream",
+			branch,
+		)
+	}
+	return true, nil
 }
 
 func (g *Git) validateLocalBranchName(
@@ -810,6 +951,13 @@ func (g *Git) WorktreeGeneration(path string) (string, error) {
 		return "", fmt.Errorf("persist worktree identity: %w", err)
 	}
 	return generation, nil
+}
+
+// ReadWorktreeGeneration returns an existing durable identity without
+// initializing one. Recovery uses absence as evidence that checkout did not
+// complete its kwt creation boundary.
+func (g *Git) ReadWorktreeGeneration(path string) (string, error) {
+	return g.readWorktreeGeneration(path)
 }
 
 func (g *Git) readWorktreeGeneration(path string) (string, error) {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -662,6 +662,24 @@ func (g *Git) RemoveWorktree(
 	})
 }
 
+// WithWorktreeGeneration runs operation while the selected worktree still
+// names expected and repository worktree mutations are excluded.
+func (g *Git) WithWorktreeGeneration(
+	path string,
+	expected string,
+	operation func() error,
+) error {
+	return g.withWorktreeMutationLock(nil, func() error {
+		if err := g.rejectActiveWorktreeCreation(nil); err != nil {
+			return err
+		}
+		if err := g.requireWorktreeGeneration(path, expected); err != nil {
+			return err
+		}
+		return operation()
+	})
+}
+
 func (g *Git) removeWorktree(path string, force bool, conditional bool) error {
 	canonicalPath := utils.CanonicalPath(path)
 	registryGit := g

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -102,19 +102,44 @@ func (g *Git) listWorktrees(excludedPath string) ([]models.Worktree, error) {
 
 // AddWorktree creates a new worktree.
 func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
+	_, err := g.addWorktreeReserved(path, branch, createBranch, false)
+	return err
+}
+
+// AddWorktreeWithGeneration creates a worktree and returns the durable
+// generation captured before the creation reservation is released.
+func (g *Git) AddWorktreeWithGeneration(
+	path, branch string,
+	createBranch bool,
+) (string, error) {
+	return g.addWorktreeReserved(path, branch, createBranch, true)
+}
+
+func (g *Git) addWorktreeReserved(
+	path, branch string,
+	createBranch bool,
+	requireGeneration bool,
+) (string, error) {
 	reservation, err := g.reserveWorktreeCreation(path, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := g.addWorktree(path, branch, createBranch); err != nil {
 		_ = reservation.release()
-		return err
+		return "", err
 	}
-	// Generation persistence is recoverable: a later locked listing will retry
-	// it, while the completed checkout remains a successful creation.
-	_ = g.initializeWorktreeGeneration(path, nil)
+	// Existing callers can recover generation through a later locked listing.
+	// Identity-requiring callers fail while preserving the completed checkout.
+	generation, generationErr := g.initializeWorktreeGenerationValue(path, nil)
 	_ = reservation.release()
-	return nil
+	if generationErr != nil && requireGeneration {
+		return "", fmt.Errorf(
+			"worktree created at %s but its generation is unavailable; preserved: %w",
+			path,
+			generationErr,
+		)
+	}
+	return generation, nil
 }
 
 func (g *Git) addWorktree(path, branch string, createBranch bool) error {
@@ -141,12 +166,57 @@ func (g *Git) AddWorktreeExisting(
 	path, branch string,
 	protectedNames []string,
 ) error {
-	return g.withWorktreeMutationLock(protectedNames, func() error {
+	_, err := g.addWorktreeExistingLocked(
+		path,
+		branch,
+		protectedNames,
+		false,
+	)
+	return err
+}
+
+// AddWorktreeExistingWithGeneration checks out an existing local branch and
+// returns its durable generation from the same mutation-locked operation.
+func (g *Git) AddWorktreeExistingWithGeneration(
+	path, branch string,
+	protectedNames []string,
+) (string, error) {
+	return g.addWorktreeExistingLocked(
+		path,
+		branch,
+		protectedNames,
+		true,
+	)
+}
+
+func (g *Git) addWorktreeExistingLocked(
+	path, branch string,
+	protectedNames []string,
+	requireGeneration bool,
+) (string, error) {
+	var generation string
+	err := g.withWorktreeMutationLock(protectedNames, func() error {
 		if err := g.rejectActiveWorktreeCreation(protectedNames); err != nil {
 			return err
 		}
-		return g.addWorktreeExisting(path, branch, protectedNames)
+		if err := g.addWorktreeExisting(path, branch, protectedNames); err != nil {
+			return err
+		}
+		if !requireGeneration {
+			return nil
+		}
+		var err error
+		generation, err = g.WorktreeGeneration(path)
+		if err != nil {
+			return fmt.Errorf(
+				"worktree created at %s but its generation is unavailable; preserved: %w",
+				path,
+				err,
+			)
+		}
+		return nil
 	})
+	return generation, err
 }
 
 func (g *Git) addWorktreeExisting(
@@ -207,17 +277,64 @@ func (g *Git) AddWorktreeTracking(
 	path, branch, remoteBranch string,
 	protectedNames []string,
 ) error {
-	return g.withWorktreeMutationLock(protectedNames, func() error {
+	_, err := g.addWorktreeTrackingLocked(
+		path,
+		branch,
+		remoteBranch,
+		protectedNames,
+		false,
+	)
+	return err
+}
+
+// AddWorktreeTrackingWithGeneration creates a tracking worktree and returns
+// its durable generation from the same mutation-locked operation.
+func (g *Git) AddWorktreeTrackingWithGeneration(
+	path, branch, remoteBranch string,
+	protectedNames []string,
+) (string, error) {
+	return g.addWorktreeTrackingLocked(
+		path,
+		branch,
+		remoteBranch,
+		protectedNames,
+		true,
+	)
+}
+
+func (g *Git) addWorktreeTrackingLocked(
+	path, branch, remoteBranch string,
+	protectedNames []string,
+	requireGeneration bool,
+) (string, error) {
+	var generation string
+	err := g.withWorktreeMutationLock(protectedNames, func() error {
 		if err := g.rejectActiveWorktreeCreation(protectedNames); err != nil {
 			return err
 		}
-		return g.addWorktreeTracking(
+		if err := g.addWorktreeTracking(
 			path,
 			branch,
 			remoteBranch,
 			protectedNames,
-		)
+		); err != nil {
+			return err
+		}
+		if !requireGeneration {
+			return nil
+		}
+		var err error
+		generation, err = g.WorktreeGeneration(path)
+		if err != nil {
+			return fmt.Errorf(
+				"worktree created at %s but its generation is unavailable; preserved: %w",
+				path,
+				err,
+			)
+		}
+		return nil
 	})
+	return generation, err
 }
 
 func (g *Git) addWorktreeTracking(
@@ -596,12 +713,24 @@ func (g *Git) initializeWorktreeGeneration(
 	path string,
 	protectedNames []string,
 ) error {
-	return g.withWorktreeMutationLock(protectedNames, func() error {
-		if _, err := g.WorktreeGeneration(path); err != nil {
+	_, err := g.initializeWorktreeGenerationValue(path, protectedNames)
+	return err
+}
+
+func (g *Git) initializeWorktreeGenerationValue(
+	path string,
+	protectedNames []string,
+) (string, error) {
+	var generation string
+	err := g.withWorktreeMutationLock(protectedNames, func() error {
+		var err error
+		generation, err = g.WorktreeGeneration(path)
+		if err != nil {
 			return fmt.Errorf("initialize worktree generation: %w", err)
 		}
 		return nil
 	})
+	return generation, err
 }
 
 // WorktreeGeneration returns a durable identity stored in the worktree's Git

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -558,14 +558,18 @@ func (g *Git) reusableTrackingBranch(
 	isolationArgs []string,
 ) (bool, error) {
 	fullBranch := "refs/heads/" + branch
+	expectedSource := remoteBranch
+	if !strings.HasPrefix(expectedSource, "refs/") {
+		expectedSource = "refs/remotes/" + expectedSource
+	}
 	args := append([]string(nil), isolationArgs...)
 	args = append(
 		args,
 		"for-each-ref",
-		"--format=%(refname)%00%(upstream)",
-		"--count=1",
+		"--format=%(refname)%00%(objectname)%00%(upstream)",
 		"--",
 		fullBranch,
+		expectedSource,
 	)
 	output, err := g.runWithoutCredentials(protectedNames, args...)
 	if err != nil {
@@ -575,18 +579,36 @@ func (g *Git) reusableTrackingBranch(
 	if output == "" {
 		return false, nil
 	}
-	parts := strings.SplitN(output, "\x00", 2)
-	if len(parts) != 2 || parts[0] != fullBranch {
-		return false, fmt.Errorf("inspect local tracking branch: invalid response")
+	var localOID string
+	var upstream string
+	var sourceOID string
+	for line := range strings.SplitSeq(output, "\n") {
+		parts := strings.Split(line, "\x00")
+		if len(parts) != 3 {
+			return false, fmt.Errorf("inspect local tracking branch: invalid response")
+		}
+		switch parts[0] {
+		case fullBranch:
+			localOID = parts[1]
+			upstream = parts[2]
+		case expectedSource:
+			sourceOID = parts[1]
+		}
 	}
-	expectedSource := remoteBranch
-	if !strings.HasPrefix(expectedSource, "refs/") {
-		expectedSource = "refs/remotes/" + expectedSource
+	if localOID == "" {
+		return false, nil
 	}
-	if parts[1] != expectedSource {
+	if upstream != expectedSource {
 		return false, fmt.Errorf(
 			"local branch %s already exists with a different upstream",
 			branch,
+		)
+	}
+	if sourceOID == "" || localOID != sourceOID {
+		return false, fmt.Errorf(
+			"local branch %s points to a different commit than %s",
+			branch,
+			expectedSource,
 		)
 	}
 	return true, nil

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -17,6 +17,16 @@ import (
 
 // ListWorktrees returns a list of all worktrees in the repository.
 func (g *Git) ListWorktrees() ([]models.Worktree, error) {
+	var worktrees []models.Worktree
+	err := g.withWorktreeMutationLock(nil, func() error {
+		var err error
+		worktrees, err = g.listWorktrees()
+		return err
+	})
+	return worktrees, err
+}
+
+func (g *Git) listWorktrees() ([]models.Worktree, error) {
 	output, err := g.run("worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/gofrs/flock"
 	gitworktree "go.kenn.io/kit/git/worktree"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
@@ -56,6 +58,12 @@ func (g *Git) ListWorktrees() ([]models.Worktree, error) {
 
 // AddWorktree creates a new worktree.
 func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
+	return g.withWorktreeMutationLock(nil, func() error {
+		return g.addWorktree(path, branch, createBranch)
+	})
+}
+
+func (g *Git) addWorktree(path, branch string, createBranch bool) error {
 	args := []string{"worktree", "add"}
 	if createBranch {
 		base, err := g.defaultWorktreeBase()
@@ -76,6 +84,15 @@ func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
 // checkout to run repository-configured hooks or filters, and without exposing
 // protected credentials to Git.
 func (g *Git) AddWorktreeExisting(
+	path, branch string,
+	protectedNames []string,
+) error {
+	return g.withWorktreeMutationLock(protectedNames, func() error {
+		return g.addWorktreeExisting(path, branch, protectedNames)
+	})
+}
+
+func (g *Git) addWorktreeExisting(
 	path, branch string,
 	protectedNames []string,
 ) error {
@@ -130,6 +147,20 @@ func (g *Git) AddWorktreeExisting(
 // AddWorktreeTracking creates a local branch and worktree that track a
 // specific remote branch.
 func (g *Git) AddWorktreeTracking(
+	path, branch, remoteBranch string,
+	protectedNames []string,
+) error {
+	return g.withWorktreeMutationLock(protectedNames, func() error {
+		return g.addWorktreeTracking(
+			path,
+			branch,
+			remoteBranch,
+			protectedNames,
+		)
+	})
+}
+
+func (g *Git) addWorktreeTracking(
 	path, branch, remoteBranch string,
 	protectedNames []string,
 ) error {
@@ -411,6 +442,12 @@ func (g *Git) refExists(ref string) bool {
 
 // AddWorktreeFromBase creates a new worktree with a branch from a specific base branch.
 func (g *Git) AddWorktreeFromBase(path, branch, baseBranch string) error {
+	return g.withWorktreeMutationLock(nil, func() error {
+		return g.addWorktreeFromBase(path, branch, baseBranch)
+	})
+}
+
+func (g *Git) addWorktreeFromBase(path, branch, baseBranch string) error {
 	args := []string{"worktree", "add", "-b", branch, path}
 	if baseBranch != "" {
 		args = append(args, baseBranch)
@@ -422,7 +459,25 @@ func (g *Git) AddWorktreeFromBase(path, branch, baseBranch string) error {
 }
 
 // RemoveWorktree removes a worktree.
-func (g *Git) RemoveWorktree(path string, force bool) error {
+func (g *Git) RemoveWorktree(
+	path string,
+	force bool,
+	ifCreatedAt *time.Time,
+) error {
+	return g.withWorktreeMutationLock(nil, func() error {
+		if ifCreatedAt != nil {
+			if err := g.requireWorktreeCreationIdentity(
+				path,
+				*ifCreatedAt,
+			); err != nil {
+				return err
+			}
+		}
+		return g.removeWorktree(path, force)
+	})
+}
+
+func (g *Git) removeWorktree(path string, force bool) error {
 	canonicalPath := utils.CanonicalPath(path)
 	registryGit := g
 	if mainRoot, err := g.getMainRepoRoot(); err == nil {
@@ -450,6 +505,61 @@ func (g *Git) RemoveWorktree(path string, force bool) error {
 		return fmt.Errorf("failed to remove worktree: %w", err)
 	}
 	return nil
+}
+
+func (g *Git) requireWorktreeCreationIdentity(
+	path string,
+	expected time.Time,
+) error {
+	canonicalPath := utils.CanonicalPath(path)
+	worktrees, err := g.ListWorktrees()
+	if err != nil {
+		return err
+	}
+	for _, worktree := range worktrees {
+		if utils.CanonicalPath(worktree.Path) != canonicalPath {
+			continue
+		}
+		if worktree.CreatedAt.IsZero() ||
+			!worktree.CreatedAt.Equal(expected) {
+			return fmt.Errorf(
+				"worktree creation identity changed for %s",
+				path,
+			)
+		}
+		return nil
+	}
+	return fmt.Errorf("worktree creation identity changed for %s", path)
+}
+
+func (g *Git) withWorktreeMutationLock(
+	protectedNames []string,
+	operation func() error,
+) error {
+	commonDirOutput, err := g.runWithoutCredentials(
+		protectedNames,
+		"rev-parse",
+		"--git-common-dir",
+	)
+	if err != nil {
+		return fmt.Errorf("resolve worktree mutation lock: %w", err)
+	}
+	commonDir := strings.TrimSpace(commonDirOutput)
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(g.workDir, commonDir)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(commonDir); resolveErr == nil {
+		commonDir = resolved
+	}
+	lock := flock.New(
+		filepath.Join(commonDir, "kwt-worktree.lock"),
+		flock.SetPermissions(0600),
+	)
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("lock worktree mutations: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+	return operation()
 }
 
 func (g *Git) hasRegisteredWorktree(canonicalPath string) (bool, error) {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -675,7 +675,7 @@ func (g *Git) removeWorktree(path string, force bool, conditional bool) error {
 		args = append(args, "--force")
 	}
 	args = append(args, path)
-	if _, err := g.run(args...); err != nil {
+	if _, err := registryGit.run(args...); err != nil {
 		stillRegistered, listErr := registryGit.hasRegisteredWorktree(canonicalPath)
 		if wasRegistered && listErr == nil && !stillRegistered {
 			if conditional {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -541,11 +541,11 @@ func (g *Git) RemoveWorktree(
 				return err
 			}
 		}
-		return g.removeWorktree(path, force)
+		return g.removeWorktree(path, force, ifGeneration != "")
 	})
 }
 
-func (g *Git) removeWorktree(path string, force bool) error {
+func (g *Git) removeWorktree(path string, force bool, conditional bool) error {
 	canonicalPath := utils.CanonicalPath(path)
 	registryGit := g
 	if mainRoot, err := g.getMainRepoRoot(); err == nil {
@@ -561,6 +561,12 @@ func (g *Git) removeWorktree(path string, force bool) error {
 	if _, err := g.run(args...); err != nil {
 		stillRegistered, listErr := registryGit.hasRegisteredWorktree(canonicalPath)
 		if wasRegistered && listErr == nil && !stillRegistered {
+			if conditional {
+				return fmt.Errorf(
+					"failed to remove worktree: %w (Git deregistered the worktree; residual directory preserved because removal was generation-conditional)",
+					err,
+				)
+			}
 			if removeErr := os.RemoveAll(path); removeErr != nil {
 				return fmt.Errorf(
 					"failed to remove worktree: %w (Git deregistered the worktree but directory cleanup failed: %v)",

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -15,18 +15,35 @@ import (
 	"go.kenn.io/kwt/pkg/models"
 )
 
+const (
+	worktreeMutationLockName        = "kwt-worktree.lock"
+	worktreeCreationLockName        = "kwt-worktree-create.lock"
+	worktreeCreationReservationName = "kwt-worktree-create.path"
+)
+
+type worktreeCreationReservation struct {
+	lock       *flock.Flock
+	recordPath string
+}
+
 // ListWorktrees returns a list of all worktrees in the repository.
 func (g *Git) ListWorktrees() ([]models.Worktree, error) {
 	var worktrees []models.Worktree
 	err := g.withWorktreeMutationLock(nil, func() error {
-		var err error
-		worktrees, err = g.listWorktrees()
+		reservedPath, creationActive, err := g.activeWorktreeCreation(nil)
+		if err != nil {
+			return err
+		}
+		if !creationActive {
+			reservedPath = ""
+		}
+		worktrees, err = g.listWorktrees(reservedPath)
 		return err
 	})
 	return worktrees, err
 }
 
-func (g *Git) listWorktrees() ([]models.Worktree, error) {
+func (g *Git) listWorktrees(excludedPath string) ([]models.Worktree, error) {
 	output, err := g.run("worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
@@ -34,7 +51,14 @@ func (g *Git) listWorktrees() ([]models.Worktree, error) {
 
 	entries := gitworktree.ParsePorcelain(output)
 	worktrees := make([]models.Worktree, 0, len(entries))
+	excluded := ""
+	if excludedPath != "" {
+		excluded = comparableWorktreePath(excludedPath)
+	}
 	for _, entry := range entries {
+		if excluded != "" && comparableWorktreePath(entry.Path) == excluded {
+			continue
+		}
 		worktree := models.Worktree{
 			Path: entry.Path, Branch: entry.Branch, CommitHash: entry.Head,
 			Prunable: entry.Prunable,
@@ -72,13 +96,19 @@ func (g *Git) listWorktrees() ([]models.Worktree, error) {
 
 // AddWorktree creates a new worktree.
 func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
-	// Checkout hooks may call back into kwt, so Git must not run while kwt's
-	// non-reentrant mutation lock is held. Once Git and its hooks finish, lock
-	// the completed worktree long enough to persist its removal identity.
-	if err := g.addWorktree(path, branch, createBranch); err != nil {
+	reservation, err := g.reserveWorktreeCreation(path, nil)
+	if err != nil {
 		return err
 	}
-	return g.initializeWorktreeGeneration(path, nil)
+	if err := g.addWorktree(path, branch, createBranch); err != nil {
+		_ = reservation.release()
+		return err
+	}
+	// Generation persistence is recoverable: a later locked listing will retry
+	// it, while the completed checkout remains a successful creation.
+	_ = g.initializeWorktreeGeneration(path, nil)
+	_ = reservation.release()
+	return nil
 }
 
 func (g *Git) addWorktree(path, branch string, createBranch bool) error {
@@ -106,6 +136,9 @@ func (g *Git) AddWorktreeExisting(
 	protectedNames []string,
 ) error {
 	return g.withWorktreeMutationLock(protectedNames, func() error {
+		if err := g.rejectActiveWorktreeCreation(protectedNames); err != nil {
+			return err
+		}
 		return g.addWorktreeExisting(path, branch, protectedNames)
 	})
 }
@@ -169,6 +202,9 @@ func (g *Git) AddWorktreeTracking(
 	protectedNames []string,
 ) error {
 	return g.withWorktreeMutationLock(protectedNames, func() error {
+		if err := g.rejectActiveWorktreeCreation(protectedNames); err != nil {
+			return err
+		}
 		return g.addWorktreeTracking(
 			path,
 			branch,
@@ -460,12 +496,17 @@ func (g *Git) refExists(ref string) bool {
 
 // AddWorktreeFromBase creates a new worktree with a branch from a specific base branch.
 func (g *Git) AddWorktreeFromBase(path, branch, baseBranch string) error {
-	// Keep the hook-capable checkout outside kwt's mutation lock; finalize the
-	// durable identity under the lock only after Git returns.
-	if err := g.addWorktreeFromBase(path, branch, baseBranch); err != nil {
+	reservation, err := g.reserveWorktreeCreation(path, nil)
+	if err != nil {
 		return err
 	}
-	return g.initializeWorktreeGeneration(path, nil)
+	if err := g.addWorktreeFromBase(path, branch, baseBranch); err != nil {
+		_ = reservation.release()
+		return err
+	}
+	_ = g.initializeWorktreeGeneration(path, nil)
+	_ = reservation.release()
+	return nil
 }
 
 func (g *Git) addWorktreeFromBase(path, branch, baseBranch string) error {
@@ -486,6 +527,9 @@ func (g *Git) RemoveWorktree(
 	ifGeneration string,
 ) error {
 	return g.withWorktreeMutationLock(nil, func() error {
+		if err := g.rejectActiveWorktreeCreation(nil); err != nil {
+			return err
+		}
 		if ifGeneration != "" {
 			if err := g.requireWorktreeGeneration(path, ifGeneration); err != nil {
 				return err
@@ -677,17 +721,122 @@ func comparableWorktreePath(path string) string {
 	)
 }
 
-func (g *Git) withWorktreeMutationLock(
+func (g *Git) reserveWorktreeCreation(
+	path string,
 	protectedNames []string,
-	operation func() error,
+) (*worktreeCreationReservation, error) {
+	commonDir, err := g.worktreeCommonDir(protectedNames)
+	if err != nil {
+		return nil, err
+	}
+	creationLock := flock.New(
+		filepath.Join(commonDir, worktreeCreationLockName),
+		flock.SetPermissions(0600),
+	)
+	recordPath := filepath.Join(commonDir, worktreeCreationReservationName)
+	var reservation *worktreeCreationReservation
+	err = g.withWorktreeMutationLock(protectedNames, func() error {
+		// Try rather than wait while holding the mutation lock: the active
+		// checkout's hook may be waiting to acquire that mutation lock for a
+		// reservation-aware list.
+		locked, lockErr := creationLock.TryLock()
+		if lockErr != nil {
+			return fmt.Errorf("reserve worktree creation: %w", lockErr)
+		}
+		if !locked {
+			return fmt.Errorf("worktree creation already in progress")
+		}
+		_ = os.Remove(recordPath)
+		if writeErr := os.WriteFile(
+			recordPath,
+			[]byte(path+"\n"),
+			0600,
+		); writeErr != nil {
+			_ = creationLock.Unlock()
+			return fmt.Errorf("record worktree creation: %w", writeErr)
+		}
+		reservation = &worktreeCreationReservation{
+			lock:       creationLock,
+			recordPath: recordPath,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return reservation, nil
+}
+
+func (r *worktreeCreationReservation) release() error {
+	removeErr := os.Remove(r.recordPath)
+	if os.IsNotExist(removeErr) {
+		removeErr = nil
+	}
+	unlockErr := r.lock.Unlock()
+	if removeErr != nil {
+		return fmt.Errorf("clear worktree creation reservation: %w", removeErr)
+	}
+	if unlockErr != nil {
+		return fmt.Errorf("release worktree creation reservation: %w", unlockErr)
+	}
+	return nil
+}
+
+func (g *Git) activeWorktreeCreation(
+	protectedNames []string,
+) (string, bool, error) {
+	commonDir, err := g.worktreeCommonDir(protectedNames)
+	if err != nil {
+		return "", false, err
+	}
+	creationLock := flock.New(
+		filepath.Join(commonDir, worktreeCreationLockName),
+		flock.SetPermissions(0600),
+	)
+	available, err := creationLock.TryLock()
+	if err != nil {
+		return "", false, fmt.Errorf("inspect worktree creation: %w", err)
+	}
+	recordPath := filepath.Join(commonDir, worktreeCreationReservationName)
+	if available {
+		_ = creationLock.Unlock()
+		_ = os.Remove(recordPath)
+		return "", false, nil
+	}
+	data, err := os.ReadFile(recordPath)
+	if err != nil {
+		return "", true, fmt.Errorf("worktree creation in progress")
+	}
+	path := strings.TrimSpace(string(data))
+	if path == "" {
+		return "", true, fmt.Errorf("worktree creation in progress")
+	}
+	return path, true, nil
+}
+
+func (g *Git) rejectActiveWorktreeCreation(
+	protectedNames []string,
 ) error {
+	_, active, err := g.activeWorktreeCreation(protectedNames)
+	if err != nil {
+		return err
+	}
+	if active {
+		return fmt.Errorf("worktree creation in progress")
+	}
+	return nil
+}
+
+func (g *Git) worktreeCommonDir(
+	protectedNames []string,
+) (string, error) {
 	commonDirOutput, err := g.runWithoutCredentials(
 		protectedNames,
 		"rev-parse",
 		"--git-common-dir",
 	)
 	if err != nil {
-		return fmt.Errorf("resolve worktree mutation lock: %w", err)
+		return "", fmt.Errorf("resolve worktree mutation lock: %w", err)
 	}
 	commonDir := strings.TrimSpace(commonDirOutput)
 	if !filepath.IsAbs(commonDir) {
@@ -696,8 +845,19 @@ func (g *Git) withWorktreeMutationLock(
 	if resolved, resolveErr := filepath.EvalSymlinks(commonDir); resolveErr == nil {
 		commonDir = resolved
 	}
+	return commonDir, nil
+}
+
+func (g *Git) withWorktreeMutationLock(
+	protectedNames []string,
+	operation func() error,
+) error {
+	commonDir, err := g.worktreeCommonDir(protectedNames)
+	if err != nil {
+		return err
+	}
 	lock := flock.New(
-		filepath.Join(commonDir, "kwt-worktree.lock"),
+		filepath.Join(commonDir, worktreeMutationLockName),
 		flock.SetPermissions(0600),
 	)
 	if err := lock.Lock(); err != nil {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -1,12 +1,13 @@
 package git
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/gofrs/flock"
 	gitworktree "go.kenn.io/kit/git/worktree"
@@ -33,6 +34,9 @@ func (g *Git) ListWorktrees() ([]models.Worktree, error) {
 		}
 		if info, statErr := os.Stat(worktree.Path); statErr == nil {
 			worktree.CreatedAt = info.ModTime()
+		}
+		if generation, generationErr := g.WorktreeGeneration(worktree.Path); generationErr == nil {
+			worktree.Generation = generation
 		}
 		worktrees = append(worktrees, worktree)
 	}
@@ -462,14 +466,11 @@ func (g *Git) addWorktreeFromBase(path, branch, baseBranch string) error {
 func (g *Git) RemoveWorktree(
 	path string,
 	force bool,
-	ifCreatedAt *time.Time,
+	ifGeneration string,
 ) error {
 	return g.withWorktreeMutationLock(nil, func() error {
-		if ifCreatedAt != nil {
-			if err := g.requireWorktreeCreationIdentity(
-				path,
-				*ifCreatedAt,
-			); err != nil {
+		if ifGeneration != "" {
+			if err := g.requireWorktreeGeneration(path, ifGeneration); err != nil {
 				return err
 			}
 		}
@@ -507,29 +508,144 @@ func (g *Git) removeWorktree(path string, force bool) error {
 	return nil
 }
 
-func (g *Git) requireWorktreeCreationIdentity(
-	path string,
-	expected time.Time,
-) error {
-	canonicalPath := utils.CanonicalPath(path)
-	worktrees, err := g.ListWorktrees()
+func (g *Git) requireWorktreeGeneration(path string, expected string) error {
+	generation, err := g.readWorktreeGeneration(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("worktree generation changed for %s", path)
 	}
-	for _, worktree := range worktrees {
-		if utils.CanonicalPath(worktree.Path) != canonicalPath {
+	if generation != expected {
+		return fmt.Errorf("worktree generation changed for %s", path)
+	}
+	return nil
+}
+
+// WorktreeGeneration returns a durable identity stored in the worktree's Git
+// administrative directory. Git removes that directory with the worktree, so
+// recreating the same path receives a different identity.
+func (g *Git) WorktreeGeneration(path string) (string, error) {
+	if generation, err := g.readWorktreeGeneration(path); err == nil {
+		return generation, nil
+	}
+
+	generationBytes := make([]byte, 16)
+	if _, err := rand.Read(generationBytes); err != nil {
+		return "", fmt.Errorf("generate worktree identity: %w", err)
+	}
+	generation := hex.EncodeToString(generationBytes)
+	gitDir, err := g.worktreeGitDir(path)
+	if err != nil {
+		return "", err
+	}
+	generationPath := filepath.Join(gitDir, "kwt-generation")
+	file, err := os.OpenFile(
+		generationPath,
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+		0600,
+	)
+	if err != nil {
+		if os.IsExist(err) {
+			return g.readWorktreeGeneration(path)
+		}
+		return "", fmt.Errorf("persist worktree identity: %w", err)
+	}
+	if _, err := fmt.Fprintln(file, generation); err != nil {
+		_ = file.Close()
+		_ = os.Remove(generationPath)
+		return "", fmt.Errorf("persist worktree identity: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(generationPath)
+		return "", fmt.Errorf("persist worktree identity: %w", err)
+	}
+	return generation, nil
+}
+
+func (g *Git) readWorktreeGeneration(path string) (string, error) {
+	gitDir, err := g.worktreeGitDir(path)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(filepath.Join(gitDir, "kwt-generation"))
+	if err != nil {
+		return "", fmt.Errorf("read worktree identity: %w", err)
+	}
+	generation := strings.TrimSpace(string(data))
+	decoded, err := hex.DecodeString(generation)
+	if err != nil || len(decoded) != 16 {
+		return "", fmt.Errorf("read worktree identity: invalid generation")
+	}
+	return generation, nil
+}
+
+func (g *Git) worktreeGitDir(path string) (string, error) {
+	dotGitPath := filepath.Join(path, ".git")
+	info, err := os.Stat(dotGitPath)
+	if err == nil {
+		if info.IsDir() {
+			return dotGitPath, nil
+		}
+		data, readErr := os.ReadFile(dotGitPath)
+		if readErr == nil {
+			gitDir := strings.TrimSpace(string(data))
+			if strings.HasPrefix(gitDir, "gitdir: ") {
+				gitDir = strings.TrimSpace(
+					strings.TrimPrefix(gitDir, "gitdir: "),
+				)
+				if !filepath.IsAbs(gitDir) {
+					gitDir = filepath.Join(path, gitDir)
+				}
+				gitDir = filepath.Clean(gitDir)
+				if gitDirInfo, statErr := os.Stat(gitDir); statErr == nil &&
+					gitDirInfo.IsDir() {
+					return gitDir, nil
+				}
+			}
+		}
+	}
+
+	commonDirOutput, commonDirErr := g.run("rev-parse", "--git-common-dir")
+	if commonDirErr != nil {
+		return "", fmt.Errorf(
+			"resolve worktree Git directory: %w",
+			commonDirErr,
+		)
+	}
+	commonDir := strings.TrimSpace(commonDirOutput)
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(g.workDir, commonDir)
+	}
+	commonDir = filepath.Clean(commonDir)
+	entries, readDirErr := os.ReadDir(filepath.Join(commonDir, "worktrees"))
+	if readDirErr != nil {
+		return "", fmt.Errorf("resolve worktree Git directory: %w", readDirErr)
+	}
+	canonicalPath := comparableWorktreePath(path)
+	for _, entry := range entries {
+		if !entry.IsDir() {
 			continue
 		}
-		if worktree.CreatedAt.IsZero() ||
-			!worktree.CreatedAt.Equal(expected) {
-			return fmt.Errorf(
-				"worktree creation identity changed for %s",
-				path,
-			)
+		adminDir := filepath.Join(commonDir, "worktrees", entry.Name())
+		gitDirFile, readErr := os.ReadFile(filepath.Join(adminDir, "gitdir"))
+		if readErr != nil {
+			continue
 		}
-		return nil
+		registeredDotGit := strings.TrimSpace(string(gitDirFile))
+		registeredPath := filepath.Dir(registeredDotGit)
+		if comparableWorktreePath(registeredPath) == canonicalPath {
+			return adminDir, nil
+		}
 	}
-	return fmt.Errorf("worktree creation identity changed for %s", path)
+	return "", fmt.Errorf("resolve worktree Git directory: worktree not found")
+}
+
+func comparableWorktreePath(path string) string {
+	if _, err := os.Stat(path); err == nil {
+		return utils.CanonicalPath(path)
+	}
+	return filepath.Join(
+		utils.CanonicalPath(filepath.Dir(path)),
+		filepath.Base(path),
+	)
 }
 
 func (g *Git) withWorktreeMutationLock(

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -72,9 +72,13 @@ func (g *Git) listWorktrees() ([]models.Worktree, error) {
 
 // AddWorktree creates a new worktree.
 func (g *Git) AddWorktree(path, branch string, createBranch bool) error {
-	return g.withWorktreeMutationLock(nil, func() error {
-		return g.addWorktree(path, branch, createBranch)
-	})
+	// Checkout hooks may call back into kwt, so Git must not run while kwt's
+	// non-reentrant mutation lock is held. Once Git and its hooks finish, lock
+	// the completed worktree long enough to persist its removal identity.
+	if err := g.addWorktree(path, branch, createBranch); err != nil {
+		return err
+	}
+	return g.initializeWorktreeGeneration(path, nil)
 }
 
 func (g *Git) addWorktree(path, branch string, createBranch bool) error {
@@ -456,9 +460,12 @@ func (g *Git) refExists(ref string) bool {
 
 // AddWorktreeFromBase creates a new worktree with a branch from a specific base branch.
 func (g *Git) AddWorktreeFromBase(path, branch, baseBranch string) error {
-	return g.withWorktreeMutationLock(nil, func() error {
-		return g.addWorktreeFromBase(path, branch, baseBranch)
-	})
+	// Keep the hook-capable checkout outside kwt's mutation lock; finalize the
+	// durable identity under the lock only after Git returns.
+	if err := g.addWorktreeFromBase(path, branch, baseBranch); err != nil {
+		return err
+	}
+	return g.initializeWorktreeGeneration(path, nil)
 }
 
 func (g *Git) addWorktreeFromBase(path, branch, baseBranch string) error {
@@ -527,6 +534,18 @@ func (g *Git) requireWorktreeGeneration(path string, expected string) error {
 		return fmt.Errorf("worktree generation changed for %s", path)
 	}
 	return nil
+}
+
+func (g *Git) initializeWorktreeGeneration(
+	path string,
+	protectedNames []string,
+) error {
+	return g.withWorktreeMutationLock(protectedNames, func() error {
+		if _, err := g.WorktreeGeneration(path); err != nil {
+			return fmt.Errorf("initialize worktree generation: %w", err)
+		}
+		return nil
+	})
 }
 
 // WorktreeGeneration returns a durable identity stored in the worktree's Git

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -863,6 +863,9 @@ func (g *Git) worktreeGitDir(path string) (string, error) {
 			continue
 		}
 		registeredDotGit := strings.TrimSpace(string(gitDirFile))
+		if !filepath.IsAbs(registeredDotGit) {
+			registeredDotGit = filepath.Join(adminDir, registeredDotGit)
+		}
 		registeredPath := filepath.Dir(registeredDotGit)
 		if comparableWorktreePath(registeredPath) == canonicalPath {
 			return adminDir, nil

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -69,9 +69,15 @@ func (g *Git) listWorktrees(excludedPath string) ([]models.Worktree, error) {
 		if info, statErr := os.Stat(worktree.Path); statErr == nil {
 			worktree.CreatedAt = info.ModTime()
 		}
-		if generation, generationErr := g.WorktreeGeneration(worktree.Path); generationErr == nil {
-			worktree.Generation = generation
+		generation, generationErr := g.WorktreeGeneration(worktree.Path)
+		if generationErr != nil {
+			return nil, fmt.Errorf(
+				"initialize worktree generation for %s: %w",
+				worktree.Path,
+				generationErr,
+			)
 		}
+		worktree.Generation = generation
 		worktrees = append(worktrees, worktree)
 	}
 
@@ -643,11 +649,22 @@ func (g *Git) readWorktreeGeneration(path string) (string, error) {
 		return "", fmt.Errorf("read worktree identity: %w", err)
 	}
 	generation := strings.TrimSpace(string(data))
-	decoded, err := hex.DecodeString(generation)
-	if err != nil || len(decoded) != 16 {
+	if err := ValidateWorktreeGeneration(generation); err != nil {
 		return "", fmt.Errorf("read worktree identity: invalid generation")
 	}
 	return generation, nil
+}
+
+// ValidateWorktreeGeneration rejects values that cannot identify one persisted
+// kwt worktree registration.
+func ValidateWorktreeGeneration(generation string) error {
+	decoded, err := hex.DecodeString(generation)
+	if err != nil || len(decoded) != 16 {
+		return fmt.Errorf(
+			"worktree generation must be a 32-character hexadecimal value",
+		)
+	}
+	return nil
 }
 
 func (g *Git) worktreeGitDir(path string) (string, error) {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -26,6 +26,26 @@ type worktreeCreationReservation struct {
 	recordPath string
 }
 
+type worktreeCreatedError struct {
+	err error
+}
+
+func (e *worktreeCreatedError) Error() string {
+	return e.err.Error()
+}
+
+func (e *worktreeCreatedError) Unwrap() error {
+	return e.err
+}
+
+func (e *worktreeCreatedError) WorktreeCreated() bool {
+	return true
+}
+
+func markWorktreeCreated(err error) error {
+	return &worktreeCreatedError{err: err}
+}
+
 // ListWorktrees returns a list of all worktrees in the repository.
 func (g *Git) ListWorktrees() ([]models.Worktree, error) {
 	var worktrees []models.Worktree
@@ -133,11 +153,11 @@ func (g *Git) addWorktreeReserved(
 	generation, generationErr := g.initializeWorktreeGenerationValue(path, nil)
 	_ = reservation.release()
 	if generationErr != nil && requireGeneration {
-		return "", fmt.Errorf(
+		return "", markWorktreeCreated(fmt.Errorf(
 			"worktree created at %s but its generation is unavailable; preserved: %w",
 			path,
 			generationErr,
-		)
+		))
 	}
 	return generation, nil
 }
@@ -208,11 +228,11 @@ func (g *Git) addWorktreeExistingLocked(
 		var err error
 		generation, err = g.WorktreeGeneration(path)
 		if err != nil {
-			return fmt.Errorf(
+			return markWorktreeCreated(fmt.Errorf(
 				"worktree created at %s but its generation is unavailable; preserved: %w",
 				path,
 				err,
-			)
+			))
 		}
 		return nil
 	})
@@ -260,11 +280,11 @@ func (g *Git) addWorktreeExisting(
 			protectedNames,
 			isolationArgs,
 		); cleanupErr != nil {
-			return fmt.Errorf(
+			return markWorktreeCreated(fmt.Errorf(
 				"failed to check out existing-branch worktree: %w (failed to remove incomplete worktree: %v)",
 				err,
 				cleanupErr,
-			)
+			))
 		}
 		return fmt.Errorf("failed to check out existing-branch worktree: %w", err)
 	}
@@ -326,11 +346,11 @@ func (g *Git) addWorktreeTrackingLocked(
 		var err error
 		generation, err = g.WorktreeGeneration(path)
 		if err != nil {
-			return fmt.Errorf(
+			return markWorktreeCreated(fmt.Errorf(
 				"worktree created at %s but its generation is unavailable; preserved: %w",
 				path,
 				err,
-			)
+			))
 		}
 		return nil
 	})
@@ -412,12 +432,12 @@ func (g *Git) addWorktreeTracking(
 			protectedNames,
 			isolationArgs,
 		); cleanupErr != nil {
-			return fmt.Errorf(
+			return markWorktreeCreated(fmt.Errorf(
 				"failed to check out worktree tracking %s: %w (failed to remove incomplete worktree: %v)",
 				remoteBranch,
 				err,
 				cleanupErr,
-			)
+			))
 		}
 		if _, cleanupErr := g.runWithoutCredentials(
 			protectedNames,

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,6 +23,7 @@ type WorktreeEntry struct {
 	RegisteredAt           time.Time  `json:"registered_at"`
 	ExpiresAt              *time.Time `json:"expires_at,omitempty"`
 	Generation             string     `json:"generation,omitempty"`
+	CreationToken          string     `json:"creation_token,omitempty"`
 	UnreviewedRemoteSource bool       `json:"unreviewed_remote_source,omitempty"`
 }
 
@@ -194,6 +195,49 @@ func (r *Registry) Register(entry *WorktreeEntry) error {
 		entries[copied.Path] = &copied
 		return true
 	})
+}
+
+// ReplaceIfCreationToken replaces a provisional creation entry only while
+// that operation still owns the registry path.
+func (r *Registry) ReplaceIfCreationToken(
+	path string,
+	creationToken string,
+	replacement *WorktreeEntry,
+) (bool, error) {
+	if creationToken == "" {
+		return false, fmt.Errorf("creation token is required")
+	}
+
+	var copied *WorktreeEntry
+	if replacement != nil {
+		value := *replacement
+		if value.RegisteredAt.IsZero() {
+			value.RegisteredAt = time.Now()
+		}
+		copied = &value
+	}
+
+	replaced := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		keys := matchingRegistryKeys(entries, path)
+		if len(keys) == 0 {
+			return false
+		}
+		for _, key := range keys {
+			if entries[key].CreationToken != creationToken {
+				return false
+			}
+		}
+		for _, key := range keys {
+			delete(entries, key)
+		}
+		if copied != nil {
+			entries[copied.Path] = copied
+		}
+		replaced = true
+		return true
+	})
+	return replaced, err
 }
 
 // Unregister removes a worktree entry by path.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -21,6 +21,7 @@ type WorktreeEntry struct {
 	IsMain                 bool       `json:"is_main"`
 	RegisteredAt           time.Time  `json:"registered_at"`
 	ExpiresAt              *time.Time `json:"expires_at,omitempty"`
+	Generation             string     `json:"generation,omitempty"`
 	UnreviewedRemoteSource bool       `json:"unreviewed_remote_source,omitempty"`
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -2,6 +2,7 @@
 package registry
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -237,6 +238,173 @@ func (r *Registry) CompareAndSwap(
 		return true
 	})
 	return replaced, err
+}
+
+// AcquireCreation holds path's creation ownership until the returned release
+// function is called. The operating system releases the lock if the creating
+// process exits, allowing a later operation to recover its provisional entry.
+func (r *Registry) AcquireCreation(
+	path string,
+) (func() error, bool, error) {
+	if err := os.MkdirAll(filepath.Dir(r.path), 0755); err != nil {
+		return nil, false, fmt.Errorf(
+			"failed to create registry directory: %w",
+			err,
+		)
+	}
+	pathHash := sha256.Sum256([]byte(creationPathKey(path)))
+	lockPath := filepath.Join(
+		filepath.Dir(r.path),
+		fmt.Sprintf(".creation-%x.lock", pathHash),
+	)
+	lock := flock.New(lockPath, flock.SetPermissions(0600))
+	acquired, err := lock.TryLock()
+	if err != nil {
+		return nil, false, fmt.Errorf("lock worktree creation: %w", err)
+	}
+	if !acquired {
+		return nil, false, nil
+	}
+	return lock.Unlock, true, nil
+}
+
+func creationPathKey(path string) string {
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	current := filepath.Clean(path)
+	var missing []string
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return utils.PathKey(resolved)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return utils.PathKey(path)
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+}
+
+// CompleteCreation finalizes only the provisional owner named by token. Other
+// fields are retained so acknowledgement or metadata updates are not lost.
+func (r *Registry) CompleteCreation(
+	path string,
+	token string,
+	generation string,
+) (bool, error) {
+	completed := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		keys := matchingRegistryKeys(entries, path)
+		if len(keys) != 1 || entries[keys[0]].CreationToken != token {
+			return false
+		}
+		entry := entries[keys[0]]
+		entry.CreationToken = ""
+		entry.Generation = generation
+		completed = true
+		return true
+	})
+	return completed, err
+}
+
+// ReclaimCreation transfers an abandoned provisional entry to a new owner.
+func (r *Registry) ReclaimCreation(
+	path string,
+	token string,
+	replacement *WorktreeEntry,
+) (bool, error) {
+	copied := *replacement
+	if copied.RegisteredAt.IsZero() {
+		copied.RegisteredAt = time.Now()
+	}
+	reclaimed := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		keys := matchingRegistryKeys(entries, path)
+		if len(keys) != 1 || entries[keys[0]].CreationToken != token {
+			return false
+		}
+		delete(entries, keys[0])
+		entries[copied.Path] = &copied
+		reclaimed = true
+		return true
+	})
+	return reclaimed, err
+}
+
+// AbortCreation restores the state replaced by token, preserving any
+// acknowledgement made while creation was active.
+func (r *Registry) AbortCreation(
+	path string,
+	token string,
+	previous *WorktreeEntry,
+) (bool, error) {
+	aborted := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		keys := matchingRegistryKeys(entries, path)
+		if len(keys) != 1 || entries[keys[0]].CreationToken != token {
+			return false
+		}
+		current := entries[keys[0]]
+		delete(entries, keys[0])
+		if previous != nil {
+			restored := *previous
+			restored.UnreviewedRemoteSource =
+				previous.UnreviewedRemoteSource &&
+					current.UnreviewedRemoteSource
+			entries[restored.Path] = &restored
+		}
+		aborted = true
+		return true
+	})
+	return aborted, err
+}
+
+// SetExpirationIfGeneration updates expiration metadata only while path still
+// names generation. Unrelated fields are retained.
+func (r *Registry) SetExpirationIfGeneration(
+	path string,
+	generation string,
+	repository string,
+	branch string,
+	expiresAt *time.Time,
+) (bool, error) {
+	updated := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		keys := matchingRegistryKeys(entries, path)
+		if len(keys) == 0 {
+			entries[path] = &WorktreeEntry{
+				Repository:   repository,
+				Branch:       branch,
+				Path:         path,
+				RegisteredAt: time.Now(),
+				ExpiresAt:    expiresAt,
+				Generation:   generation,
+			}
+			updated = true
+			return true
+		}
+		if len(keys) != 1 {
+			return false
+		}
+		entry := entries[keys[0]]
+		if entry.CreationToken != "" ||
+			entry.Generation != generation {
+			return false
+		}
+		entry.Repository = repository
+		entry.Branch = branch
+		entry.Path = path
+		entry.IsMain = false
+		entry.ExpiresAt = expiresAt
+		updated = true
+		return true
+	})
+	return updated, err
 }
 
 func sameWorktreeEntry(left *WorktreeEntry, right *WorktreeEntry) bool {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"go.kenn.io/kwt/internal/utils"
 )
 
 // WorktreeEntry represents a registered worktree.
@@ -206,6 +207,26 @@ func (r *Registry) Unregister(path string) error {
 	})
 }
 
+// UnregisterIfGeneration removes path only while its registry entry still
+// names the generation the caller acted on.
+func (r *Registry) UnregisterIfGeneration(
+	path string,
+	generation string,
+) (bool, error) {
+	removed := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		for _, key := range matchingRegistryKeys(entries, path) {
+			if entries[key].Generation != generation {
+				continue
+			}
+			delete(entries, key)
+			removed = true
+		}
+		return removed
+	})
+	return removed, err
+}
+
 // List returns all registered worktrees.
 func (r *Registry) List() []*WorktreeEntry {
 	r.mu.RLock()
@@ -308,13 +329,7 @@ func matchingRegistryKeys(
 }
 
 func comparableRegistryPath(path string) string {
-	if absolute, err := filepath.Abs(path); err == nil {
-		path = absolute
-	}
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		path = resolved
-	}
-	return filepath.Clean(path)
+	return utils.PathKey(path)
 }
 
 // ListExpired returns all worktrees that have expired.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -252,7 +252,7 @@ func (r *Registry) AcquireCreation(
 			err,
 		)
 	}
-	pathHash := sha256.Sum256([]byte(creationPathKey(path)))
+	pathHash := sha256.Sum256([]byte(comparableRegistryPath(path)))
 	lockPath := filepath.Join(
 		filepath.Dir(r.path),
 		fmt.Sprintf(".creation-%x.lock", pathHash),
@@ -266,28 +266,6 @@ func (r *Registry) AcquireCreation(
 		return nil, false, nil
 	}
 	return lock.Unlock, true, nil
-}
-
-func creationPathKey(path string) string {
-	if absolute, err := filepath.Abs(path); err == nil {
-		path = absolute
-	}
-	current := filepath.Clean(path)
-	var missing []string
-	for {
-		if resolved, err := filepath.EvalSymlinks(current); err == nil {
-			for i := len(missing) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, missing[i])
-			}
-			return utils.PathKey(resolved)
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return utils.PathKey(path)
-		}
-		missing = append(missing, filepath.Base(current))
-		current = parent
-	}
 }
 
 // CompleteCreation finalizes only the provisional owner named by token. Other
@@ -564,7 +542,25 @@ func matchingRegistryKeys(
 }
 
 func comparableRegistryPath(path string) string {
-	return utils.PathKey(path)
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	current := filepath.Clean(path)
+	var missing []string
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return utils.PathKey(resolved)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return utils.PathKey(path)
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }
 
 // ListExpired returns all worktrees that have expired.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -197,17 +197,14 @@ func (r *Registry) Register(entry *WorktreeEntry) error {
 	})
 }
 
-// ReplaceIfCreationToken replaces a provisional creation entry only while
-// that operation still owns the registry path.
-func (r *Registry) ReplaceIfCreationToken(
+// CompareAndSwap replaces a path only while its complete registry entry still
+// matches the caller's observed state. A nil expected entry claims an
+// unregistered path; a nil replacement removes the matched entry.
+func (r *Registry) CompareAndSwap(
 	path string,
-	creationToken string,
+	expected *WorktreeEntry,
 	replacement *WorktreeEntry,
 ) (bool, error) {
-	if creationToken == "" {
-		return false, fmt.Errorf("creation token is required")
-	}
-
 	var copied *WorktreeEntry
 	if replacement != nil {
 		value := *replacement
@@ -220,11 +217,14 @@ func (r *Registry) ReplaceIfCreationToken(
 	replaced := false
 	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
 		keys := matchingRegistryKeys(entries, path)
-		if len(keys) == 0 {
-			return false
-		}
-		for _, key := range keys {
-			if entries[key].CreationToken != creationToken {
+		switch {
+		case expected == nil:
+			if len(keys) != 0 {
+				return false
+			}
+		default:
+			if len(keys) != 1 ||
+				!sameWorktreeEntry(entries[keys[0]], expected) {
 				return false
 			}
 		}
@@ -238,6 +238,29 @@ func (r *Registry) ReplaceIfCreationToken(
 		return true
 	})
 	return replaced, err
+}
+
+func sameWorktreeEntry(left *WorktreeEntry, right *WorktreeEntry) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Repository == right.Repository &&
+		left.Branch == right.Branch &&
+		left.Path == right.Path &&
+		left.Hash == right.Hash &&
+		left.IsMain == right.IsMain &&
+		left.RegisteredAt.Equal(right.RegisteredAt) &&
+		sameOptionalTime(left.ExpiresAt, right.ExpiresAt) &&
+		left.Generation == right.Generation &&
+		left.CreationToken == right.CreationToken &&
+		left.UnreviewedRemoteSource == right.UnreviewedRemoteSource
+}
+
+func sameOptionalTime(left *time.Time, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Equal(*right)
 }
 
 // Unregister removes a worktree entry by path.
@@ -260,7 +283,8 @@ func (r *Registry) UnregisterIfGeneration(
 	removed := false
 	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
 		for _, key := range matchingRegistryKeys(entries, path) {
-			if entries[key].Generation != generation {
+			if entries[key].CreationToken != "" ||
+				entries[key].Generation != generation {
 				continue
 			}
 			delete(entries, key)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -217,12 +217,11 @@ func (r *Registry) CompareAndSwap(
 	replaced := false
 	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
 		keys := matchingRegistryKeys(entries, path)
-		switch {
-		case expected == nil:
+		if expected == nil {
 			if len(keys) != 0 {
 				return false
 			}
-		default:
+		} else {
 			if len(keys) != 1 ||
 				!sameWorktreeEntry(entries[keys[0]], expected) {
 				return false

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -412,6 +412,8 @@ func TestRegistryCreationFinalizationPreservesReplacementOwner(t *testing.T) {
 		Branch:        "feature/original",
 		CreationToken: "original-creation",
 	}))
+	observed, ok := r.Get(path)
+	require.True(t, ok)
 	replacementExpiry := time.Now().Add(time.Hour)
 	require.NoError(t, r.Register(&WorktreeEntry{
 		Path:       path,
@@ -420,9 +422,9 @@ func TestRegistryCreationFinalizationPreservesReplacementOwner(t *testing.T) {
 		ExpiresAt:  &replacementExpiry,
 	}))
 
-	finalized, err := r.ReplaceIfCreationToken(
+	finalized, err := r.CompareAndSwap(
 		path,
-		"original-creation",
+		observed,
 		&WorktreeEntry{
 			Path:       path,
 			Branch:     "feature/original",
@@ -438,6 +440,64 @@ func TestRegistryCreationFinalizationPreservesReplacementOwner(t *testing.T) {
 	assert.Equal(t, "fedcba9876543210fedcba9876543210", entry.Generation)
 	require.NotNil(t, entry.ExpiresAt)
 	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
+}
+
+func TestRegistryCreationClaimRejectsChangedObservedEntry(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "reused-worktree")
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:       path,
+		Branch:     "feature/observed",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}))
+	observed, ok := r.Get(path)
+	require.True(t, ok)
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:       path,
+		Branch:     "feature/replacement",
+		Generation: "fedcba9876543210fedcba9876543210",
+	}))
+
+	claimed, err := r.CompareAndSwap(
+		path,
+		observed,
+		&WorktreeEntry{
+			Path:          path,
+			Branch:        "feature/claimant",
+			CreationToken: "claimant-creation",
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, claimed)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.Equal(t, "feature/replacement", entry.Branch)
+	assert.Equal(t, "fedcba9876543210fedcba9876543210", entry.Generation)
+}
+
+func TestRegistryLegacyCleanupPreservesProvisionalCreation(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "provisional-worktree")
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:          path,
+		Branch:        "feature/creating",
+		CreationToken: "active-creation",
+	}))
+
+	removed, err := r.UnregisterIfGeneration(path, "")
+
+	require.NoError(t, err)
+	assert.False(t, removed)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.Equal(t, "active-creation", entry.CreationToken)
 }
 
 func TestWorktreeEntry_ExpiresAt_JSONMarshal(t *testing.T) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -501,6 +501,54 @@ func TestRegistryCreationLockKeepsIdentityAfterDestinationAppears(
 	require.NoError(t, release())
 }
 
+func TestRegistryReclaimsAliasedAbandonedCreation(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	canonicalParent := t.TempDir()
+	aliasParent := filepath.Join(t.TempDir(), "alias")
+	require.NoError(t, os.Symlink(canonicalParent, aliasParent))
+	aliasPath := filepath.Join(aliasParent, "creating-worktree")
+	canonicalPath := filepath.Join(canonicalParent, "creating-worktree")
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:                   aliasPath,
+		Branch:                 "feature/abandoned",
+		CreationToken:          "abandoned-creation",
+		UnreviewedRemoteSource: true,
+	}))
+	replacement := &WorktreeEntry{
+		Path:                   canonicalPath,
+		Branch:                 "feature/recovered",
+		CreationToken:          "replacement-creation",
+		UnreviewedRemoteSource: true,
+	}
+
+	reclaimed, err := r.ReclaimCreation(
+		canonicalPath,
+		"abandoned-creation",
+		replacement,
+	)
+
+	require.NoError(t, err)
+	require.True(t, reclaimed)
+	assert.Len(t, r.List(), 1)
+	require.NoError(t, os.Mkdir(canonicalPath, 0755))
+	completed, err := r.CompleteCreation(
+		canonicalPath,
+		"replacement-creation",
+		"0123456789abcdef0123456789abcdef",
+	)
+	require.NoError(t, err)
+	require.True(t, completed)
+	assert.Len(t, r.List(), 1)
+	entry, ok := r.Get(aliasPath)
+	require.True(t, ok)
+	assert.Equal(t, canonicalPath, entry.Path)
+	assert.Empty(t, entry.CreationToken)
+	assert.Equal(t, "0123456789abcdef0123456789abcdef", entry.Generation)
+}
+
 func TestRegistryCreationFinalizationPreservesAcknowledgement(t *testing.T) {
 	r := &Registry{
 		entries: make(map[string]*WorktreeEntry),

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWorktreeEntry_IsExpired(t *testing.T) {
@@ -369,6 +372,33 @@ func TestRegistryConcurrentAcknowledgementPreservesOtherMutation(t *testing.T) {
 	if !reloaded.IsUnreviewedRemoteSource("/worktrees/new") {
 		t.Error("concurrent registration was lost")
 	}
+}
+
+func TestRegistryConditionalUnregisterPreservesReplacementGeneration(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "reused-worktree")
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:       path,
+		Generation: "0123456789abcdef0123456789abcdef",
+	}))
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:       path,
+		Generation: "fedcba9876543210fedcba9876543210",
+	}))
+
+	removed, err := r.UnregisterIfGeneration(
+		path,
+		"0123456789abcdef0123456789abcdef",
+	)
+
+	require.NoError(t, err)
+	assert.False(t, removed)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.Equal(t, "fedcba9876543210fedcba9876543210", entry.Generation)
 }
 
 func TestWorktreeEntry_ExpiresAt_JSONMarshal(t *testing.T) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -442,6 +442,157 @@ func TestRegistryCreationFinalizationPreservesReplacementOwner(t *testing.T) {
 	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
 }
 
+func TestRegistryCreationLockDistinguishesActiveAndAbandonedClaims(
+	t *testing.T,
+) {
+	registryPath := filepath.Join(t.TempDir(), "registry.json")
+	first := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    registryPath,
+	}
+	second := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    registryPath,
+	}
+	worktreePath := filepath.Join(t.TempDir(), "creating-worktree")
+
+	releaseFirst, acquired, err := first.AcquireCreation(worktreePath)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	_, acquired, err = second.AcquireCreation(worktreePath)
+	require.NoError(t, err)
+	assert.False(t, acquired)
+
+	require.NoError(t, releaseFirst())
+	releaseSecond, acquired, err := second.AcquireCreation(worktreePath)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NoError(t, releaseSecond())
+}
+
+func TestRegistryCreationLockKeepsIdentityAfterDestinationAppears(
+	t *testing.T,
+) {
+	registryPath := filepath.Join(t.TempDir(), "registry.json")
+	first := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    registryPath,
+	}
+	second := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    registryPath,
+	}
+	canonicalParent := t.TempDir()
+	aliasParent := filepath.Join(t.TempDir(), "alias")
+	require.NoError(t, os.Symlink(canonicalParent, aliasParent))
+	aliasPath := filepath.Join(aliasParent, "creating-worktree")
+	canonicalPath := filepath.Join(canonicalParent, "creating-worktree")
+
+	release, acquired, err := first.AcquireCreation(aliasPath)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NoError(t, os.Mkdir(canonicalPath, 0755))
+
+	_, acquired, err = second.AcquireCreation(canonicalPath)
+
+	require.NoError(t, err)
+	assert.False(t, acquired)
+	require.NoError(t, release())
+}
+
+func TestRegistryCreationFinalizationPreservesAcknowledgement(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "created-worktree")
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:                   path,
+		Branch:                 "feature/reviewed",
+		CreationToken:          "creation-owner",
+		UnreviewedRemoteSource: true,
+	}))
+	require.NoError(t, r.AcknowledgeRemoteSource(path))
+
+	finalized, err := r.CompleteCreation(
+		path,
+		"creation-owner",
+		"0123456789abcdef0123456789abcdef",
+	)
+
+	require.NoError(t, err)
+	require.True(t, finalized)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.Empty(t, entry.CreationToken)
+	assert.Equal(t, "0123456789abcdef0123456789abcdef", entry.Generation)
+	assert.False(t, entry.UnreviewedRemoteSource)
+}
+
+func TestRegistryCreationAbortPreservesReviewedState(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "reviewed-worktree")
+	previous := &WorktreeEntry{
+		Path:                   path,
+		Branch:                 "feature/reviewed",
+		UnreviewedRemoteSource: false,
+	}
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:                   path,
+		Branch:                 "feature/replacement",
+		CreationToken:          "creation-owner",
+		UnreviewedRemoteSource: true,
+	}))
+
+	aborted, err := r.AbortCreation(path, "creation-owner", previous)
+
+	require.NoError(t, err)
+	require.True(t, aborted)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.Equal(t, "feature/reviewed", entry.Branch)
+	assert.False(t, entry.UnreviewedRemoteSource)
+}
+
+func TestRegistryExpirationUpdatePreservesAcknowledgement(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "expiring-worktree")
+	generation := "0123456789abcdef0123456789abcdef"
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:                   path,
+		Branch:                 "feature/reviewed",
+		Generation:             generation,
+		UnreviewedRemoteSource: true,
+	}))
+	require.NoError(t, r.AcknowledgeRemoteSource(path))
+	expiresAt := time.Now().Add(time.Hour)
+
+	updated, err := r.SetExpirationIfGeneration(
+		path,
+		generation,
+		"https://github.com/example/repository.git",
+		"feature/reviewed",
+		&expiresAt,
+	)
+
+	require.NoError(t, err)
+	require.True(t, updated)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.False(t, entry.UnreviewedRemoteSource)
+	assert.Equal(t, generation, entry.Generation)
+	assert.Equal(t, "https://github.com/example/repository.git", entry.Repository)
+	require.NotNil(t, entry.ExpiresAt)
+	assert.True(t, entry.ExpiresAt.Equal(expiresAt))
+}
+
 func TestRegistryCreationClaimRejectsChangedObservedEntry(t *testing.T) {
 	r := &Registry{
 		entries: make(map[string]*WorktreeEntry),

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -401,6 +401,45 @@ func TestRegistryConditionalUnregisterPreservesReplacementGeneration(t *testing.
 	assert.Equal(t, "fedcba9876543210fedcba9876543210", entry.Generation)
 }
 
+func TestRegistryCreationFinalizationPreservesReplacementOwner(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "reused-worktree")
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:          path,
+		Branch:        "feature/original",
+		CreationToken: "original-creation",
+	}))
+	replacementExpiry := time.Now().Add(time.Hour)
+	require.NoError(t, r.Register(&WorktreeEntry{
+		Path:       path,
+		Branch:     "feature/replacement",
+		Generation: "fedcba9876543210fedcba9876543210",
+		ExpiresAt:  &replacementExpiry,
+	}))
+
+	finalized, err := r.ReplaceIfCreationToken(
+		path,
+		"original-creation",
+		&WorktreeEntry{
+			Path:       path,
+			Branch:     "feature/original",
+			Generation: "0123456789abcdef0123456789abcdef",
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, finalized)
+	entry, ok := r.Get(path)
+	require.True(t, ok)
+	assert.Equal(t, "feature/replacement", entry.Branch)
+	assert.Equal(t, "fedcba9876543210fedcba9876543210", entry.Generation)
+	require.NotNil(t, entry.ExpiresAt)
+	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
+}
+
 func TestWorktreeEntry_ExpiresAt_JSONMarshal(t *testing.T) {
 	// Test that ExpiresAt is omitted when nil (backwards compatibility)
 	entry := &WorktreeEntry{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -105,6 +106,19 @@ func CanonicalPath(path string) string {
 		path = resolved
 	}
 	return filepath.Clean(path)
+}
+
+// PathKey returns a canonical path key suitable for identity maps. Windows
+// filesystem paths compare case-insensitively and Git may vary separators.
+func PathKey(path string) string {
+	return platformPathKey(CanonicalPath(path), runtime.GOOS)
+}
+
+func platformPathKey(path string, goos string) string {
+	if goos == "windows" {
+		return strings.ToLower(strings.ReplaceAll(path, `\`, "/"))
+	}
+	return filepath.ToSlash(path)
 }
 
 // IsSameOrChildPath reports whether path names parent or a directory nested

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -118,7 +118,7 @@ func platformPathKey(path string, goos string) string {
 	if goos == "windows" {
 		return strings.ToLower(strings.ReplaceAll(path, `\`, "/"))
 	}
-	return filepath.ToSlash(path)
+	return path
 }
 
 // IsSameOrChildPath reports whether path names parent or a directory nested

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -366,3 +366,22 @@ func TestIsSameOrChildPathResolvesSymlinkedAncestor(t *testing.T) {
 		t.Errorf("a parent reached through a symlink must still contain %q", child)
 	}
 }
+
+func TestPlatformPathKeyFoldsWindowsCaseAndSeparators(t *testing.T) {
+	got := platformPathKey(`C:\Worktrees\Feature`, "windows")
+
+	if got != "c:/worktrees/feature" {
+		t.Fatalf("platformPathKey() = %q, want c:/worktrees/feature", got)
+	}
+}
+
+func TestPlatformPathKeyPreservesUnixBackslashes(t *testing.T) {
+	got := platformPathKey(`/worktrees/feature\name`, "darwin")
+
+	if got != `/worktrees/feature\name` {
+		t.Fatalf(
+			"platformPathKey() = %q, want /worktrees/feature\\name",
+			got,
+		)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -2,6 +2,8 @@
 package worktree
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,7 +59,11 @@ type Manager struct {
 
 type remoteSourceState interface {
 	Register(*registry.WorktreeEntry) error
-	Unregister(string) error
+	ReplaceIfCreationToken(
+		string,
+		string,
+		*registry.WorktreeEntry,
+	) (bool, error)
 	Get(string) (*registry.WorktreeEntry, bool)
 }
 
@@ -206,9 +212,14 @@ func (m *Manager) addUnreviewedSource(
 		return "", "", fmt.Errorf("open remote-source state: %w", err)
 	}
 	previous, existed := state.Get(path)
+	creationToken, err := newRegistryCreationToken()
+	if err != nil {
+		return "", "", err
+	}
 	entry := &registry.WorktreeEntry{
 		Branch:                 branch,
 		Path:                   path,
+		CreationToken:          creationToken,
 		UnreviewedRemoteSource: true,
 	}
 	if err := state.Register(entry); err != nil {
@@ -220,10 +231,18 @@ func (m *Manager) addUnreviewedSource(
 		var restoreErr error
 		switch {
 		case existed:
-			restoreErr = state.Register(previous)
+			_, restoreErr = state.ReplaceIfCreationToken(
+				path,
+				creationToken,
+				previous,
+			)
 		default:
 			if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-				restoreErr = state.Unregister(path)
+				_, restoreErr = state.ReplaceIfCreationToken(
+					path,
+					creationToken,
+					nil,
+				)
 			}
 		}
 		if restoreErr != nil {
@@ -236,13 +255,33 @@ func (m *Manager) addUnreviewedSource(
 		return "", "", err
 	}
 	entry.Generation = generation
-	if err := state.Register(entry); err != nil {
+	entry.CreationToken = ""
+	replaced, err := state.ReplaceIfCreationToken(
+		path,
+		creationToken,
+		entry,
+	)
+	if err != nil {
 		return "", "", fmt.Errorf(
 			"record remote-source worktree generation: %w",
 			err,
 		)
 	}
+	if !replaced {
+		return "", "", fmt.Errorf(
+			"worktree created at %s but registry ownership changed; preserved",
+			path,
+		)
+	}
 	return path, generation, nil
+}
+
+func newRegistryCreationToken() (string, error) {
+	tokenBytes := make([]byte, 16)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return "", fmt.Errorf("generate registry creation token: %w", err)
+	}
+	return hex.EncodeToString(tokenBytes), nil
 }
 
 // AddFromBase creates a new worktree with a branch from a specific base branch

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/registry"
@@ -27,7 +28,7 @@ type GitInterface interface {
 		protectedNames []string,
 	) error
 	AddWorktreeFromBase(path, branch, baseBranch string) error
-	RemoveWorktree(path string, force bool) error
+	RemoveWorktree(path string, force bool, ifCreatedAt *time.Time) error
 	DeleteBranch(branch string, force bool) error
 	PruneWorktrees() error
 	GetRepositoryName() (string, error)
@@ -182,14 +183,29 @@ func (m *Manager) AddFromBase(branch string, baseBranch string, customPath strin
 }
 
 // Remove deletes a worktree.
-func (m *Manager) Remove(path string, force bool) error {
-	return m.git.RemoveWorktree(path, force)
+func (m *Manager) Remove(
+	path string,
+	force bool,
+	ifCreatedAt *time.Time,
+) error {
+	return m.git.RemoveWorktree(path, force, ifCreatedAt)
 }
 
 // RemoveWithBranch deletes a worktree and optionally its branch.
-func (m *Manager) RemoveWithBranch(path string, branch string, forceWorktree bool, deleteBranch bool, forceBranch bool) error {
+func (m *Manager) RemoveWithBranch(
+	path string,
+	branch string,
+	forceWorktree bool,
+	deleteBranch bool,
+	forceBranch bool,
+	ifCreatedAt *time.Time,
+) error {
 	// First remove the worktree
-	if err := m.git.RemoveWorktree(path, forceWorktree); err != nil {
+	if err := m.git.RemoveWorktree(
+		path,
+		forceWorktree,
+		ifCreatedAt,
+	); err != nil {
 		return err
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -4,6 +4,7 @@ package worktree
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -306,34 +307,39 @@ func (m *Manager) addUnreviewedSource(
 
 	generation, err := add()
 	if err != nil {
-		recoveredGeneration, found, recoveryErr :=
-			m.registeredGeneration(path)
 		var cleaned bool
 		var cleanupErr error
-		switch {
-		case recoveryErr == nil && found:
-			cleaned, cleanupErr = state.CompleteCreation(
-				path,
-				creationToken,
-				recoveredGeneration,
-			)
-		case existed && !reclaimedAbandoned:
+		if errorCreatedWorktree(err) {
+			recoveredGeneration, found, recoveryErr :=
+				m.registeredGeneration(path)
+			if recoveryErr == nil && found {
+				cleaned, cleanupErr = state.CompleteCreation(
+					path,
+					creationToken,
+					recoveredGeneration,
+				)
+			} else {
+				cleaned, cleanupErr = state.CompleteCreation(
+					path,
+					creationToken,
+					"",
+				)
+			}
+		} else {
+			restore := previous
+			if reclaimedAbandoned {
+				if pathExists(path) {
+					finalized := *previous
+					finalized.CreationToken = ""
+					restore = &finalized
+				} else {
+					restore = nil
+				}
+			}
 			cleaned, cleanupErr = state.AbortCreation(
 				path,
 				creationToken,
-				previous,
-			)
-		case pathExists(path):
-			cleaned, cleanupErr = state.CompleteCreation(
-				path,
-				creationToken,
-				"",
-			)
-		default:
-			cleaned, cleanupErr = state.AbortCreation(
-				path,
-				creationToken,
-				previous,
+				restore,
 			)
 		}
 		if cleanupErr != nil {
@@ -370,6 +376,13 @@ func (m *Manager) addUnreviewedSource(
 		)
 	}
 	return path, generation, nil
+}
+
+func errorCreatedWorktree(err error) bool {
+	var created interface {
+		WorktreeCreated() bool
+	}
+	return errors.As(err, &created) && created.WorktreeCreated()
 }
 
 func (m *Manager) registeredGeneration(

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -59,12 +59,24 @@ type Manager struct {
 }
 
 type remoteSourceState interface {
+	AbortCreation(
+		string,
+		string,
+		*registry.WorktreeEntry,
+	) (bool, error)
+	AcquireCreation(string) (func() error, bool, error)
 	CompareAndSwap(
 		string,
 		*registry.WorktreeEntry,
 		*registry.WorktreeEntry,
 	) (bool, error)
+	CompleteCreation(string, string, string) (bool, error)
 	Get(string) (*registry.WorktreeEntry, bool)
+	ReclaimCreation(
+		string,
+		string,
+		*registry.WorktreeEntry,
+	) (bool, error)
 }
 
 // AddOptions controls optional behavior for creating a worktree.
@@ -206,18 +218,31 @@ func (m *Manager) addUnreviewedSource(
 	path,
 	branch string,
 	add func() (string, error),
-) (string, string, error) {
+) (resultPath string, resultGeneration string, resultErr error) {
 	state, err := m.openRemoteSourceState()
 	if err != nil {
 		return "", "", fmt.Errorf("open remote-source state: %w", err)
 	}
-	previous, existed := state.Get(path)
-	if existed && previous.CreationToken != "" {
+	release, acquired, err := state.AcquireCreation(path)
+	if err != nil {
+		return "", "", fmt.Errorf("lock remote-source creation: %w", err)
+	}
+	if !acquired {
 		return "", "", fmt.Errorf(
 			"worktree creation in progress for %s",
 			path,
 		)
 	}
+	defer func() {
+		if err := release(); err != nil && resultErr == nil {
+			resultErr = fmt.Errorf(
+				"release remote-source creation lock: %w",
+				err,
+			)
+		}
+	}()
+
+	previous, existed := state.Get(path)
 	creationToken, err := newRegistryCreationToken()
 	if err != nil {
 		return "", "", err
@@ -229,11 +254,46 @@ func (m *Manager) addUnreviewedSource(
 		CreationToken:          creationToken,
 		UnreviewedRemoteSource: true,
 	}
-	var expected *registry.WorktreeEntry
-	if existed {
-		expected = previous
+	var claimed bool
+	reclaimedAbandoned := false
+	if existed && previous.CreationToken != "" {
+		generation, found, recoveryErr := m.registeredGeneration(path)
+		if recoveryErr == nil && found {
+			completed, completeErr := state.CompleteCreation(
+				path,
+				previous.CreationToken,
+				generation,
+			)
+			if completeErr != nil {
+				return "", "", fmt.Errorf(
+					"recover completed remote-source worktree: %w",
+					completeErr,
+				)
+			}
+			if !completed {
+				return "", "", fmt.Errorf(
+					"registry ownership changed for %s; retry creation",
+					path,
+				)
+			}
+			return "", "", fmt.Errorf(
+				"recovered completed remote-source worktree at %s; retry after reviewing it",
+				path,
+			)
+		}
+		claimed, err = state.ReclaimCreation(
+			path,
+			previous.CreationToken,
+			entry,
+		)
+		reclaimedAbandoned = claimed
+	} else {
+		var expected *registry.WorktreeEntry
+		if existed {
+			expected = previous
+		}
+		claimed, err = state.CompareAndSwap(path, expected, entry)
 	}
-	claimed, err := state.CompareAndSwap(path, expected, entry)
 	if err != nil {
 		return "", "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
 	}
@@ -246,39 +306,56 @@ func (m *Manager) addUnreviewedSource(
 
 	generation, err := add()
 	if err != nil {
-		var restoreErr error
+		recoveredGeneration, found, recoveryErr :=
+			m.registeredGeneration(path)
+		var cleaned bool
+		var cleanupErr error
 		switch {
-		case existed:
-			_, restoreErr = state.CompareAndSwap(
+		case recoveryErr == nil && found:
+			cleaned, cleanupErr = state.CompleteCreation(
 				path,
-				entry,
+				creationToken,
+				recoveredGeneration,
+			)
+		case existed && !reclaimedAbandoned:
+			cleaned, cleanupErr = state.AbortCreation(
+				path,
+				creationToken,
 				previous,
 			)
+		case pathExists(path):
+			cleaned, cleanupErr = state.CompleteCreation(
+				path,
+				creationToken,
+				"",
+			)
 		default:
-			if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-				_, restoreErr = state.CompareAndSwap(
-					path,
-					entry,
-					nil,
-				)
-			}
+			cleaned, cleanupErr = state.AbortCreation(
+				path,
+				creationToken,
+				previous,
+			)
 		}
-		if restoreErr != nil {
+		if cleanupErr != nil {
 			return "", "", fmt.Errorf(
-				"%w (failed to restore remote-source state: %v)",
+				"%w (failed to finalize remote-source state: %v)",
 				err,
-				restoreErr,
+				cleanupErr,
+			)
+		}
+		if !cleaned {
+			return "", "", fmt.Errorf(
+				"%w (registry ownership changed for %s; preserved)",
+				err,
+				path,
 			)
 		}
 		return "", "", err
 	}
-	completed := *entry
-	completed.Generation = generation
-	completed.CreationToken = ""
-	replaced, err := state.CompareAndSwap(
+	replaced, err := state.CompleteCreation(
 		path,
-		entry,
-		&completed,
+		creationToken,
+		generation,
 	)
 	if err != nil {
 		return "", "", fmt.Errorf(
@@ -293,6 +370,34 @@ func (m *Manager) addUnreviewedSource(
 		)
 	}
 	return path, generation, nil
+}
+
+func (m *Manager) registeredGeneration(
+	path string,
+) (string, bool, error) {
+	worktrees, err := m.git.ListWorktrees()
+	if err != nil {
+		return "", false, err
+	}
+	pathKey := utils.PathKey(path)
+	for _, worktree := range worktrees {
+		if utils.PathKey(worktree.Path) != pathKey {
+			continue
+		}
+		if worktree.Generation == "" {
+			return "", false, fmt.Errorf(
+				"worktree generation unavailable for %s",
+				path,
+			)
+		}
+		return worktree.Generation, true, nil
+	}
+	return "", false, nil
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func newRegistryCreationToken() (string, error) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -21,11 +21,23 @@ import (
 type GitInterface interface {
 	ListWorktrees() ([]models.Worktree, error)
 	AddWorktree(path, branch string, createBranch bool) error
+	AddWorktreeWithGeneration(
+		path, branch string,
+		createBranch bool,
+	) (string, error)
 	AddWorktreeExisting(path, branch string, protectedNames []string) error
+	AddWorktreeExistingWithGeneration(
+		path, branch string,
+		protectedNames []string,
+	) (string, error)
 	AddWorktreeTracking(
 		path, branch, remoteBranch string,
 		protectedNames []string,
 	) error
+	AddWorktreeTrackingWithGeneration(
+		path, branch, remoteBranch string,
+		protectedNames []string,
+	) (string, error)
 	AddWorktreeFromBase(path, branch, baseBranch string) error
 	RemoveWorktree(path string, force bool, ifGeneration string) error
 	DeleteBranch(branch string, force bool) error
@@ -91,18 +103,74 @@ func (m *Manager) AddWithOptions(branch string, customPath string, createBranch 
 	return path, nil
 }
 
+// AddWithGeneration creates a worktree and returns the durable generation
+// captured before creation synchronization is released.
+func (m *Manager) AddWithGeneration(
+	branch string,
+	customPath string,
+	createBranch bool,
+	opts AddOptions,
+) (string, string, error) {
+	if !createBranch {
+		return m.addExistingWithGeneration(branch, customPath)
+	}
+
+	path, err := m.preparePath(customPath, branch, nil)
+	if err != nil {
+		return "", "", err
+	}
+	generation, err := m.git.AddWorktreeWithGeneration(
+		path,
+		branch,
+		createBranch,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	if !opts.SkipSetup {
+		m.runPostWorktreeSetup(branch, path)
+	}
+	return path, generation, nil
+}
+
 func (m *Manager) addExisting(branch, customPath string) (string, error) {
 	path, err := m.preparePath(customPath, branch, nil)
 	if err != nil {
 		return "", err
 	}
-	return m.addUnreviewedSource(path, branch, func() error {
-		return m.git.AddWorktreeExisting(
-			path,
-			branch,
-			credentials.ProtectedNames(m.config),
-		)
-	})
+	path, _, err = m.addUnreviewedSource(
+		path,
+		branch,
+		func() (string, error) {
+			return "", m.git.AddWorktreeExisting(
+				path,
+				branch,
+				credentials.ProtectedNames(m.config),
+			)
+		},
+	)
+	return path, err
+}
+
+func (m *Manager) addExistingWithGeneration(
+	branch,
+	customPath string,
+) (string, string, error) {
+	path, err := m.preparePath(customPath, branch, nil)
+	if err != nil {
+		return "", "", err
+	}
+	return m.addUnreviewedSource(
+		path,
+		branch,
+		func() (string, error) {
+			return m.git.AddWorktreeExistingWithGeneration(
+				path,
+				branch,
+				credentials.ProtectedNames(m.config),
+			)
+		},
+	)
 }
 
 // AddTracking creates a worktree on a local branch that tracks remoteBranch.
@@ -114,23 +182,54 @@ func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, 
 		return "", err
 	}
 
-	return m.addUnreviewedSource(path, branch, func() error {
-		return m.git.AddWorktreeTracking(
-			path,
-			branch,
-			remoteBranch,
-			credentials.ProtectedNames(m.config),
-		)
-	})
+	path, _, err = m.addUnreviewedSource(
+		path,
+		branch,
+		func() (string, error) {
+			return "", m.git.AddWorktreeTracking(
+				path,
+				branch,
+				remoteBranch,
+				credentials.ProtectedNames(m.config),
+			)
+		},
+	)
+	return path, err
+}
+
+// AddTrackingWithGeneration creates a tracking worktree and returns the
+// generation captured before its mutation lock is released.
+func (m *Manager) AddTrackingWithGeneration(
+	branch,
+	remoteBranch,
+	customPath string,
+) (string, string, error) {
+	path, err := m.preparePath(customPath, branch, nil)
+	if err != nil {
+		return "", "", err
+	}
+	return m.addUnreviewedSource(
+		path,
+		branch,
+		func() (string, error) {
+			return m.git.AddWorktreeTrackingWithGeneration(
+				path,
+				branch,
+				remoteBranch,
+				credentials.ProtectedNames(m.config),
+			)
+		},
+	)
 }
 
 func (m *Manager) addUnreviewedSource(
-	path, branch string,
-	add func() error,
-) (string, error) {
+	path,
+	branch string,
+	add func() (string, error),
+) (string, string, error) {
 	state, err := m.openRemoteSourceState()
 	if err != nil {
-		return "", fmt.Errorf("open remote-source state: %w", err)
+		return "", "", fmt.Errorf("open remote-source state: %w", err)
 	}
 	previous, existed := state.Get(path)
 	entry := &registry.WorktreeEntry{
@@ -139,10 +238,11 @@ func (m *Manager) addUnreviewedSource(
 		UnreviewedRemoteSource: true,
 	}
 	if err := state.Register(entry); err != nil {
-		return "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
+		return "", "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
 	}
 
-	if err := add(); err != nil {
+	generation, err := add()
+	if err != nil {
 		var restoreErr error
 		switch {
 		case existed:
@@ -153,16 +253,15 @@ func (m *Manager) addUnreviewedSource(
 			}
 		}
 		if restoreErr != nil {
-			return "", fmt.Errorf(
+			return "", "", fmt.Errorf(
 				"%w (failed to restore remote-source state: %v)",
 				err,
 				restoreErr,
 			)
 		}
-		return "", err
+		return "", "", err
 	}
-
-	return path, nil
+	return path, generation, nil
 }
 
 // AddFromBase creates a new worktree with a branch from a specific base branch

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/registry"
@@ -28,7 +27,7 @@ type GitInterface interface {
 		protectedNames []string,
 	) error
 	AddWorktreeFromBase(path, branch, baseBranch string) error
-	RemoveWorktree(path string, force bool, ifCreatedAt *time.Time) error
+	RemoveWorktree(path string, force bool, ifGeneration string) error
 	DeleteBranch(branch string, force bool) error
 	PruneWorktrees() error
 	GetRepositoryName() (string, error)
@@ -186,9 +185,9 @@ func (m *Manager) AddFromBase(branch string, baseBranch string, customPath strin
 func (m *Manager) Remove(
 	path string,
 	force bool,
-	ifCreatedAt *time.Time,
+	ifGeneration string,
 ) error {
-	return m.git.RemoveWorktree(path, force, ifCreatedAt)
+	return m.git.RemoveWorktree(path, force, ifGeneration)
 }
 
 // RemoveWithBranch deletes a worktree and optionally its branch.
@@ -198,13 +197,13 @@ func (m *Manager) RemoveWithBranch(
 	forceWorktree bool,
 	deleteBranch bool,
 	forceBranch bool,
-	ifCreatedAt *time.Time,
+	ifGeneration string,
 ) error {
 	// First remove the worktree
 	if err := m.git.RemoveWorktree(
 		path,
 		forceWorktree,
-		ifCreatedAt,
+		ifGeneration,
 	); err != nil {
 		return err
 	}
@@ -255,13 +254,22 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 		return nil, err
 	}
 
-	var matches []models.Worktree
 	canonicalPattern := utils.CanonicalPath(pattern)
+	var exactMatches []models.Worktree
+	for _, wt := range worktrees {
+		if utils.CanonicalPath(wt.Path) == canonicalPattern {
+			exactMatches = append(exactMatches, wt)
+		}
+	}
+	if len(exactMatches) > 0 {
+		return exactMatches, nil
+	}
+
+	var matches []models.Worktree
 	pattern = strings.ToLower(pattern)
 	pathPattern := strings.ToLower(filepath.ToSlash(pattern))
 	for _, wt := range worktrees {
 		if strings.Contains(strings.ToLower(wt.Branch), pattern) ||
-			utils.CanonicalPath(wt.Path) == canonicalPattern ||
 			strings.Contains(
 				strings.ToLower(filepath.ToSlash(wt.Path)),
 				pathPattern,

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -134,21 +134,7 @@ func (m *Manager) AddWithGeneration(
 }
 
 func (m *Manager) addExisting(branch, customPath string) (string, error) {
-	path, err := m.preparePath(customPath, branch, nil)
-	if err != nil {
-		return "", err
-	}
-	path, _, err = m.addUnreviewedSource(
-		path,
-		branch,
-		func() (string, error) {
-			return "", m.git.AddWorktreeExisting(
-				path,
-				branch,
-				credentials.ProtectedNames(m.config),
-			)
-		},
-	)
+	path, _, err := m.addExistingWithGeneration(branch, customPath)
 	return path, err
 }
 
@@ -177,22 +163,10 @@ func (m *Manager) addExistingWithGeneration(
 // Repository setup is intentionally deferred: the remote checkout is
 // untrusted until the user has reviewed it.
 func (m *Manager) AddTracking(branch, remoteBranch, customPath string) (string, error) {
-	path, err := m.preparePath(customPath, branch, nil)
-	if err != nil {
-		return "", err
-	}
-
-	path, _, err = m.addUnreviewedSource(
-		path,
+	path, _, err := m.AddTrackingWithGeneration(
 		branch,
-		func() (string, error) {
-			return "", m.git.AddWorktreeTracking(
-				path,
-				branch,
-				remoteBranch,
-				credentials.ProtectedNames(m.config),
-			)
-		},
+		remoteBranch,
+		customPath,
 	)
 	return path, err
 }
@@ -260,6 +234,13 @@ func (m *Manager) addUnreviewedSource(
 			)
 		}
 		return "", "", err
+	}
+	entry.Generation = generation
+	if err := state.Register(entry); err != nil {
+		return "", "", fmt.Errorf(
+			"record remote-source worktree generation: %w",
+			err,
+		)
 	}
 	return path, generation, nil
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -212,6 +212,12 @@ func (m *Manager) addUnreviewedSource(
 		return "", "", fmt.Errorf("open remote-source state: %w", err)
 	}
 	previous, existed := state.Get(path)
+	if existed && previous.CreationToken != "" {
+		return "", "", fmt.Errorf(
+			"worktree creation in progress for %s",
+			path,
+		)
+	}
 	creationToken, err := newRegistryCreationToken()
 	if err != nil {
 		return "", "", err

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -256,10 +256,12 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 	}
 
 	var matches []models.Worktree
+	canonicalPattern := utils.CanonicalPath(pattern)
 	pattern = strings.ToLower(pattern)
 	pathPattern := strings.ToLower(filepath.ToSlash(pattern))
 	for _, wt := range worktrees {
 		if strings.Contains(strings.ToLower(wt.Branch), pattern) ||
+			utils.CanonicalPath(wt.Path) == canonicalPattern ||
 			strings.Contains(
 				strings.ToLower(filepath.ToSlash(wt.Path)),
 				pathPattern,

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -264,17 +264,6 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 		return exactBranchMatches, nil
 	}
 
-	lowerPattern := strings.ToLower(pattern)
-	var branchMatches []models.Worktree
-	for _, wt := range worktrees {
-		if strings.Contains(strings.ToLower(wt.Branch), lowerPattern) {
-			branchMatches = append(branchMatches, wt)
-		}
-	}
-	if len(branchMatches) > 0 {
-		return branchMatches, nil
-	}
-
 	if filepath.IsAbs(pattern) {
 		canonicalPattern := utils.CanonicalPath(pattern)
 		var exactPathMatches []models.Worktree
@@ -286,6 +275,17 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 		if len(exactPathMatches) > 0 {
 			return exactPathMatches, nil
 		}
+	}
+
+	lowerPattern := strings.ToLower(pattern)
+	var branchMatches []models.Worktree
+	for _, wt := range worktrees {
+		if strings.Contains(strings.ToLower(wt.Branch), lowerPattern) {
+			branchMatches = append(branchMatches, wt)
+		}
+	}
+	if len(branchMatches) > 0 {
+		return branchMatches, nil
 	}
 
 	pathPattern := strings.ToLower(filepath.ToSlash(pattern))

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -345,10 +345,10 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 	}
 
 	if filepath.IsAbs(pattern) {
-		canonicalPattern := utils.CanonicalPath(pattern)
+		canonicalPattern := utils.PathKey(pattern)
 		var exactPathMatches []models.Worktree
 		for _, wt := range worktrees {
-			if utils.CanonicalPath(wt.Path) == canonicalPattern {
+			if utils.PathKey(wt.Path) == canonicalPattern {
 				exactPathMatches = append(exactPathMatches, wt)
 			}
 		}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -257,9 +257,13 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 
 	var matches []models.Worktree
 	pattern = strings.ToLower(pattern)
+	pathPattern := strings.ToLower(filepath.ToSlash(pattern))
 	for _, wt := range worktrees {
 		if strings.Contains(strings.ToLower(wt.Branch), pattern) ||
-			strings.Contains(strings.ToLower(wt.Path), pattern) {
+			strings.Contains(
+				strings.ToLower(filepath.ToSlash(wt.Path)),
+				pathPattern,
+			) {
 			matches = append(matches, wt)
 		}
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/registry"
@@ -58,10 +59,9 @@ type Manager struct {
 }
 
 type remoteSourceState interface {
-	Register(*registry.WorktreeEntry) error
-	ReplaceIfCreationToken(
+	CompareAndSwap(
 		string,
-		string,
+		*registry.WorktreeEntry,
 		*registry.WorktreeEntry,
 	) (bool, error)
 	Get(string) (*registry.WorktreeEntry, bool)
@@ -219,11 +219,23 @@ func (m *Manager) addUnreviewedSource(
 	entry := &registry.WorktreeEntry{
 		Branch:                 branch,
 		Path:                   path,
+		RegisteredAt:           time.Now(),
 		CreationToken:          creationToken,
 		UnreviewedRemoteSource: true,
 	}
-	if err := state.Register(entry); err != nil {
+	var expected *registry.WorktreeEntry
+	if existed {
+		expected = previous
+	}
+	claimed, err := state.CompareAndSwap(path, expected, entry)
+	if err != nil {
 		return "", "", fmt.Errorf("mark remote-source worktree unreviewed: %w", err)
+	}
+	if !claimed {
+		return "", "", fmt.Errorf(
+			"registry ownership changed for %s; retry creation",
+			path,
+		)
 	}
 
 	generation, err := add()
@@ -231,16 +243,16 @@ func (m *Manager) addUnreviewedSource(
 		var restoreErr error
 		switch {
 		case existed:
-			_, restoreErr = state.ReplaceIfCreationToken(
+			_, restoreErr = state.CompareAndSwap(
 				path,
-				creationToken,
+				entry,
 				previous,
 			)
 		default:
 			if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-				_, restoreErr = state.ReplaceIfCreationToken(
+				_, restoreErr = state.CompareAndSwap(
 					path,
-					creationToken,
+					entry,
 					nil,
 				)
 			}
@@ -254,12 +266,13 @@ func (m *Manager) addUnreviewedSource(
 		}
 		return "", "", err
 	}
-	entry.Generation = generation
-	entry.CreationToken = ""
-	replaced, err := state.ReplaceIfCreationToken(
+	completed := *entry
+	completed.Generation = generation
+	completed.CreationToken = ""
+	replaced, err := state.CompareAndSwap(
 		path,
-		creationToken,
 		entry,
+		&completed,
 	)
 	if err != nil {
 		return "", "", fmt.Errorf(

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -254,31 +254,51 @@ func (m *Manager) GetMatchingWorktrees(pattern string) ([]models.Worktree, error
 		return nil, err
 	}
 
-	canonicalPattern := utils.CanonicalPath(pattern)
-	var exactMatches []models.Worktree
+	var exactBranchMatches []models.Worktree
 	for _, wt := range worktrees {
-		if utils.CanonicalPath(wt.Path) == canonicalPattern {
-			exactMatches = append(exactMatches, wt)
+		if strings.EqualFold(wt.Branch, pattern) {
+			exactBranchMatches = append(exactBranchMatches, wt)
 		}
 	}
-	if len(exactMatches) > 0 {
-		return exactMatches, nil
+	if len(exactBranchMatches) > 0 {
+		return exactBranchMatches, nil
 	}
 
-	var matches []models.Worktree
-	pattern = strings.ToLower(pattern)
+	lowerPattern := strings.ToLower(pattern)
+	var branchMatches []models.Worktree
+	for _, wt := range worktrees {
+		if strings.Contains(strings.ToLower(wt.Branch), lowerPattern) {
+			branchMatches = append(branchMatches, wt)
+		}
+	}
+	if len(branchMatches) > 0 {
+		return branchMatches, nil
+	}
+
+	if filepath.IsAbs(pattern) {
+		canonicalPattern := utils.CanonicalPath(pattern)
+		var exactPathMatches []models.Worktree
+		for _, wt := range worktrees {
+			if utils.CanonicalPath(wt.Path) == canonicalPattern {
+				exactPathMatches = append(exactPathMatches, wt)
+			}
+		}
+		if len(exactPathMatches) > 0 {
+			return exactPathMatches, nil
+		}
+	}
+
 	pathPattern := strings.ToLower(filepath.ToSlash(pattern))
+	var pathMatches []models.Worktree
 	for _, wt := range worktrees {
-		if strings.Contains(strings.ToLower(wt.Branch), pattern) ||
-			strings.Contains(
-				strings.ToLower(filepath.ToSlash(wt.Path)),
-				pathPattern,
-			) {
-			matches = append(matches, wt)
+		if strings.Contains(
+			strings.ToLower(filepath.ToSlash(wt.Path)),
+			pathPattern,
+		) {
+			pathMatches = append(pathMatches, wt)
 		}
 	}
-
-	return matches, nil
+	return pathMatches, nil
 }
 
 // ValidateWorktreePath checks if a path can be used for a new worktree.

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -46,6 +46,7 @@ type GitInterface interface {
 	RemoveWorktree(path string, force bool, ifGeneration string) error
 	DeleteBranch(branch string, force bool) error
 	PruneWorktrees() error
+	ReadWorktreeGeneration(path string) (string, error)
 	GetRepositoryName() (string, error)
 	GetRecentCommits(path string, limit int) ([]models.CommitInfo, error)
 	GetRepositoryURL() (string, error)
@@ -388,24 +389,11 @@ func errorCreatedWorktree(err error) bool {
 func (m *Manager) registeredGeneration(
 	path string,
 ) (string, bool, error) {
-	worktrees, err := m.git.ListWorktrees()
+	generation, err := m.git.ReadWorktreeGeneration(path)
 	if err != nil {
 		return "", false, err
 	}
-	pathKey := utils.PathKey(path)
-	for _, worktree := range worktrees {
-		if utils.PathKey(worktree.Path) != pathKey {
-			continue
-		}
-		if worktree.Generation == "" {
-			return "", false, fmt.Errorf(
-				"worktree generation unavailable for %s",
-				path,
-			)
-		}
-		return worktree.Generation, true, nil
-	}
-	return "", false, nil
+	return generation, true, nil
 }
 
 func pathExists(path string) bool {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -82,6 +82,17 @@ func (m *mockGit) AddWorktree(path, branch string, createBranch bool) error {
 	return nil
 }
 
+func (m *mockGit) AddWorktreeWithGeneration(
+	path,
+	branch string,
+	createBranch bool,
+) (string, error) {
+	if err := m.AddWorktree(path, branch, createBranch); err != nil {
+		return "", err
+	}
+	return "0123456789abcdef0123456789abcdef", nil
+}
+
 func (m *mockGit) AddWorktreeTracking(
 	path, branch, remoteBranch string,
 	protectedNames []string,
@@ -98,6 +109,23 @@ func (m *mockGit) AddWorktreeTracking(
 	return nil
 }
 
+func (m *mockGit) AddWorktreeTrackingWithGeneration(
+	path,
+	branch,
+	remoteBranch string,
+	protectedNames []string,
+) (string, error) {
+	if err := m.AddWorktreeTracking(
+		path,
+		branch,
+		remoteBranch,
+		protectedNames,
+	); err != nil {
+		return "", err
+	}
+	return "0123456789abcdef0123456789abcdef", nil
+}
+
 func (m *mockGit) AddWorktreeExisting(
 	path, branch string,
 	protectedNames []string,
@@ -112,6 +140,17 @@ func (m *mockGit) AddWorktreeExisting(
 		Branch: branch,
 	})
 	return nil
+}
+
+func (m *mockGit) AddWorktreeExistingWithGeneration(
+	path,
+	branch string,
+	protectedNames []string,
+) (string, error) {
+	if err := m.AddWorktreeExisting(path, branch, protectedNames); err != nil {
+		return "", err
+	}
+	return "0123456789abcdef0123456789abcdef", nil
 }
 
 func (m *mockGit) RemoveWorktree(

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -35,7 +35,6 @@ type mockGit struct {
 	trackingSource    string
 	existingSource    string
 	protectedNames    []string
-	initializeOnList  bool
 }
 
 type mockRemoteSourceState struct {
@@ -150,14 +149,6 @@ func (m *mockRemoteSourceState) AbortCreation(
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
 	if m.listError != nil {
 		return nil, m.listError
-	}
-	if m.initializeOnList {
-		for i := range m.worktrees {
-			if m.worktrees[i].Generation == "" {
-				m.worktrees[i].Generation =
-					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-			}
-		}
 	}
 	return m.worktrees, nil
 }
@@ -708,10 +699,11 @@ func TestManagerAddTrackingFinalizesAbandonedCompletedCheckout(t *testing.T) {
 	assert.True(t, entry.UnreviewedRemoteSource)
 }
 
-func TestManagerAddTrackingDoesNotInitializeAbandonedCheckoutDuringRecovery(
+func TestManagerAddTrackingPreservesAbandonedGenerationlessCheckout(
 	t *testing.T,
 ) {
 	worktreePath := filepath.Join(t.TempDir(), "incomplete-worktree")
+	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
 	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
 		worktreePath: {
 			Path:                   worktreePath,
@@ -721,7 +713,7 @@ func TestManagerAddTrackingDoesNotInitializeAbandonedCheckoutDuringRecovery(
 		},
 	}}
 	mockG := &mockGit{
-		initializeOnList: true,
+		addError: errors.New("already registered without a generation"),
 		worktrees: []models.Worktree{{
 			Path:   worktreePath,
 			Branch: "feature/incomplete",
@@ -732,23 +724,20 @@ func TestManagerAddTrackingDoesNotInitializeAbandonedCheckoutDuringRecovery(
 		return state, nil
 	}
 
-	path, err := manager.AddTracking(
+	_, err := manager.AddTracking(
 		"feature/incomplete",
 		"refs/remotes/origin/feature/incomplete",
 		worktreePath,
 	)
 
-	require.NoError(t, err)
-	assert.Equal(t, worktreePath, path)
-	assert.Equal(
-		t,
-		"refs/remotes/origin/feature/incomplete",
-		mockG.trackingSource,
-	)
+	require.ErrorContains(t, err, "already registered without a generation")
+	assert.Empty(t, mockG.trackingSource)
 	entry, ok := state.entries[worktreePath]
 	require.True(t, ok)
 	assert.Empty(t, entry.CreationToken)
-	assert.Equal(t, "0123456789abcdef0123456789abcdef", entry.Generation)
+	assert.Empty(t, entry.Generation)
+	assert.Equal(t, "feature/incomplete", entry.Branch)
+	assert.True(t, entry.UnreviewedRemoteSource)
 }
 
 func TestManagerAddTrackingDoesNotExpandRemoteBranchEnvironmentReferences(

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -492,6 +492,34 @@ func TestManagerAddTrackingRetainsMarkerWhenFailedCheckoutPathExists(t *testing.
 	assert.True(t, entry.UnreviewedRemoteSource)
 }
 
+func TestManagerAddTrackingRejectsActiveCreationMarker(t *testing.T) {
+	worktreePath := filepath.Join(t.TempDir(), "creating-worktree")
+	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
+		worktreePath: {
+			Path:          worktreePath,
+			Branch:        "feature/creating",
+			CreationToken: "active-creation",
+		},
+	}}
+	mockG := &mockGit{}
+	manager := New(mockG, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	_, err := manager.AddTracking(
+		"feature/competing",
+		"refs/remotes/origin/feature/competing",
+		worktreePath,
+	)
+
+	require.ErrorContains(t, err, "worktree creation in progress")
+	assert.Empty(t, mockG.worktrees)
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok)
+	assert.Equal(t, "active-creation", entry.CreationToken)
+}
+
 func TestManagerAddTrackingDoesNotExpandRemoteBranchEnvironmentReferences(
 	t *testing.T,
 ) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -48,9 +48,21 @@ func (m *mockRemoteSourceState) Register(entry *registry.WorktreeEntry) error {
 	return nil
 }
 
-func (m *mockRemoteSourceState) Unregister(path string) error {
+func (m *mockRemoteSourceState) ReplaceIfCreationToken(
+	path string,
+	creationToken string,
+	replacement *registry.WorktreeEntry,
+) (bool, error) {
+	entry, ok := m.entries[path]
+	if !ok || entry.CreationToken != creationToken {
+		return false, nil
+	}
 	delete(m.entries, path)
-	return nil
+	if replacement != nil {
+		copied := *replacement
+		m.entries[replacement.Path] = &copied
+	}
+	return true, nil
 }
 
 func (m *mockRemoteSourceState) Get(

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -681,6 +681,28 @@ func TestManagerGetMatchingWorktreesPrefersExactPath(t *testing.T) {
 	assert.Equal(t, "feature/task", matches[0].Branch)
 }
 
+func TestManagerGetMatchingWorktreesPrefersAbsolutePathOverBranchSubstring(
+	t *testing.T,
+) {
+	exactPath := filepath.Join(t.TempDir(), "task")
+	unrelatedPath := filepath.Join(t.TempDir(), "unrelated")
+	m := New(&mockGit{
+		worktrees: []models.Worktree{
+			{Path: exactPath, Branch: "feature/task"},
+			{
+				Path:   unrelatedPath,
+				Branch: "topic" + filepath.ToSlash(exactPath),
+			},
+		},
+	}, &models.Config{})
+
+	matches, err := m.GetMatchingWorktrees(exactPath)
+
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, exactPath, matches[0].Path)
+}
+
 func TestManagerGetMatchingWorktreesPrefersBranchOverRelativeSymlink(t *testing.T) {
 	currentPath := t.TempDir()
 	mainPath := t.TempDir()

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -37,7 +37,8 @@ type mockGit struct {
 }
 
 type mockRemoteSourceState struct {
-	entries map[string]*registry.WorktreeEntry
+	entries        map[string]*registry.WorktreeEntry
+	creationActive bool
 }
 
 func (m *mockRemoteSourceState) CompareAndSwap(
@@ -73,6 +74,65 @@ func (m *mockRemoteSourceState) Get(
 	}
 	copied := *entry
 	return &copied, true
+}
+
+func (m *mockRemoteSourceState) AcquireCreation(
+	_ string,
+) (func() error, bool, error) {
+	if m.creationActive {
+		return nil, false, nil
+	}
+	m.creationActive = true
+	return func() error {
+		m.creationActive = false
+		return nil
+	}, true, nil
+}
+
+func (m *mockRemoteSourceState) CompleteCreation(
+	path string,
+	token string,
+	generation string,
+) (bool, error) {
+	entry, ok := m.entries[path]
+	if !ok || entry.CreationToken != token {
+		return false, nil
+	}
+	entry.CreationToken = ""
+	entry.Generation = generation
+	return true, nil
+}
+
+func (m *mockRemoteSourceState) ReclaimCreation(
+	path string,
+	token string,
+	replacement *registry.WorktreeEntry,
+) (bool, error) {
+	entry, ok := m.entries[path]
+	if !ok || entry.CreationToken != token {
+		return false, nil
+	}
+	copied := *replacement
+	m.entries[path] = &copied
+	return true, nil
+}
+
+func (m *mockRemoteSourceState) AbortCreation(
+	path string,
+	token string,
+	previous *registry.WorktreeEntry,
+) (bool, error) {
+	entry, ok := m.entries[path]
+	if !ok || entry.CreationToken != token {
+		return false, nil
+	}
+	delete(m.entries, path)
+	if previous != nil {
+		copied := *previous
+		copied.UnreviewedRemoteSource = entry.UnreviewedRemoteSource
+		m.entries[path] = &copied
+	}
+	return true, nil
 }
 
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
@@ -490,6 +550,7 @@ func TestManagerAddTrackingRetainsMarkerWhenFailedCheckoutPathExists(t *testing.
 	entry, ok := state.entries[worktreePath]
 	require.True(t, ok, "a possibly materialized checkout must remain isolated")
 	assert.True(t, entry.UnreviewedRemoteSource)
+	assert.Empty(t, entry.CreationToken)
 }
 
 func TestManagerAddTrackingRejectsActiveCreationMarker(t *testing.T) {
@@ -500,7 +561,7 @@ func TestManagerAddTrackingRejectsActiveCreationMarker(t *testing.T) {
 			Branch:        "feature/creating",
 			CreationToken: "active-creation",
 		},
-	}}
+	}, creationActive: true}
 	mockG := &mockGit{}
 	manager := New(mockG, &models.Config{})
 	manager.openRemoteSourceState = func() (remoteSourceState, error) {
@@ -518,6 +579,75 @@ func TestManagerAddTrackingRejectsActiveCreationMarker(t *testing.T) {
 	entry, ok := state.entries[worktreePath]
 	require.True(t, ok)
 	assert.Equal(t, "active-creation", entry.CreationToken)
+}
+
+func TestManagerAddTrackingRecoversAbandonedCreationMarker(t *testing.T) {
+	worktreePath := filepath.Join(t.TempDir(), "abandoned-worktree")
+	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
+		worktreePath: {
+			Path:          worktreePath,
+			Branch:        "feature/abandoned",
+			CreationToken: "abandoned-creation",
+		},
+	}}
+	mockG := &mockGit{}
+	manager := New(mockG, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	path, err := manager.AddTracking(
+		"feature/recovered",
+		"refs/remotes/origin/feature/recovered",
+		worktreePath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, worktreePath, path)
+	assert.Len(t, mockG.worktrees, 1)
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok)
+	assert.Equal(t, "feature/recovered", entry.Branch)
+	assert.Empty(t, entry.CreationToken)
+	assert.Equal(t, "0123456789abcdef0123456789abcdef", entry.Generation)
+	assert.True(t, entry.UnreviewedRemoteSource)
+}
+
+func TestManagerAddTrackingFinalizesAbandonedCompletedCheckout(t *testing.T) {
+	worktreePath := filepath.Join(t.TempDir(), "completed-worktree")
+	generation := "fedcba9876543210fedcba9876543210"
+	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
+		worktreePath: {
+			Path:                   worktreePath,
+			Branch:                 "feature/completed",
+			CreationToken:          "abandoned-creation",
+			UnreviewedRemoteSource: true,
+		},
+	}}
+	mockG := &mockGit{worktrees: []models.Worktree{{
+		Path:       worktreePath,
+		Branch:     "feature/completed",
+		Generation: generation,
+	}}}
+	manager := New(mockG, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	_, err := manager.AddTracking(
+		"feature/replacement",
+		"refs/remotes/origin/feature/replacement",
+		worktreePath,
+	)
+
+	require.ErrorContains(t, err, "recovered completed remote-source worktree")
+	assert.Len(t, mockG.worktrees, 1, "recovery must not replace the checkout")
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok)
+	assert.Equal(t, "feature/completed", entry.Branch)
+	assert.Empty(t, entry.CreationToken)
+	assert.Equal(t, generation, entry.Generation)
+	assert.True(t, entry.UnreviewedRemoteSource)
 }
 
 func TestManagerAddTrackingDoesNotExpandRemoteBranchEnvironmentReferences(

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -39,23 +40,21 @@ type mockRemoteSourceState struct {
 	entries map[string]*registry.WorktreeEntry
 }
 
-func (m *mockRemoteSourceState) Register(entry *registry.WorktreeEntry) error {
-	if m.entries == nil {
-		m.entries = make(map[string]*registry.WorktreeEntry)
-	}
-	copied := *entry
-	m.entries[entry.Path] = &copied
-	return nil
-}
-
-func (m *mockRemoteSourceState) ReplaceIfCreationToken(
+func (m *mockRemoteSourceState) CompareAndSwap(
 	path string,
-	creationToken string,
+	expected *registry.WorktreeEntry,
 	replacement *registry.WorktreeEntry,
 ) (bool, error) {
 	entry, ok := m.entries[path]
-	if !ok || entry.CreationToken != creationToken {
+	if expected == nil {
+		if ok {
+			return false, nil
+		}
+	} else if !ok || !reflect.DeepEqual(entry, expected) {
 		return false, nil
+	}
+	if m.entries == nil {
+		m.entries = make(map[string]*registry.WorktreeEntry)
 	}
 	delete(m.entries, path)
 	if replacement != nil {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -730,6 +730,26 @@ func TestManagerGetMatchingWorktreesPrefersExactPath(t *testing.T) {
 	assert.Equal(t, "feature/task", matches[0].Branch)
 }
 
+func TestManagerGetMatchingWorktreesPrefersCaseFoldedWindowsExactPath(
+	t *testing.T,
+) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path comparison")
+	}
+	m := New(&mockGit{
+		worktrees: []models.Worktree{
+			{Path: `C:\work\foo`, Branch: "feature/foo"},
+			{Path: `C:\work\foo-old`, Branch: "feature/foo-old"},
+		},
+	}, &models.Config{})
+
+	matches, err := m.GetMatchingWorktrees(`c:\WORK\foo`)
+
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, `C:\work\foo`, matches[0].Path)
+}
+
 func TestManagerGetMatchingWorktreesPrefersAbsolutePathOverBranchSubstring(
 	t *testing.T,
 ) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -645,6 +645,26 @@ func TestManagerGetMatchingWorktrees(t *testing.T) {
 	}
 }
 
+func TestManagerGetMatchingWorktreesResolvesEquivalentPaths(t *testing.T) {
+	target := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "worktree-alias")
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	m := New(&mockGit{
+		worktrees: []models.Worktree{{
+			Path:   target,
+			Branch: "feature/equivalent-path",
+		}},
+	}, &models.Config{})
+
+	matches, err := m.GetMatchingWorktrees(alias)
+
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "feature/equivalent-path", matches[0].Branch)
+}
+
 func TestManagerValidateWorktreePath(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -41,6 +41,14 @@ type mockRemoteSourceState struct {
 	creationActive bool
 }
 
+type materializedAddError struct {
+	error
+}
+
+func (materializedAddError) WorktreeCreated() bool {
+	return true
+}
+
 func (m *mockRemoteSourceState) CompareAndSwap(
 	path string,
 	expected *registry.WorktreeEntry,
@@ -129,7 +137,9 @@ func (m *mockRemoteSourceState) AbortCreation(
 	delete(m.entries, path)
 	if previous != nil {
 		copied := *previous
-		copied.UnreviewedRemoteSource = entry.UnreviewedRemoteSource
+		copied.UnreviewedRemoteSource =
+			previous.UnreviewedRemoteSource &&
+				entry.UnreviewedRemoteSource
 		m.entries[path] = &copied
 	}
 	return true, nil
@@ -472,16 +482,25 @@ func TestManagerAddExistingMarksSourceUnreviewedAndSkipsSetup(t *testing.T) {
 func TestManagerAddTrackingRestoresExistingMarkerAfterGitFailure(t *testing.T) {
 	worktreePath := t.TempDir()
 	future := time.Now().Add(time.Hour)
+	generation := "fedcba9876543210fedcba9876543210"
 	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
 		worktreePath: {
 			Path:                   worktreePath,
 			Branch:                 "feature/existing",
 			Repository:             "github.com/acme/widget",
 			ExpiresAt:              &future,
-			UnreviewedRemoteSource: true,
+			Generation:             generation,
+			UnreviewedRemoteSource: false,
 		},
 	}}
-	manager := New(&mockGit{addError: errors.New("already checked out")}, &models.Config{})
+	manager := New(&mockGit{
+		addError: errors.New("already checked out"),
+		worktrees: []models.Worktree{{
+			Path:       worktreePath,
+			Branch:     "feature/existing",
+			Generation: generation,
+		}},
+	}, &models.Config{})
 	manager.openRemoteSourceState = func() (remoteSourceState, error) {
 		return state, nil
 	}
@@ -495,9 +514,10 @@ func TestManagerAddTrackingRestoresExistingMarkerAfterGitFailure(t *testing.T) {
 	require.Error(t, err)
 	entry, ok := state.entries[worktreePath]
 	require.True(t, ok, "failed repeated add must retain the safety marker")
-	assert.True(t, entry.UnreviewedRemoteSource)
+	assert.False(t, entry.UnreviewedRemoteSource)
 	assert.Equal(t, "github.com/acme/widget", entry.Repository)
 	assert.Equal(t, &future, entry.ExpiresAt)
+	assert.Equal(t, generation, entry.Generation)
 }
 
 func TestManagerAddTrackingReplacesStaleMetadataAfterSuccess(t *testing.T) {
@@ -535,7 +555,9 @@ func TestManagerAddTrackingReplacesStaleMetadataAfterSuccess(t *testing.T) {
 func TestManagerAddTrackingRetainsMarkerWhenFailedCheckoutPathExists(t *testing.T) {
 	worktreePath := t.TempDir()
 	state := &mockRemoteSourceState{}
-	manager := New(&mockGit{addError: errors.New("checkout failed")}, &models.Config{})
+	manager := New(&mockGit{addError: materializedAddError{
+		error: errors.New("checkout failed"),
+	}}, &models.Config{})
 	manager.openRemoteSourceState = func() (remoteSourceState, error) {
 		return state, nil
 	}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -342,6 +342,11 @@ func TestManagerAddTrackingUsesRemoteSource(t *testing.T) {
 	)
 	require.Contains(t, state.entries, worktreePath)
 	assert.True(t, state.entries[worktreePath].UnreviewedRemoteSource)
+	assert.Equal(
+		t,
+		"0123456789abcdef0123456789abcdef",
+		state.entries[worktreePath].Generation,
+	)
 	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
 	assert.NoFileExists(t, filepath.Join(worktreePath, "setup-ran"))
 }
@@ -385,6 +390,11 @@ func TestManagerAddExistingMarksSourceUnreviewedAndSkipsSetup(t *testing.T) {
 	)
 	require.Contains(t, state.entries, worktreePath)
 	assert.True(t, state.entries[worktreePath].UnreviewedRemoteSource)
+	assert.Equal(
+		t,
+		"0123456789abcdef0123456789abcdef",
+		state.entries[worktreePath].Generation,
+	)
 	assert.NoFileExists(t, filepath.Join(worktreePath, "copy-me"))
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -117,7 +117,7 @@ func (m *mockGit) AddWorktreeExisting(
 func (m *mockGit) RemoveWorktree(
 	path string,
 	force bool,
-	ifCreatedAt *time.Time,
+	ifGeneration string,
 ) error {
 	if m.removeError != nil {
 		return m.removeError
@@ -471,7 +471,7 @@ func TestManagerRemove(t *testing.T) {
 	m := New(mockG, &models.Config{})
 
 	// Remove worktree
-	err := m.Remove("/path/to/worktree1", false, nil)
+	err := m.Remove("/path/to/worktree1", false, "")
 	if err != nil {
 		t.Fatalf("Remove() error = %v", err)
 	}
@@ -663,6 +663,22 @@ func TestManagerGetMatchingWorktreesResolvesEquivalentPaths(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
 	assert.Equal(t, "feature/equivalent-path", matches[0].Branch)
+}
+
+func TestManagerGetMatchingWorktreesPrefersExactPath(t *testing.T) {
+	exactPath := filepath.Join(t.TempDir(), "task")
+	m := New(&mockGit{
+		worktrees: []models.Worktree{
+			{Path: exactPath, Branch: "feature/task"},
+			{Path: exactPath + "-old", Branch: "feature/task-old"},
+		},
+	}, &models.Config{})
+
+	matches, err := m.GetMatchingWorktrees(exactPath)
+
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "feature/task", matches[0].Branch)
 }
 
 func TestManagerValidateWorktreePath(t *testing.T) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	configpkg "go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -34,6 +35,7 @@ type mockGit struct {
 	trackingSource    string
 	existingSource    string
 	protectedNames    []string
+	initializeOnList  bool
 }
 
 type mockRemoteSourceState struct {
@@ -149,7 +151,28 @@ func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
 	if m.listError != nil {
 		return nil, m.listError
 	}
+	if m.initializeOnList {
+		for i := range m.worktrees {
+			if m.worktrees[i].Generation == "" {
+				m.worktrees[i].Generation =
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			}
+		}
+	}
 	return m.worktrees, nil
+}
+
+func (m *mockGit) ReadWorktreeGeneration(path string) (string, error) {
+	for _, worktree := range m.worktrees {
+		if utils.PathKey(worktree.Path) != utils.PathKey(path) {
+			continue
+		}
+		if worktree.Generation == "" {
+			return "", errors.New("worktree generation is not initialized")
+		}
+		return worktree.Generation, nil
+	}
+	return "", errors.New("worktree not found")
 }
 
 func (m *mockGit) AddWorktree(path, branch string, createBranch bool) error {
@@ -183,6 +206,13 @@ func (m *mockGit) AddWorktreeTracking(
 	}
 	m.trackingSource = remoteBranch
 	m.protectedNames = append([]string(nil), protectedNames...)
+	for i := range m.worktrees {
+		if utils.PathKey(m.worktrees[i].Path) == utils.PathKey(path) &&
+			m.worktrees[i].Generation == "" {
+			m.worktrees[i].Branch = branch
+			return nil
+		}
+	}
 	m.worktrees = append(m.worktrees, models.Worktree{
 		Path:   path,
 		Branch: branch,
@@ -204,7 +234,13 @@ func (m *mockGit) AddWorktreeTrackingWithGeneration(
 	); err != nil {
 		return "", err
 	}
-	return "0123456789abcdef0123456789abcdef", nil
+	generation := "0123456789abcdef0123456789abcdef"
+	for i := range m.worktrees {
+		if utils.PathKey(m.worktrees[i].Path) == utils.PathKey(path) {
+			m.worktrees[i].Generation = generation
+		}
+	}
+	return generation, nil
 }
 
 func (m *mockGit) AddWorktreeExisting(
@@ -670,6 +706,49 @@ func TestManagerAddTrackingFinalizesAbandonedCompletedCheckout(t *testing.T) {
 	assert.Empty(t, entry.CreationToken)
 	assert.Equal(t, generation, entry.Generation)
 	assert.True(t, entry.UnreviewedRemoteSource)
+}
+
+func TestManagerAddTrackingDoesNotInitializeAbandonedCheckoutDuringRecovery(
+	t *testing.T,
+) {
+	worktreePath := filepath.Join(t.TempDir(), "incomplete-worktree")
+	state := &mockRemoteSourceState{entries: map[string]*registry.WorktreeEntry{
+		worktreePath: {
+			Path:                   worktreePath,
+			Branch:                 "feature/incomplete",
+			CreationToken:          "abandoned-creation",
+			UnreviewedRemoteSource: true,
+		},
+	}}
+	mockG := &mockGit{
+		initializeOnList: true,
+		worktrees: []models.Worktree{{
+			Path:   worktreePath,
+			Branch: "feature/incomplete",
+		}},
+	}
+	manager := New(mockG, &models.Config{})
+	manager.openRemoteSourceState = func() (remoteSourceState, error) {
+		return state, nil
+	}
+
+	path, err := manager.AddTracking(
+		"feature/incomplete",
+		"refs/remotes/origin/feature/incomplete",
+		worktreePath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, worktreePath, path)
+	assert.Equal(
+		t,
+		"refs/remotes/origin/feature/incomplete",
+		mockG.trackingSource,
+	)
+	entry, ok := state.entries[worktreePath]
+	require.True(t, ok)
+	assert.Empty(t, entry.CreationToken)
+	assert.Equal(t, "0123456789abcdef0123456789abcdef", entry.Generation)
 }
 
 func TestManagerAddTrackingDoesNotExpandRemoteBranchEnvironmentReferences(

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -681,6 +681,27 @@ func TestManagerGetMatchingWorktreesPrefersExactPath(t *testing.T) {
 	assert.Equal(t, "feature/task", matches[0].Branch)
 }
 
+func TestManagerGetMatchingWorktreesPrefersBranchOverRelativeSymlink(t *testing.T) {
+	currentPath := t.TempDir()
+	mainPath := t.TempDir()
+	t.Chdir(currentPath)
+	if err := os.Symlink(".", "main"); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	m := New(&mockGit{
+		worktrees: []models.Worktree{
+			{Path: currentPath, Branch: "feature/current"},
+			{Path: mainPath, Branch: "main"},
+		},
+	}, &models.Config{})
+
+	matches, err := m.GetMatchingWorktrees("main")
+
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, mainPath, matches[0].Path)
+}
+
 func TestManagerValidateWorktreePath(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -114,7 +114,11 @@ func (m *mockGit) AddWorktreeExisting(
 	return nil
 }
 
-func (m *mockGit) RemoveWorktree(path string, force bool) error {
+func (m *mockGit) RemoveWorktree(
+	path string,
+	force bool,
+	ifCreatedAt *time.Time,
+) error {
 	if m.removeError != nil {
 		return m.removeError
 	}
@@ -467,7 +471,7 @@ func TestManagerRemove(t *testing.T) {
 	m := New(mockG, &models.Config{})
 
 	// Remove worktree
-	err := m.Remove("/path/to/worktree1", false)
+	err := m.Remove("/path/to/worktree1", false, nil)
 	if err != nil {
 		t.Fatalf("Remove() error = %v", err)
 	}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -10,6 +10,7 @@ type Worktree struct {
 	CommitHash     string    `json:"commit_hash"`                // Current HEAD commit hash
 	IsMain         bool      `json:"is_main"`                    // Whether this is the main worktree
 	CreatedAt      time.Time `json:"created_at"`                 // Worktree directory modification time
+	Generation     string    `json:"generation"`                 // Durable identity for this worktree registration
 	Repository     string    `json:"repository"`                 // Repository slug, e.g. github.com/owner/name
 	SessionName    string    `json:"session_name"`               // Computed tmux workspace session name
 	TmuxSocketName string    `json:"tmux_socket_name,omitempty"` // Protected alternate tmux socket

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -14,6 +14,7 @@ func TestWorktreeJSON(t *testing.T) {
 		CommitHash: "abc123def456",
 		IsMain:     false,
 		CreatedAt:  now,
+		Generation: "0123456789abcdef0123456789abcdef",
 	}
 
 	// Test marshaling
@@ -43,6 +44,9 @@ func TestWorktreeJSON(t *testing.T) {
 	}
 	if !decoded.CreatedAt.Equal(wt.CreatedAt) {
 		t.Errorf("CreatedAt mismatch: got %v, want %v", decoded.CreatedAt, wt.CreatedAt)
+	}
+	if decoded.Generation != wt.Generation {
+		t.Errorf("Generation mismatch: got %s, want %s", decoded.Generation, wt.Generation)
 	}
 }
 


### PR DESCRIPTION
Worktree removal currently identifies its target by path. If another process removes and recreates that path after a user or client confirms deletion, kwt can act on a checkout that was never approved.

This PR gives each linked worktree a durable random generation stored in its Git administrative directory and exposes that identity through inventory. `kwt remove --if-generation` compares the expected generation and removes the worktree under the same repository mutation boundary. The TUI, expired-worktree pruning, and failed-materialization cleanup carry the same precondition, while ordinary CLI removal remains unconditional unless explicitly requested.

To keep that identity trustworthy, worktree listing and discovery capture metadata and generation from one coherent repository snapshot. Hook-capable creation uses a crash-safe reservation so hooks can re-enter kwt without exposing an incomplete checkout or deadlocking. Pruning shares the mutation boundary, and partial Git removal failures preserve residual directories rather than recursively deleting a possible replacement.

Registry state follows the same ownership model. Creation uses a provisional token backed by an OS-released path lock; active creators cannot be overwritten, crashed claims can be recovered, and completed checkouts are finalized without losing concurrent acknowledgement state. Expiration and cleanup updates are generation-scoped so they cannot overwrite or unregister replacement worktrees.

Exact worktree paths take precedence over fuzzy matching, with native Unix and Windows path semantics preserved. Removal also validates repository identity, including repositories without a network origin, before destructive TUI operations proceed.