### PR TITLE
Replace kwt during external tmux attachment

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,6 +79,14 @@ An exact worktree-root path is resolved directly from Git before pattern
 matching, including registered primary checkouts and linked worktrees outside
 the configured global worktree base.
 
+On Unix-like systems, an external ordinary or protected attachment replaces
+the `kwt` process with the tmux client. tmux therefore owns signal handling and
+the final exit status, and no waiting `kwt` parent remains. Windows retains a
+waiting parent because it has no Unix process-replacement primitive.
+An ordinary open from inside tmux switches the current client instead.
+Protected attachment always remains external because it targets a separate
+workspace-specific socket.
+
 `kwt open <exact-worktree-path> --start-session` performs the same layout and
 session bootstrap without attaching a client. Use it before an external
 ordinary tmux client attaches to a session that may not exist yet. The exact
@@ -135,7 +143,7 @@ With `--json`, success returns:
   "project": {
     "repository": "github.com/kenn-io/kwt",
     "name": "kwt",
-    "path": "/home/wesm/code/kwt",
+    "path": "/code/kwt",
     "last_touched": "2026-07-27T11:16:16Z"
   }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -175,7 +175,9 @@ session without attaching, for clients that provide their own ordinary tmux
 presentation. It does not execute configured layouts or agent commands.
 Attach with `kwt pr attach <workspace.path>`, which verifies the persisted
 identity, creates or repairs that protected blank session when needed, and
-uses `attach-session -E`.
+uses `attach-session -E`. This is an interactive exception to the PR JSON
+contract: failures before attachment remain structured, but after a successful
+Unix process replacement tmux owns terminal output and the final exit status.
 
 ### Repository identity fallback
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -5,8 +5,9 @@ desktop application should render the records returned by kwt and pass the
 selected pull-request identifier back to kwt. It should not call GitHub,
 construct Git refs or worktree names, or reproduce workspace setup.
 
-The commands are noninteractive and always emit JSON. Pass `--json` explicitly
-to document that a caller depends on the automation contract:
+`kwt pr list` and `kwt pr import` are noninteractive and always emit JSON.
+Pass `--json` explicitly to document that a caller depends on the automation
+contract:
 
 ```sh
 kwt pr list --project github.com/acme/widget --state open --json
@@ -32,6 +33,15 @@ kwt's protected path:
 ```sh
 kwt pr attach <workspace.path>
 ```
+
+`kwt pr attach` is an interactive exception to the JSON automation contract.
+Validation and session-establishment failures that occur before attachment
+still use the structured error envelope and stable PR exit status. On
+Unix-like systems, a successful handoff replaces `kwt` with tmux; from that
+point onward, tmux owns terminal output, signal handling, and the final exit
+status. An immediate tmux client failure after replacement therefore uses
+tmux's native diagnostic and status rather than a JSON envelope. Windows
+retains a waiting `kwt` parent and can still wrap a returned tmux failure.
 
 The attach command resolves the persisted workspace identity, verifies the
 recorded project clone and exact live worktree identity, and creates or repairs
@@ -407,8 +417,12 @@ another import returns `import_conflict`.
 
 ## Failure contract
 
-Failures write a JSON error to stdout, a credential-free diagnostic to stderr,
-and return a stable nonzero status. For example:
+Failures from `kwt pr list`, `kwt pr import`, and the validation or session
+establishment phase of `kwt pr attach` write a JSON error to stdout, a
+credential-free diagnostic to stderr, and return a stable nonzero status. The
+Unix attachment handoff is the exception described above: after process
+replacement succeeds, tmux owns any later diagnostic and exit status. For
+example:
 
 ```json
 {

--- a/internal/tmux/attach_process_unix.go
+++ b/internal/tmux/attach_process_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func replaceAttachProcess(cmd *exec.Cmd) error {
+	return syscall.Exec(cmd.Path, cmd.Args, cmd.Env)
+}

--- a/internal/tmux/attach_process_unix_test.go
+++ b/internal/tmux/attach_process_unix_test.go
@@ -1,0 +1,50 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+)
+
+const unixAttachProcessHelper = "KWT_TEST_UNIX_ATTACH_PROCESS"
+
+func TestReplaceAttachProcessReplacesUnixProcess(t *testing.T) {
+	if os.Getenv(unixAttachProcessHelper) == "1" {
+		cmd := exec.Command(
+			"sh",
+			"-c",
+			`test "$$" = "$KWT_TEST_UNIX_ATTACH_PID" && printf replaced`,
+		)
+		cmd.Env = append(
+			os.Environ(),
+			"KWT_TEST_UNIX_ATTACH_PID="+strconv.Itoa(os.Getpid()),
+		)
+		if err := replaceAttachProcess(cmd); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "replace process: %v", err)
+			os.Exit(41)
+		}
+		_, _ = fmt.Fprint(os.Stderr, "replacement returned")
+		os.Exit(42)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper := exec.Command(
+		executable,
+		"-test.run=^TestReplaceAttachProcessReplacesUnixProcess$",
+	)
+	helper.Env = append(os.Environ(), unixAttachProcessHelper+"=1")
+	output, err := helper.CombinedOutput()
+	if err != nil {
+		t.Fatalf("replacement helper failed: %v: %s", err, output)
+	}
+	if string(output) != "replaced" {
+		t.Fatalf("replacement output = %q, want %q", output, "replaced")
+	}
+}

--- a/internal/tmux/attach_process_windows.go
+++ b/internal/tmux/attach_process_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package tmux
+
+import (
+	"os"
+	"os/exec"
+)
+
+func replaceAttachProcess(cmd *exec.Cmd) error {
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/tmux/attach_process_windows_test.go
+++ b/internal/tmux/attach_process_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+const windowsAttachProcessHelper = "KWT_TEST_WINDOWS_ATTACH_PROCESS"
+
+func TestReplaceAttachProcessWaitsOnWindows(t *testing.T) {
+	if os.Getenv(windowsAttachProcessHelper) == "1" {
+		os.Exit(23)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper := exec.Command(
+		executable,
+		"-test.run=^TestReplaceAttachProcessWaitsOnWindows$",
+	)
+	helper.Env = append(os.Environ(), windowsAttachProcessHelper+"=1")
+	err = replaceAttachProcess(helper)
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("replacement error = %v, want child exit error", err)
+	}
+	if exitErr.ExitCode() != 23 {
+		t.Fatalf("replacement exit code = %d, want 23", exitErr.ExitCode())
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -39,7 +39,10 @@ type TmuxCommand struct {
 	command         string
 	socketName      string
 	extraStripNames map[string]bool
+	attachProcess   attachProcessFunc
 }
+
+type attachProcessFunc func(*exec.Cmd) error
 
 func NewTmuxCommand(command string) *TmuxCommand {
 	return NewTmuxCommandWithStripNames(command, nil)
@@ -75,6 +78,7 @@ func NewTmuxCommandForSocketWithStripNames(
 		command:         command,
 		socketName:      strings.TrimSpace(socketName),
 		extraStripNames: extra,
+		attachProcess:   replaceAttachProcess,
 	}
 }
 
@@ -187,22 +191,33 @@ func (t *TmuxCommand) KillSession(sessionName string) error {
 }
 
 func (t *TmuxCommand) AttachSession(sessionName string) error {
-	cmd := t.attachSessionCmd(sessionName)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return t.runAttachProcess(
+		context.Background(),
+		t.attachSessionCmd(sessionName),
+	)
 }
 
 func (t *TmuxCommand) AttachSessionWithoutEnvironment(
 	ctx context.Context,
 	sessionName string,
 ) error {
-	cmd := t.attachSessionWithoutEnvironmentCmd(ctx, sessionName)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return t.runAttachProcess(
+		ctx,
+		t.attachSessionWithoutEnvironmentCmd(ctx, sessionName),
+	)
+}
+
+func (t *TmuxCommand) runAttachProcess(
+	ctx context.Context,
+	cmd *exec.Cmd,
+) error {
+	if cmd.Err != nil {
+		return cmd.Err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return t.attachProcess(cmd)
 }
 
 func (t *TmuxCommand) attachSessionWithoutEnvironmentCmd(

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -2,6 +2,9 @@ package tmux
 
 import (
 	"context"
+	"errors"
+	"os"
+	"os/exec"
 	"slices"
 	"testing"
 )
@@ -265,6 +268,140 @@ func TestProtectedAttachStripsParentTmuxIdentity(t *testing.T) {
 	}
 	if !foundUnrelated {
 		t.Error("protected attach dropped UNRELATED_VAR")
+	}
+}
+
+func TestExternalAttachReplacesCurrentProcess(t *testing.T) {
+	t.Setenv("EDITOR", "vim")
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+	t.Setenv("TMUX_PANE", "%7")
+	t.Setenv("KWT_GITHUB_TOKEN", "secret")
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementErr := errors.New("replacement attempted")
+
+	tests := []struct {
+		name     string
+		attach   func(*TmuxCommand) error
+		wantArgs []string
+		wantGone []string
+	}{
+		{
+			name: "ordinary",
+			attach: func(tc *TmuxCommand) error {
+				return tc.AttachSession("workspace")
+			},
+			wantArgs: []string{
+				executable, "-L", "kwt-test-socket",
+				"attach-session", "-t", "workspace",
+			},
+			wantGone: []string{"EDITOR", "KWT_GITHUB_TOKEN"},
+		},
+		{
+			name: "protected",
+			attach: func(tc *TmuxCommand) error {
+				return tc.AttachSessionWithoutEnvironment(
+					context.Background(),
+					"workspace",
+				)
+			},
+			wantArgs: []string{
+				executable, "-L", "kwt-test-socket",
+				"attach-session", "-E", "-t", "workspace",
+			},
+			wantGone: []string{
+				"EDITOR", "TMUX", "TMUX_PANE", "KWT_GITHUB_TOKEN",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := NewTmuxCommandForSocketWithStripNames(
+				executable,
+				"kwt-test-socket",
+				[]string{"KWT_GITHUB_TOKEN"},
+			)
+			var got *exec.Cmd
+			tc.attachProcess = func(cmd *exec.Cmd) error {
+				got = cmd
+				return replacementErr
+			}
+
+			err := tt.attach(tc)
+			if !errors.Is(err, replacementErr) {
+				t.Fatalf(
+					"attach error = %v, want replacement error",
+					err,
+				)
+			}
+			if got == nil {
+				t.Fatal("attachment did not attempt process replacement")
+			}
+			if !slices.Equal(got.Args, tt.wantArgs) {
+				t.Errorf(
+					"replacement args = %v, want %v",
+					got.Args,
+					tt.wantArgs,
+				)
+			}
+			for _, name := range tt.wantGone {
+				for _, entry := range got.Env {
+					if hasEnvName(entry, name) {
+						t.Errorf(
+							"replacement environment leaked %s",
+							name,
+						)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExternalAttachReturnsLookupErrorBeforeReplacement(t *testing.T) {
+	tc := NewTmuxCommand("kwt-test-missing-tmux-executable")
+	called := false
+	tc.attachProcess = func(*exec.Cmd) error {
+		called = true
+		return nil
+	}
+
+	err := tc.AttachSession("workspace")
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("attach error = %v, want executable-not-found", err)
+	}
+	if called {
+		t.Fatal("process replacement called after command lookup failed")
+	}
+}
+
+func TestProtectedExternalAttachReturnsCanceledContextBeforeReplacement(
+	t *testing.T,
+) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tc := NewTmuxCommand(executable)
+	called := false
+	tc.attachProcess = func(*exec.Cmd) error {
+		called = true
+		return nil
+	}
+
+	err = tc.AttachSessionWithoutEnvironment(ctx, "workspace")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("attach error = %v, want context canceled", err)
+	}
+	if called {
+		t.Fatal("process replacement called after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Why

External tmux attachment is a terminal handoff: after kwt validates or creates the session, it has no cleanup or result processing left. Keeping kwt as a waiting parent for the lifetime of the tmux client leaves obsolete executables resident after upgrades and makes a healthy attachment look like a stuck process.

## Approach

On Unix-like systems, both ordinary and protected external attachments now replace kwt with the already-built tmux command. That preserves socket selection, session targeting, sanitized environments, protected `-E` behavior, and the additional protected-client environment filtering. Command lookup failures still return before replacement is attempted.

Windows retains the existing child-and-wait behavior because it has no Unix exec primitive. In-tmux `switch-client` behavior is unchanged. After successful Unix replacement, tmux intentionally owns signals and the final exit status.

## Risk and verification

Regression coverage pins the executable, arguments, environment, protected path, and lookup-error boundary. The tmux package passes normal and race-enabled tests, the Windows package cross-compiles, and the full repository test, build, lint, vet, and documentation gates pass.