### PR TITLE
Add doctor diagnostics and merged-PR pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ kwt exec feature/new-ui -- npm test
 # Delete a worktree
 kwt remove feature/new-ui
 kwt remove -b feature/new-ui
+
+# Diagnose and repair structural worktree metadata
+kwt doctor
+kwt doctor --fix
+
+# Preview clean worktrees whose exact GitHub pull request is merged
+kwt prune --merged --dry-run
 ```
 
 When `-b` creates a branch, `kwt` fetches `origin` and starts from its default
@@ -123,7 +130,10 @@ using `kwt open` to explicitly create and attach its workspace.
 
 Global config lives at `~/.config/kwt/config.toml`, or
 `$KWT_HOME/config.toml` when `KWT_HOME` is set. Repository-local overrides live
-in `.kwt.toml` and are trust-gated before use.
+in `.kwt.toml` and are trust-gated before use. When `KWT_HOME` is set, that same
+directory also holds `registry.json` and `pull-requests.json`, isolating kwt's
+persistent state as a unit. Without it, each store follows its documented
+platform config-directory behavior.
 
 `config.toml` is the source of truth for layouts and agent commands. Workspaces
 launch as a blank single-pane session unless a layout is selected — via
@@ -222,11 +232,11 @@ kwt sync forget <host-id>
 
 When multi-machine sync is enabled, `kwt sync status` publishes this host before
 reading the hub. Successful mutations also publish best-effort: `kwt add`, local
-and global `kwt remove`, and `kwt prune --expired` when it actually removes or
-unregisters an expired worktree. Normal `kwt prune` publishes after every
-successful run. Dry-runs, expired-prune no-ops, and failed removals do not
-publish. Missing hub config, disabled multi-machine sync, or publish failures
-never make the mutation command fail; publish warnings may be written to stderr.
+and global `kwt remove`, and explicit `kwt prune --expired` or `--merged`
+policies when they actually remove a worktree. Doctor inspection and repair,
+dry-runs, prune no-ops, and failed removals do not publish. Missing hub config,
+disabled multi-machine sync, or publish failures never make the mutation command
+fail; publish warnings may be written to stderr.
 
 ### Project Discovery
 
@@ -259,31 +269,32 @@ spaces.
 
 ## Commands
 
-| Command          | Purpose                                   |
-| ---------------- | ----------------------------------------- |
-| `kwt`, `kwt tui` | Cross-project dashboard                   |
-| `kwt add`        | Create a worktree                         |
-| `kwt open`       | Open or establish a workspace session     |
-| `kwt list`       | List worktrees                            |
-| `kwt status`     | Show git status, sync state, and activity |
-| `kwt projects`   | List or register project repositories     |
-| `kwt pr`         | Discover and import pull requests as JSON |
-| `kwt get`        | Print a matching worktree path            |
-| `kwt cd`         | Open a shell in a matching worktree       |
-| `kwt exec`       | Run a command in a matching worktree      |
-| `kwt remove`     | Delete a worktree, optionally its branch  |
-| `kwt prune`      | Clean up stale Git worktree metadata      |
-| `kwt sync`       | Publish and inspect multi-machine status  |
-| `kwt tmux`       | Manage standalone tmux sessions           |
-| `kwt workspace`  | Manage directory workspaces               |
-| `kwt config`     | Read and write config values              |
-| `kwt completion` | Generate shell completion and integration |
+| Command          | Purpose                                     |
+| ---------------- | ------------------------------------------- |
+| `kwt`, `kwt tui` | Cross-project dashboard                     |
+| `kwt add`        | Create a worktree                           |
+| `kwt open`       | Open or establish a workspace session       |
+| `kwt list`       | List worktrees                              |
+| `kwt status`     | Show git status, sync state, and activity   |
+| `kwt projects`   | List or register project repositories       |
+| `kwt pr`         | Discover and import pull requests as JSON   |
+| `kwt get`        | Print a matching worktree path              |
+| `kwt cd`         | Open a shell in a matching worktree         |
+| `kwt exec`       | Run a command in a matching worktree        |
+| `kwt remove`     | Delete a worktree, optionally its branch    |
+| `kwt doctor`     | Inspect or repair structural worktree state |
+| `kwt prune`      | Remove live worktrees by an explicit policy |
+| `kwt sync`       | Publish and inspect multi-machine status    |
+| `kwt tmux`       | Manage standalone tmux sessions             |
+| `kwt workspace`  | Manage directory workspaces                 |
+| `kwt config`     | Read and write config values                |
+| `kwt completion` | Generate shell completion and integration   |
 
 Run `kwt <command> --help` for flags and examples.
 
 ## Requirements
 
-- Git 2.20+
+- Git 2.31+
 - Go 1.26+ to build from source
 - tmux for workspace launch and `kwt tmux`
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ Run `kwt <command> --help` for flags and examples.
 
 ## Requirements
 
-- Git 2.31+
+- Git 2.20+
+  - Git 2.31+ for `kwt doctor` and `kwt prune --expired` or `--merged`
 - Go 1.26+ to build from source
 - tmux for workspace launch and `kwt tmux`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -104,10 +104,11 @@ Notable user-facing changes to kwt, grouped by release.
   exist, its target permissions, and unknown project fields written by newer
   versions. Project relocation also refuses a target already claimed by another
   current registration inside that transaction.
-- Existing `KWT_HOME` installations retain their pre-upgrade worktree registry:
-  when the new registry is absent, kwt validates and atomically copies the
-  platform-config registry without overwriting either file. Ordinary project
-  registration also preserves unknown fields from newer kwt versions.
+- `KWT_HOME` now isolates registry state as well as configuration. kwt never
+  imports the platform-config registry automatically; users moving an existing
+  installation must copy `registry.json` explicitly before using the new home.
+  Ordinary project registration also preserves unknown fields from newer kwt
+  versions.
 - Merged cleanliness checks include ignored untracked files, and every global
   candidate is removed through the stable resolved main repository rather than
   a linked worktree that an earlier removal may delete. Expiration cleanliness

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,9 +44,10 @@ Notable user-facing changes to kwt, grouped by release.
 
 ### Breaking changes
 
-- Raise the minimum supported Git version from 2.20 to 2.31. Doctor and merged
-  pruning rely on the worktree inventory annotations introduced in 2.31, while
-  structural repair uses Git's native worktree repair command.
+- Keep the general minimum supported Git version at 2.20. `kwt doctor` and the
+  `kwt prune --expired` or `--merged` policies require Git 2.31 because their
+  inventory relies on worktree annotations introduced in 2.31; structural
+  repair also uses Git's native worktree repair command.
 - Bare `kwt prune` no longer performs Git metadata pruning. For structural
   cleanup, run `kwt doctor --fix`. `kwt prune --expired` is now only a live
   expiration policy; already-absent paths report `doctor_required` instead of

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,153 @@ description: Release history for kwt
 
 Notable user-facing changes to kwt, grouped by release.
 
+## Unreleased
+
+### New features
+
+- Diagnose moved or deleted project registrations, broken linked-worktree
+  backlinks, stale Git records, and registry drift with read-only `kwt doctor`.
+  `kwt doctor --fix` relocates one unambiguous identity match, removes an
+  unchanged stale registration when no match exists, removes stale duplicates
+  when the matching live repository is already registered, and leaves multiple
+  clones or multiple registrations claiming one target for manual choice.
+- Read large doctor reports as an action-first dashboard: safe repairs appear
+  before findings that need review, healthy repositories and opaque generation
+  values are omitted, and terminal output adapts to width and color settings.
+  After `doctor --fix`, completed repairs are listed before remaining findings;
+  `--quiet` suppresses the report when only the exit status matters. Versioned
+  JSON includes both the completed repairs and the final rescan for automation.
+- Adopt generation-less live registry records with guarded compare-and-swap
+  after clearing inherited expiration metadata; nonempty generation conflicts
+  remain manual. Registry reconciliation uses canonical path identity so
+  symlink aliases still match live worktrees. Repository-wide Git metadata
+  pruning is also declined whenever any removable record is outside the
+  verified fix scope.
+- Diagnose multiple registry path spellings that resolve to one live worktree.
+  `kwt doctor --fix` collapses a complete group only when all policy metadata
+  agrees. Equivalent aliases for a confirmed-absent path are removed as one
+  guarded group in the same fix run, including when a symlink appears above
+  multiple missing path components; conflicting or incompletely inspected
+  aliases remain visible for manual review.
+- Report existing registry paths that are not verified Git worktrees as
+  `unverified_registry_entry`; these records remain manual even when they carry
+  a valid-looking generation.
+- Preview or remove clean linked worktrees for explicitly merged GitHub pull
+  requests with `kwt prune --merged [--dry-run]`. Exact head-SHA evidence works
+  for squash and rebase merges while preserving local branches.
+
+### Breaking changes
+
+- Raise the minimum supported Git version from 2.20 to 2.31. Doctor and merged
+  pruning rely on the worktree inventory annotations introduced in 2.31, while
+  structural repair uses Git's native worktree repair command.
+- Bare `kwt prune` no longer performs Git metadata pruning. For structural
+  cleanup, run `kwt doctor --fix`. `kwt prune --expired` is now only a live
+  expiration policy; already-absent paths report `doctor_required` instead of
+  being silently unregistered.
+
+### Safety
+
+- Doctor and merged pruning now fail closed when global worktree discovery
+  encounters traversal, metadata access, or malformed linked `.git` file
+  errors, and linked-only repositories participate in consistency inspection.
+  Missing-project relocation and removal also remain manual whenever any
+  configured, global, or registered repository could not be inspected, so a
+  partial inventory cannot hide another matching clone. Dangling symlinks are
+  reported as unreachable instead of confirmed absent.
+- Doctor declines repository-wide backlink repair when any backlink Git could
+  change is ambiguous or otherwise outside the validated fix scope, while
+  continuing independent metadata and registry cleanup. Registry records are
+  excluded only while their creator holds the path lock; abandoned tokens can
+  be diagnosed and repaired under that same lock. New expiration records use
+  the destination worktree's origin and persist only credential-free canonical
+  repository identities; relative filesystem remotes are rejected. Doctor
+  normalizes or redacts legacy registry and configured-project values before
+  rendering them. Origin-based expiration records remain valid when a fork
+  clone is configured under its upstream project.
+- Policy removals require a valid durable generation and recheck generation,
+  HEAD, repository identity, local branch, exact upstream, verified worktree
+  backlink, and required cleanliness under the repository mutation lock.
+  Merged pruning refuses inconsistent backlinks before running candidate-local
+  Git commands. It reads worktree-specific upstream configuration, honors
+  Git's `url.*.insteadOf` rewriting, and resolves GitHub base and source
+  repository transfers before provider matching. Each linked worktree's
+  observed origin is kept separate from the configured PR base and revalidated
+  at removal. Globally discovered repositories without a configured project
+  use each candidate's own origin as its PR base instead of sharing a sibling's
+  fallback. Imported pull-request provenance must also match the canonical live
+  workspace and main-repository paths, with symlink aliases treated as the same
+  filesystem identity. Doctor and dry-run inventory remain read-only.
+  Expiration pruning resolves a unique administrative directory before policy
+  checks and revalidates that backlink under the same lock. It also compares the
+  complete registry policy under the Git mutation lock, preserving a worktree
+  when its expiration changes after inspection. New imported-PR provenance
+  records carry the durable worktree generation. Ordinary open protection
+  re-reads that generation from the live path whenever pull-request provenance
+  exists and fails closed when it cannot verify the current worktree, so stale
+  discovery and TUI rows cannot bypass protected attach. Attach and merged
+  pruning ignore a nonempty recorded generation when it differs from the live
+  worktree, so stale provenance cannot affect a same-path replacement;
+  generation-less legacy records remain compatible.
+- Global configuration writers now share one lock and atomic replacement path.
+  Project repair compares the exact persisted entry, revalidates the old and
+  target paths, and reloads both config and registry state before reporting the
+  result, so concurrent edits remain safe no-ops. Atomic updates preserve an
+  existing config-file symlink, including when its final target does not yet
+  exist, its target permissions, and unknown project fields written by newer
+  versions. Project relocation also refuses a target already claimed by another
+  current registration inside that transaction.
+- Existing `KWT_HOME` installations retain their pre-upgrade worktree registry:
+  when the new registry is absent, kwt validates and atomically copies the
+  platform-config registry without overwriting either file. Ordinary project
+  registration also preserves unknown fields from newer kwt versions.
+- Merged cleanliness checks include ignored untracked files, and every global
+  candidate is removed through the stable resolved main repository rather than
+  a linked worktree that an earlier removal may delete. Expiration cleanliness
+  retains Git's normal treatment of ignored build artifacts. Lock-scoped
+  dry-run validation reports locked and main worktrees as ineligible. Git
+  commands run against merged-prune candidates with kwt's GitHub and fleet
+  credentials removed, including during lock-time validation and removal.
+- Merged pruning reports stale individual paths as `doctor_required` and
+  continues evaluating other repositories; incomplete directory traversal
+  remains fatal. When Git deregisters a worktree but leaves residual files,
+  expiration and merged pruning complete guarded bookkeeping and report
+  `cleanup_incomplete` with the path to inspect.
+- Generation-less registry adoption rechecks the live generation under the Git
+  mutation lock, and merged pruning rejects multiple canonical registry aliases,
+  so same-path replacements and duplicate legacy records remain preserved for
+  review.
+- Worktree generation lookup now validates each administrative directory's
+  reverse `gitdir` mapping and scans every claimant before accepting a match, so
+  a stale backlink cannot borrow a sibling's identity and duplicate backlinks
+  are reported as ambiguous. Main worktrees initialized with Git's standard
+  separate Git directory layout are accepted only after the same duplicate-
+  claimant scan. Doctor and merged pruning resolve those repositories from a
+  verified checkout or configured `core.worktree` instead of assuming the
+  common directory is `<checkout>/.git`; linked-only layouts without a reverse
+  main-path fact remain manual. Merged pruning includes finalized registry-only
+  worktrees, while doctor derives repository identity from the resolved main
+  checkout rather than a linked worktree's origin override.
+- Merged pruning retains every configured, global, and registry inventory
+  root's direct `.git` claim before candidate deduplication. A copied directory
+  that claims a real worktree's administrative directory now preserves the
+  affected candidate as `doctor_required` while unrelated candidates continue.
+- Merged pruning no longer substitutes a linked worktree's origin for a missing
+  or invalid configured project identity; those candidates require doctor
+  review, while live-origin fallback remains available to unconfigured roots.
+- Canonically duplicate project paths retain every configured repository claim.
+  Equivalent URL and slug identities remain eligible, while conflicting or
+  invalid competing claims for one verified repository classify every affected
+  candidate as `doctor_required` before pull-request lookup.
+- Pull-request provider failures now use only declared prune reasons:
+  authentication and network failures remain specific, while other provider
+  errors use `provider_failure`. The detailed provider code remains available
+  as evidence and every provider failure includes remediation.
+- Live-origin fallback now also requires a complete configured-project
+  inventory. An unavailable configured root preserves global and registry-only
+  candidates as `doctor_required`, preventing a rediscovered fork from becoming
+  the pull-request base; healthy configured projects remain eligible.
+
 ## 0.4.0
 
 <small>2026-08-02</small>

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -11,6 +11,7 @@ abstraction belongs in `kwt`.
 
 - [TUI and project registry](tui-projects.md)
 - [Multi-machine sync architecture](multi-machine-sync.md)
+- [Worktree maintenance](worktree-maintenance.md)
 
 Feature specs and implementation plans should be folded into these maintained
 notes once they ship, so draft checklists do not compete with the current

--- a/docs/design/worktree-maintenance.md
+++ b/docs/design/worktree-maintenance.md
@@ -1,0 +1,304 @@
+# Worktree Maintenance
+
+Worktree maintenance separates structural consistency repair from policies that
+remove live worktrees. `kwt doctor` owns consistency; `kwt prune` owns explicit
+live-removal policies.
+
+## Inventory boundaries
+
+Git's `worktree list --porcelain` output is the source of truth per repository.
+Configured projects, discoverable repositories under the global worktree
+directory, and existing registry paths provide bounded repository roots;
+registry metadata and pull-request provenance are auxiliary joins. Registry
+records with an active creation token are not roots because creation still owns
+their incomplete state. Duplicate roots that resolve to the same Git common
+directory produce one repository report.
+
+Linked-worktree administrative directories are accepted only when their
+`gitdir` file maps back to that exact worktree. A stale `.git` backlink to a
+sibling worktree cannot supply generation or identity state. Repository-level
+identity comes from the resolved main repository; linked-worktree origins are
+retained separately for candidate-specific validation.
+
+Inventory roots retain whether they came from configured projects. A configured
+root requires a canonical configured repository identity; live-origin fallback
+is reserved for unconfigured global and finalized-registry discovery.
+
+Maintenance discovery is strict: traversal failures and unexpected `.git`
+stat or read errors make the inventory incomplete instead of silently hiding a
+subtree. Every discovered main or linked worktree is inspected as a repository
+root and deduplicated by its canonical Git common directory. A linked root that
+Git cannot inspect remains visible as a `project_unreachable` finding.
+
+Maintenance inventory has two modes:
+
+- Read-only inspection reads each existing `kwt-generation` file without
+  creating one. Doctor and prune preflight use this mode, so diagnostics and
+  dry-runs do not adopt legacy worktrees as a side effect.
+- Ordinary operational listing may initialize a missing generation. This keeps
+  normal `kwt list` behavior as the explicit adoption path for a verified live
+  worktree.
+
+The local inspector contains no provider logic. It gathers Git, filesystem,
+registry, and provenance facts; merged-PR classification is a later provider
+layer and completes before mutation starts.
+
+## Structural repair
+
+Doctor reports stable findings for broken or ambiguous backlinks, missing
+worktree directories, stale registry entries, missing generations, unreachable
+projects, repository identity mismatches, and moved or stale project
+registrations. The default is read-only.
+The JSON finding codes are `broken_worktree_backlink`,
+`ambiguous_worktree_backlink`, `missing_worktree_directory`,
+`stale_registry_entry`, `missing_generation`,
+`registry_generation_mismatch`, `project_unreachable`, and
+`repository_identity_mismatch`, `duplicate_registry_entry`, plus
+`project_path_moved`, `stale_project_registration`, and
+`ambiguous_project_relocation` for project configuration.
+
+`doctor --fix` handles only uniquely identified structural state. For each Git
+common directory it:
+
+1. acquires that repository's worktree mutation lock;
+2. rejects an active worktree-creation reservation;
+3. revalidates the inspected path, Git directory, backlink, generation, and
+   existence facts;
+4. repairs uniquely owned backlinks only when every backlink Git could change
+   is included in the validated fix scope;
+5. inventories again and verifies that every record native Git pruning could
+   remove is a uniquely fixable record in the expected snapshot;
+6. invokes immediate native Git metadata pruning only when that complete scope
+   remains valid.
+
+Repair must precede pruning: a repaired backlink can make a moved live worktree
+usable again, while pruning first could discard the administrative record that
+repair needs. Locks are acquired and released one repository at a time; doctor
+never holds multiple repository locks.
+
+After mutation, doctor rescans and compares stable finding code/path pairs with
+the pre-fix report. Human output lists resolved findings under **Fixed** before
+the final inventory; JSON carries them in `fixed` and counts them in
+`summary.fixed_findings`. `--quiet` suppresses the result report without
+changing exit status and is mutually exclusive with `--json`.
+
+Git may repair several backlinks in one repository even when given one linked
+worktree path. Doctor therefore declines backlink repair for that repository if
+any live repairable backlink is ambiguous or otherwise outside the validated
+fix scope. This preserves every manual-only backlink unchanged while allowing
+independent missing-record pruning and registry cleanup to continue.
+
+Registry cleanup follows Git maintenance. Records with a valid generation use
+generation-guarded removal. A confirmed-absent legacy record without a
+generation uses full-entry compare-and-delete under the registry lock, so a
+concurrent replacement is preserved. When a live registry record's generation
+is missing, `doctor --fix` adopts the verified Git generation only by
+compare-and-swap and clears any inherited expiration. A nonempty generation
+mismatch identifies a possible replacement worktree; it remains a manual
+conflict so policy metadata cannot transfer across generations. Inspection and
+repair use the same canonical path identity, so a registry path reached through
+an existing symlink still reconciles with its live Git worktree. Ambiguous
+identities stay reported for manual review. Generation adoption rechecks the
+inspected generation under the repository mutation lock and performs the
+registry compare-and-swap inside that guard; a replacement becomes a no-op.
+Registry records are excluded only
+while another process holds their creation lock. A token left after its owner
+exits is abandoned state: doctor inspects it and reacquires that path lock
+before guarded reconciliation or removal. New expiration records store the
+destination worktree's observed `origin` as a credential-free canonical
+repository identity. Relative filesystem remotes are rejected. Doctor
+accepts that identity when it matches either the configured project or the
+verified live origin for the recorded worktree path. It normalizes legacy URL
+values and renders unparseable legacy identities as `[redacted]` rather than
+echoing raw remote data. Configured project identities follow the same output
+boundary: canonical URL forms are rendered as credential-free identities,
+while malformed values are omitted and reachable projects fall back to their
+canonical live origin or local identity.
+
+Registry entries are grouped by canonical filesystem path before individual
+classification. Two raw paths that resolve to the same live worktree produce
+one `duplicate_registry_entry` finding instead of being silently treated as
+healthy. A group containing an actively owned creation token remains deferred
+until creation finishes, consistent with other registry inspection. Otherwise,
+the finding is fixable only when every repository value resolves to the same
+credential-free identity, and branch, hash, main-worktree flag, registration
+time, expiration, generation, and unreviewed-source policy are equal. Differing
+or unsafe metadata remains a manual finding.
+
+For a fixable group, inspection carries the complete observed entries as a
+private repair condition. Registry mutation validates the complete alias group
+under one registry lock, then replaces it with one unchanged entry. It prefers
+the path spelling recorded by Git for the live worktree; if no raw entry uses
+that spelling, it retains the lexicographically first path for deterministic
+behavior. Any concurrent addition, removal, metadata change, or creation token
+makes the transaction a no-op. This grouped compare-and-swap is required
+because ordinary path-based registry operations intentionally reject multiple
+keys that resolve to the same path.
+
+Project repair starts only after an effective configured path is confirmed
+absent. A credential-free repository identity may select exactly one
+visible main repository as a relocation target. Multiple distinct matching
+clones produce `ambiguous_project_relocation` and require manual choice; an
+unsafe path-derived identity remains `project_unreachable`. When no matching
+repository is visible, `stale_project_registration` authorizes removal of the
+unchanged registration. If the sole matching live repository is already
+registered, the stale entry is also a `stale_project_registration`; repair
+removes the exact unchanged duplicate instead of relocating it onto the live
+entry and creating two registrations for one path. If multiple missing
+registrations independently select the same live target, all remain manual
+`ambiguous_project_relocation` findings because kwt cannot safely choose which
+registration metadata should survive.
+
+Inspection keeps the raw project entry from global TOML beside its independently
+expanded filesystem view. After Git and registry work is complete, `--fix`
+rechecks that the old path is still absent and that a relocation target still
+has the expected canonical main path, common directory, and repository
+identity. It then performs a full-entry compare-and-swap under the shared
+global-config writer lock. Relocation changes only the path and canonical
+repository identity; removal deletes only the exact raw entry. Concurrent
+edits and duplicate entries are no-ops. Unknown project fields are retained so
+a newer kwt version can extend the entry without older repair code erasing its
+metadata. The atomic writer resolves an existing `config.toml` symlink and
+replaces its target, preserving the symlink and target permissions. The
+repaired path is persisted as the verified absolute canonical main-repository
+path. The same global-config transaction refuses a relocation if any other
+current project entry already resolves to the target path. This lock-scoped
+target guard prevents a concurrent registration—or an earlier repair from a
+stale report—from creating duplicate project entries even when inspection saw
+only one relocation claimant.
+
+After every fix attempt, doctor reloads global configuration and the registry
+before rescanning. Its report and exit status therefore describe persisted
+post-fix state rather than the inspection that authorized the attempt. Human
+output groups safe repairs before findings that need review, omits healthy
+repositories and opaque machine evidence, and shortens paths only for display.
+Versioned JSON retains exact paths and evidence.
+
+## Conditional live removal
+
+Expiration and merged-PR decisions are made outside the mutation lock, but a
+decision never authorizes path-only deletion. The Git removal transaction
+rechecks its supplied conditions under the repository lock immediately before
+removal:
+
+- the durable 32-character generation;
+- expected HEAD when the policy depends on it;
+- canonical repository identity when the policy depends on it;
+- the linked worktree's local branch and exact upstream repository and branch
+  when merged-PR evidence depends on them;
+- cleanliness when required.
+
+The transaction also rejects active creation reservations, main worktrees, and
+worktrees that Git marks as locked. Dry-runs use the same lock-scoped inventory
+and precondition validation as removals. A changed condition returns a typed
+reason such as `generation_changed`, `head_changed`,
+`repository_identity_changed`, `locked_worktree`, or `dirty_worktree`; the
+worktree remains.
+
+Merged-prune inventory carries the protected credential names derived from the
+loaded global configuration into the removal transaction. Every Git process
+that may execute worktree-selected configuration—including inventory, origin
+and upstream reads, status checks, lock-time revalidation, and removal—runs
+with kwt's GitHub and fleet credentials removed from its environment.
+
+Generation-less or malformed-generation live worktrees are never automatically
+removed. `--force` for expiration policy can relax cleanliness only. Ignored
+artifacts do not make an expired worktree dirty. Merged-PR policy uses the
+stricter rule that ignored untracked files are also local data, and it has no
+force mode. Expiration removal compares the complete observed registry entry
+while the Git mutation lock is held. Extending or clearing the expiration after
+inspection preserves the worktree with `expiration_policy_changed`.
+
+## Merged pull-request evidence
+
+Imported worktrees fetch the recorded PR number and require the live workspace
+path, branch, head SHA, source identity, project identity, canonical main
+repository path, durable generation when recorded, and repository alias history
+to match persisted provenance.
+Workspace and project paths compare by canonical filesystem identity, so an
+existing symlink alias is equivalent to its resolved path.
+
+Ordinary worktrees derive source repository and branch from the configured Git
+upstream as observed from the linked worktree, including worktree-specific Git
+configuration. GitHub resolves the configured base repository before validating
+imported alias history or looking up pull requests, so repository transfers do
+not invalidate recorded aliases. It also resolves the observed upstream source
+repository for provider matching and diagnostic head lookup while preserving
+the observed identity for lock-time revalidation. GitHub's commit-associated PR
+endpoint must return exactly one result whose base repository, source
+repository, source branch, and head SHA match the local facts and whose
+`merged_at` value is non-null. Exact PR head SHA survives squash and rebase
+merges; local `git branch --merged` ancestry does not.
+The configured project identity is the PR base even when the checkout's
+`origin` points at a fork. The observed `origin` identity is read separately
+from each linked worktree, retained apart from the PR base, and revalidated
+under the repository lock before dry-run approval or removal. For a globally
+discovered repository with no configured project, each candidate uses its own
+observed `origin` as its PR base; sibling worktrees never share a fallback base.
+
+That live-origin fallback is available only when every configured project root
+was inspected successfully. If any configured root is unavailable, candidates
+reached solely through global or registry discovery report `doctor_required`
+before provider lookup. Healthy configured projects remain eligible. This
+repository-wide guard is intentionally conservative: local evidence cannot
+prove that a rediscovered fork is unrelated to the missing configured upstream,
+so a merged pull request against the fork must not authorize removal. Running
+`kwt doctor --fix` to relocate or remove the stale registration restores the
+fallback on the next complete inspection.
+
+An unavailable or noncanonical `origin` fails closed before provider lookup. An
+expiration registry identity may match either this verified live origin or the
+configured PR base, preserving existing origin-based records in fork clones.
+
+When no exact commit result exists, source-head lookup is diagnostic only. It
+distinguishes an advanced branch from no associated PR but cannot authorize
+removal. Closed-but-unmerged PRs, multiple matches, missing upstream identity,
+and provider failures preserve the worktree with stable reasons.
+
+All candidate lookups finish before the first removal. A failure for one
+candidate does not erase another candidate's confirmed result. After removal,
+registry and imported-PR provenance cleanup use their observed generation or
+complete value. New provenance records include the worktree generation, so a
+same-path re-import cannot be deleted by cleanup for the removed incarnation; a
+concurrent replacement produces `cleanup_incomplete` rather than being
+overwritten. Every removal runs from the resolved main repository,
+so deleting a globally discovered linked worktree cannot invalidate the Git
+context needed to remove later candidates. Fleet state publishes once after any
+actual removal, never for doctor, dry-runs, or no-ops.
+
+## Command migration and statuses
+
+The command split is intentional:
+
+```text
+kwt prune                 -> kwt doctor --fix
+kwt prune --expired       -> live expiry policy; absent paths point to doctor
+kwt prune --merged        -> clean, exact merged-PR policy
+```
+
+Doctor exits `0` when healthy, `1` when findings remain, and `2` when inspection
+or fixes cannot complete. Prune exits `0` when confirmed candidates are handled
+or absent, `1` for safety skips or per-candidate failures, and `2` for usage or
+inventory failures. Both commands provide versioned JSON output.
+JSON result reports are written to stdout without duplicating human result
+summaries on stderr.
+
+Prune reports one stable outcome for every considered path. Policy and safety
+outcomes include `removed`, `would_remove`, `missing_generation`,
+`doctor_required`, `dirty_worktree`, `head_advanced_after_pr`,
+`no_associated_pr`, `pr_not_merged`, `source_repository_unavailable`,
+`source_repository_mismatch`, `source_branch_mismatch`, `ambiguous_pr_match`,
+`authentication_failed`, `network_failure`, `generation_changed`,
+`expiration_policy_changed`, `head_changed`, `repository_identity_changed`, `main_worktree`,
+`locked_worktree`, and `cleanup_incomplete`.
+`no_associated_pr` and `pr_not_merged` are normal non-candidates and do not by
+themselves make prune exit nonzero.
+An individually discovered path that cannot be inspected becomes a
+`doctor_required` outcome while other repositories continue. A strict discovery
+error still aborts with exit `2` because the inventory is incomplete. A Git
+removal that deregisters the worktree but leaves residual files completes
+guarded registry and provenance bookkeeping, then reports `cleanup_incomplete`
+with the residual path rather than treating the mutation as wholly failed.
+Multiple registry entries that canonicalize to one candidate path also produce
+`doctor_required`; merged pruning requires one unique registry snapshot before
+it can authorize or clean up that worktree.

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -1,8 +1,9 @@
 # Install kwt
 
-kwt supports macOS, Linux, and Windows. Git 2.31 or newer is required. tmux is
-required for workspace launch and the `kwt tmux` commands, but the
-worktree-oriented CLI can still be used without it.
+kwt supports macOS, Linux, and Windows. Git 2.20 or newer is required. The
+`kwt doctor` command and `kwt prune --expired` or `--merged` policies require
+Git 2.31 or newer. tmux is required for workspace launch and the `kwt tmux`
+commands, but the worktree-oriented CLI can still be used without it.
 
 ## Install with Go
 

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -1,8 +1,8 @@
 # Install kwt
 
-kwt supports macOS, Linux, and Windows. Git is required. tmux is required for
-workspace launch and the `kwt tmux` commands, but the worktree-oriented CLI can
-still be used without it.
+kwt supports macOS, Linux, and Windows. Git 2.31 or newer is required. tmux is
+required for workspace launch and the `kwt tmux` commands, but the
+worktree-oriented CLI can still be used without it.
 
 ## Install with Go
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Before you start
 
-[Install kwt](install.md), then make sure `kwt`, Git 2.31 or newer, and tmux are
+[Install kwt](install.md), then make sure `kwt`, Git 2.20 or newer, and tmux are
 available in your terminal. You do not need to edit configuration before the
 first run.
 
@@ -130,7 +130,8 @@ merged timestamp. It preserves the local branch.
 
 Bare `kwt prune` no longer mutates metadata. Use `kwt doctor --fix` for
 structural cleanup, `kwt prune --expired` for live expiration policy, and
-`kwt prune --merged` for merged-pull-request policy.
+`kwt prune --merged` for merged-pull-request policy. These maintenance commands
+require Git 2.31 or newer.
 
 Next, see [Agent workspaces](../workflows/agent-workspaces.md) to configure tmux
 layouts or the [CLI reference](../reference/cli.md) for the complete command

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -2,8 +2,9 @@
 
 ## Before you start
 
-[Install kwt](install.md), then make sure `kwt`, Git, and tmux are available in
-your terminal. You do not need to edit configuration before the first run.
+[Install kwt](install.md), then make sure `kwt`, Git 2.31 or newer, and tmux are
+available in your terminal. You do not need to edit configuration before the
+first run.
 
 ## Open the dashboard
 
@@ -113,11 +114,23 @@ kwt pr list --project github.com/acme/widget --json
 ```sh
 kwt remove feature/new-ui
 kwt remove -b feature/new-ui
-kwt prune
+kwt doctor
+kwt doctor --fix
+kwt prune --merged --dry-run
+kwt prune --merged
 ```
 
-`remove -b` removes both the worktree and the matching branch. `prune` cleans up
-stale Git worktree metadata.
+`remove -b` removes both the worktree and the matching branch. `doctor` is a
+read-only consistency check; `doctor --fix` repairs uniquely owned backlinks
+and stale metadata, then prints completed repairs before any issues that
+remain. Add `--quiet` when a script needs only the exit status. Merged pruning
+removes only clean linked worktrees with a
+valid kwt generation and one exact GitHub pull request that has an explicit
+merged timestamp. It preserves the local branch.
+
+Bare `kwt prune` no longer mutates metadata. Use `kwt doctor --fix` for
+structural cleanup, `kwt prune --expired` for live expiration policy, and
+`kwt prune --merged` for merged-pull-request policy.
 
 Next, see [Agent workspaces](../workflows/agent-workspaces.md) to configure tmux
 layouts or the [CLI reference](../reference/cli.md) for the complete command

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,6 +3,10 @@
 Run `kwt <command> --help` for command-specific flags. This page summarizes the
 stable command surface.
 
+Kwt requires Git 2.31 or newer. Maintenance inventory relies on
+`git worktree list --expire`, and structural repair uses
+`git worktree repair`.
+
 | Command          | Purpose                                                |
 | ---------------- | ------------------------------------------------------ |
 | `kwt`, `kwt tui` | Open the cross-project and multi-machine dashboard.    |
@@ -17,7 +21,8 @@ stable command surface.
 | `kwt cd`         | Open a shell in a matching worktree.                   |
 | `kwt exec`       | Run a command in a matching worktree.                  |
 | `kwt remove`     | Delete a worktree, optionally its branch.              |
-| `kwt prune`      | Clean up stale Git worktree metadata.                  |
+| `kwt doctor`     | Inspect or repair structural worktree consistency.     |
+| `kwt prune`      | Remove live worktrees by an explicit policy.           |
 | `kwt sync`       | Publish and inspect multi-machine sync state.          |
 | `kwt tmux`       | Manage standalone tmux sessions.                       |
 | `kwt workspace`  | Manage directory workspaces.                           |
@@ -39,6 +44,8 @@ kwt pr import 17 --project github.com/acme/widget \
   --start-session --json
 kwt sync status
 kwt exec fix/parser-race -- go test ./internal/parser
+kwt doctor
+kwt prune --merged --dry-run
 kwt workspace add ~/notes
 kwt workspace list
 kwt workspace list --json
@@ -142,6 +149,174 @@ holding the repository's worktree-mutation lock, so automation cannot delete a
 replacement checkout created at the same path. Ordinary directory changes do
 not alter the generation.
 
+## `kwt doctor`
+
+```sh
+kwt doctor          # inspect without changing anything
+kwt doctor --fix    # apply only confirmed, unambiguous repairs
+kwt doctor --json   # emit exact findings for automation
+kwt doctor --quiet  # print nothing; use the exit status
+```
+
+Doctor reads project registrations, Git worktree metadata, filesystem
+backlinks, the global worktree directory, and live registry paths. The human
+report starts with a summary, lists **Ready to fix** findings before **Needs
+review**, and omits healthy repositories. Long home and temporary paths are
+shortened for display; `--json` keeps exact paths and versioned evidence.
+After `--fix`, the report first lists each completed repair under **Fixed**,
+followed by findings that remain after the rescan. JSON exposes the same
+repairs in `fixed` and counts them in `summary.fixed_findings`. Use `--quiet`
+when only the exit status matters; it cannot be combined with `--json`.
+
+If a registered project path is confirmed absent, doctor searches only its
+bounded local inventory for the same credential-free repository identity:
+
+- one matching main repository produces `project_path_moved` and `--fix`
+  updates the registration to that verified absolute path;
+- one matching main repository that is already registered produces
+  `stale_project_registration` and `--fix` removes only the unchanged duplicate;
+- multiple missing registrations that claim the same matching repository
+  produce `ambiguous_project_relocation` and require you to choose which
+  registration should remain;
+- no match produces `stale_project_registration` and `--fix` removes the
+  unchanged registration;
+- multiple matching clones produce `ambiguous_project_relocation` and require
+  a manual choice; and
+- path-derived, malformed, or otherwise unsafe identities remain
+  `project_unreachable` and are never changed automatically.
+
+Project changes use full-entry compare-and-swap, preserve the name and last
+touched time, and become safe no-ops if the path, target, or global config
+changes concurrently. A relocation is also a no-op if another project becomes
+registered at the target before the config transaction commits. Doctor reloads
+both global config and the registry before its final report, so a successful
+fix can exit healthy while a no-op remains an
+exit-`1` finding. Generation-less registry adoption also rechecks the live Git
+generation while holding the repository mutation lock, so a replacement at the
+same path is never assigned the inspected worktree's generation.
+
+`kwt doctor --fix` repairs only uniquely owned backlinks and confirmed-absent
+Git or registry records. It can adopt a generation-less registry record with
+compare-and-swap after clearing inherited expiration metadata, including when
+the registry path is a symlink alias for the live Git worktree. A nonempty
+registry/Git generation mismatch is a possible replacement conflict and stays manual.
+Because Git can repair multiple backlinks in one operation, doctor
+skips backlink repair for a repository unless every repairable backlink is in
+the validated fix scope. Doctor repairs backlinks before native metadata
+pruning, prunes only when every removable record is in the validated fix scope,
+revalidates under each repository's mutation lock, and rescans before reporting
+the final state. A linked worktree's administrative directory is accepted only
+when a full scan of the repository's worktree metadata finds exactly one
+reverse backlink to that path. Registry entries are not reported or changed
+while their creator still holds the path lock. Tokens abandoned after a creator
+exits are inspected and cleaned only after doctor acquires that same lock.
+Doctor groups registry paths by canonical filesystem identity. Equivalent
+aliases for one live worktree appear under **Duplicate registry paths**, and `--fix`
+atomically collapses the unchanged group to the path spelling recorded by Git.
+Equivalent aliases for a worktree path confirmed absent are removed as one
+unchanged group during the same fix run after absence is rechecked. Aliases with
+different generations, expiration, source-review state, or other policy
+metadata, incompletely inspectable groups, and aliases for an existing path
+that is not a verified Git worktree remain under **Needs review**. It
+normalizes legacy registry and configured project URLs before comparison and
+output. Values that cannot be converted to credential-free identities are
+redacted or omitted; reachable projects fall back to the canonical live origin
+or local identity. Origin-based expiration records are valid when they match
+the verified origin for that worktree, even when the configured project names
+an upstream repository. It never removes a live worktree. A live worktree
+without a valid Git generation is manual until a normal listing from the
+verified repository (`kwt list`) adopts it; rerun `kwt doctor --fix` afterward
+to reconcile a generation-less legacy registry record. Project registration
+repair runs afterward, so Git, registry, and global-config locks are never
+nested.
+
+Exit status is `0` when healthy, `1` when findings remain, and `2` when
+inspection or requested fixes cannot complete.
+
+## `kwt prune`
+
+Prune requires exactly one live-removal policy:
+
+```sh
+kwt prune --expired --dry-run
+kwt prune --expired
+kwt prune --expired --force
+kwt prune --merged --dry-run
+kwt prune --merged
+```
+
+`--expired` evaluates registered expiration times. An expired entry whose path
+is already absent reports `doctor_required` and points to `kwt doctor --fix`;
+expiration pruning no longer silently unregisters it. `--force` is available
+only for expiration policy and never bypasses the generation requirement.
+Ignored build artifacts do not count as dirty for expiration policy and are
+removed with the worktree; use `--dry-run` to preview the decision. Kwt
+rechecks the complete expiration record before removal. If another command
+extends or clears the expiration after inspection, the worktree is preserved
+with `expiration_policy_changed`.
+
+`--merged` inventories linked worktrees from configured projects, the global
+worktree directory, and finalized registry entries, then confirms GitHub
+pull-request evidence before any removal begins. Registry entries still owned
+by a creation token remain doctor-only. Imported worktrees must match their
+complete provenance, including canonical live workspace and main-repository
+paths; an existing
+symlink alias is equivalent to its resolved path. New imported-worktree
+provenance also carries the durable generation, preventing an old record from
+matching a replacement at the same path. Ordinary worktrees must have
+an exact configured upstream repository and branch read from that linked worktree,
+and their current HEAD must exactly match one associated PR head SHA
+with a non-null merged timestamp. GitHub repository redirects are resolved
+before PR lookup and checked against imported provenance aliases. Redirects for
+the upstream source repository are also resolved for PR matching and diagnostic
+head lookup, while the observed upstream remains the lock-time removal
+condition. This recognizes squash and rebase merges without using local
+ancestry. A configured project remains the PR base when its local `origin` is a
+fork; kwt reads the observed origin from each linked worktree separately and
+revalidates it, the local branch, and the upstream under the repository lock.
+If a configured project's repository identity is missing or invalid, the
+candidate reports `doctor_required`; only unconfigured discovery roots may use
+their live origin as the PR base. That fallback also requires every configured
+project root to be inspectable. If one is stale or temporarily unavailable,
+globally and registry-discovered candidates report `doctor_required` before
+GitHub lookup, while candidates from healthy configured projects remain
+eligible. Run `kwt doctor --fix` to repair or remove the stale registration and
+restore unconfigured discovery.
+When global discovery finds a repository that is not configured, each
+worktree's own observed origin becomes its PR base; one worktree's origin is
+never reused for a sibling. An expiration registry record may identify either
+that verified origin or the configured project. A missing or noncanonical
+origin preserves the worktree before provider lookup. Advanced heads, ambiguous matches,
+closed-but-unmerged PRs, dirty worktrees, and missing generations are preserved
+with explicit reasons. There is no merged-policy force mode, and removal
+preserves the local branch. Ignored untracked files count as local changes and
+also preserve the worktree. Removals execute from the resolved main repository,
+so pruning one globally discovered worktree does not strand later candidates.
+Multiple registry paths that resolve to the same worktree are ambiguous and
+report `doctor_required` instead of allowing path-order-dependent removal.
+Git commands run against candidate worktrees without kwt's GitHub or fleet
+credentials in their environment, including during lock-scoped validation and
+removal. This prevents worktree-selected filters, hooks, or filesystem monitors
+from receiving those tokens.
+
+An individual path under the global worktree directory that is no longer a
+usable Git worktree reports `doctor_required`; it does not prevent other
+repositories from being evaluated. An incomplete directory traversal still
+stops inspection with exit status `2`, because kwt cannot know what was missed.
+If Git deregisters a worktree but cannot remove every file, prune completes its
+guarded registry and provenance cleanup, publishes the new fleet state, and
+reports `cleanup_incomplete` with the residual path for manual inspection.
+
+Both policies support `--dry-run` and `--json`. Exit status is `0` when all
+confirmed candidates were handled or no candidate exists, `1` for safety skips,
+provider failures, or incomplete cleanup, and `2` when inspection or command
+usage cannot complete. Bare `kwt prune` is an exit-`2` usage error: run
+`kwt doctor --fix` for the stale-metadata behavior that the bare command used to
+perform. JSON result reports use stdout without duplicating human result
+summaries on stderr. Dry-runs revalidate Git's current inventory under the same
+repository lock as removal and report `locked_worktree` or `main_worktree`
+instead of claiming those paths would be removed.
+
 ## `kwt projects`
 
 `--json` emits an array of the registered project repositories (`{repository,
@@ -204,6 +379,11 @@ identity, creates or repairs that protected blank session when needed, and
 uses `attach-session -E`. This is an interactive exception to the PR JSON
 contract: failures before attachment remain structured, but after a successful
 Unix process replacement tmux owns terminal output and the final exit status.
+Provenance with a durable generation applies only to that exact worktree
+incarnation. If the path is later reused, stale provenance neither protects the
+replacement from ordinary `kwt open` nor authorizes `kwt pr attach` or merged
+pruning. Generation-less legacy provenance continues to match by its verified
+path, branch, and repository identity.
 
 ### Repository identity fallback
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,9 +3,9 @@
 Run `kwt <command> --help` for command-specific flags. This page summarizes the
 stable command surface.
 
-Kwt requires Git 2.31 or newer. Maintenance inventory relies on
-`git worktree list --expire`, and structural repair uses
-`git worktree repair`.
+Kwt requires Git 2.20 or newer. `kwt doctor` and the `kwt prune --expired` or
+`--merged` policies require Git 2.31 or newer: maintenance inventory relies on
+`git worktree list --expire`, and structural repair uses `git worktree repair`.
 
 | Command          | Purpose                                                |
 | ---------------- | ------------------------------------------------------ |
@@ -151,6 +151,8 @@ not alter the generation.
 
 ## `kwt doctor`
 
+Requires Git 2.31 or newer.
+
 ```sh
 kwt doctor          # inspect without changing anything
 kwt doctor --fix    # apply only confirmed, unambiguous repairs
@@ -235,7 +237,7 @@ inspection or requested fixes cannot complete.
 
 ## `kwt prune`
 
-Prune requires exactly one live-removal policy:
+Prune requires Git 2.31 or newer and exactly one live-removal policy:
 
 ```sh
 kwt prune --expired --dry-run

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,10 +7,10 @@ directory also holds `registry.json` and `pull-requests.json`, isolating kwt's
 persistent state as a unit. Without it, each store follows its documented
 platform config-directory behavior.
 
-When an existing installation first upgrades to this layout with `KWT_HOME`
-set, kwt copies a legacy platform-config `registry.json` into `KWT_HOME` if the
-new registry does not exist. An existing `KWT_HOME/registry.json` always wins,
-and the legacy file is retained as a rollback copy.
+`KWT_HOME` is an isolation boundary: kwt never imports registry entries from
+the platform config directory automatically. To move an existing installation,
+stop other kwt processes and copy its `registry.json` into `KWT_HOME` before
+running kwt with the new home. Do not combine two registry files.
 
 The global file is the source of truth for worktree naming, tmux layouts, agent
 commands, repository setup rules, and the known project registry.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,7 +2,15 @@
 
 Global config lives at `~/.config/kwt/config.toml`, or at
 `$KWT_HOME/config.toml` when `KWT_HOME` is set. Repository-local overrides live
-in `.kwt.toml` and are trust-gated before use.
+in `.kwt.toml` and are trust-gated before use. When `KWT_HOME` is set, that same
+directory also holds `registry.json` and `pull-requests.json`, isolating kwt's
+persistent state as a unit. Without it, each store follows its documented
+platform config-directory behavior.
+
+When an existing installation first upgrades to this layout with `KWT_HOME`
+set, kwt copies a legacy platform-config `registry.json` into `KWT_HOME` if the
+new registry does not exist. An existing `KWT_HOME/registry.json` always wins,
+and the legacy file is retained as a rollback copy.
 
 The global file is the source of truth for worktree naming, tmux layouts, agent
 commands, repository setup rules, and the known project registry.
@@ -83,6 +91,9 @@ name = "kwt"
 path = "~/code/kwt"
 last_touched = "2026-07-04T12:00:00Z"
 ```
+
+Project refreshes update these known fields without discarding additional
+fields written by a newer kwt version.
 
 ## Directory workspaces
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -165,11 +165,12 @@ commands therefore do not run during PR import: environment scrubbing alone
 cannot prevent same-user processes from reading kwt configuration or token
 files from disk.
 
-Kwt requires Git 2.31 or newer. PR import uses per-worktree Git configuration
+Kwt requires Git 2.20 or newer. PR import uses per-worktree Git configuration
 to make plain `git push` target the PR head without changing push behavior in
 the main checkout, and checks that capability before it fetches refs, adds
-remotes, or creates a worktree. The global version floor also supplies the
-worktree inventory and repair operations used by maintenance commands.
+remotes, or creates a worktree. The `kwt doctor` command and explicit
+`kwt prune` policies require Git 2.31 or newer for their worktree inventory and
+repair operations.
 
 ## Listing contract
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -165,10 +165,11 @@ commands therefore do not run during PR import: environment scrubbing alone
 cannot prevent same-user processes from reading kwt configuration or token
 files from disk.
 
-Import requires Git 2.20 or newer because kwt uses per-worktree Git
-configuration to make plain `git push` target the PR head without changing
-push behavior in the main checkout. kwt checks this requirement before it
-fetches refs, adds remotes, or creates a worktree.
+Kwt requires Git 2.31 or newer. PR import uses per-worktree Git configuration
+to make plain `git push` target the PR head without changing push behavior in
+the main checkout, and checks that capability before it fetches refs, adds
+remotes, or creates a worktree. The global version floor also supplies the
+worktree inventory and repair operations used by maintenance commands.
 
 ## Listing contract
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -36,6 +36,7 @@ nav = [
       { "Overview" = "design/index.md" },
       { "TUI and project registry" = "design/tui-projects.md" },
       { "Multi-machine sync architecture" = "design/multi-machine-sync.md" },
+      { "Worktree maintenance" = "design/worktree-maintenance.md" },
     ] },
   ] },
 ]

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -249,8 +249,6 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to open registry: %w", err)
 			}
 
-			repoURL, _ := ctx.Git.GetRepositoryURL()
-
 			t := time.Now().Add(expiresDuration)
 			expiresAt = &t
 
@@ -259,7 +257,6 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				reg,
 				worktreePath,
 				worktreeGeneration,
-				repoURL,
 				branch,
 				expiresAt,
 			); err != nil {
@@ -291,10 +288,11 @@ func registerWorktreeExpiration(
 	reg *registry.Registry,
 	worktreePath string,
 	generation string,
-	repository string,
 	branch string,
 	expiresAt *time.Time,
 ) error {
+	remote, _ := git.New(worktreePath).GetRepositoryURL()
+	repository, _ := url.CanonicalRepositoryIdentityFromRemote(remote)
 	return g.WithWorktreeGeneration(
 		worktreePath,
 		generation,

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -184,7 +184,6 @@ func TestRegisterWorktreeExpirationRejectsRecreatedWorktree(t *testing.T) {
 		reg,
 		worktreePath,
 		originalGeneration,
-		"https://github.com/example/original.git",
 		"feature/original",
 		&staleExpiry,
 	)
@@ -223,7 +222,6 @@ func TestRegisterWorktreeExpirationCreatesOrdinaryWorktreeEntry(t *testing.T) {
 		reg,
 		worktreePath,
 		generation,
-		"https://github.com/example/repository.git",
 		"feature/ordinary",
 		&expiresAt,
 	)
@@ -235,6 +233,54 @@ func TestRegisterWorktreeExpirationCreatesOrdinaryWorktreeEntry(t *testing.T) {
 	assert.Equal(t, "feature/ordinary", entry.Branch)
 	require.NotNil(t, entry.ExpiresAt)
 	assert.True(t, entry.ExpiresAt.Equal(expiresAt))
+}
+
+func TestRegisterWorktreeExpirationUsesDestinationRemoteIdentity(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "destination-origin")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "feature/destination-origin", worktreePath)
+	runTUITestGit(t, repoPath, "config", "extensions.worktreeConfig", "true")
+	runTUITestGit(t, worktreePath, "config", "--worktree", "remote.origin.url", "https://github.com/acme/destination.git")
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	expiresAt := time.Now().Add(time.Hour)
+
+	err = registerWorktreeExpiration(
+		git.New(repoPath), reg, worktreePath, generation,
+		"feature/destination-origin", &expiresAt,
+	)
+
+	require.NoError(t, err)
+	entry, ok := reg.Get(worktreePath)
+	require.True(t, ok)
+	assert.Equal(t, "github.com/acme/destination", entry.Repository)
+}
+
+func TestRegisterWorktreeExpirationRejectsRelativeDestinationRemote(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "relative-origin")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "feature/relative-origin", worktreePath)
+	runTUITestGit(t, repoPath, "config", "extensions.worktreeConfig", "true")
+	runTUITestGit(t, worktreePath, "config", "--worktree", "remote.origin.url", "credentials/team/repo.git")
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	reg, err := registry.New()
+	require.NoError(t, err)
+	expiresAt := time.Now().Add(time.Hour)
+
+	err = registerWorktreeExpiration(
+		git.New(repoPath), reg, worktreePath, generation,
+		"feature/relative-origin", &expiresAt,
+	)
+
+	require.NoError(t, err)
+	entry, ok := reg.Get(worktreePath)
+	require.True(t, ok)
+	assert.Empty(t, entry.Repository)
 }
 
 func TestRegisterWorktreeExpirationRejectsProvisionalCreation(t *testing.T) {
@@ -267,7 +313,6 @@ func TestRegisterWorktreeExpirationRejectsProvisionalCreation(t *testing.T) {
 		reg,
 		worktreePath,
 		generation,
-		"https://github.com/example/repository.git",
 		"feature/creating",
 		&expiresAt,
 	)

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/maintenance"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+var (
+	doctorFix   bool
+	doctorJSON  bool
+	doctorQuiet bool
+)
+
+type doctorRegistry interface {
+	maintenance.RegistryMutator
+	List() []*registry.WorktreeEntry
+	CreationActive(string) (bool, error)
+}
+
+var (
+	loadDoctorSnapshot = config.LoadGlobalSnapshot
+	openDoctorRegistry = func() (doctorRegistry, error) {
+		return registry.New()
+	}
+	doctorInspect = func(
+		ctx context.Context,
+		cfg *models.Config,
+		registrations []config.ProjectRegistration,
+		entries []*registry.WorktreeEntry,
+		creationActive func(string) (bool, error),
+	) (maintenance.Report, error) {
+		inspector := maintenance.NewInspector(cfg, entries, registrations)
+		inspector.CreationActive = creationActive
+		return inspector.Inspect(ctx)
+	}
+	doctorApplyFixes = func(
+		ctx context.Context,
+		report maintenance.Report,
+		reg doctorRegistry,
+		entries []*registry.WorktreeEntry,
+	) error {
+		return (&maintenance.Fixer{
+			Registry: reg, RegistryEntries: entries, Projects: doctorProjectMutator{},
+		}).Fix(ctx, report)
+	}
+)
+
+type doctorProjectMutator struct{}
+
+func (doctorProjectMutator) CompareAndSwapProject(
+	expected config.ProjectRegistration,
+	replacement *models.Project,
+) (bool, error) {
+	return config.CompareAndSwapProject(expected, replacement)
+}
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Inspect worktree consistency without changing it",
+	Long: `Inspect project registrations, configured repositories, Git worktree
+metadata, filesystem backlinks, and the kwt registry. The default mode is
+read-only. Use --fix to apply only uniquely owned structural repairs and
+stale-record cleanup. When a project path is confirmed-absent, --fix can
+relocate or remove the unchanged registration only when the result is
+unambiguous.
+
+Read-only inspection does not initialize a missing generation. Adopt a live
+generation-less worktree with kwt list from its verified repository before
+requesting automated policy removal.`,
+	Args: cobra.NoArgs,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireConfigInitialization(); err != nil {
+			return writeMaintenanceError(
+				cmd, "doctor", "initialization_failed", err.Error(), 2, doctorJSON,
+			)
+		}
+		return nil
+	},
+	RunE: runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+	doctorCmd.Flags().BoolVar(&doctorFix, "fix", false, "Repair uniquely owned structural findings")
+	doctorCmd.Flags().BoolVar(&doctorJSON, "json", false, "Output a machine-readable report")
+	doctorCmd.Flags().BoolVar(&doctorQuiet, "quiet", false, "Suppress the report; exit status still indicates remaining findings")
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) error {
+	if doctorQuiet && doctorJSON {
+		return writeMaintenanceError(
+			cmd, "doctor", "incompatible_flags", "--quiet and --json are mutually exclusive", 2, false,
+		)
+	}
+	ctx := cmd.Context()
+	snapshot, err := loadDoctorSnapshot()
+	if err != nil {
+		return writeMaintenanceError(
+			cmd, "doctor", "inspection_failed",
+			fmt.Sprintf("load global configuration: %v", err), 2, doctorJSON,
+		)
+	}
+	reg, err := openDoctorRegistry()
+	if err != nil {
+		return writeMaintenanceError(
+			cmd, "doctor", "inspection_failed",
+			fmt.Sprintf("open worktree registry: %v", err), 2, doctorJSON,
+		)
+	}
+	entries := reg.List()
+	report, err := doctorInspect(ctx, snapshot.Config, snapshot.Projects, entries, reg.CreationActive)
+	if err != nil {
+		return writeMaintenanceError(
+			cmd, "doctor", "inspection_failed", err.Error(), 2, doctorJSON,
+		)
+	}
+	beforeFix := report
+	if doctorFix && report.Summary.Findings > 0 {
+		if err := doctorApplyFixes(ctx, report, reg, entries); err != nil {
+			return writeMaintenanceError(
+				cmd, "doctor", "fix_failed", err.Error(), 2, doctorJSON,
+			)
+		}
+		snapshot, err = loadDoctorSnapshot()
+		if err != nil {
+			return writeMaintenanceError(
+				cmd, "doctor", "inspection_failed",
+				fmt.Sprintf("reload global configuration after fixes: %v", err), 2, doctorJSON,
+			)
+		}
+		reg, err = openDoctorRegistry()
+		if err != nil {
+			return writeMaintenanceError(
+				cmd, "doctor", "inspection_failed",
+				fmt.Sprintf("reopen worktree registry after fixes: %v", err), 2, doctorJSON,
+			)
+		}
+		report, err = doctorInspect(ctx, snapshot.Config, snapshot.Projects, reg.List(), reg.CreationActive)
+		if err != nil {
+			return writeMaintenanceError(
+				cmd, "doctor", "inspection_failed",
+				fmt.Sprintf("rescan after fixes: %v", err), 2, doctorJSON,
+			)
+		}
+		report.Fixed = resolvedDoctorFindings(beforeFix, report)
+		for _, repository := range report.Fixed {
+			report.Summary.FixedFindings += len(repository.Findings)
+		}
+	}
+	report.SchemaVersion = maintenance.SchemaVersion
+	report.Command = "doctor"
+	report.Fix = doctorFix
+	if !doctorQuiet {
+		if err := renderDoctorReport(cmd, report, doctorJSON); err != nil {
+			return writeMaintenanceError(
+				cmd, "doctor", "output_failed", err.Error(), 2, doctorJSON,
+			)
+		}
+	}
+	if report.Summary.Findings > 0 {
+		cmd.Root().SilenceUsage = true
+		cmd.Root().SilenceErrors = true
+		return &maintenanceCommandError{
+			code: 1,
+			err:  fmt.Errorf("%d worktree maintenance issue(s) remain", report.Summary.Findings),
+		}
+	}
+	return nil
+}
+
+func resolvedDoctorFindings(before, after maintenance.Report) []maintenance.RepositoryReport {
+	type findingKey struct {
+		code maintenance.FindingCode
+		path string
+	}
+	remaining := make(map[findingKey]bool)
+	for _, repository := range after.Repositories {
+		for _, finding := range repository.Findings {
+			remaining[findingKey{code: finding.Code, path: utils.PathKey(finding.Path)}] = true
+		}
+	}
+	resolved := make([]maintenance.RepositoryReport, 0)
+	for _, repository := range before.Repositories {
+		fixed := repository
+		fixed.Worktrees = nil
+		fixed.Findings = nil
+		for _, finding := range repository.Findings {
+			key := findingKey{code: finding.Code, path: utils.PathKey(finding.Path)}
+			if finding.Fixable && !remaining[key] {
+				fixed.Findings = append(fixed.Findings, finding)
+			}
+		}
+		if len(fixed.Findings) > 0 {
+			resolved = append(resolved, fixed)
+		}
+	}
+	return resolved
+}

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -73,7 +73,7 @@ unambiguous.
 
 Read-only inspection does not initialize a missing generation. Adopt a live
 generation-less worktree with kwt list from its verified repository before
-requesting automated policy removal.`,
+requesting automated policy removal. Doctor requires Git 2.31 or newer.`,
 	Args: cobra.NoArgs,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := requireConfigInitialization(); err != nil {
@@ -98,6 +98,9 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		return writeMaintenanceError(
 			cmd, "doctor", "incompatible_flags", "--quiet and --json are mutually exclusive", 2, false,
 		)
+	}
+	if err := checkMaintenanceGitVersion(cmd, "doctor", doctorJSON); err != nil {
+		return err
 	}
 	ctx := cmd.Context()
 	snapshot, err := loadDoctorSnapshot()

--- a/internal/cmd/doctor_output.go
+++ b/internal/cmd/doctor_output.go
@@ -1,0 +1,455 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/mattn/go-runewidth"
+	"go.kenn.io/kwt/internal/maintenance"
+)
+
+type doctorRenderOptions struct {
+	Width   int
+	Color   bool
+	HomeDir string
+	TempDir string
+}
+
+type doctorFindingPresentation struct {
+	Rank   int
+	Title  string
+	Action string
+	Known  bool
+}
+
+type doctorFindingGroup struct {
+	Code         maintenance.FindingCode
+	Fixable      bool
+	Presentation doctorFindingPresentation
+	Repositories []doctorRepositoryFindings
+}
+
+type doctorRepositoryFindings struct {
+	Label    string
+	Findings []maintenance.Finding
+}
+
+type doctorStyles struct {
+	title, summary, ready, review, group, repository, path, muted, action lipgloss.Style
+}
+
+func renderDoctorHuman(report maintenance.Report, options doctorRenderOptions) string {
+	if options.Width <= 0 {
+		options.Width = 100
+	}
+	if (report.Summary.Healthy || report.Summary.Findings == 0) && report.Summary.FixedFindings == 0 {
+		return doctorStyled(options.Color, lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true),
+			"✓ Worktree maintenance is healthy.") + "\n"
+	}
+
+	styles := newDoctorStyles()
+	groups := doctorFindingGroups(report)
+	var output strings.Builder
+	writeDoctorLine(&output, doctorStyled(options.Color, styles.title, "kwt doctor"))
+	reviewVerb := "need"
+	if report.Summary.ManualFindings == 1 {
+		reviewVerb = "needs"
+	}
+	summary := fmt.Sprintf("%d %s · %d ready to fix · %d %s review",
+		report.Summary.Findings, plural(report.Summary.Findings, "issue", "issues"),
+		report.Summary.FixableFindings, report.Summary.ManualFindings, reviewVerb)
+	if report.Summary.FixedFindings > 0 {
+		remainVerb := "remain"
+		if report.Summary.Findings == 1 {
+			remainVerb = "remains"
+		}
+		summary = fmt.Sprintf("%d fixed · %d %s %s · %d ready to fix · %d %s review",
+			report.Summary.FixedFindings,
+			report.Summary.Findings, plural(report.Summary.Findings, "issue", "issues"),
+			remainVerb,
+			report.Summary.FixableFindings, report.Summary.ManualFindings, reviewVerb)
+	}
+	writeDoctorWrapped(&output, "", doctorStyled(options.Color, styles.summary, summary), options.Width)
+
+	if report.Summary.FixedFindings > 0 {
+		fixedGroups := doctorFindingGroups(maintenance.Report{Repositories: report.Fixed})
+		renderDoctorSection(&output, "Fixed", report.Summary.FixedFindings, true, false, fixedGroups, options, styles)
+	}
+	renderDoctorSection(&output, "Ready to fix", report.Summary.FixableFindings, true, true, groups, options, styles)
+	renderDoctorSection(&output, "Needs review", report.Summary.ManualFindings, false, true, groups, options, styles)
+	if report.Summary.Findings == 0 {
+		writeDoctorLine(&output, "")
+		writeDoctorLine(&output, doctorStyled(options.Color, styles.ready, "No issues remain."))
+	}
+	if report.Summary.FixableFindings > 0 {
+		writeDoctorLine(&output, "")
+		footer := fmt.Sprintf("Run kwt doctor --fix to repair confirmed issues. (%d available)", report.Summary.FixableFindings)
+		writeDoctorWrapped(&output, "", doctorStyled(options.Color, styles.action, footer), options.Width)
+	}
+	return output.String()
+}
+
+func renderDoctorSection(
+	output *strings.Builder,
+	title string,
+	count int,
+	fixable bool,
+	showAction bool,
+	groups []doctorFindingGroup,
+	options doctorRenderOptions,
+	styles doctorStyles,
+) {
+	if count == 0 {
+		return
+	}
+	writeDoctorLine(output, "")
+	headingStyle := styles.review
+	if fixable {
+		headingStyle = styles.ready
+	}
+	writeDoctorLine(output, doctorStyled(options.Color, headingStyle,
+		fmt.Sprintf("%s  %d", title, count)))
+	for _, group := range groups {
+		if group.Fixable != fixable {
+			continue
+		}
+		groupCount := 0
+		for _, repository := range group.Repositories {
+			groupCount += len(repository.Findings)
+		}
+		writeDoctorLine(output, "")
+		groupHeading := middleElide(fmt.Sprintf("%s (%d)", group.Presentation.Title, groupCount), max(8, options.Width-2))
+		writeDoctorLine(output, "  "+doctorStyled(options.Color, styles.group, groupHeading))
+		for _, repository := range group.Repositories {
+			label := doctorDisplayPath(repository.Label, max(8, options.Width-4), options)
+			writeDoctorLine(output, "    "+doctorStyled(options.Color, styles.repository, label))
+			for _, finding := range repository.Findings {
+				renderDoctorFinding(output, finding, group.Presentation, options, styles)
+			}
+		}
+		action := group.Presentation.Action
+		if action == "" {
+			for _, repository := range group.Repositories {
+				for _, finding := range repository.Findings {
+					if finding.Remediation != "" {
+						action = finding.Remediation
+						break
+					}
+				}
+				if action != "" {
+					break
+				}
+			}
+		}
+		if showAction && action != "" {
+			writeDoctorWrapped(output, "    Next: ", doctorStyled(options.Color, styles.action, action), options.Width)
+		}
+	}
+}
+
+func renderDoctorFinding(
+	output *strings.Builder,
+	finding maintenance.Finding,
+	presentation doctorFindingPresentation,
+	options doctorRenderOptions,
+	styles doctorStyles,
+) {
+	const rowPrefix = "      • "
+	available := max(8, options.Width-runewidth.StringWidth(rowPrefix))
+	line := ""
+	switch finding.Code {
+	case maintenance.ProjectPathMoved:
+		oldPath := finding.Evidence["old_path"]
+		newPath := finding.Evidence["new_path"]
+		if oldPath == "" {
+			oldPath = finding.Path
+		}
+		line = doctorPathTransition(oldPath, newPath, available, options)
+	case maintenance.BrokenWorktreeBacklink:
+		current := finding.Evidence["current_target"]
+		expected := finding.Evidence["expected_target"]
+		if current != "" && expected != "" {
+			line = doctorPathTransition(current, expected, available, options)
+		}
+	case maintenance.AmbiguousProjectRelocation:
+		line = doctorDisplayPath(finding.Path, available, options)
+	default:
+		line = doctorDisplayPath(finding.Path, available, options)
+	}
+	if line == "" {
+		line = doctorDisplayPath(finding.Path, available, options)
+	}
+	if line == "" {
+		line = finding.Message
+	}
+	writeDoctorLine(output, rowPrefix+doctorStyled(options.Color, styles.path, line))
+
+	if finding.Code == maintenance.AmbiguousProjectRelocation {
+		candidates := splitDoctorEvidencePaths(finding.Evidence["candidate_paths"])
+		for _, candidate := range candidates {
+			writeDoctorLine(output, "        "+doctorStyled(options.Color, styles.muted,
+				"candidate: "+doctorDisplayPath(candidate, max(8, options.Width-19), options)))
+		}
+	}
+	if finding.Code == maintenance.AmbiguousWorktreeBacklink {
+		for _, claimant := range splitDoctorClaimants(finding.Evidence["claimants"]) {
+			writeDoctorLine(output, "        "+doctorStyled(options.Color, styles.muted,
+				"claimed by: "+doctorDisplayPath(claimant, max(8, options.Width-20), options)))
+		}
+	}
+	if finding.Code == maintenance.DuplicateRegistryEntry {
+		for _, alias := range splitDoctorEvidencePaths(finding.Evidence["paths"]) {
+			writeDoctorLine(output, "        "+doctorStyled(options.Color, styles.muted,
+				"alias: "+doctorDisplayPath(alias, max(8, options.Width-15), options)))
+		}
+	}
+	if (!presentation.Known || !finding.Fixable) && finding.Message != "" && finding.Message != line {
+		writeDoctorWrapped(output, "        ", doctorStyled(options.Color, styles.muted, finding.Message), options.Width)
+	}
+	for _, evidence := range doctorHumanEvidence(finding) {
+		writeDoctorWrapped(output, "        ", doctorStyled(options.Color, styles.muted, evidence), options.Width)
+	}
+}
+
+func doctorFindingGroups(report maintenance.Report) []doctorFindingGroup {
+	type groupKey struct {
+		fixable bool
+		code    maintenance.FindingCode
+		action  string
+	}
+	type groupAccumulator struct {
+		presentation doctorFindingPresentation
+		repositories map[string][]maintenance.Finding
+	}
+	accumulators := make(map[groupKey]*groupAccumulator)
+	for _, repository := range report.Repositories {
+		if len(repository.Findings) == 0 {
+			continue
+		}
+		label := repository.RepositoryIdentity
+		if label == "" {
+			label = repository.Root
+		}
+		if label == "" {
+			label = "Registry"
+		}
+		for _, finding := range repository.Findings {
+			presentation := doctorPresentation(finding.Code)
+			action := presentation.Action
+			if !finding.Fixable || action == "" {
+				action = finding.Remediation
+			}
+			key := groupKey{fixable: finding.Fixable, code: finding.Code, action: action}
+			accumulator := accumulators[key]
+			if accumulator == nil {
+				presentation.Action = action
+				accumulator = &groupAccumulator{
+					presentation: presentation,
+					repositories: make(map[string][]maintenance.Finding),
+				}
+				accumulators[key] = accumulator
+			}
+			accumulator.repositories[label] = append(accumulator.repositories[label], finding)
+		}
+	}
+
+	groups := make([]doctorFindingGroup, 0, len(accumulators))
+	for key, accumulator := range accumulators {
+		group := doctorFindingGroup{Code: key.code, Fixable: key.fixable, Presentation: accumulator.presentation}
+		for label, findings := range accumulator.repositories {
+			sort.Slice(findings, func(left, right int) bool {
+				if findings[left].Path == findings[right].Path {
+					return findings[left].Message < findings[right].Message
+				}
+				return findings[left].Path < findings[right].Path
+			})
+			group.Repositories = append(group.Repositories, doctorRepositoryFindings{Label: label, Findings: findings})
+		}
+		sort.Slice(group.Repositories, func(left, right int) bool {
+			return group.Repositories[left].Label < group.Repositories[right].Label
+		})
+		groups = append(groups, group)
+	}
+	sort.Slice(groups, func(left, right int) bool {
+		if groups[left].Fixable != groups[right].Fixable {
+			return groups[left].Fixable
+		}
+		if groups[left].Presentation.Rank != groups[right].Presentation.Rank {
+			return groups[left].Presentation.Rank < groups[right].Presentation.Rank
+		}
+		if groups[left].Code != groups[right].Code {
+			return groups[left].Code < groups[right].Code
+		}
+		return groups[left].Presentation.Action < groups[right].Presentation.Action
+	})
+	return groups
+}
+
+func doctorHumanEvidence(finding maintenance.Finding) []string {
+	labels := []struct {
+		key   string
+		label string
+	}{
+		{key: "configured_repository", label: "configured"},
+		{key: "registry_repository", label: "registry"},
+		{key: "live_repository", label: "live"},
+	}
+	result := make([]string, 0, len(labels))
+	for _, item := range labels {
+		if value := finding.Evidence[item.key]; value != "" {
+			result = append(result, item.label+": "+value)
+		}
+	}
+	return result
+}
+
+func doctorPresentation(code maintenance.FindingCode) doctorFindingPresentation {
+	presentations := map[maintenance.FindingCode]doctorFindingPresentation{
+		maintenance.ProjectPathMoved:           {Rank: 10, Title: "Project moved", Action: "Update the registration to the verified repository path.", Known: true},
+		maintenance.StaleProjectRegistration:   {Rank: 20, Title: "Stale project registration", Action: "Remove the confirmed stale project registration.", Known: true},
+		maintenance.BrokenWorktreeBacklink:     {Rank: 30, Title: "Outdated worktree backlink", Action: "Repair the verified worktree backlink.", Known: true},
+		maintenance.MissingWorktreeDirectory:   {Rank: 40, Title: "Missing worktree directory", Action: "Prune the confirmed stale Git worktree record.", Known: true},
+		maintenance.StaleRegistryEntry:         {Rank: 50, Title: "Stale registry entry", Action: "Remove the confirmed stale registry record.", Known: true},
+		maintenance.RegistryGenerationMismatch: {Rank: 60, Title: "Registry generation mismatch", Action: "Reconcile only the verified legacy registry record.", Known: true},
+		maintenance.DuplicateRegistryEntry:     {Rank: 70, Title: "Duplicate registry paths", Action: "Collapse equivalent aliases to one registry record.", Known: true},
+		maintenance.AmbiguousProjectRelocation: {Rank: 10, Title: "Project location is ambiguous", Action: "Choose the intended repository path and update the registration manually.", Known: true},
+		maintenance.ProjectUnreachable:         {Rank: 20, Title: "Repository could not be inspected", Action: "Restore access or update the registration, then rerun kwt doctor.", Known: true},
+		maintenance.AmbiguousWorktreeBacklink:  {Rank: 30, Title: "Worktree backlink is ambiguous", Action: "Choose the intended worktree and repair the conflicting copy manually.", Known: true},
+		maintenance.RepositoryIdentityMismatch: {Rank: 40, Title: "Repository identity mismatch", Action: "Review the configured, registry, and live repository identities.", Known: true},
+		maintenance.UnverifiedRegistryEntry:    {Rank: 45, Title: "Unverified registry path", Action: "Review or remove the unverified registry policy manually.", Known: true},
+		maintenance.MissingGeneration:          {Rank: 50, Title: "Missing worktree generation", Action: "Initialize the Git generation from the verified repository, then rerun doctor.", Known: true},
+	}
+	if presentation, ok := presentations[code]; ok {
+		return presentation
+	}
+	title := strings.TrimSpace(strings.ReplaceAll(string(code), "_", " "))
+	if title == "" {
+		title = "Unknown finding"
+	}
+	return doctorFindingPresentation{Rank: 1000, Title: strings.ToUpper(title[:1]) + title[1:]}
+}
+
+func doctorPathTransition(oldPath, newPath string, width int, options doctorRenderOptions) string {
+	if newPath == "" {
+		return doctorDisplayPath(oldPath, width, options)
+	}
+	oldDisplay := doctorDisplayPath(oldPath, 0, options)
+	newDisplay := doctorDisplayPath(newPath, 0, options)
+	separator := " → "
+	budget := max(2, width-runewidth.StringWidth(separator))
+	leftBudget := budget / 2
+	rightBudget := budget - leftBudget
+	return middleElide(oldDisplay, leftBudget) + separator + middleElide(newDisplay, rightBudget)
+}
+
+func doctorDisplayPath(path string, width int, options doctorRenderOptions) string {
+	display := shortenDoctorPath(path, options.HomeDir, "~")
+	if display == path {
+		display = shortenDoctorPath(path, options.TempDir, "$TMPDIR")
+	}
+	if width > 0 {
+		display = middleElide(display, width)
+	}
+	return display
+}
+
+func shortenDoctorPath(path, prefix, replacement string) string {
+	if path == "" || prefix == "" {
+		return path
+	}
+	cleanPath := filepath.Clean(path)
+	cleanPrefix := filepath.Clean(prefix)
+	if cleanPath == cleanPrefix {
+		return replacement
+	}
+	relative, err := filepath.Rel(cleanPrefix, cleanPath)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return filepath.Join(replacement, relative)
+}
+
+func middleElide(value string, width int) string {
+	if width <= 0 || runewidth.StringWidth(value) <= width {
+		return value
+	}
+	if width == 1 {
+		return "…"
+	}
+	contentWidth := width - 1
+	leftWidth := contentWidth / 2
+	rightWidth := contentWidth - leftWidth
+	left := runewidth.Truncate(value, leftWidth, "")
+	right := runewidth.TruncatePrefix(value, rightWidth, "")
+	return left + "…" + right
+}
+
+func splitDoctorEvidencePaths(value string) []string {
+	var result []string
+	for _, path := range strings.Split(value, "\n") {
+		if path = strings.TrimSpace(path); path != "" {
+			result = append(result, path)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func splitDoctorClaimants(value string) []string {
+	var result []string
+	for _, claimant := range strings.Split(value, ",") {
+		if claimant = strings.TrimSpace(claimant); claimant != "" {
+			result = append(result, claimant)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func writeDoctorWrapped(output *strings.Builder, prefix, value string, width int) {
+	available := max(8, width-runewidth.StringWidth(prefix))
+	wrapped := lipgloss.Wrap(value, available, " ")
+	for index, line := range strings.Split(wrapped, "\n") {
+		linePrefix := strings.Repeat(" ", runewidth.StringWidth(prefix))
+		if index == 0 {
+			linePrefix = prefix
+		}
+		writeDoctorLine(output, linePrefix+line)
+	}
+}
+
+func writeDoctorLine(output *strings.Builder, line string) {
+	output.WriteString(line)
+	output.WriteByte('\n')
+}
+
+func newDoctorStyles() doctorStyles {
+	return doctorStyles{
+		title:      lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")),
+		summary:    lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
+		ready:      lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10")),
+		review:     lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("11")),
+		group:      lipgloss.NewStyle().Bold(true),
+		repository: lipgloss.NewStyle().Foreground(lipgloss.Color("12")),
+		path:       lipgloss.NewStyle().Foreground(lipgloss.Color("14")),
+		muted:      lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
+		action:     lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
+	}
+}
+
+func doctorStyled(enabled bool, style lipgloss.Style, value string) string {
+	if !enabled {
+		return value
+	}
+	return style.Render(value)
+}
+
+func plural(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}

--- a/internal/cmd/doctor_output_test.go
+++ b/internal/cmd/doctor_output_test.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/maintenance"
+)
+
+func TestRenderDoctorHumanOrganizesFindingsByAction(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	report := doctorOutputReport(generation)
+
+	output := renderDoctorHuman(report, doctorRenderOptions{
+		Width: 80, Color: false, HomeDir: "/home/user-a", TempDir: "/tmp",
+	})
+
+	summary := strings.Index(output, "3 issues")
+	ready := strings.Index(output, "Ready to fix")
+	manual := strings.Index(output, "Needs review")
+	require.GreaterOrEqual(t, summary, 0, output)
+	assert.Greater(t, ready, summary, output)
+	assert.Greater(t, manual, ready, output)
+	assert.Contains(t, output, "Project moved")
+	assert.Contains(t, output, "Stale registry entry")
+	assert.Contains(t, output, "Project location is ambiguous")
+	assert.Contains(t, output, "github.com/acme/widget")
+	assert.Contains(t, output, "Registry")
+	assert.NotContains(t, output, "github.com/acme/healthy")
+	assert.Contains(t, output, filepath.Join("~", "old", "widget")+" → /repos/widget")
+	assert.Contains(t, output, filepath.Join("$TMPDIR", "kwt-stale"))
+	assert.Contains(t, output, "/repos/widget-one")
+	assert.Contains(t, output, "/repos/widget-two")
+	assert.NotContains(t, output, generation)
+	assert.NotContains(t, output, "\x1b[")
+	assert.Equal(t, 1, strings.Count(output, "Run kwt doctor --fix to repair confirmed issues."), output)
+}
+
+func TestRenderDoctorHumanWrapsAndElidesAtNarrowWidth(t *testing.T) {
+	report := doctorOutputReport("opaque-generation")
+	report.Repositories[0].Findings[0].Evidence["old_path"] =
+		"/home/user-a/code/github.com/acme/a-very-long-repository-name/widget"
+
+	output := renderDoctorHuman(report, doctorRenderOptions{
+		Width: 40, Color: false, HomeDir: "/home/user-a", TempDir: "/tmp",
+	})
+
+	assert.Contains(t, output, "~")
+	assert.Contains(t, output, "…")
+	for _, line := range strings.Split(strings.TrimSuffix(output, "\n"), "\n") {
+		assert.LessOrEqual(t, runewidth.StringWidth(line), 40, "line exceeds width: %q", line)
+	}
+}
+
+func TestRenderDoctorHumanShowsUnknownFinding(t *testing.T) {
+	report := maintenance.Report{
+		Repositories: []maintenance.RepositoryReport{{Findings: []maintenance.Finding{{
+			Code: "future_finding", Path: "/worktrees/topic", Message: "future detail",
+			Remediation: "Review the future finding.",
+		}}}},
+		Summary: maintenance.Summary{Findings: 1, ManualFindings: 1},
+	}
+
+	output := renderDoctorHuman(report, doctorRenderOptions{Width: 80})
+
+	assert.Contains(t, output, "Future finding")
+	assert.Contains(t, output, "future detail")
+	assert.Contains(t, output, "Review the future finding.")
+}
+
+func TestDoctorPresentationLabelsUnverifiedRegistryEntry(t *testing.T) {
+	presentation := doctorPresentation(maintenance.UnverifiedRegistryEntry)
+
+	assert.True(t, presentation.Known)
+	assert.Equal(t, "Unverified registry path", presentation.Title)
+	assert.Contains(t, presentation.Action, "registry")
+}
+
+func TestRenderDoctorHumanShowsDuplicateRegistryAliases(t *testing.T) {
+	aliases := []string{"/worktrees/topic", "/aliases/topic"}
+	report := maintenance.Report{
+		Repositories: []maintenance.RepositoryReport{{
+			RepositoryIdentity: "github.com/acme/widget",
+			Findings: []maintenance.Finding{{
+				Code: maintenance.DuplicateRegistryEntry, Path: aliases[0],
+				Message:     "multiple equivalent registry paths resolve to the same live worktree",
+				Remediation: "Run kwt doctor --fix to collapse the unchanged aliases.",
+				Fixable:     true,
+				Evidence:    map[string]string{"paths": strings.Join(aliases, "\n")},
+			}},
+		}},
+		Summary: maintenance.Summary{Findings: 1, FixableFindings: 1},
+	}
+
+	output := renderDoctorHuman(report, doctorRenderOptions{Width: 80})
+
+	assert.Contains(t, output, "Duplicate registry paths")
+	assert.Contains(t, output, "alias: /worktrees/topic")
+	assert.Contains(t, output, "alias: /aliases/topic")
+	assert.Contains(t, output, "Collapse equivalent aliases to one registry record.")
+}
+
+func TestRenderDoctorHumanUsesColorOnlyWhenEnabled(t *testing.T) {
+	report := doctorOutputReport("opaque-generation")
+
+	colored := renderDoctorHuman(report, doctorRenderOptions{Width: 80, Color: true})
+	plain := renderDoctorHuman(report, doctorRenderOptions{Width: 80, Color: false})
+
+	assert.Contains(t, colored, "\x1b[")
+	assert.NotContains(t, plain, "\x1b[")
+}
+
+func TestRenderDoctorHumanKeepsManualFindingDetailsActionable(t *testing.T) {
+	report := maintenance.Report{
+		Repositories: []maintenance.RepositoryReport{
+			{
+				RepositoryIdentity: "github.com/acme/a-repository-identity-that-is-too-long-for-the-terminal",
+				Findings: []maintenance.Finding{
+					{
+						Code: maintenance.RegistryGenerationMismatch, Path: "/worktrees/topic",
+						Message:     "registry and Git generations identify different worktrees",
+						Remediation: "Review the replacement conflict; do not transfer expiration policy.",
+					},
+					{
+						Code: maintenance.RepositoryIdentityMismatch, Path: "/worktrees/identity",
+						Message:     "registry identity does not match the live repository",
+						Remediation: "Review the repository identities.",
+						Evidence: map[string]string{
+							"configured_repository": "github.com/acme/widget",
+							"registry_repository":   "github.com/other/widget",
+							"live_repository":       "github.com/user/widget",
+							"git_generation":        "hidden-generation",
+						},
+					},
+				},
+			},
+			{
+				Root: "/a/very/long/repository/root/that/is/not/reachable",
+				Findings: []maintenance.Finding{{
+					Code: maintenance.ProjectUnreachable, Path: "/missing/widget",
+					Message:     "configured project could not be inspected: permission denied",
+					Remediation: "Restore filesystem access.",
+				}},
+			},
+		},
+		Summary: maintenance.Summary{Findings: 3, ManualFindings: 3},
+	}
+
+	output := renderDoctorHuman(report, doctorRenderOptions{Width: 52})
+
+	assert.Contains(t, output, "Review the replacement conflict")
+	assert.NotContains(t, output, "verified legacy")
+	assert.Contains(t, output, "permission denied")
+	assert.Contains(t, output, "configured: github.com/acme/widget")
+	assert.Contains(t, output, "registry: github.com/other/widget")
+	assert.Contains(t, output, "live: github.com/user/widget")
+	assert.NotContains(t, output, "hidden-generation")
+	for _, line := range strings.Split(strings.TrimSuffix(output, "\n"), "\n") {
+		assert.LessOrEqual(t, runewidth.StringWidth(line), 52, "line exceeds width: %q", line)
+	}
+}
+
+func TestRenderDoctorHumanShowsRepairsBeforeRemainingFindings(t *testing.T) {
+	report := maintenance.Report{
+		Fixed: []maintenance.RepositoryReport{{
+			RepositoryIdentity: "github.com/acme/widget",
+			Findings: []maintenance.Finding{{
+				Code:    maintenance.BrokenWorktreeBacklink,
+				Path:    "/worktrees/topic",
+				Fixable: true,
+				Evidence: map[string]string{
+					"current_target":  "/old/.git/worktrees/topic",
+					"expected_target": "/new/.git/worktrees/topic",
+				},
+			}},
+		}},
+		Summary: maintenance.Summary{FixedFindings: 1, Findings: 1, ManualFindings: 1},
+		Repositories: []maintenance.RepositoryReport{{
+			Root: "/worktrees/orphan",
+			Findings: []maintenance.Finding{{
+				Code: maintenance.ProjectUnreachable, Path: "/worktrees/orphan",
+				Message: "repository could not be inspected", Remediation: "Inspect it manually.",
+			}},
+		}},
+	}
+
+	output := renderDoctorHuman(report, doctorRenderOptions{Width: 100})
+
+	fixed := strings.Index(output, "Fixed  1")
+	remaining := strings.Index(output, "Needs review  1")
+	require.GreaterOrEqual(t, fixed, 0, output)
+	assert.Greater(t, remaining, fixed, output)
+	assert.Contains(t, output, "1 fixed · 1 issue remains")
+	assert.Contains(t, output, "/old/.git/worktrees/topic → /new/.git/worktrees/topic")
+	assert.NotContains(t, output[:remaining], "Next:")
+}
+
+func doctorOutputReport(generation string) maintenance.Report {
+	return maintenance.Report{
+		Repositories: []maintenance.RepositoryReport{
+			{
+				RepositoryIdentity: "github.com/acme/widget",
+				Findings: []maintenance.Finding{
+					{
+						Code: maintenance.ProjectPathMoved, Path: "/home/user-a/old/widget",
+						Message: "one matching repository was found", Fixable: true,
+						Remediation: "Run kwt doctor --fix to update the project.",
+						Evidence: map[string]string{
+							"old_path": "/home/user-a/old/widget", "new_path": "/repos/widget",
+						},
+					},
+					{
+						Code: maintenance.AmbiguousProjectRelocation, Path: "/home/user-a/old/ambiguous",
+						Message:     "multiple matching repositories were found",
+						Remediation: "Choose the intended repository path.",
+						Evidence: map[string]string{
+							"candidate_paths": "/repos/widget-two\n/repos/widget-one",
+						},
+					},
+				},
+			},
+			{
+				Findings: []maintenance.Finding{{
+					Code: maintenance.StaleRegistryEntry, Path: "/tmp/kwt-stale",
+					Message: "registry path is absent", Fixable: true,
+					Remediation: "Run kwt doctor --fix to remove the entry.",
+					Evidence:    map[string]string{"generation": generation},
+				}},
+			},
+			{RepositoryIdentity: "github.com/acme/healthy"},
+		},
+		Summary: maintenance.Summary{
+			Findings: 3, FixableFindings: 2, ManualFindings: 1,
+		},
+	}
+}

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -52,6 +52,7 @@ func TestDoctorHelpDescribesMaintenanceContract(t *testing.T) {
 	assert.Contains(t, help, "project registrations")
 	assert.Contains(t, help, "confirmed-absent")
 	assert.Contains(t, help, "relocate or remove")
+	assert.Contains(t, help, "Git 2.31")
 }
 
 func TestDoctorInitializationFailureUsesMaintenanceErrorContract(t *testing.T) {
@@ -70,6 +71,37 @@ func TestDoctorInitializationFailureUsesMaintenanceErrorContract(t *testing.T) {
 	assert.Equal(t, "doctor", envelope.Command)
 	assert.Equal(t, "initialization_failed", envelope.Error.Code)
 	assert.Contains(t, stderr.String(), "config unavailable")
+}
+
+func TestDoctorRejectsUnsupportedGitVersion(t *testing.T) {
+	for _, jsonOutput := range []bool{false, true} {
+		t.Run(map[bool]string{false: "human", true: "json"}[jsonOutput], func(t *testing.T) {
+			resetDoctorCommandDeps(t)
+			doctorJSON = jsonOutput
+			requireMaintenanceGitVersion = func() error {
+				return errors.New("Git 2.31 or newer is required; found Git 2.30.2")
+			}
+			loadDoctorSnapshot = func() (*config.GlobalSnapshot, error) {
+				t.Fatal("configuration must not load when Git is unsupported")
+				return nil, nil
+			}
+			cmd, stdout, stderr := doctorTestCommand()
+
+			err := runDoctor(cmd, nil)
+
+			assertExitCode(t, err, 2)
+			assert.Contains(t, stderr.String(), "unsupported_git_version")
+			assert.Contains(t, stderr.String(), "Git 2.31")
+			if jsonOutput {
+				var envelope maintenanceErrorEnvelope
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+				assert.Equal(t, "doctor", envelope.Command)
+				assert.Equal(t, "unsupported_git_version", envelope.Error.Code)
+			} else {
+				assert.Empty(t, stdout.String())
+			}
+		})
+	}
 }
 
 func TestRenderDoctorReportUsesHumanDashboard(t *testing.T) {
@@ -169,6 +201,10 @@ func TestDoctorRejectsQuietWithJSON(t *testing.T) {
 	resetDoctorCommandDeps(t)
 	doctorQuiet = true
 	doctorJSON = true
+	requireMaintenanceGitVersion = func() error {
+		t.Fatal("version check must not hide incompatible flag usage")
+		return nil
+	}
 	cmd, _, stderr := doctorTestCommand()
 
 	err := runDoctor(cmd, nil)
@@ -395,6 +431,7 @@ func resetDoctorCommandDeps(t *testing.T) {
 	oldOpen := openDoctorRegistry
 	oldInspect := doctorInspect
 	oldFixes := doctorApplyFixes
+	oldRequireMaintenanceGitVersion := requireMaintenanceGitVersion
 	oldSilenceUsage := rootCmd.SilenceUsage
 	oldSilenceErrors := rootCmd.SilenceErrors
 	t.Cleanup(func() {
@@ -405,12 +442,14 @@ func resetDoctorCommandDeps(t *testing.T) {
 		openDoctorRegistry = oldOpen
 		doctorInspect = oldInspect
 		doctorApplyFixes = oldFixes
+		requireMaintenanceGitVersion = oldRequireMaintenanceGitVersion
 		rootCmd.SilenceUsage = oldSilenceUsage
 		rootCmd.SilenceErrors = oldSilenceErrors
 	})
 	doctorFix = false
 	doctorJSON = false
 	doctorQuiet = false
+	requireMaintenanceGitVersion = func() error { return nil }
 	loadDoctorSnapshot = func() (*config.GlobalSnapshot, error) {
 		return &config.GlobalSnapshot{Config: &models.Config{}}, nil
 	}

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -1,0 +1,436 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/maintenance"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestDoctorReadOnlyReportsFixInstruction(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+		return doctorFindingReport(), nil
+	}
+	var fixCalls int
+	doctorApplyFixes = func(context.Context, maintenance.Report, doctorRegistry, []*registry.WorktreeEntry) error {
+		fixCalls++
+		return nil
+	}
+	cmd, stdout, stderr := doctorTestCommand()
+
+	err := runDoctor(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Zero(t, fixCalls)
+	assert.Contains(t, stdout.String(), "kwt doctor --fix")
+	assert.Empty(t, stderr.String())
+}
+
+func TestDoctorHelpDescribesMaintenanceContract(t *testing.T) {
+	var output bytes.Buffer
+	doctorCmd.SetOut(&output)
+	t.Cleanup(func() { doctorCmd.SetOut(nil) })
+
+	require.NoError(t, doctorCmd.Help())
+
+	help := output.String()
+	assert.Contains(t, help, "read-only")
+	assert.Contains(t, help, "--fix")
+	assert.Contains(t, help, "--json")
+	assert.Contains(t, help, "--quiet")
+	assert.Contains(t, help, "missing generation")
+	assert.Contains(t, help, "project registrations")
+	assert.Contains(t, help, "confirmed-absent")
+	assert.Contains(t, help, "relocate or remove")
+}
+
+func TestDoctorInitializationFailureUsesMaintenanceErrorContract(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorJSON = true
+	oldInitErr := configInitErr
+	configInitErr = errors.New("config unavailable")
+	t.Cleanup(func() { configInitErr = oldInitErr })
+	cmd, stdout, stderr := doctorTestCommand()
+
+	err := doctorCmd.PersistentPreRunE(cmd, nil)
+
+	assertExitCode(t, err, 2)
+	var envelope maintenanceErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "doctor", envelope.Command)
+	assert.Equal(t, "initialization_failed", envelope.Error.Code)
+	assert.Contains(t, stderr.String(), "config unavailable")
+}
+
+func TestRenderDoctorReportUsesHumanDashboard(t *testing.T) {
+	report := doctorFindingReport()
+	report.Repositories[0].Findings[0].Evidence = map[string]string{
+		"generation": "0123456789abcdef0123456789abcdef",
+	}
+	cmd, stdout, _ := doctorTestCommand()
+
+	require.NoError(t, renderDoctorReport(cmd, report, false))
+
+	output := stdout.String()
+	assert.Contains(t, output, "kwt doctor")
+	assert.Contains(t, output, "Ready to fix")
+	assert.Contains(t, output, "Outdated worktree backlink")
+	assert.NotContains(t, output, "0123456789abcdef0123456789abcdef")
+}
+
+func TestDoctorFixRescans(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorFix = true
+	var inspections int
+	doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+		inspections++
+		if inspections == 1 {
+			return doctorFindingReport(), nil
+		}
+		return doctorHealthyReport(), nil
+	}
+	var fixCalls int
+	doctorApplyFixes = func(context.Context, maintenance.Report, doctorRegistry, []*registry.WorktreeEntry) error {
+		fixCalls++
+		return nil
+	}
+	cmd, stdout, _ := doctorTestCommand()
+
+	err := runDoctor(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, inspections)
+	assert.Equal(t, 1, fixCalls)
+	assert.Contains(t, stdout.String(), "Fixed  1")
+	assert.Contains(t, stdout.String(), "/worktrees/topic")
+	assert.Contains(t, stdout.String(), "No issues remain")
+}
+
+func TestDoctorFixJSONIncludesResolvedFindings(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorFix = true
+	doctorJSON = true
+	var inspections int
+	doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+		inspections++
+		if inspections == 1 {
+			return doctorFindingReport(), nil
+		}
+		return doctorHealthyReport(), nil
+	}
+	doctorApplyFixes = func(context.Context, maintenance.Report, doctorRegistry, []*registry.WorktreeEntry) error {
+		return nil
+	}
+	cmd, stdout, _ := doctorTestCommand()
+
+	require.NoError(t, runDoctor(cmd, nil))
+	var report maintenance.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	require.Len(t, report.Fixed, 1)
+	require.Len(t, report.Fixed[0].Findings, 1)
+	assert.Equal(t, maintenance.BrokenWorktreeBacklink, report.Fixed[0].Findings[0].Code)
+	assert.Equal(t, 1, report.Summary.FixedFindings)
+	assert.Empty(t, report.Repositories)
+}
+
+func TestDoctorQuietSuppressesSuccessfulFixReport(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorFix = true
+	doctorQuiet = true
+	var inspections int
+	doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+		inspections++
+		if inspections == 1 {
+			return doctorFindingReport(), nil
+		}
+		return doctorHealthyReport(), nil
+	}
+	doctorApplyFixes = func(context.Context, maintenance.Report, doctorRegistry, []*registry.WorktreeEntry) error {
+		return nil
+	}
+	cmd, stdout, stderr := doctorTestCommand()
+
+	require.NoError(t, runDoctor(cmd, nil))
+	assert.Empty(t, stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestDoctorRejectsQuietWithJSON(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorQuiet = true
+	doctorJSON = true
+	cmd, _, stderr := doctorTestCommand()
+
+	err := runDoctor(cmd, nil)
+
+	assertExitCode(t, err, 2)
+	assert.Contains(t, stderr.String(), "mutually exclusive")
+}
+
+func TestDoctorFixReloadsConfigAndRegistryBeforeRescan(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorFix = true
+	snapshots := []*config.GlobalSnapshot{
+		{Config: &models.Config{Projects: []models.Project{{Path: "/old/widget"}}}},
+		{Config: &models.Config{Projects: []models.Project{{Path: "/repos/widget"}}}},
+	}
+	var loads int
+	loadDoctorSnapshot = func() (*config.GlobalSnapshot, error) {
+		result := snapshots[loads]
+		loads++
+		return result, nil
+	}
+	var opens int
+	openDoctorRegistry = func() (doctorRegistry, error) {
+		opens++
+		return &fakeDoctorRegistry{}, nil
+	}
+	var inspectedPaths []string
+	doctorInspect = func(
+		_ context.Context,
+		cfg *models.Config,
+		_ []config.ProjectRegistration,
+		_ []*registry.WorktreeEntry,
+		_ func(string) (bool, error),
+	) (maintenance.Report, error) {
+		inspectedPaths = append(inspectedPaths, cfg.Projects[0].Path)
+		if len(inspectedPaths) == 1 {
+			return doctorFindingReport(), nil
+		}
+		return doctorHealthyReport(), nil
+	}
+	doctorApplyFixes = func(
+		context.Context,
+		maintenance.Report,
+		doctorRegistry,
+		[]*registry.WorktreeEntry,
+	) error {
+		return nil
+	}
+	cmd, _, _ := doctorTestCommand()
+
+	require.NoError(t, runDoctor(cmd, nil))
+	assert.Equal(t, 2, loads)
+	assert.Equal(t, 2, opens)
+	assert.Equal(t, []string{"/old/widget", "/repos/widget"}, inspectedPaths)
+}
+
+func TestDoctorFixNoOpLeavesFinding(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorFix = true
+	doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+		return doctorFindingReport(), nil
+	}
+	doctorApplyFixes = func(context.Context, maintenance.Report, doctorRegistry, []*registry.WorktreeEntry) error {
+		return nil
+	}
+	cmd, _, _ := doctorTestCommand()
+
+	err := runDoctor(cmd, nil)
+
+	assertExitCode(t, err, 1)
+}
+
+func TestDoctorFixReloadFailuresExitTwo(t *testing.T) {
+	tests := []struct {
+		name        string
+		configure   func()
+		wantMessage string
+	}{
+		{
+			name: "configuration reload",
+			configure: func() {
+				var loads int
+				loadDoctorSnapshot = func() (*config.GlobalSnapshot, error) {
+					loads++
+					if loads == 2 {
+						return nil, errors.New("config unavailable")
+					}
+					return &config.GlobalSnapshot{Config: &models.Config{}}, nil
+				}
+			},
+			wantMessage: "reload global configuration after fixes",
+		},
+		{
+			name: "registry reopen",
+			configure: func() {
+				var opens int
+				openDoctorRegistry = func() (doctorRegistry, error) {
+					opens++
+					if opens == 2 {
+						return nil, errors.New("registry unavailable")
+					}
+					return &fakeDoctorRegistry{}, nil
+				}
+			},
+			wantMessage: "reopen worktree registry after fixes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDoctorCommandDeps(t)
+			doctorFix = true
+			doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+				return doctorFindingReport(), nil
+			}
+			doctorApplyFixes = func(context.Context, maintenance.Report, doctorRegistry, []*registry.WorktreeEntry) error {
+				return nil
+			}
+			tt.configure()
+			cmd, _, _ := doctorTestCommand()
+
+			err := runDoctor(cmd, nil)
+
+			assertExitCode(t, err, 2)
+			assert.ErrorContains(t, err, tt.wantMessage)
+		})
+	}
+}
+
+func TestDoctorJSONEnvelope(t *testing.T) {
+	resetDoctorCommandDeps(t)
+	doctorJSON = true
+	doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+		return doctorFindingReport(), nil
+	}
+	cmd, stdout, stderr := doctorTestCommand()
+
+	err := runDoctor(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, float64(1), envelope["schema_version"])
+	assert.Equal(t, "doctor", envelope["command"])
+	assert.Equal(t, false, envelope["fix"])
+	assert.NotContains(t, stdout.String(), "Repository:")
+	assert.Empty(t, stderr.String())
+}
+
+func TestDoctorExitCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		report     maintenance.Report
+		inspectErr error
+		want       int
+	}{
+		{name: "healthy", report: doctorHealthyReport(), want: 0},
+		{name: "findings", report: doctorFindingReport(), want: 1},
+		{name: "inspection error", inspectErr: errors.New("inventory failed"), want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDoctorCommandDeps(t)
+			doctorInspect = func(context.Context, *models.Config, []config.ProjectRegistration, []*registry.WorktreeEntry, func(string) (bool, error)) (maintenance.Report, error) {
+				return tt.report, tt.inspectErr
+			}
+			cmd, _, _ := doctorTestCommand()
+
+			err := runDoctor(cmd, nil)
+
+			if tt.want == 0 {
+				require.NoError(t, err)
+				return
+			}
+			assertExitCode(t, err, tt.want)
+		})
+	}
+}
+
+func doctorFindingReport() maintenance.Report {
+	return maintenance.Report{
+		SchemaVersion: maintenance.SchemaVersion,
+		Repositories: []maintenance.RepositoryReport{{
+			Root: "/repos/widget", RepositoryIdentity: "github.com/acme/widget",
+			Findings: []maintenance.Finding{{
+				Code: maintenance.BrokenWorktreeBacklink, Path: "/worktrees/topic",
+				Message: "broken backlink", Remediation: "Run kwt doctor --fix.", Fixable: true,
+			}},
+		}},
+		Summary: maintenance.Summary{Findings: 1, FixableFindings: 1},
+	}
+}
+
+func doctorHealthyReport() maintenance.Report {
+	return maintenance.Report{
+		SchemaVersion: maintenance.SchemaVersion,
+		Summary:       maintenance.Summary{Healthy: true},
+	}
+}
+
+func doctorTestCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetContext(context.Background())
+	return cmd, stdout, stderr
+}
+
+func assertExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	require.Error(t, err)
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, want, coded.ExitCode())
+}
+
+func resetDoctorCommandDeps(t *testing.T) {
+	t.Helper()
+	oldFix := doctorFix
+	oldJSON := doctorJSON
+	oldQuiet := doctorQuiet
+	oldLoad := loadDoctorSnapshot
+	oldOpen := openDoctorRegistry
+	oldInspect := doctorInspect
+	oldFixes := doctorApplyFixes
+	oldSilenceUsage := rootCmd.SilenceUsage
+	oldSilenceErrors := rootCmd.SilenceErrors
+	t.Cleanup(func() {
+		doctorFix = oldFix
+		doctorJSON = oldJSON
+		doctorQuiet = oldQuiet
+		loadDoctorSnapshot = oldLoad
+		openDoctorRegistry = oldOpen
+		doctorInspect = oldInspect
+		doctorApplyFixes = oldFixes
+		rootCmd.SilenceUsage = oldSilenceUsage
+		rootCmd.SilenceErrors = oldSilenceErrors
+	})
+	doctorFix = false
+	doctorJSON = false
+	doctorQuiet = false
+	loadDoctorSnapshot = func() (*config.GlobalSnapshot, error) {
+		return &config.GlobalSnapshot{Config: &models.Config{}}, nil
+	}
+	openDoctorRegistry = func() (doctorRegistry, error) { return &fakeDoctorRegistry{}, nil }
+}
+
+type fakeDoctorRegistry struct{}
+
+func (*fakeDoctorRegistry) List() []*registry.WorktreeEntry                     { return nil }
+func (*fakeDoctorRegistry) UnregisterIfGeneration(string, string) (bool, error) { return false, nil }
+func (*fakeDoctorRegistry) CompareAndSwap(string, *registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error) {
+	return false, nil
+}
+func (*fakeDoctorRegistry) CompareAndSwapAliases(
+	[]*registry.WorktreeEntry,
+	*registry.WorktreeEntry,
+) (bool, error) {
+	return false, nil
+}
+func (*fakeDoctorRegistry) AcquireCreation(string) (func() error, bool, error) {
+	return func() error { return nil }, true, nil
+}
+func (*fakeDoctorRegistry) CreationActive(string) (bool, error) { return false, nil }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -161,6 +161,7 @@ func annotateProtectedSocketIdentity(
 		branch     string
 		session    string
 		repository string
+		generation string
 	}
 	socketByIdentity := make(map[workspaceIdentity]string, len(records))
 	for _, record := range records {
@@ -180,6 +181,7 @@ func annotateProtectedSocketIdentity(
 			branch:     workspace.Branch,
 			session:    workspace.SessionName,
 			repository: pullrequest.NormalizeRepositoryIdentity(repository),
+			generation: workspace.Generation,
 		}
 		socketByIdentity[key] =
 			tmux.ProtectedWorkspaceSocketName(
@@ -195,8 +197,13 @@ func annotateProtectedSocketIdentity(
 			repository: pullrequest.NormalizeRepositoryIdentity(
 				worktrees[i].Repository,
 			),
+			generation: worktrees[i].Generation,
 		}
 		worktrees[i].TmuxSocketName = socketByIdentity[key]
+		if worktrees[i].TmuxSocketName == "" {
+			key.generation = ""
+			worktrees[i].TmuxSocketName = socketByIdentity[key]
+		}
 	}
 }
 

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -86,6 +86,26 @@ func TestStaleProvenanceDoesNotLabelReusedWorktreePath(t *testing.T) {
 	}
 }
 
+func TestStaleProvenanceGenerationDoesNotLabelReusedWorktreePath(t *testing.T) {
+	worktrees := []models.Worktree{{
+		Path: "/worktrees/reused", Branch: "pr-32",
+		Repository: "github.com/acme/widget", SessionName: "kwt-workspace-pr-32",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}}
+	annotateProtectedSocketIdentity(worktrees, map[string]pullrequest.Provenance{
+		"pr-32": {
+			Project: pullrequest.Project{Identity: "github.com/acme/widget"},
+			Workspace: pullrequest.Workspace{
+				Path: "/worktrees/reused", Branch: "pr-32",
+				Repository: "github.com/acme/widget", SessionName: "kwt-workspace-pr-32",
+				Generation: "fedcba9876543210fedcba9876543210",
+			},
+		},
+	})
+
+	assert.Empty(t, worktrees[0].TmuxSocketName)
+}
+
 func TestProtectedSocketEnrichmentReportsUnreadableProvenance(t *testing.T) {
 	kwtHome := t.TempDir()
 	t.Setenv("KWT_HOME", kwtHome)

--- a/internal/cmd/maintenance_git.go
+++ b/internal/cmd/maintenance_git.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/git"
+)
+
+const (
+	maintenanceGitMajor = 2
+	maintenanceGitMinor = 31
+)
+
+var requireMaintenanceGitVersion = func() error {
+	return git.RequireVersion(maintenanceGitMajor, maintenanceGitMinor)
+}
+
+func checkMaintenanceGitVersion(
+	cmd *cobra.Command,
+	command string,
+	jsonOutput bool,
+) error {
+	if err := requireMaintenanceGitVersion(); err != nil {
+		return writeMaintenanceError(
+			cmd,
+			command,
+			"unsupported_git_version",
+			err.Error(),
+			2,
+			jsonOutput,
+		)
+	}
+	return nil
+}

--- a/internal/cmd/maintenance_output.go
+++ b/internal/cmd/maintenance_output.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/maintenance"
+	"golang.org/x/term"
+)
+
+type maintenanceCommandError struct {
+	code int
+	err  error
+}
+
+func (e *maintenanceCommandError) Error() string { return e.err.Error() }
+func (e *maintenanceCommandError) Unwrap() error { return e.err }
+func (e *maintenanceCommandError) ExitCode() int { return e.code }
+
+type maintenanceErrorBody struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
+type maintenanceErrorEnvelope struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Command       string               `json:"command"`
+	Error         maintenanceErrorBody `json:"error"`
+}
+
+func renderDoctorReport(
+	cmd *cobra.Command,
+	report maintenance.Report,
+	jsonOutput bool,
+) error {
+	if jsonOutput {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	}
+	_, err := io.WriteString(cmd.OutOrStdout(), renderDoctorHuman(report, doctorOptionsForCommand(cmd)))
+	return err
+}
+
+func doctorOptionsForCommand(cmd *cobra.Command) doctorRenderOptions {
+	options := doctorRenderOptions{Width: 100, HomeDir: userHomeDir(), TempDir: os.TempDir()}
+	output, ok := cmd.OutOrStdout().(*os.File)
+	if !ok || !term.IsTerminal(int(output.Fd())) {
+		return options
+	}
+	if width, _, err := term.GetSize(int(output.Fd())); err == nil && width > 0 {
+		options.Width = width
+	}
+	_, noColor := os.LookupEnv("NO_COLOR")
+	options.Color = !noColor && os.Getenv("CLICOLOR") != "0"
+	return options
+}
+
+func userHomeDir() string {
+	home, _ := os.UserHomeDir()
+	return home
+}
+
+func writeMaintenanceError(
+	cmd *cobra.Command,
+	command string,
+	code string,
+	message string,
+	exitCode int,
+	jsonOutput bool,
+) error {
+	cmd.Root().SilenceUsage = true
+	cmd.Root().SilenceErrors = true
+	if jsonOutput {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		_ = encoder.Encode(maintenanceErrorEnvelope{
+			SchemaVersion: maintenance.SchemaVersion,
+			Command:       command,
+			Error: maintenanceErrorBody{
+				Code: code, Message: message, Retryable: false,
+			},
+		})
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "kwt %s: %s: %s\n", command, code, message)
+	return &maintenanceCommandError{code: exitCode, err: fmt.Errorf("%s", message)}
+}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -258,7 +258,10 @@ func openSelectedWorktree(
 	startSession bool,
 	stdinInteractive bool,
 ) error {
-	if err := rejectProtectedWorkspaceOpen(commandCtx, entry.Path); err != nil {
+	if err := rejectProtectedWorkspaceOpen(
+		commandCtx,
+		entry.Path,
+	); err != nil {
 		return err
 	}
 	if err := acknowledgeRemoteSourcePath(entry.Path); err != nil {

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -380,12 +380,14 @@ func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 ) {
 	t.Setenv("KWT_HOME", t.TempDir())
 	workspacePath := t.TempDir()
+	liveGeneration := "0123456789abcdef0123456789abcdef"
+	stubPRWorkspaceGeneration(t, workspacePath, liveGeneration)
 	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
 		context.Background(),
 		func(records map[string]pullrequest.Provenance) error {
-			records["pr-32"] = pullrequest.Provenance{
-				Workspace: pullrequest.Workspace{Path: workspacePath},
-			}
+			records["pr-32"] = pullrequest.Provenance{Workspace: pullrequest.Workspace{
+				Path: workspacePath, Generation: liveGeneration,
+			}}
 			return nil
 		},
 	))
@@ -394,7 +396,8 @@ func TestOpenSelectedWorktreeRefusesProtectedPullRequestWorkspace(
 		context.Background(),
 		&CommandContext{Config: &models.Config{}},
 		&discovery.GlobalWorktreeEntry{
-			Path: workspacePath,
+			Path:       workspacePath,
+			Generation: "fedcba9876543210fedcba9876543210",
 			RepositoryInfo: &url.RepositoryInfo{
 				FullPath: "github.com/acme/widget",
 			},

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -14,6 +14,7 @@ import (
 	"go.kenn.io/kwt/internal/credentials"
 	gitadapter "go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/registry"
 	"go.kenn.io/kwt/internal/tmux"
 	urlutil "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
@@ -715,7 +716,13 @@ func defaultNewPRService(
 	g := gitadapter.New(project.Path)
 	manager := worktree.New(g, cfg)
 	backend := pullrequest.NewGitBackend(
-		g, manager, project, cfg.Fleet.TokenEnv,
+		g,
+		manager,
+		project,
+		func() (pullrequest.WorktreeCreationGuard, error) {
+			return registry.New()
+		},
+		cfg.Fleet.TokenEnv,
 	)
 	return pullrequest.NewService(
 		provider,

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -323,13 +323,12 @@ func rejectProtectedWorkspaceOpen(
 	ctx context.Context,
 	workspacePath string,
 ) error {
-	path := utils.CanonicalPath(workspacePath)
 	var recordedGenerations []string
 	err := pullrequest.NewFileStore(prStorePath()).View(
 		ctx,
 		func(records map[string]pullrequest.Provenance) error {
 			for _, record := range records {
-				if utils.CanonicalPath(record.Workspace.Path) == path {
+				if samePRPath(record.Workspace.Path, workspacePath) {
 					recordedGenerations = append(
 						recordedGenerations,
 						record.Workspace.Generation,

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -41,7 +41,14 @@ var (
 	validatePRWorkspaceSessionConfig = defaultValidatePRWorkspaceSessionConfig
 	startPRWorkspaceSession          = defaultStartPRWorkspaceSession
 	attachPRWorkspaceSession         = defaultAttachPRWorkspaceSession
+	readPRWorkspaceGeneration        = func(path string) (string, error) {
+		return gitadapter.New(path).ReadWorktreeGeneration(path)
+	}
 )
+
+func provenanceGenerationMatches(recorded, live string) bool {
+	return recorded == "" || recorded == live
+}
 
 var prCmd = &cobra.Command{
 	Use:   "pr",
@@ -233,13 +240,13 @@ func importedWorkspaceProvenance(
 	workspacePath string,
 ) (pullrequest.Provenance, error) {
 	path := utils.CanonicalPath(workspacePath)
-	var matches []pullrequest.Provenance
+	var pathMatches []pullrequest.Provenance
 	err := pullrequest.NewFileStore(prStorePath()).View(
 		ctx,
 		func(records map[string]pullrequest.Provenance) error {
 			for _, record := range records {
 				if utils.CanonicalPath(record.Workspace.Path) == path {
-					matches = append(matches, record)
+					pathMatches = append(pathMatches, record)
 				}
 			}
 			return nil
@@ -252,6 +259,31 @@ func importedWorkspaceProvenance(
 			false,
 			err,
 		)
+	}
+	liveGeneration := ""
+	for _, record := range pathMatches {
+		if record.Workspace.Generation == "" {
+			continue
+		}
+		liveGeneration, err = readPRWorkspaceGeneration(workspacePath)
+		if err != nil {
+			return pullrequest.Provenance{}, pullrequest.NewError(
+				pullrequest.CodeWorkspaceCreation,
+				"failed to inspect live workspace generation",
+				false,
+				err,
+			)
+		}
+		break
+	}
+	matches := make([]pullrequest.Provenance, 0, len(pathMatches))
+	for _, record := range pathMatches {
+		if provenanceGenerationMatches(
+			record.Workspace.Generation,
+			liveGeneration,
+		) {
+			matches = append(matches, record)
+		}
 	}
 	if len(matches) != 1 {
 		return pullrequest.Provenance{}, pullrequest.NewError(
@@ -291,14 +323,16 @@ func rejectProtectedWorkspaceOpen(
 	workspacePath string,
 ) error {
 	path := utils.CanonicalPath(workspacePath)
-	protected := false
+	var recordedGenerations []string
 	err := pullrequest.NewFileStore(prStorePath()).View(
 		ctx,
 		func(records map[string]pullrequest.Provenance) error {
 			for _, record := range records {
 				if utils.CanonicalPath(record.Workspace.Path) == path {
-					protected = true
-					break
+					recordedGenerations = append(
+						recordedGenerations,
+						record.Workspace.Generation,
+					)
 				}
 			}
 			return nil
@@ -310,7 +344,26 @@ func rejectProtectedWorkspaceOpen(
 			err,
 		)
 	}
-	if protected {
+	if len(recordedGenerations) == 0 {
+		return nil
+	}
+	liveGeneration, err := readPRWorkspaceGeneration(workspacePath)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to verify live generation for pull-request workspace: %w",
+			err,
+		)
+	}
+	if err := gitadapter.ValidateWorktreeGeneration(liveGeneration); err != nil {
+		return fmt.Errorf(
+			"failed to verify live generation for pull-request workspace: %w",
+			err,
+		)
+	}
+	for _, recordedGeneration := range recordedGenerations {
+		if !provenanceGenerationMatches(recordedGeneration, liveGeneration) {
+			continue
+		}
 		return fmt.Errorf(
 			"protected pull-request workspaces must be opened with kwt pr attach %s",
 			workspacePath,
@@ -413,6 +466,7 @@ func livePRWorkspaces(
 			Path:       candidate.Path,
 			Branch:     candidate.Branch,
 			Repository: project.Identity,
+			Generation: candidate.Generation,
 			SessionName: tmux.WorkspaceSessionName(
 				info,
 				candidate.Branch,
@@ -463,6 +517,10 @@ func containsPRWorkspace(
 		if utils.CanonicalPath(candidate.Path) ==
 			utils.CanonicalPath(recorded.Workspace.Path) &&
 			candidate.Branch == recorded.Workspace.Branch &&
+			provenanceGenerationMatches(
+				recorded.Workspace.Generation,
+				candidate.Generation,
+			) &&
 			prWorkspaceIdentityMatches(candidate, recorded) {
 			return true
 		}
@@ -846,7 +904,7 @@ func samePRPath(left, right string) bool {
 	leftAbs, leftErr := filepath.Abs(left)
 	rightAbs, rightErr := filepath.Abs(right)
 	if leftErr != nil || rightErr != nil {
-		return filepath.Clean(left) == filepath.Clean(right)
+		return utils.PathKey(left) == utils.PathKey(right)
 	}
 	if resolved, err := filepath.EvalSymlinks(leftAbs); err == nil {
 		leftAbs = resolved
@@ -854,7 +912,7 @@ func samePRPath(left, right string) bool {
 	if resolved, err := filepath.EvalSymlinks(rightAbs); err == nil {
 		rightAbs = resolved
 	}
-	return filepath.Clean(leftAbs) == filepath.Clean(rightAbs)
+	return utils.PathKey(leftAbs) == utils.PathKey(rightAbs)
 }
 
 func prStorePath() string {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v89/github"
@@ -60,6 +62,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldStartWorkspaceSession := startPRWorkspaceSession
 	oldAttachWorkspaceSession := attachPRWorkspaceSession
 	oldInspectProjectClone := inspectPRProjectClone
+	oldReadWorkspaceGeneration := readPRWorkspaceGeneration
 	t.Cleanup(func() {
 		loadPRConfig = oldLoad
 		loadPRTargetConfig = oldTargetLoad
@@ -73,6 +76,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		startPRWorkspaceSession = oldStartWorkspaceSession
 		attachPRWorkspaceSession = oldAttachWorkspaceSession
 		inspectPRProjectClone = oldInspectProjectClone
+		readPRWorkspaceGeneration = oldReadWorkspaceGeneration
 	})
 	loadPRConfig = func() (*models.Config, error) { return cfg, nil }
 	loadPRTargetConfig = func(string, bool) (*models.Config, error) { return cfg, nil }
@@ -95,6 +99,16 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	prStartSession = false
 	validatePRWorkspaceSessionConfig = func(*models.Config) error {
 		return nil
+	}
+}
+
+func stubPRWorkspaceGeneration(t *testing.T, path, generation string) {
+	t.Helper()
+	oldRead := readPRWorkspaceGeneration
+	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
+	readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+		assert.Equal(t, path, gotPath)
+		return generation, nil
 	}
 }
 
@@ -733,6 +747,178 @@ func TestRunPRAttachRejectsStaleProvenanceAgainstLiveInventory(t *testing.T) {
 	assert.False(t, attached)
 }
 
+func TestRunPRAttachIgnoresStaleGenerationBeforeCounting(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	live := pullrequest.Workspace{
+		Path: "/worktrees/reused", Branch: "pr-32",
+		Repository: "github.com/acme/widget", SessionName: "kwt-workspace-pr-32",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	project := pullrequest.Project{Identity: live.Repository, Path: "/repos/widget"}
+	stale := live
+	stale.Generation = "fedcba9876543210fedcba9876543210"
+	record := pullrequest.Provenance{Project: project, Workspace: live}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["current"] = record
+			records["stale"] = pullrequest.Provenance{Project: project, Workspace: stale}
+			return nil
+		},
+	))
+	withPRCommandDeps(t, testPRConfig(), &fakePRService{})
+	readPRWorkspaceGeneration = func(string) (string, error) {
+		return live.Generation, nil
+	}
+	inspectPRProjectClone = func(
+		_ context.Context,
+		got pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		assert.Equal(t, record, got)
+		return project, []pullrequest.Workspace{live}, nil
+	}
+	attached := false
+	attachPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) error {
+		attached = true
+		return nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRAttach(cmd, []string{live.Path})
+
+	require.NoError(t, err)
+	assert.True(t, attached)
+}
+
+func TestImportedWorkspaceProvenanceRejectsUnreadableLiveGeneration(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	workspace := pullrequest.Workspace{
+		Path: "/worktrees/pr-32", Branch: "pr-32",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["record"] = pullrequest.Provenance{Workspace: workspace}
+			return nil
+		},
+	))
+	oldRead := readPRWorkspaceGeneration
+	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
+	readPRWorkspaceGeneration = func(string) (string, error) {
+		return "", errors.New("generation unavailable")
+	}
+
+	_, err := importedWorkspaceProvenance(context.Background(), workspace.Path)
+
+	assertPRCode(t, err, pullrequest.CodeWorkspaceCreation)
+	assert.Contains(t, err.Error(), "generation")
+}
+
+func TestProtectedWorkspaceOpenMatchesGeneration(t *testing.T) {
+	tests := []struct {
+		name               string
+		recordedGeneration string
+		liveGeneration     string
+		wantProtected      bool
+	}{
+		{
+			name: "matching", recordedGeneration: "0123456789abcdef0123456789abcdef",
+			liveGeneration: "0123456789abcdef0123456789abcdef",
+			wantProtected:  true,
+		},
+		{
+			name: "replacement", recordedGeneration: "fedcba9876543210fedcba9876543210",
+			liveGeneration: "0123456789abcdef0123456789abcdef",
+			wantProtected:  false,
+		},
+		{
+			name:           "legacy",
+			liveGeneration: "0123456789abcdef0123456789abcdef", wantProtected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KWT_HOME", t.TempDir())
+			path := "/worktrees/reused"
+			require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+				context.Background(),
+				func(records map[string]pullrequest.Provenance) error {
+					records["record"] = pullrequest.Provenance{Workspace: pullrequest.Workspace{
+						Path: path, Generation: tt.recordedGeneration,
+					}}
+					return nil
+				},
+			))
+			oldRead := readPRWorkspaceGeneration
+			t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
+			readCalls := 0
+			readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+				readCalls++
+				assert.Equal(t, path, gotPath)
+				return tt.liveGeneration, nil
+			}
+
+			err := rejectProtectedWorkspaceOpen(context.Background(), path)
+
+			if tt.wantProtected {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, 1, readCalls)
+		})
+	}
+}
+
+func TestProtectedWorkspaceOpenFailsClosedWhenLiveGenerationIsUnavailable(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	path := "/worktrees/protected"
+	recordedGeneration := "0123456789abcdef0123456789abcdef"
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["record"] = pullrequest.Provenance{Workspace: pullrequest.Workspace{
+				Path: path, Generation: recordedGeneration,
+			}}
+			return nil
+		},
+	))
+	oldRead := readPRWorkspaceGeneration
+	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
+	readPRWorkspaceGeneration = func(string) (string, error) {
+		return "", errors.New("generation unavailable")
+	}
+
+	err := rejectProtectedWorkspaceOpen(context.Background(), path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "live generation")
+}
+
+func TestProtectedWorkspaceOpenSkipsGenerationReadWithoutProvenance(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	oldRead := readPRWorkspaceGeneration
+	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
+	readCalls := 0
+	readPRWorkspaceGeneration = func(string) (string, error) {
+		readCalls++
+		return "", errors.New("must not be called")
+	}
+
+	err := rejectProtectedWorkspaceOpen(
+		context.Background(),
+		"/worktrees/ordinary",
+	)
+
+	require.NoError(t, err)
+	assert.Zero(t, readCalls)
+}
+
 func TestInspectPRProjectCloneUsesRegisteredIdentityOverForkOrigin(
 	t *testing.T,
 ) {
@@ -882,6 +1068,26 @@ func TestTransferredProvenanceMatchesLiveWorkspaceAcrossAliases(
 	}, record))
 }
 
+func TestContainsPRWorkspaceRejectsMismatchedGeneration(t *testing.T) {
+	live := pullrequest.Workspace{
+		Path: "/worktrees/reused", Branch: "pr-32",
+		Repository: "github.com/acme/widget", SessionName: "kwt-workspace-pr-32",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	record := pullrequest.Provenance{
+		Project: pullrequest.Project{Identity: live.Repository},
+		Workspace: pullrequest.Workspace{
+			Path: live.Path, Branch: live.Branch,
+			Repository: live.Repository, SessionName: live.SessionName,
+			Generation: "fedcba9876543210fedcba9876543210",
+		},
+	}
+
+	assert.False(t, containsPRWorkspace([]pullrequest.Workspace{live}, record))
+	record.Workspace.Generation = ""
+	assert.True(t, containsPRWorkspace([]pullrequest.Workspace{live}, record))
+}
+
 func TestInspectPRProjectCloneUsesLiveIdentityWithoutRegistration(
 	t *testing.T,
 ) {
@@ -1013,14 +1219,16 @@ func TestLivePRWorkspacesExcludePrunableAndMissingPaths(
 				Branch: "missing",
 			},
 			{
-				Path:   livePath,
-				Branch: "live",
+				Path:       livePath,
+				Branch:     "live",
+				Generation: "0123456789abcdef0123456789abcdef",
 			},
 		},
 	)
 
 	require.Len(t, workspaces, 1)
 	assert.Equal(t, "live", workspaces[0].Branch)
+	assert.Equal(t, "0123456789abcdef0123456789abcdef", workspaces[0].Generation)
 }
 
 func newPRInspectionRepo(t *testing.T) string {
@@ -1273,6 +1481,14 @@ func TestValidatePRProjectNormalizesGitHubIdentityCase(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "github.com/acme/widget", project.Identity)
+}
+
+func TestSamePRPathUsesPlatformPathIdentity(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path identity is case-insensitive")
+	}
+	root := t.TempDir()
+	assert.True(t, samePRPath(root, strings.ToUpper(root)))
 }
 
 func TestValidatePRProjectRejectsEmptyPath(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -900,6 +900,36 @@ func TestProtectedWorkspaceOpenFailsClosedWhenLiveGenerationIsUnavailable(t *tes
 	assert.Contains(t, err.Error(), "live generation")
 }
 
+func TestProtectedWorkspaceOpenUsesPlatformPathIdentity(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path identity is case-insensitive")
+	}
+	t.Setenv("KWT_HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "protected-workspace")
+	recordedPath := strings.ToUpper(path)
+	generation := "0123456789abcdef0123456789abcdef"
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["record"] = pullrequest.Provenance{Workspace: pullrequest.Workspace{
+				Path: recordedPath, Generation: generation,
+			}}
+			return nil
+		},
+	))
+	oldRead := readPRWorkspaceGeneration
+	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
+	readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+		assert.Equal(t, path, gotPath)
+		return generation, nil
+	}
+
+	err := rejectProtectedWorkspaceOpen(context.Background(), path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "protected pull-request workspace")
+}
+
 func TestProtectedWorkspaceOpenSkipsGenerationReadWithoutProvenance(t *testing.T) {
 	t.Setenv("KWT_HOME", t.TempDir())
 	oldRead := readPRWorkspaceGeneration

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -49,9 +49,9 @@ var pruneCmd = &cobra.Command{
 	Long: `Remove live worktrees only when an explicit policy confirms them.
 
 Use --expired for expiration-based removal or --merged for pull-request-based
-removal. Structural Git metadata and
-registry cleanup belong to kwt doctor --fix; bare kwt prune is no longer a
-mutation command.`,
+removal. Structural Git metadata and registry cleanup belong to
+kwt doctor --fix; bare kwt prune is no longer a mutation command. Prune
+policies require Git 2.31 or newer.`,
 	Example: `  # Preview expired worktrees
   kwt prune --expired --dry-run
 
@@ -100,20 +100,23 @@ func runPrune(cmd *cobra.Command, args []string) error {
 			"--force is not available with --merged", 2, pruneJSON,
 		)
 	}
+	if !pruneExpired && !pruneMerged {
+		return writeMaintenanceError(
+			cmd,
+			"prune",
+			"policy_required",
+			"choose --expired or --merged for live removal; run kwt doctor --fix for structural metadata cleanup",
+			2,
+			pruneJSON,
+		)
+	}
+	if err := checkMaintenanceGitVersion(cmd, "prune", pruneJSON); err != nil {
+		return err
+	}
 	if pruneExpired {
 		return runPruneExpired(cmd, args)
 	}
-	if pruneMerged {
-		return runPruneMerged(cmd, args)
-	}
-	return writeMaintenanceError(
-		cmd,
-		"prune",
-		"policy_required",
-		"choose --expired or --merged for live removal; run kwt doctor --fix for structural metadata cleanup",
-		2,
-		pruneJSON,
-	)
+	return runPruneMerged(cmd, args)
 }
 
 func runPruneExpired(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -1,218 +1,396 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
+	"sort"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/prunepolicy"
 	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
+)
+
+type pruneExpiredRegistry interface {
+	ListExpired() []*registry.WorktreeEntry
+	EntryMatches(string, *registry.WorktreeEntry) (bool, error)
+	RemoveIfMatchAfter(string, *registry.WorktreeEntry, func() error) (bool, error)
+}
+
+var (
+	openPruneExpiredRegistry = func() (pruneExpiredRegistry, error) {
+		return registry.New()
+	}
+	validatePruneExpiredWorktree = func(g *git.Git, path string, conditions git.WorktreeRemovalConditions) error {
+		return g.ValidateWorktreeRemoval(path, conditions)
+	}
+	removePruneExpiredWorktree = func(
+		g *git.Git, path string, force bool, conditions git.WorktreeRemovalConditions,
+		claim func(func() error) (bool, error),
+	) (bool, error) {
+		return g.RemoveWorktreeCheckedAfterClaim(path, force, conditions, claim)
+	}
 )
 
 var (
 	pruneExpired bool
+	pruneMerged  bool
 	pruneDryRun  bool
 	pruneForce   bool
+	pruneJSON    bool
 )
 
-// pruneCmd represents the prune command.
 var pruneCmd = &cobra.Command{
 	Use:   "prune",
-	Short: "Clean up deleted worktree information",
-	Long: `Clean up worktree information for directories that have been deleted.
+	Short: "Remove live worktrees by an explicit policy",
+	Long: `Remove live worktrees only when an explicit policy confirms them.
 
-This command removes administrative files from .git/worktrees for worktrees
-whose working directories have been deleted from the filesystem.
-
-With --expired, a live worktree is removed only when its recorded generation
-still matches. Legacy expiration records without a generation are skipped.`,
-	Example: `  # Clean up stale worktree information
-  kwt prune
-
-  # Preview expired worktrees
+Use --expired for expiration-based removal or --merged for pull-request-based
+removal. Structural Git metadata and
+registry cleanup belong to kwt doctor --fix; bare kwt prune is no longer a
+mutation command.`,
+	Example: `  # Preview expired worktrees
   kwt prune --expired --dry-run
 
   # Remove expired worktrees
   kwt prune --expired
 
-  # Force remove even if dirty
-  kwt prune --expired --force`,
+  # Force removal of dirty expired worktrees
+  kwt prune --expired --force
+
+  # Preview and remove clean worktrees for merged pull requests
+  kwt prune --merged --dry-run
+  kwt prune --merged`,
+	Args: cobra.NoArgs,
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		// Prune operates across the global worktree fleet. Repository-local
+		// configuration from the caller's cwd must not redirect that scope.
+		if err := requireConfigInitialization(); err != nil {
+			return writeMaintenanceError(
+				cmd, "prune", "initialization_failed", err.Error(), 2, pruneJSON,
+			)
+		}
+		return nil
+	},
 	RunE: runPrune,
 }
 
 func init() {
 	rootCmd.AddCommand(pruneCmd)
-
-	pruneCmd.Flags().BoolVar(&pruneExpired, "expired", false, "Remove expired worktrees")
-	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be removed")
-	pruneCmd.Flags().BoolVar(&pruneForce, "force", false, "Remove even if uncommitted changes")
+	pruneCmd.Flags().BoolVar(&pruneExpired, "expired", false, "Remove expired live worktrees")
+	pruneCmd.Flags().BoolVar(&pruneMerged, "merged", false, "Remove clean worktrees for explicitly merged pull requests")
+	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Preview policy outcomes without removing")
+	pruneCmd.Flags().BoolVar(&pruneForce, "force", false, "Allow dirty expiration-policy removal")
+	pruneCmd.Flags().BoolVar(&pruneJSON, "json", false, "Output a machine-readable report")
 }
 
 func runPrune(cmd *cobra.Command, args []string) error {
+	if pruneExpired && pruneMerged {
+		return writeMaintenanceError(
+			cmd, "prune", "incompatible_policies",
+			"--expired and --merged are mutually exclusive", 2, pruneJSON,
+		)
+	}
+	if pruneMerged && pruneForce {
+		return writeMaintenanceError(
+			cmd, "prune", "incompatible_flags",
+			"--force is not available with --merged", 2, pruneJSON,
+		)
+	}
 	if pruneExpired {
 		return runPruneExpired(cmd, args)
 	}
-
-	return ExecuteWithArgs(true, func(ctx *CommandContext, cmd *cobra.Command, args []string) error {
-		if err := ctx.WorktreeManager.Prune(); err != nil {
-			return fmt.Errorf("failed to prune worktrees: %w", err)
-		}
-
-		ctx.Printer.PrintSuccess("Pruned stale worktree information")
-		publishFleetBestEffortForCommand(cmd, ctx.Config)
-		return nil
-	})(cmd, args)
+	if pruneMerged {
+		return runPruneMerged(cmd, args)
+	}
+	return writeMaintenanceError(
+		cmd,
+		"prune",
+		"policy_required",
+		"choose --expired or --merged for live removal; run kwt doctor --fix for structural metadata cleanup",
+		2,
+		pruneJSON,
+	)
 }
 
-func runPruneExpired(cmd *cobra.Command, args []string) error {
-	reg, err := registry.New()
+func runPruneExpired(cmd *cobra.Command, _ []string) error {
+	reg, err := openPruneExpiredRegistry()
 	if err != nil {
-		return fmt.Errorf("failed to open registry: %w", err)
+		return writeMaintenanceError(
+			cmd, "prune", "inspection_failed",
+			fmt.Sprintf("open worktree registry: %v", err), 2, pruneJSON,
+		)
 	}
-
 	expired := reg.ListExpired()
-	if len(expired) == 0 {
-		fmt.Println("No expired worktrees found")
-		return nil
+	sort.Slice(expired, func(left, right int) bool {
+		return expired[left].Path < expired[right].Path
+	})
+	report := prunepolicy.Report{
+		SchemaVersion: prunepolicy.SchemaVersion,
+		Command:       "prune",
+		Policy:        "expired",
+		DryRun:        pruneDryRun,
+		Outcomes:      make([]prunepolicy.Outcome, 0, len(expired)),
 	}
-
-	var removed int
-	var skipped int
-	var changed int
-
+	removedWorktrees := 0
 	for _, entry := range expired {
-		// Never remove main worktrees
-		if entry.IsMain {
+		outcome := prunepolicy.Outcome{Path: entry.Path, Branch: entry.Branch}
+		switch {
+		case entry.IsMain:
+			outcome.Reason = prunepolicy.MainWorktree
+			outcome.Message = "main worktrees are never eligible for policy removal"
+			outcome.Remediation = "Remove the expiration from the main-worktree registry entry."
+		case pathIsMissing(entry.Path):
+			outcome.Reason = prunepolicy.DoctorRequired
+			outcome.Message = "expired registry path is already absent"
+			outcome.Remediation = "Run kwt doctor --fix for structural Git and registry cleanup."
+		case git.ValidateWorktreeGeneration(entry.Generation) != nil:
+			outcome.Reason = prunepolicy.MissingGeneration
+			outcome.Message = "live expired worktree has no valid durable generation"
+			outcome.Remediation = "Run kwt list from its repository to initialize Git state, then run kwt doctor --fix to reconcile the registry before retrying."
+		default:
+			if _, statErr := os.Stat(entry.Path); statErr != nil {
+				outcome.Reason = prunepolicy.PathUnavailable
+				outcome.Message = fmt.Sprintf("could not inspect expired worktree path: %v", statErr)
+				outcome.Remediation = "Restore filesystem access and retry."
+				break
+			}
+			g := git.New(entry.Path)
+			expectedGitDir, gitDirErr := expiredWorktreeGitDir(g, entry.Path)
+			if gitDirErr != nil {
+				outcome = pruneOutcomeForError(entry.Path, entry.Branch, gitDirErr)
+				break
+			}
+			conditions := git.WorktreeRemovalConditions{
+				ExpectedGitDir: expectedGitDir,
+				Generation:     entry.Generation,
+				RequireClean:   !pruneForce,
+			}
+			if err := validatePruneExpiredWorktree(g, entry.Path, conditions); err != nil {
+				outcome = pruneOutcomeForError(entry.Path, entry.Branch, err)
+				break
+			}
 			if pruneDryRun {
-				fmt.Printf("Would skip (main worktree): %s\n", entry.Path)
-			}
-			skipped++
-			continue
-		}
-
-		// If the worktree directory is already gone, unregistering the entry
-		// is the only remaining mutation and does not require a git status check.
-		if _, err := os.Stat(entry.Path); os.IsNotExist(err) {
-			if pruneDryRun {
-				fmt.Printf("Would unregister (already deleted): %s\n", entry.Path)
-				removed++
-				continue
-			}
-			unregistered, err := reg.UnregisterIfGeneration(
-				entry.Path,
-				entry.Generation,
-			)
-			if err != nil {
-				fmt.Printf("Warning: failed to unregister %s: %v\n", entry.Path, err)
-				skipped++
-				continue
-			}
-			if !unregistered {
-				fmt.Printf(
-					"Skipping (registry generation changed): %s\n",
-					entry.Path,
-				)
-				skipped++
-				continue
-			}
-			fmt.Printf("Unregistered (already deleted): %s\n", entry.Path)
-			removed++
-			changed++
-			continue
-		}
-
-		if err := git.ValidateWorktreeGeneration(entry.Generation); err != nil {
-			if pruneDryRun {
-				fmt.Printf(
-					"Would skip (missing worktree generation): %s\n",
-					entry.Path,
-				)
-			} else {
-				fmt.Printf(
-					"Skipping (missing worktree generation): %s\n",
-					entry.Path,
-				)
-			}
-			skipped++
-			continue
-		}
-
-		// Check for uncommitted changes unless --force
-		if !pruneForce {
-			dirty, err := isWorktreeDirty(entry.Path)
-			if err != nil {
-				fmt.Printf("Warning: could not check status for %s: %v\n", entry.Path, err)
-				skipped++
-				continue
-			}
-			if dirty {
-				if pruneDryRun {
-					fmt.Printf("Would skip (uncommitted changes): %s\n", entry.Path)
-				} else {
-					fmt.Printf("Skipping (uncommitted changes): %s (use --force to override)\n", entry.Path)
+				matched, matchErr := reg.EntryMatches(entry.Path, entry)
+				if matchErr != nil {
+					outcome.Reason = prunepolicy.PathUnavailable
+					outcome.Message = fmt.Sprintf("could not revalidate expiration policy: %v", matchErr)
+					outcome.Remediation = "Restore registry access and retry."
+					break
 				}
-				skipped++
-				continue
+				if !matched {
+					outcome = expirationPolicyChangedOutcome(entry)
+					break
+				}
+				outcome.Reason = prunepolicy.WouldRemove
+				outcome.Message = "expired worktree satisfies removal preconditions"
+				break
+			}
+			var residualWarning error
+			removed, removeErr := removePruneExpiredWorktree(
+				g, entry.Path, pruneForce, conditions,
+				func(remove func() error) (bool, error) {
+					return reg.RemoveIfMatchAfter(entry.Path, entry, func() error {
+						err := remove()
+						if git.WorktreeWasRemoved(err) {
+							residualWarning = err
+							return nil
+						}
+						return err
+					})
+				},
+			)
+			if removeErr != nil {
+				if removed {
+					removedWorktrees++
+					outcome.Reason = prunepolicy.CleanupIncomplete
+					outcome.Message = "worktree was removed but matching registry cleanup did not complete"
+					outcome.Remediation = "Run kwt doctor --fix to reconcile the remaining registry state."
+					outcome.Evidence = map[string]string{
+						"worktree_removed": "true", "cleanup_error": removeErr.Error(),
+					}
+					break
+				}
+				outcome = pruneOutcomeForError(entry.Path, entry.Branch, removeErr)
+				break
+			}
+			if !removed {
+				outcome = expirationPolicyChangedOutcome(entry)
+				break
+			}
+			removedWorktrees++
+			if residualWarning != nil {
+				outcome.Reason = prunepolicy.CleanupIncomplete
+				outcome.Message = residualWarning.Error()
+				outcome.Remediation = "Inspect the path and remove it only if it contains leftovers from the removed worktree."
+				outcome.Evidence = map[string]string{
+					"worktree_removed": "true", "cleanup_error": residualWarning.Error(),
+				}
+			} else {
+				outcome.Reason = prunepolicy.Removed
+				outcome.Message = "expired worktree removed"
 			}
 		}
-
-		if pruneDryRun {
-			fmt.Printf("Would remove: %s (branch: %s)\n", entry.Path, entry.Branch)
-			removed++
-			continue
-		}
-
-		// Remove the worktree using git
-		g := git.New(entry.Path)
-		if err := g.RemoveWorktree(
-			entry.Path,
-			pruneForce,
-			entry.Generation,
-		); err != nil {
-			if !git.WorktreeWasRemoved(err) {
-				fmt.Printf("Failed to remove worktree %s: %v\n", entry.Path, err)
-				skipped++
-				continue
-			}
-			fmt.Printf("Warning: %v\n", err)
-		}
-		changed++
-
-		// Unregister from registry
-		if _, err := reg.UnregisterIfGeneration(
-			entry.Path,
-			entry.Generation,
-		); err != nil {
-			fmt.Printf("Warning: failed to unregister %s: %v\n", entry.Path, err)
-		}
-
-		fmt.Printf("Removed: %s (branch: %s)\n", entry.Path, entry.Branch)
-		removed++
+		report.Outcomes = append(report.Outcomes, outcome)
 	}
-
-	if pruneDryRun {
-		fmt.Printf("\nDry run: would remove %d worktree(s), skip %d\n", removed, skipped)
-	} else {
-		fmt.Printf("\nRemoved %d expired worktree(s), skipped %d\n", removed, skipped)
+	report.Finalize()
+	if err := renderPruneReport(cmd, report, pruneJSON); err != nil {
+		return writeMaintenanceError(
+			cmd, "prune", "output_failed", err.Error(), 2, false,
+		)
 	}
-
-	if changed > 0 {
+	if removedWorktrees > 0 {
 		if cfg, err := loadFleetConfig(); err == nil {
 			publishFleetBestEffortForCommand(cmd, cfg)
 		}
 	}
-
+	if exitCode := report.ExitCode(); exitCode != 0 {
+		cmd.Root().SilenceUsage = true
+		cmd.Root().SilenceErrors = true
+		if !pruneJSON {
+			_, _ = fmt.Fprintf(
+				cmd.ErrOrStderr(),
+				"kwt prune: candidates_skipped: %d candidate(s) require attention\n",
+				report.Summary.Skipped,
+			)
+		}
+		return &maintenanceCommandError{
+			code: exitCode,
+			err:  fmt.Errorf("%d prune candidate(s) require attention", report.Summary.Skipped),
+		}
+	}
 	return nil
 }
 
-// isWorktreeDirty checks if a worktree has uncommitted changes.
-func isWorktreeDirty(path string) (bool, error) {
-	cmd := exec.Command("git", "-C", path, "status", "--porcelain")
-	output, err := cmd.Output()
+func expiredWorktreeGitDir(g *git.Git, path string) (string, error) {
+	inspections, err := g.InspectWorktrees()
 	if err != nil {
-		return false, fmt.Errorf("failed to check git status: %w", err)
+		return "", &git.ConditionError{Reason: git.ReasonBacklinkChanged, Path: path}
 	}
-	return strings.TrimSpace(string(output)) != "", nil
+	matches := make([]git.WorktreeInspection, 0, 1)
+	for _, inspection := range inspections {
+		if utils.PathKey(inspection.Path) == utils.PathKey(path) {
+			matches = append(matches, inspection)
+		}
+	}
+	if len(matches) != 1 {
+		return "", &git.ConditionError{Reason: git.ReasonBacklinkChanged, Path: path}
+	}
+	inspection := matches[0]
+	if inspection.GitDirError != "" || inspection.GitDir == "" ||
+		inspection.DotGitTarget == "" ||
+		utils.PathKey(inspection.DotGitTarget) != utils.PathKey(inspection.GitDir) {
+		return "", &git.ConditionError{Reason: git.ReasonBacklinkChanged, Path: path}
+	}
+	return inspection.GitDir, nil
+}
+
+func expirationPolicyChangedOutcome(entry *registry.WorktreeEntry) prunepolicy.Outcome {
+	return prunepolicy.Outcome{
+		Path: entry.Path, Branch: entry.Branch,
+		Reason:      prunepolicy.ExpirationPolicyChanged,
+		Message:     "expiration policy changed after candidate inspection",
+		Remediation: "Review the current expiration and retry if the worktree is still eligible.",
+	}
+}
+
+func pathIsMissing(path string) bool {
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
+}
+
+func pruneOutcomeForError(path string, branch string, err error) prunepolicy.Outcome {
+	outcome := prunepolicy.Outcome{Path: path, Branch: branch}
+	var conditionErr *git.ConditionError
+	if errors.As(err, &conditionErr) {
+		switch conditionErr.Reason {
+		case git.ReasonBacklinkChanged:
+			outcome.Reason = prunepolicy.DoctorRequired
+			outcome.Message = "worktree backlink changed after candidate selection"
+			outcome.Remediation = "Run kwt doctor and repair the reported structural state before retrying."
+		case git.ReasonGenerationChanged:
+			outcome.Reason = prunepolicy.GenerationChanged
+			outcome.Message = "worktree generation changed after candidate selection"
+		case git.ReasonHeadChanged:
+			outcome.Reason = prunepolicy.HeadChanged
+			outcome.Message = "worktree HEAD changed after candidate selection"
+		case git.ReasonRepositoryChanged:
+			outcome.Reason = prunepolicy.RepositoryChanged
+			outcome.Message = "worktree repository identity changed after candidate selection"
+		case git.ReasonBranchChanged:
+			outcome.Reason = prunepolicy.SourceBranchMismatch
+			outcome.Message = "worktree branch changed after candidate selection"
+		case git.ReasonUpstreamRepositoryChanged:
+			outcome.Reason = prunepolicy.SourceRepositoryMismatch
+			outcome.Message = "worktree upstream repository changed after candidate selection"
+		case git.ReasonUpstreamBranchChanged:
+			outcome.Reason = prunepolicy.SourceBranchMismatch
+			outcome.Message = "worktree upstream branch changed after candidate selection"
+		case git.ReasonDirty:
+			outcome.Reason = prunepolicy.DirtyWorktree
+			outcome.Message = "worktree has uncommitted changes"
+			outcome.Remediation = "Commit or discard the changes, or use --force with --expired."
+		case git.ReasonLocked:
+			outcome.Reason = prunepolicy.LockedWorktree
+			outcome.Message = "worktree is locked"
+			outcome.Remediation = "Unlock the worktree with git worktree unlock, then retry."
+		case git.ReasonMainWorktree:
+			outcome.Reason = prunepolicy.MainWorktree
+			outcome.Message = "main worktrees are never eligible for policy removal"
+			outcome.Remediation = "Remove the expiration from the main-worktree registry entry."
+		}
+		return outcome
+	}
+	outcome.Reason = prunepolicy.RemovalFailed
+	outcome.Message = fmt.Sprintf("worktree removal failed: %v", err)
+	outcome.Remediation = "Inspect the local Git worktree state and retry."
+	return outcome
+}
+
+func renderPruneReport(
+	cmd *cobra.Command,
+	report prunepolicy.Report,
+	jsonOutput bool,
+) error {
+	if jsonOutput {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	}
+	if len(report.Outcomes) == 0 {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No %s worktrees found.\n", report.Policy)
+		return err
+	}
+	for _, outcome := range report.Outcomes {
+		if _, err := fmt.Fprintf(
+			cmd.OutOrStdout(),
+			"[%s] %s: %s\n",
+			outcome.Reason,
+			outcome.Path,
+			outcome.Message,
+		); err != nil {
+			return err
+		}
+		if outcome.Remediation != "" {
+			if _, err := fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"  remediation: %s\n",
+				outcome.Remediation,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"Candidates: %d, removed: %d, would remove: %d, skipped: %d\n",
+		report.Summary.Candidates,
+		report.Summary.Removed,
+		report.Summary.WouldRemove,
+		report.Summary.Skipped,
+	)
+	return err
 }

--- a/internal/cmd/prune_merged.go
+++ b/internal/cmd/prune_merged.go
@@ -134,10 +134,13 @@ func runPruneMerged(cmd *cobra.Command, _ []string) error {
 			outcomes[index] = outcome
 			continue
 		}
+		worktreeRemoved := false
 		removeErr := withPruneMergedOwnershipGuard(ctx, reg, store, candidate, func() error {
-			return removePruneMergedWorktree(candidate)
+			err := removePruneMergedWorktree(candidate)
+			worktreeRemoved = err == nil || git.WorktreeWasRemoved(err)
+			return err
 		})
-		if removeErr != nil && !git.WorktreeWasRemoved(removeErr) {
+		if removeErr != nil && !worktreeRemoved {
 			providerEvidence := outcome.Evidence
 			outcome = pruneOutcomeForError(candidate.Policy.Path, candidate.Policy.Branch, removeErr)
 			outcome.Evidence = providerEvidence

--- a/internal/cmd/prune_merged.go
+++ b/internal/cmd/prune_merged.go
@@ -1,0 +1,698 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
+	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/prunepolicy"
+	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/registry"
+	repositoryurl "go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+type pruneMergedRegistry interface {
+	List() []*registry.WorktreeEntry
+	UnregisterIfGeneration(string, string) (bool, error)
+}
+
+type pruneMergedProvenanceStore interface {
+	View(context.Context, func(map[string]pullrequest.Provenance) error) error
+	RemoveIfMatch(context.Context, string, pullrequest.Provenance) (bool, error)
+}
+
+type pruneMergedCandidate struct {
+	Policy           prunepolicy.MergedCandidate
+	RepositoryRoot   string
+	ExpectedGitDir   string
+	ProvenanceKey    string
+	RegistryExpected bool
+	InitialOutcome   *prunepolicy.Outcome
+	ProtectedNames   []string
+}
+
+var (
+	loadPruneMergedConfig   = config.Load
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) {
+		return registry.New()
+	}
+	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore {
+		return pullrequest.NewFileStore(prStorePath())
+	}
+	inspectPruneMergedCandidates = defaultInspectPruneMergedCandidates
+	findPruneMergedGlobalPaths   = discovery.FindGlobalWorktreePathsStrict
+	newPruneMergedProvider       = func(ctx context.Context) (prunepolicy.MergedProvider, error) {
+		return pullrequest.NewAuthenticatedGitHubProvider(ctx)
+	}
+	validatePruneMergedWorktree = defaultValidatePruneMergedWorktree
+	removePruneMergedWorktree   = defaultRemovePruneMergedWorktree
+)
+
+func runPruneMerged(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	cfg, err := loadPruneMergedConfig()
+	if err != nil {
+		return mergedPruneExecutionError(cmd, fmt.Sprintf("load global configuration: %v", err))
+	}
+	reg, err := openPruneMergedRegistry()
+	if err != nil {
+		return mergedPruneExecutionError(cmd, fmt.Sprintf("open worktree registry: %v", err))
+	}
+	store := openPruneMergedProvenanceStore()
+	records := make(map[string]pullrequest.Provenance)
+	if err := store.View(ctx, func(current map[string]pullrequest.Provenance) error {
+		for key, value := range current {
+			records[key] = value
+		}
+		return nil
+	}); err != nil {
+		return mergedPruneExecutionError(cmd, fmt.Sprintf("read pull-request provenance: %v", err))
+	}
+	candidates, err := inspectPruneMergedCandidates(ctx, cfg, records, reg.List())
+	if err != nil {
+		return mergedPruneExecutionError(cmd, err.Error())
+	}
+	sort.Slice(candidates, func(left, right int) bool {
+		return utils.PathKey(candidates[left].Policy.Path) < utils.PathKey(candidates[right].Policy.Path)
+	})
+
+	policyCandidates := make([]prunepolicy.MergedCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.InitialOutcome == nil {
+			policyCandidates = append(policyCandidates, candidate.Policy)
+		}
+	}
+	lazyProvider := &lazyPruneMergedProvider{ctx: ctx, open: newPruneMergedProvider}
+	evaluated := prunepolicy.EvaluateMerged(ctx, lazyProvider, policyCandidates)
+	evaluationIndex := 0
+	outcomes := make([]prunepolicy.Outcome, len(candidates))
+	for index, candidate := range candidates {
+		if candidate.InitialOutcome != nil {
+			outcomes[index] = *candidate.InitialOutcome
+			continue
+		}
+		outcomes[index] = evaluated[evaluationIndex]
+		evaluationIndex++
+	}
+
+	removedWorktrees := 0
+	for index := range candidates {
+		candidate := candidates[index]
+		outcome := outcomes[index]
+		if outcome.Reason != prunepolicy.EligibleMerged {
+			outcomes[index] = withMergedRemediation(outcome)
+			continue
+		}
+		if pruneDryRun {
+			if err := validatePruneMergedWorktree(candidate); err != nil {
+				providerEvidence := outcome.Evidence
+				outcome = pruneOutcomeForError(candidate.Policy.Path, candidate.Policy.Branch, err)
+				outcome.Evidence = providerEvidence
+				if outcome.Reason == prunepolicy.DirtyWorktree {
+					outcome.Remediation = "Commit or discard the changes, then retry; merged pruning has no force mode."
+				}
+				outcomes[index] = outcome
+				continue
+			}
+			outcome.Reason = prunepolicy.WouldRemove
+			outcome.Message = "worktree satisfies merged pull-request removal preconditions"
+			outcomes[index] = outcome
+			continue
+		}
+		removeErr := removePruneMergedWorktree(candidate)
+		if removeErr != nil && !git.WorktreeWasRemoved(removeErr) {
+			providerEvidence := outcome.Evidence
+			outcome = pruneOutcomeForError(candidate.Policy.Path, candidate.Policy.Branch, removeErr)
+			outcome.Evidence = providerEvidence
+			if outcome.Reason == prunepolicy.DirtyWorktree {
+				outcome.Remediation = "Commit or discard the changes, then retry; merged pruning has no force mode."
+			}
+			outcomes[index] = outcome
+			continue
+		}
+		removedWorktrees++
+		cleanupProblems := make([]string, 0, 3)
+		if removeErr != nil {
+			cleanupProblems = append(cleanupProblems, removeErr.Error())
+		}
+		if candidate.RegistryExpected {
+			removed, cleanupErr := reg.UnregisterIfGeneration(
+				candidate.Policy.Path, candidate.Policy.Generation,
+			)
+			if cleanupErr != nil {
+				cleanupProblems = append(cleanupProblems, "registry: "+cleanupErr.Error())
+			} else if !removed {
+				cleanupProblems = append(cleanupProblems, "registry record changed")
+			}
+		}
+		if candidate.Policy.Provenance != nil {
+			removed, cleanupErr := store.RemoveIfMatch(
+				ctx, candidate.ProvenanceKey, *candidate.Policy.Provenance,
+			)
+			if cleanupErr != nil {
+				cleanupProblems = append(cleanupProblems, "provenance: "+cleanupErr.Error())
+			} else if !removed {
+				cleanupProblems = append(cleanupProblems, "provenance record changed")
+			}
+		}
+		if len(cleanupProblems) > 0 {
+			outcome.Reason = prunepolicy.CleanupIncomplete
+			outcome.Message = "worktree was removed but matching state cleanup did not complete"
+			if removeErr != nil {
+				outcome.Message = removeErr.Error()
+			}
+			outcome.Remediation = "Run kwt doctor --fix and review pull-request provenance before retrying cleanup."
+			outcome.Evidence["worktree_removed"] = "true"
+			outcome.Evidence["cleanup_error"] = strings.Join(cleanupProblems, "; ")
+		} else {
+			outcome.Reason = prunepolicy.Removed
+			outcome.Message = "worktree for merged pull request removed"
+		}
+		outcomes[index] = outcome
+	}
+
+	report := prunepolicy.Report{
+		SchemaVersion: prunepolicy.SchemaVersion,
+		Command:       "prune",
+		Policy:        "merged",
+		DryRun:        pruneDryRun,
+		Outcomes:      outcomes,
+	}
+	report.Finalize()
+	if err := renderPruneReport(cmd, report, pruneJSON); err != nil {
+		return writeMaintenanceError(cmd, "prune", "output_failed", err.Error(), 2, false)
+	}
+	if removedWorktrees > 0 {
+		publishFleetBestEffortForCommand(cmd, cfg)
+	}
+	if exitCode := report.ExitCode(); exitCode != 0 {
+		cmd.Root().SilenceUsage = true
+		cmd.Root().SilenceErrors = true
+		if !pruneJSON {
+			_, _ = fmt.Fprintf(
+				cmd.ErrOrStderr(),
+				"kwt prune: candidates_skipped: %d candidate(s) require attention\n",
+				report.Summary.Skipped,
+			)
+		}
+		return &maintenanceCommandError{
+			code: exitCode,
+			err:  fmt.Errorf("%d prune candidate(s) require attention", report.Summary.Skipped),
+		}
+	}
+	return nil
+}
+
+func mergedPruneExecutionError(cmd *cobra.Command, message string) error {
+	return writeMaintenanceError(cmd, "prune", "inspection_failed", message, 2, pruneJSON)
+}
+
+func defaultRemovePruneMergedWorktree(candidate pruneMergedCandidate) error {
+	return git.New(candidate.RepositoryRoot).RemoveWorktreeChecked(
+		candidate.Policy.Path,
+		false,
+		pruneMergedRemovalConditions(candidate),
+	)
+}
+
+func defaultValidatePruneMergedWorktree(candidate pruneMergedCandidate) error {
+	return git.New(candidate.RepositoryRoot).ValidateWorktreeRemoval(
+		candidate.Policy.Path,
+		pruneMergedRemovalConditions(candidate),
+	)
+}
+
+func pruneMergedRemovalConditions(candidate pruneMergedCandidate) git.WorktreeRemovalConditions {
+	return git.WorktreeRemovalConditions{
+		ExpectedGitDir:     candidate.ExpectedGitDir,
+		Generation:         candidate.Policy.Generation,
+		Head:               candidate.Policy.Head,
+		RepositoryIdentity: candidate.Policy.LiveRepository,
+		Branch:             candidate.Policy.Branch,
+		UpstreamRepository: candidate.Policy.SourceRepository,
+		UpstreamBranch:     candidate.Policy.SourceBranch,
+		RequireClean:       true,
+		IncludeIgnored:     true,
+		ProtectedNames:     candidate.ProtectedNames,
+	}
+}
+
+type lazyPruneMergedProvider struct {
+	ctx      context.Context
+	open     func(context.Context) (prunepolicy.MergedProvider, error)
+	provider prunepolicy.MergedProvider
+	err      error
+	opened   bool
+}
+
+func (p *lazyPruneMergedProvider) ensure() (prunepolicy.MergedProvider, error) {
+	if !p.opened {
+		p.opened = true
+		p.provider, p.err = p.open(p.ctx)
+	}
+	return p.provider, p.err
+}
+
+func (p *lazyPruneMergedProvider) Get(
+	ctx context.Context, repository pullrequest.Repository, number int,
+) (pullrequest.PullRequest, error) {
+	provider, err := p.ensure()
+	if err != nil {
+		return pullrequest.PullRequest{}, err
+	}
+	return provider.Get(ctx, repository, number)
+}
+
+func (p *lazyPruneMergedProvider) ResolveRepository(
+	ctx context.Context,
+	repository pullrequest.Repository,
+) (pullrequest.Repository, error) {
+	provider, err := p.ensure()
+	if err != nil {
+		return pullrequest.Repository{}, err
+	}
+	return provider.ResolveRepository(ctx, repository)
+}
+
+func (p *lazyPruneMergedProvider) ListForCommit(
+	ctx context.Context, repository pullrequest.Repository, sha string,
+) ([]pullrequest.PullRequest, error) {
+	provider, err := p.ensure()
+	if err != nil {
+		return nil, err
+	}
+	return provider.ListForCommit(ctx, repository, sha)
+}
+
+func (p *lazyPruneMergedProvider) ListByHead(
+	ctx context.Context,
+	repository pullrequest.Repository,
+	owner string,
+	branch string,
+) ([]pullrequest.PullRequest, error) {
+	provider, err := p.ensure()
+	if err != nil {
+		return nil, err
+	}
+	return provider.ListByHead(ctx, repository, owner, branch)
+}
+
+func defaultInspectPruneMergedCandidates(
+	ctx context.Context,
+	cfg *models.Config,
+	records map[string]pullrequest.Provenance,
+	registryEntries []*registry.WorktreeEntry,
+) ([]pruneMergedCandidate, error) {
+	if cfg == nil {
+		return nil, errors.New("global configuration is unavailable")
+	}
+	protectedNames := credentials.ProtectedNames(cfg)
+	type inventoryRoot struct {
+		path         string
+		repository   string
+		repositories []string
+		configured   bool
+	}
+	roots := make([]inventoryRoot, 0, len(cfg.Projects)+len(registryEntries))
+	rootIndexes := make(map[string]int, cap(roots))
+	configuredInventoryIncomplete := false
+	appendRoot := func(root inventoryRoot) {
+		if strings.TrimSpace(root.path) == "" {
+			return
+		}
+		key := utils.PathKey(root.path)
+		if index, exists := rootIndexes[key]; exists {
+			if root.configured {
+				roots[index].configured = true
+				roots[index].repositories = append(
+					roots[index].repositories,
+					root.repository,
+				)
+			}
+			return
+		}
+		if root.configured {
+			root.repositories = []string{root.repository}
+		}
+		rootIndexes[key] = len(roots)
+		roots = append(roots, root)
+	}
+	configuredRepositoriesByPath := make(map[string][]string)
+	for _, project := range cfg.Projects {
+		if strings.TrimSpace(project.Path) == "" {
+			configuredInventoryIncomplete = true
+			continue
+		}
+		pathKey := utils.PathKey(project.Path)
+		configuredRepositoriesByPath[pathKey] = append(
+			configuredRepositoriesByPath[pathKey],
+			project.Repository,
+		)
+		appendRoot(inventoryRoot{
+			path: project.Path, repository: project.Repository, configured: true,
+		})
+	}
+	if strings.TrimSpace(cfg.Worktree.BaseDir) != "" {
+		paths, err := findPruneMergedGlobalPaths(cfg.Worktree.BaseDir)
+		if err != nil {
+			return nil, fmt.Errorf("discover global worktrees: %w", err)
+		}
+		for _, path := range paths {
+			appendRoot(inventoryRoot{path: path})
+		}
+	}
+	for _, entry := range registryEntries {
+		if entry == nil || entry.CreationToken != "" {
+			continue
+		}
+		appendRoot(inventoryRoot{path: entry.Path})
+	}
+	seen := make(map[string]bool)
+	var candidates []pruneMergedCandidate
+	configuredClaims := make(map[string]map[string]struct{})
+	backlinkClaims := make(map[string]map[string]string)
+	configuredClaimKey := func(raw string) string {
+		identity, ok := repositoryurl.CanonicalRepositoryIdentity(raw)
+		if !ok {
+			return "invalid"
+		}
+		return "identity:" + repositoryurl.FoldRepositoryIdentity(identity)
+	}
+	for _, root := range roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if target, backlinkErr := git.ReadWorktreeBacklink(root.path); backlinkErr == nil && target != "" {
+			targetKey := utils.PathKey(target)
+			claimants := backlinkClaims[targetKey]
+			if claimants == nil {
+				claimants = make(map[string]string)
+				backlinkClaims[targetKey] = claimants
+			}
+			claimants[utils.PathKey(root.path)] = utils.CanonicalPath(root.path)
+		}
+		g := git.New(root.path)
+		inspections, err := g.InspectWorktreesWithoutCredentials(protectedNames)
+		if err != nil {
+			if root.configured {
+				configuredInventoryIncomplete = true
+			}
+			pathKey := utils.PathKey(root.path)
+			if !seen[pathKey] {
+				seen[pathKey] = true
+				policy := prunepolicy.MergedCandidate{Path: root.path}
+				candidates = append(candidates, pruneMergedCandidate{
+					Policy:         policy,
+					RepositoryRoot: root.path,
+					ProtectedNames: append([]string(nil), protectedNames...),
+					InitialOutcome: initialMergedOutcome(
+						policy,
+						prunepolicy.DoctorRequired,
+						fmt.Sprintf("worktree path could not be inspected: %v", err),
+					),
+				})
+			}
+			continue
+		}
+		mainRepositoryPath, err := g.GetMainRepositoryPathWithoutCredentials(
+			protectedNames,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("inspect main repository path for %s: %w", root.path, err)
+		}
+		mainRepositoryPath = utils.CanonicalPath(mainRepositoryPath)
+		if root.configured {
+			mainKey := utils.PathKey(mainRepositoryPath)
+			claims := configuredClaims[mainKey]
+			if claims == nil {
+				claims = make(map[string]struct{})
+				configuredClaims[mainKey] = claims
+			}
+			for _, repository := range root.repositories {
+				claims[configuredClaimKey(repository)] = struct{}{}
+			}
+			for _, inspection := range inspections {
+				for _, repository := range configuredRepositoriesByPath[utils.PathKey(inspection.Path)] {
+					claims[configuredClaimKey(repository)] = struct{}{}
+				}
+			}
+		}
+		configuredRepository, hasConfiguredRepository := repositoryurl.CanonicalRepositoryIdentity(root.repository)
+		for _, inspection := range inspections {
+			if inspection.IsMain {
+				continue
+			}
+			pathKey := utils.PathKey(inspection.Path)
+			if seen[pathKey] {
+				continue
+			}
+			seen[pathKey] = true
+			backlinkMatches := !inspection.Exists ||
+				(inspection.GitDirError == "" &&
+					inspection.GitDir != "" &&
+					inspection.DotGitTarget != "" &&
+					utils.PathKey(inspection.DotGitTarget) ==
+						utils.PathKey(inspection.GitDir))
+			liveRepository := ""
+			if inspection.Exists && backlinkMatches {
+				liveRepository = repositoryIdentityFromGit(
+					git.New(inspection.Path),
+					protectedNames,
+				)
+			}
+			projectRepository := configuredRepository
+			if !root.configured {
+				projectRepository = liveRepository
+			}
+			candidate := pruneMergedCandidate{
+				RepositoryRoot: mainRepositoryPath,
+				ExpectedGitDir: inspection.GitDir,
+				ProtectedNames: append([]string(nil), protectedNames...),
+				Policy: prunepolicy.MergedCandidate{
+					Path: inspection.Path, Branch: inspection.Branch, Head: inspection.Head,
+					Generation: inspection.Generation, IsMain: inspection.IsMain,
+					MainRepositoryPath: mainRepositoryPath,
+					ProjectRepository:  projectRepository, LiveRepository: liveRepository,
+				},
+			}
+			if !backlinkMatches {
+				candidate.InitialOutcome = initialMergedOutcome(
+					candidate.Policy,
+					prunepolicy.DoctorRequired,
+					"worktree backlink does not match its verified Git administrative directory",
+				)
+			}
+			if root.configured && !hasConfiguredRepository {
+				candidate.InitialOutcome = initialMergedOutcome(
+					candidate.Policy,
+					prunepolicy.DoctorRequired,
+					"configured project repository identity is unavailable",
+				)
+			}
+			if !inspection.Exists {
+				candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.DoctorRequired, "Git records a worktree path that is absent")
+			}
+			if inspection.Locked && candidate.InitialOutcome == nil {
+				candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.LockedWorktree, "locked worktree requires manual review")
+			}
+			if !root.configured && configuredInventoryIncomplete &&
+				candidate.InitialOutcome == nil {
+				candidate.InitialOutcome = initialMergedOutcome(
+					candidate.Policy,
+					prunepolicy.DoctorRequired,
+					"configured project inventory is incomplete; run kwt doctor before pruning unconfigured worktrees",
+				)
+			}
+			attachMergedRegistrySnapshot(&candidate, registryEntries)
+			attachMergedProvenance(&candidate, records)
+			if inspection.Exists && !inspection.IsMain && backlinkMatches {
+				status, statusErr := g.RunCommandWithoutCredentials(
+					protectedNames,
+					"-C", inspection.Path, "status", "--ignored", "--porcelain", "--untracked-files=normal",
+				)
+				if statusErr != nil {
+					candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.PathUnavailable, fmt.Sprintf("inspect worktree status: %v", statusErr))
+				} else {
+					candidate.Policy.Dirty = strings.TrimSpace(status) != ""
+				}
+				upstream, upstreamErr := git.New(inspection.Path).
+					BranchUpstreamWithoutCredentials(inspection.Branch, protectedNames)
+				if upstreamErr == nil {
+					candidate.Policy.SourceBranch = upstream.Branch
+					candidate.Policy.SourceRepository, _ = repositoryurl.CanonicalRepositoryIdentityFromRemote(upstream.RepositoryURL)
+				}
+			}
+			candidates = append(candidates, candidate)
+		}
+	}
+	for index := range candidates {
+		candidate := &candidates[index]
+		claims := configuredClaims[utils.PathKey(candidate.Policy.MainRepositoryPath)]
+		if len(claims) >= 2 {
+			candidate.InitialOutcome = initialMergedOutcome(
+				candidate.Policy,
+				prunepolicy.DoctorRequired,
+				"conflicting configured project repository identities require doctor review",
+			)
+		}
+		claimants := backlinkClaims[utils.PathKey(candidate.ExpectedGitDir)]
+		conflicts := make([]string, 0, len(claimants))
+		candidatePathKey := utils.PathKey(candidate.Policy.Path)
+		for claimantKey, claimant := range claimants {
+			if claimantKey != candidatePathKey {
+				conflicts = append(conflicts, claimant)
+			}
+		}
+		if len(conflicts) == 0 {
+			continue
+		}
+		sort.Strings(conflicts)
+		candidate.InitialOutcome = initialMergedOutcome(
+			candidate.Policy,
+			prunepolicy.DoctorRequired,
+			"worktree administrative directory is claimed by another discovered path",
+		)
+		candidate.InitialOutcome.Evidence["claimants"] = strings.Join(conflicts, "\n")
+	}
+	return candidates, nil
+}
+
+func repositoryIdentityFromGit(g *git.Git, protectedNames []string) string {
+	remote, err := g.RunCommandWithoutCredentials(
+		protectedNames,
+		"remote", "get-url", "origin",
+	)
+	if err != nil {
+		return ""
+	}
+	identity, _ := repositoryurl.CanonicalRepositoryIdentityFromRemote(strings.TrimSpace(remote))
+	return identity
+}
+
+func attachMergedRegistrySnapshot(
+	candidate *pruneMergedCandidate, entries []*registry.WorktreeEntry,
+) {
+	matches := make([]*registry.WorktreeEntry, 0, 1)
+	for _, entry := range entries {
+		if entry == nil || utils.PathKey(entry.Path) != utils.PathKey(candidate.Policy.Path) {
+			continue
+		}
+		matches = append(matches, entry)
+	}
+	if len(matches) == 0 {
+		return
+	}
+	candidate.RegistryExpected = true
+	if len(matches) > 1 {
+		if candidate.InitialOutcome == nil {
+			candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.DoctorRequired, "multiple registry entries identify the same worktree path")
+		}
+		return
+	}
+	entry := matches[0]
+	if entry.Generation != candidate.Policy.Generation && candidate.InitialOutcome == nil {
+		candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.DoctorRequired, "registry generation does not match the Git worktree")
+	}
+	if entry.Repository != "" && candidate.InitialOutcome == nil {
+		registryRepository, ok :=
+			repositoryurl.CanonicalRepositoryIdentity(entry.Repository)
+		if !ok || !mergedRepositoryIdentityMatchesAny(
+			registryRepository,
+			candidate.Policy.ProjectRepository,
+			candidate.Policy.LiveRepository,
+		) {
+			candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.RepositoryChanged, "registry repository identity does not match the configured project or live worktree origin")
+		}
+	}
+}
+
+func mergedRepositoryIdentityMatchesAny(identity string, candidates ...string) bool {
+	folded := repositoryurl.FoldRepositoryIdentity(identity)
+	for _, candidate := range candidates {
+		if candidate != "" && folded == repositoryurl.FoldRepositoryIdentity(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func attachMergedProvenance(
+	candidate *pruneMergedCandidate, records map[string]pullrequest.Provenance,
+) {
+	keys := make([]string, 0, len(records))
+	for key := range records {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	pathMatches := 0
+	for _, key := range keys {
+		record := records[key]
+		if !samePRPath(record.Workspace.Path, candidate.Policy.Path) {
+			continue
+		}
+		if !provenanceGenerationMatches(
+			record.Workspace.Generation,
+			candidate.Policy.Generation,
+		) {
+			continue
+		}
+		pathMatches++
+		if record.Workspace.Branch != candidate.Policy.Branch || candidate.Policy.Provenance != nil {
+			continue
+		}
+		copy := record
+		candidate.Policy.Provenance = &copy
+		candidate.ProvenanceKey = key
+	}
+	if pathMatches != 1 || (pathMatches == 1 && candidate.Policy.Provenance == nil) {
+		if pathMatches > 0 && candidate.InitialOutcome == nil {
+			candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.DoctorRequired, "pull-request provenance path or branch is ambiguous")
+		}
+	}
+}
+
+func initialMergedOutcome(
+	candidate prunepolicy.MergedCandidate, reason prunepolicy.Reason, message string,
+) *prunepolicy.Outcome {
+	outcome := prunepolicy.Outcome{
+		Path: candidate.Path, Branch: candidate.Branch, Reason: reason, Message: message,
+		Evidence: map[string]string{"head_sha": candidate.Head},
+	}
+	return &outcome
+}
+
+func withMergedRemediation(outcome prunepolicy.Outcome) prunepolicy.Outcome {
+	if outcome.Remediation != "" {
+		return outcome
+	}
+	switch outcome.Reason {
+	case prunepolicy.MissingGeneration:
+		outcome.Remediation = "Run kwt list from the verified repository to adopt the worktree, then retry."
+	case prunepolicy.DirtyWorktree:
+		outcome.Remediation = "Commit or discard the changes, then retry; merged pruning has no force mode."
+	case prunepolicy.DoctorRequired, prunepolicy.RepositoryChanged:
+		outcome.Remediation = "Run kwt doctor and repair the reported structural state before retrying."
+	case prunepolicy.LockedWorktree:
+		outcome.Remediation = "Unlock the worktree with git worktree unlock, then retry."
+	case prunepolicy.HeadAdvancedAfterPR:
+		outcome.Remediation = "Review the commits added after the pull request head and remove the worktree manually if appropriate."
+	case prunepolicy.SourceRepositoryUnavailable:
+		outcome.Remediation = "Configure an exact upstream remote and branch, then retry."
+	case prunepolicy.SourceRepositoryMismatch, prunepolicy.SourceBranchMismatch, prunepolicy.AmbiguousPRMatch:
+		outcome.Remediation = "Review the worktree upstream and associated pull requests; no worktree was removed."
+	case prunepolicy.AuthenticationFailed:
+		outcome.Remediation = "Set KWT_GITHUB_TOKEN or run gh auth login, then retry."
+	case prunepolicy.NetworkFailure:
+		outcome.Remediation = "Restore provider connectivity and retry."
+	}
+	return outcome
+}

--- a/internal/cmd/prune_merged.go
+++ b/internal/cmd/prune_merged.go
@@ -380,6 +380,7 @@ func defaultInspectPruneMergedCandidates(
 	var candidates []pruneMergedCandidate
 	configuredClaims := make(map[string]map[string]struct{})
 	backlinkClaims := make(map[string]map[string]string)
+	invalidInventoryRoots := make(map[string][]string)
 	configuredClaimKey := func(raw string) string {
 		identity, ok := repositoryurl.CanonicalRepositoryIdentity(raw)
 		if !ok {
@@ -430,6 +431,34 @@ func defaultInspectPruneMergedCandidates(
 			return nil, fmt.Errorf("inspect main repository path for %s: %w", root.path, err)
 		}
 		mainRepositoryPath = utils.CanonicalPath(mainRepositoryPath)
+		if !git.HasExactWorktreeRoot(inspections, root.path) {
+			if root.configured {
+				configuredInventoryIncomplete = true
+			}
+			mainKey := utils.PathKey(mainRepositoryPath)
+			invalidInventoryRoots[mainKey] = append(
+				invalidInventoryRoots[mainKey],
+				utils.CanonicalPath(root.path),
+			)
+			pathKey := utils.PathKey(root.path)
+			if !seen[pathKey] {
+				seen[pathKey] = true
+				policy := prunepolicy.MergedCandidate{
+					Path: root.path, MainRepositoryPath: mainRepositoryPath,
+				}
+				candidates = append(candidates, pruneMergedCandidate{
+					Policy:         policy,
+					RepositoryRoot: mainRepositoryPath,
+					ProtectedNames: append([]string(nil), protectedNames...),
+					InitialOutcome: initialMergedOutcome(
+						policy,
+						prunepolicy.DoctorRequired,
+						"inventory path is not an exact worktree root",
+					),
+				})
+			}
+			continue
+		}
 		if root.configured {
 			mainKey := utils.PathKey(mainRepositoryPath)
 			claims := configuredClaims[mainKey]
@@ -536,6 +565,17 @@ func defaultInspectPruneMergedCandidates(
 	}
 	for index := range candidates {
 		candidate := &candidates[index]
+		invalidRoots := invalidInventoryRoots[utils.PathKey(candidate.Policy.MainRepositoryPath)]
+		if len(invalidRoots) != 0 {
+			sort.Strings(invalidRoots)
+			candidate.InitialOutcome = initialMergedOutcome(
+				candidate.Policy,
+				prunepolicy.DoctorRequired,
+				"repository inventory includes a path that is not an exact worktree root",
+			)
+			candidate.InitialOutcome.Evidence["inventory_paths"] =
+				strings.Join(invalidRoots, "\n")
+		}
 		claims := configuredClaims[utils.PathKey(candidate.Policy.MainRepositoryPath)]
 		if len(claims) >= 2 {
 			candidate.InitialOutcome = initialMergedOutcome(

--- a/internal/cmd/prune_merged.go
+++ b/internal/cmd/prune_merged.go
@@ -25,7 +25,7 @@ type pruneMergedRegistry interface {
 	List() []*registry.WorktreeEntry
 	AcquireCreation(string) (func() error, bool, error)
 	EntryMatches(string, *registry.WorktreeEntry) (bool, error)
-	UnregisterIfGeneration(string, string) (bool, error)
+	RemoveIfMatchAfter(string, *registry.WorktreeEntry, func() error) (bool, error)
 }
 
 type pruneMergedProvenanceStore interface {
@@ -135,11 +135,37 @@ func runPruneMerged(cmd *cobra.Command, _ []string) error {
 			continue
 		}
 		worktreeRemoved := false
+		var residualWarning error
 		removeErr := withPruneMergedOwnershipGuard(ctx, reg, store, candidate, func() error {
-			err := removePruneMergedWorktree(candidate)
-			worktreeRemoved = err == nil || git.WorktreeWasRemoved(err)
+			removed, err := removePruneMergedWorktree(
+				candidate,
+				func(remove func() error) (bool, error) {
+					return reg.RemoveIfMatchAfter(
+						candidate.Policy.Path,
+						candidate.RegistryEntry,
+						func() error {
+							err := remove()
+							if git.WorktreeWasRemoved(err) {
+								residualWarning = err
+								return nil
+							}
+							return err
+						},
+					)
+				},
+			)
+			worktreeRemoved = removed
+			if err == nil && !removed {
+				return fmt.Errorf(
+					"worktree ownership changed after inspection for %s",
+					candidate.Policy.Path,
+				)
+			}
 			return err
 		})
+		if removeErr == nil && residualWarning != nil {
+			removeErr = residualWarning
+		}
 		if removeErr != nil && !worktreeRemoved {
 			providerEvidence := outcome.Evidence
 			outcome = pruneOutcomeForError(candidate.Policy.Path, candidate.Policy.Branch, removeErr)
@@ -151,19 +177,9 @@ func runPruneMerged(cmd *cobra.Command, _ []string) error {
 			continue
 		}
 		removedWorktrees++
-		cleanupProblems := make([]string, 0, 3)
+		cleanupProblems := make([]string, 0, 2)
 		if removeErr != nil {
 			cleanupProblems = append(cleanupProblems, removeErr.Error())
-		}
-		if candidate.RegistryExpected {
-			removed, cleanupErr := reg.UnregisterIfGeneration(
-				candidate.Policy.Path, candidate.Policy.Generation,
-			)
-			if cleanupErr != nil {
-				cleanupProblems = append(cleanupProblems, "registry: "+cleanupErr.Error())
-			} else if !removed {
-				cleanupProblems = append(cleanupProblems, "registry record changed")
-			}
 		}
 		if candidate.Policy.Provenance != nil {
 			removed, cleanupErr := store.RemoveIfMatch(
@@ -227,11 +243,15 @@ func mergedPruneExecutionError(cmd *cobra.Command, message string) error {
 	return writeMaintenanceError(cmd, "prune", "inspection_failed", message, 2, pruneJSON)
 }
 
-func defaultRemovePruneMergedWorktree(candidate pruneMergedCandidate) error {
-	return git.New(candidate.RepositoryRoot).RemoveWorktreeChecked(
+func defaultRemovePruneMergedWorktree(
+	candidate pruneMergedCandidate,
+	claim func(func() error) (bool, error),
+) (bool, error) {
+	return git.New(candidate.RepositoryRoot).RemoveWorktreeCheckedAfterClaim(
 		candidate.Policy.Path,
 		false,
 		pruneMergedRemovalConditions(candidate),
+		claim,
 	)
 }
 

--- a/internal/cmd/prune_merged.go
+++ b/internal/cmd/prune_merged.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -22,6 +23,8 @@ import (
 
 type pruneMergedRegistry interface {
 	List() []*registry.WorktreeEntry
+	AcquireCreation(string) (func() error, bool, error)
+	EntryMatches(string, *registry.WorktreeEntry) (bool, error)
 	UnregisterIfGeneration(string, string) (bool, error)
 }
 
@@ -36,6 +39,7 @@ type pruneMergedCandidate struct {
 	ExpectedGitDir   string
 	ProvenanceKey    string
 	RegistryExpected bool
+	RegistryEntry    *registry.WorktreeEntry
 	InitialOutcome   *prunepolicy.Outcome
 	ProtectedNames   []string
 }
@@ -113,7 +117,9 @@ func runPruneMerged(cmd *cobra.Command, _ []string) error {
 			continue
 		}
 		if pruneDryRun {
-			if err := validatePruneMergedWorktree(candidate); err != nil {
+			if err := withPruneMergedOwnershipGuard(ctx, reg, store, candidate, func() error {
+				return validatePruneMergedWorktree(candidate)
+			}); err != nil {
 				providerEvidence := outcome.Evidence
 				outcome = pruneOutcomeForError(candidate.Policy.Path, candidate.Policy.Branch, err)
 				outcome.Evidence = providerEvidence
@@ -128,7 +134,9 @@ func runPruneMerged(cmd *cobra.Command, _ []string) error {
 			outcomes[index] = outcome
 			continue
 		}
-		removeErr := removePruneMergedWorktree(candidate)
+		removeErr := withPruneMergedOwnershipGuard(ctx, reg, store, candidate, func() error {
+			return removePruneMergedWorktree(candidate)
+		})
 		if removeErr != nil && !git.WorktreeWasRemoved(removeErr) {
 			providerEvidence := outcome.Evidence
 			outcome = pruneOutcomeForError(candidate.Policy.Path, candidate.Policy.Branch, removeErr)
@@ -229,6 +237,77 @@ func defaultValidatePruneMergedWorktree(candidate pruneMergedCandidate) error {
 		candidate.Policy.Path,
 		pruneMergedRemovalConditions(candidate),
 	)
+}
+
+func withPruneMergedOwnershipGuard(
+	ctx context.Context,
+	reg pruneMergedRegistry,
+	store pruneMergedProvenanceStore,
+	candidate pruneMergedCandidate,
+	operation func() error,
+) (resultErr error) {
+	release, acquired, err := reg.AcquireCreation(candidate.Policy.Path)
+	if err != nil {
+		return fmt.Errorf("lock worktree ownership: %w", err)
+	}
+	if !acquired {
+		return fmt.Errorf("worktree creation is in progress for %s", candidate.Policy.Path)
+	}
+	defer func() {
+		if err := release(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("release worktree ownership lock: %w", err))
+		}
+	}()
+
+	matches, err := reg.EntryMatches(candidate.Policy.Path, candidate.RegistryEntry)
+	if err != nil {
+		return fmt.Errorf("revalidate worktree registry ownership: %w", err)
+	}
+	if !matches {
+		return fmt.Errorf("worktree ownership changed after inspection for %s", candidate.Policy.Path)
+	}
+	provenanceMatches, err := pruneMergedProvenanceMatches(ctx, store, candidate)
+	if err != nil {
+		return fmt.Errorf("revalidate pull-request provenance ownership: %w", err)
+	}
+	if !provenanceMatches {
+		return fmt.Errorf("worktree ownership changed after inspection for %s", candidate.Policy.Path)
+	}
+	return operation()
+}
+
+func pruneMergedProvenanceMatches(
+	ctx context.Context,
+	store pruneMergedProvenanceStore,
+	candidate pruneMergedCandidate,
+) (bool, error) {
+	pathMatches := 0
+	expectedMatches := false
+	err := store.View(ctx, func(records map[string]pullrequest.Provenance) error {
+		for key, record := range records {
+			if !samePRPath(record.Workspace.Path, candidate.Policy.Path) ||
+				!provenanceGenerationMatches(
+					record.Workspace.Generation,
+					candidate.Policy.Generation,
+				) {
+				continue
+			}
+			pathMatches++
+			if candidate.Policy.Provenance != nil &&
+				key == candidate.ProvenanceKey &&
+				reflect.DeepEqual(record, *candidate.Policy.Provenance) {
+				expectedMatches = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if candidate.Policy.Provenance == nil {
+		return pathMatches == 0, nil
+	}
+	return pathMatches == 1 && expectedMatches, nil
 }
 
 func pruneMergedRemovalConditions(candidate pruneMergedCandidate) git.WorktreeRemovalConditions {
@@ -639,6 +718,8 @@ func attachMergedRegistrySnapshot(
 		return
 	}
 	entry := matches[0]
+	copy := *entry
+	candidate.RegistryEntry = &copy
 	if entry.Generation != candidate.Policy.Generation && candidate.InitialOutcome == nil {
 		candidate.InitialOutcome = initialMergedOutcome(candidate.Policy, prunepolicy.DoctorRequired, "registry generation does not match the Git worktree")
 	}

--- a/internal/cmd/prune_merged_test.go
+++ b/internal/cmd/prune_merged_test.go
@@ -575,6 +575,36 @@ func TestPruneMergedInventoryIncludesFinalizedRegistryWorktreeRoot(t *testing.T)
 	assert.True(t, candidates[0].RegistryExpected)
 }
 
+func TestPruneMergedInventoryRejectsRegistrySubdirectory(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(
+		t, repositoryRoot, "remote", "add", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	branch := "feature/registered-subdirectory"
+	worktreePath := filepath.Join(t.TempDir(), "registered-subdirectory")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	_, err := git.New(repositoryRoot).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	registryPath := filepath.Join(worktreePath, "nested")
+	require.NoError(t, os.Mkdir(registryPath, 0o755))
+	entry := &registry.WorktreeEntry{
+		Path: registryPath, Repository: commandBaseRepo,
+	}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), &models.Config{}, nil, []*registry.WorktreeEntry{entry},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, utils.PathKey(registryPath), utils.PathKey(candidates[0].Policy.Path))
+	require.NotNil(t, candidates[0].InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidates[0].InitialOutcome.Reason)
+	assert.Contains(t, candidates[0].InitialOutcome.Message, "exact worktree root")
+}
+
 func TestPruneMergedInventoryExcludesRegistryWorktreeWithCreationToken(t *testing.T) {
 	entry := &registry.WorktreeEntry{
 		Path: filepath.Join(t.TempDir(), "creating"), CreationToken: "creator",

--- a/internal/cmd/prune_merged_test.go
+++ b/internal/cmd/prune_merged_test.go
@@ -36,6 +36,7 @@ type fakePruneMergedRegistry struct {
 	entries       []*registry.WorktreeEntry
 	creationBusy  bool
 	creationCalls int
+	releaseErr    error
 	entryMatches  func(string, *registry.WorktreeEntry) (bool, error)
 }
 
@@ -51,7 +52,7 @@ func (r *fakePruneMergedRegistry) AcquireCreation(string) (func() error, bool, e
 	if r.creationBusy {
 		return nil, false, nil
 	}
-	return func() error { return nil }, true, nil
+	return func() error { return r.releaseErr }, true, nil
 }
 
 func (r *fakePruneMergedRegistry) EntryMatches(
@@ -276,6 +277,34 @@ func TestPruneMergedDoesNotRemoveWhenProvenanceAppearsAfterSnapshot(t *testing.T
 	assert.Contains(t, stdout.String(), "ownership")
 	assert.Equal(t, 2, store.viewCalls)
 	assert.Zero(t, removed)
+}
+
+func TestPruneMergedCleansOwnershipAfterRemovalWhenGuardReleaseFails(t *testing.T) {
+	resetPruneMergedCommand(t)
+	pruneJSON = true
+	candidate := commandMergedCandidate("/worktrees/removed-before-unlock", commandMergedHead)
+	candidate.RegistryExpected = true
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	reg := &fakePruneMergedRegistry{
+		removed: true, releaseErr: errors.New("unlock failed"),
+	}
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	var report prunepolicy.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	require.Len(t, report.Outcomes, 1)
+	assert.Equal(t, prunepolicy.CleanupIncomplete, report.Outcomes[0].Reason)
+	assert.Equal(t, "true", report.Outcomes[0].Evidence["worktree_removed"])
+	assert.Contains(t, report.Outcomes[0].Evidence["cleanup_error"], "unlock failed")
+	assert.Equal(t, 1, reg.calls)
+	assert.Equal(t, 1, publications)
 }
 
 func TestPruneMergedRemovesWorktreePreservesBranchAndPublishesOnce(t *testing.T) {

--- a/internal/cmd/prune_merged_test.go
+++ b/internal/cmd/prune_merged_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,11 +41,38 @@ type fakePruneMergedRegistry struct {
 	entryMatches  func(string, *registry.WorktreeEntry) (bool, error)
 }
 
+type observedPruneMergedRegistry struct {
+	*registry.Registry
+	checked chan struct{}
+	once    sync.Once
+}
+
+func (r *observedPruneMergedRegistry) EntryMatches(
+	path string,
+	expected *registry.WorktreeEntry,
+) (bool, error) {
+	matched, err := r.Registry.EntryMatches(path, expected)
+	if err == nil && matched {
+		r.once.Do(func() { close(r.checked) })
+	}
+	return matched, err
+}
+
 func (r *fakePruneMergedRegistry) List() []*registry.WorktreeEntry { return r.entries }
 
-func (r *fakePruneMergedRegistry) UnregisterIfGeneration(string, string) (bool, error) {
+func (r *fakePruneMergedRegistry) RemoveIfMatchAfter(
+	_ string,
+	_ *registry.WorktreeEntry,
+	removal func() error,
+) (bool, error) {
 	r.calls++
-	return r.removed, r.err
+	if r.err != nil || !r.removed {
+		return false, r.err
+	}
+	if err := removal(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *fakePruneMergedRegistry) AcquireCreation(string) (func() error, bool, error) {
@@ -63,6 +91,17 @@ func (r *fakePruneMergedRegistry) EntryMatches(
 		return true, nil
 	}
 	return r.entryMatches(path, expected)
+}
+
+func fakePruneMergedRemoval(
+	remove func(pruneMergedCandidate) error,
+) func(pruneMergedCandidate, func(func() error) (bool, error)) (bool, error) {
+	return func(
+		candidate pruneMergedCandidate,
+		claim func(func() error) (bool, error),
+	) (bool, error) {
+		return claim(func() error { return remove(candidate) })
+	}
 }
 
 type fakePruneMergedProvenance struct {
@@ -152,7 +191,9 @@ func TestPruneMergedDryRunAndJSONDoNotMutateOrPublish(t *testing.T) {
 		return nil
 	}
 	removed := 0
-	removePruneMergedWorktree = func(pruneMergedCandidate) error { removed++; return nil }
+	removePruneMergedWorktree = fakePruneMergedRemoval(
+		func(pruneMergedCandidate) error { removed++; return nil },
+	)
 	publications := 0
 	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
 	cmd, stdout, stderr := fleetTestCommand()
@@ -182,7 +223,9 @@ func TestPruneMergedDryRunMapsRevalidationChanges(t *testing.T) {
 		return &git.ConditionError{Reason: git.ReasonDirty, Path: got.Policy.Path}
 	}
 	removed := 0
-	removePruneMergedWorktree = func(pruneMergedCandidate) error { removed++; return nil }
+	removePruneMergedWorktree = fakePruneMergedRemoval(
+		func(pruneMergedCandidate) error { removed++; return nil },
+	)
 	cmd, stdout, stderr := fleetTestCommand()
 
 	err := runPrune(cmd, nil)
@@ -206,10 +249,10 @@ func TestPruneMergedDoesNotRemoveWhileCandidateCreationIsActive(t *testing.T) {
 	reg := &fakePruneMergedRegistry{creationBusy: true}
 	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
 	removed := 0
-	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+	removePruneMergedWorktree = fakePruneMergedRemoval(func(pruneMergedCandidate) error {
 		removed++
 		return nil
-	}
+	})
 	cmd, stdout, _ := fleetTestCommand()
 
 	err := runPrune(cmd, nil)
@@ -235,10 +278,10 @@ func TestPruneMergedDoesNotRemoveWhenRegistryOwnershipAppearsAfterSnapshot(
 	}
 	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
 	removed := 0
-	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+	removePruneMergedWorktree = fakePruneMergedRemoval(func(pruneMergedCandidate) error {
 		removed++
 		return nil
-	}
+	})
 	cmd, stdout, _ := fleetTestCommand()
 
 	err := runPrune(cmd, nil)
@@ -246,6 +289,76 @@ func TestPruneMergedDoesNotRemoveWhenRegistryOwnershipAppearsAfterSnapshot(
 	assertExitCode(t, err, 1)
 	assert.Contains(t, stdout.String(), "ownership")
 	assert.Zero(t, removed)
+}
+
+func TestPruneMergedDoesNotRemoveWhenExpirationAppearsBeforeGitLock(t *testing.T) {
+	resetPruneMergedCommand(t)
+	t.Setenv("KWT_HOME", t.TempDir())
+	pruneJSON = true
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	runTUITestGit(t, repositoryRoot, "remote", "add", "source", "https://github.com/octocat/widget.git")
+	branch := "feature/concurrent-expiration"
+	worktreePath := filepath.Join(t.TempDir(), "concurrent-expiration")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "config", "branch."+branch+".remote", "source")
+	runTUITestGit(t, repositoryRoot, "config", "branch."+branch+".merge", "refs/heads/topic")
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	g := git.New(repositoryRoot)
+	generation, err := g.WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	head := strings.TrimSpace(runTUITestGitOutput(t, worktreePath, "rev-parse", "HEAD"))
+	candidate := commandMergedCandidate(worktreePath, head)
+	candidate.RepositoryRoot = repositoryRoot
+	candidate.Policy.Branch = branch
+	candidate.Policy.Generation = generation
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	removePruneMergedWorktree = defaultRemovePruneMergedWorktree
+	realRegistry, err := registry.New()
+	require.NoError(t, err)
+	registryChecked := make(chan struct{})
+	observedRegistry := &observedPruneMergedRegistry{
+		Registry: realRegistry,
+		checked:  registryChecked,
+	}
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) {
+		return observedRegistry, nil
+	}
+	gitLocked := make(chan struct{})
+	expirationDone := make(chan error, 1)
+	go func() {
+		expirationDone <- g.WithWorktreeGeneration(worktreePath, generation, func() error {
+			close(gitLocked)
+			<-registryChecked
+			expiresAt := time.Now().Add(time.Hour)
+			updated, updateErr := realRegistry.SetExpirationIfGeneration(
+				worktreePath,
+				generation,
+				commandBaseRepo,
+				branch,
+				&expiresAt,
+			)
+			if updateErr != nil {
+				return updateErr
+			}
+			if !updated {
+				return errors.New("expiration registration was not updated")
+			}
+			return nil
+		})
+	}()
+	<-gitLocked
+	cmd, stdout, _ := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	require.NoError(t, <-expirationDone)
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), "ownership")
+	assert.DirExists(t, worktreePath)
+	_, registered := realRegistry.Get(worktreePath)
+	assert.True(t, registered)
 }
 
 func TestPruneMergedDoesNotRemoveWhenProvenanceAppearsAfterSnapshot(t *testing.T) {
@@ -265,10 +378,10 @@ func TestPruneMergedDoesNotRemoveWhenProvenanceAppearsAfterSnapshot(t *testing.T
 	}
 	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
 	removed := 0
-	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+	removePruneMergedWorktree = fakePruneMergedRemoval(func(pruneMergedCandidate) error {
 		removed++
 		return nil
-	}
+	})
 	cmd, stdout, _ := fleetTestCommand()
 
 	err := runPrune(cmd, nil)
@@ -433,9 +546,9 @@ func TestPruneMergedMapsRemovalPreconditionChanges(t *testing.T) {
 			candidate := commandMergedCandidate("/worktrees/"+tc.name, commandMergedHead)
 			setPruneMergedInventory(candidate)
 			setPruneMergedProvider(providerForCommandCandidates(candidate))
-			removePruneMergedWorktree = func(candidate pruneMergedCandidate) error {
+			removePruneMergedWorktree = fakePruneMergedRemoval(func(candidate pruneMergedCandidate) error {
 				return &git.ConditionError{Reason: tc.gitReason, Path: candidate.Policy.Path}
-			}
+			})
 			publications := 0
 			publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
 			cmd, stdout, _ := fleetTestCommand()
@@ -577,9 +690,9 @@ func TestPruneMergedCompletesBookkeepingAfterGitDeregistersWithResidualFiles(t *
 		removeResult: true,
 	}
 	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
-	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+	removePruneMergedWorktree = fakePruneMergedRemoval(func(pruneMergedCandidate) error {
 		return completedWorktreeRemovalWarning{message: "worktree removed, but files remain"}
-	}
+	})
 	publications := 0
 	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
 	cmd, stdout, _ := fleetTestCommand()
@@ -608,10 +721,10 @@ func TestPruneMergedContinuesAfterPartialProviderFailure(t *testing.T) {
 	}
 	setPruneMergedProvider(provider)
 	var removed []string
-	removePruneMergedWorktree = func(candidate pruneMergedCandidate) error {
+	removePruneMergedWorktree = fakePruneMergedRemoval(func(candidate pruneMergedCandidate) error {
 		removed = append(removed, candidate.Policy.Path)
 		return nil
-	}
+	})
 	publications := 0
 	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
 	cmd, stdout, _ := fleetTestCommand()
@@ -1326,7 +1439,15 @@ func TestPruneMergedInventoryStripsCredentialsFromWorktreeGitProcesses(t *testin
 	assert.Equal(t, "unset|unset", string(probeContents))
 	require.NoError(t, os.WriteFile(probeOutput, []byte("not-invoked"), 0o600))
 
-	require.NoError(t, defaultRemovePruneMergedWorktree(candidates[0]))
+	removed, err := defaultRemovePruneMergedWorktree(
+		candidates[0],
+		func(remove func() error) (bool, error) {
+			err := remove()
+			return err == nil || git.WorktreeWasRemoved(err), err
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, removed)
 	probeContents, err = os.ReadFile(probeOutput)
 	require.NoError(t, err)
 	assert.Equal(t, "unset|unset", string(probeContents))
@@ -1392,7 +1513,9 @@ func resetPruneMergedCommand(t *testing.T) {
 	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore {
 		return &fakePruneMergedProvenance{removeResult: true}
 	}
-	removePruneMergedWorktree = func(pruneMergedCandidate) error { return nil }
+	removePruneMergedWorktree = fakePruneMergedRemoval(
+		func(pruneMergedCandidate) error { return nil },
+	)
 }
 
 func resetPruneMergedDeps(t *testing.T) {

--- a/internal/cmd/prune_merged_test.go
+++ b/internal/cmd/prune_merged_test.go
@@ -1,0 +1,1328 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/prunepolicy"
+	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+const (
+	commandMergedHead = "0123456789abcdef0123456789abcdef01234567"
+	commandBaseRepo   = "github.com/acme/widget"
+	commandSourceRepo = "github.com/octocat/widget"
+)
+
+type fakePruneMergedRegistry struct {
+	removed bool
+	err     error
+	calls   int
+	entries []*registry.WorktreeEntry
+}
+
+func (r *fakePruneMergedRegistry) List() []*registry.WorktreeEntry { return r.entries }
+
+func (r *fakePruneMergedRegistry) UnregisterIfGeneration(string, string) (bool, error) {
+	r.calls++
+	return r.removed, r.err
+}
+
+type fakePruneMergedProvenance struct {
+	records       map[string]pullrequest.Provenance
+	removeResult  bool
+	removeErr     error
+	removedKey    string
+	removedRecord pullrequest.Provenance
+}
+
+func (s *fakePruneMergedProvenance) View(
+	_ context.Context, fn func(map[string]pullrequest.Provenance) error,
+) error {
+	records := make(map[string]pullrequest.Provenance, len(s.records))
+	for key, value := range s.records {
+		records[key] = value
+	}
+	return fn(records)
+}
+
+func (s *fakePruneMergedProvenance) RemoveIfMatch(
+	_ context.Context, key string, expected pullrequest.Provenance,
+) (bool, error) {
+	s.removedKey = key
+	s.removedRecord = expected
+	return s.removeResult, s.removeErr
+}
+
+type fakePruneMergedProvider struct {
+	forCommit func(string) ([]pullrequest.PullRequest, error)
+	byHead    func(string, string) ([]pullrequest.PullRequest, error)
+	get       func(int) (pullrequest.PullRequest, error)
+}
+
+func (p *fakePruneMergedProvider) ResolveRepository(
+	_ context.Context,
+	repository pullrequest.Repository,
+) (pullrequest.Repository, error) {
+	return repository, nil
+}
+
+func (p *fakePruneMergedProvider) Get(
+	_ context.Context, _ pullrequest.Repository, number int,
+) (pullrequest.PullRequest, error) {
+	if p.get == nil {
+		return pullrequest.PullRequest{}, errors.New("unexpected Get")
+	}
+	return p.get(number)
+}
+
+func (p *fakePruneMergedProvider) ListForCommit(
+	_ context.Context, _ pullrequest.Repository, sha string,
+) ([]pullrequest.PullRequest, error) {
+	if p.forCommit == nil {
+		return nil, errors.New("unexpected ListForCommit")
+	}
+	return p.forCommit(sha)
+}
+
+func (p *fakePruneMergedProvider) ListByHead(
+	_ context.Context, _ pullrequest.Repository, owner, branch string,
+) ([]pullrequest.PullRequest, error) {
+	if p.byHead == nil {
+		return nil, nil
+	}
+	return p.byHead(owner, branch)
+}
+
+func TestPruneMergedDryRunAndJSONDoNotMutateOrPublish(t *testing.T) {
+	resetPruneMergedCommand(t)
+	pruneDryRun = true
+	pruneJSON = true
+	candidate := commandMergedCandidate("/worktrees/topic", commandMergedHead)
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	validated := 0
+	validatePruneMergedWorktree = func(got pruneMergedCandidate) error {
+		validated++
+		assert.Equal(t, candidate, got)
+		return nil
+	}
+	removed := 0
+	removePruneMergedWorktree = func(pruneMergedCandidate) error { removed++; return nil }
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout.String(), stderr.String())
+	var report prunepolicy.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, "merged", report.Policy)
+	assert.True(t, report.DryRun)
+	require.Len(t, report.Outcomes, 1)
+	assert.Equal(t, prunepolicy.WouldRemove, report.Outcomes[0].Reason)
+	assert.Equal(t, 1, validated)
+	assert.Zero(t, removed)
+	assert.Zero(t, publications)
+}
+
+func TestPruneMergedDryRunMapsRevalidationChanges(t *testing.T) {
+	resetPruneMergedCommand(t)
+	pruneDryRun = true
+	pruneJSON = true
+	candidate := commandMergedCandidate("/worktrees/changed", commandMergedHead)
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	validatePruneMergedWorktree = func(got pruneMergedCandidate) error {
+		return &git.ConditionError{Reason: git.ReasonDirty, Path: got.Policy.Path}
+	}
+	removed := 0
+	removePruneMergedWorktree = func(pruneMergedCandidate) error { removed++; return nil }
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	var report prunepolicy.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	require.Len(t, report.Outcomes, 1)
+	assert.Equal(t, prunepolicy.DirtyWorktree, report.Outcomes[0].Reason)
+	assert.Equal(t, "https://github.com/acme/widget/pull/17", report.Outcomes[0].Evidence["pr_url"])
+	assert.Empty(t, stderr.String())
+	assert.Zero(t, removed)
+}
+
+func TestPruneMergedRemovesWorktreePreservesBranchAndPublishesOnce(t *testing.T) {
+	resetPruneMergedCommand(t)
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	runTUITestGit(t, repositoryRoot, "remote", "add", "source", "https://github.com/octocat/widget.git")
+	branch := "feature/merged-real"
+	worktreePath := filepath.Join(t.TempDir(), "merged-real")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "config", "branch."+branch+".remote", "source")
+	runTUITestGit(t, repositoryRoot, "config", "branch."+branch+".merge", "refs/heads/topic")
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	generation, err := git.New(repositoryRoot).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	head := strings.TrimSpace(runTUITestGitOutput(t, worktreePath, "rev-parse", "HEAD"))
+	candidate := commandMergedCandidate(worktreePath, head)
+	candidate.RepositoryRoot = repositoryRoot
+	candidate.Policy.Branch = branch
+	candidate.Policy.Generation = generation
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	removePruneMergedWorktree = defaultRemovePruneMergedWorktree
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout.String(), stderr.String())
+	assert.Contains(t, stdout.String(), string(prunepolicy.Removed))
+	assert.NoDirExists(t, worktreePath)
+	assert.Contains(t, runTUITestGitOutput(t, repositoryRoot, "branch", "--list", branch), branch)
+	assert.Equal(t, 1, publications)
+}
+
+func TestPruneMergedRemovesMultipleGloballyDiscoveredWorktrees(t *testing.T) {
+	resetPruneMergedCommand(t)
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	runTUITestGit(t, repositoryRoot, "remote", "add", "source", "https://github.com/octocat/widget.git")
+	worktreeBase := t.TempDir()
+	type worktreeFixture struct {
+		path       string
+		branch     string
+		source     string
+		head       string
+		generation string
+	}
+	fixtures := []worktreeFixture{
+		{path: filepath.Join(worktreeBase, "01-discovery"), branch: "feature/first", source: "first-topic"},
+		{path: filepath.Join(worktreeBase, "02-other"), branch: "feature/second", source: "second-topic"},
+	}
+	entries := make([]*registry.WorktreeEntry, 0, len(fixtures))
+	for index := range fixtures {
+		fixture := &fixtures[index]
+		runTUITestGit(t, repositoryRoot, "branch", fixture.branch)
+		runTUITestGit(t, repositoryRoot, "config", "branch."+fixture.branch+".remote", "source")
+		runTUITestGit(t, repositoryRoot, "config", "branch."+fixture.branch+".merge", "refs/heads/"+fixture.source)
+		runTUITestGit(t, repositoryRoot, "worktree", "add", fixture.path, fixture.branch)
+		runTUITestGit(t, fixture.path, "commit", "--allow-empty", "-m", fixture.branch)
+		fixture.head = strings.TrimSpace(runTUITestGitOutput(t, fixture.path, "rev-parse", "HEAD"))
+		var err error
+		fixture.generation, err = git.New(repositoryRoot).WorktreeGeneration(fixture.path)
+		require.NoError(t, err)
+		entries = append(entries, &registry.WorktreeEntry{
+			Path: fixture.path, Generation: fixture.generation, Repository: commandBaseRepo,
+		})
+	}
+	loadPruneMergedConfig = func() (*models.Config, error) {
+		return &models.Config{Worktree: models.WorktreeConfig{BaseDir: worktreeBase}}, nil
+	}
+	findPruneMergedGlobalPaths = func(string) ([]string, error) {
+		return []string{fixtures[0].path, fixtures[1].path}, nil
+	}
+	inspectPruneMergedCandidates = defaultInspectPruneMergedCandidates
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) {
+		return &fakePruneMergedRegistry{removed: true, entries: entries}, nil
+	}
+	setPruneMergedProvider(&fakePruneMergedProvider{
+		forCommit: func(sha string) ([]pullrequest.PullRequest, error) {
+			for _, fixture := range fixtures {
+				if fixture.head != sha {
+					continue
+				}
+				candidate := commandMergedCandidate(fixture.path, fixture.head)
+				candidate.Policy.Branch = fixture.branch
+				candidate.Policy.SourceBranch = fixture.source
+				return []pullrequest.PullRequest{commandMergedPR(candidate)}, nil
+			}
+			return nil, nil
+		},
+	})
+	removePruneMergedWorktree = defaultRemovePruneMergedWorktree
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {}
+	cmd, stdout, stderr := fleetTestCommand()
+	cmd.SetContext(context.Background())
+
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout.String(), stderr.String())
+	assert.NoDirExists(t, fixtures[0].path)
+	assert.NoDirExists(t, fixtures[1].path)
+}
+
+func TestPruneMergedMapsRemovalPreconditionChanges(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		gitReason git.ConditionReason
+		want      prunepolicy.Reason
+	}{
+		{name: "backlink", gitReason: git.ReasonBacklinkChanged, want: prunepolicy.DoctorRequired},
+		{name: "generation", gitReason: git.ReasonGenerationChanged, want: prunepolicy.GenerationChanged},
+		{name: "head", gitReason: git.ReasonHeadChanged, want: prunepolicy.HeadChanged},
+		{name: "identity", gitReason: git.ReasonRepositoryChanged, want: prunepolicy.RepositoryChanged},
+		{name: "branch", gitReason: git.ReasonBranchChanged, want: prunepolicy.SourceBranchMismatch},
+		{name: "upstream repository", gitReason: git.ReasonUpstreamRepositoryChanged, want: prunepolicy.SourceRepositoryMismatch},
+		{name: "upstream branch", gitReason: git.ReasonUpstreamBranchChanged, want: prunepolicy.SourceBranchMismatch},
+		{name: "dirty", gitReason: git.ReasonDirty, want: prunepolicy.DirtyWorktree},
+		{name: "locked", gitReason: git.ReasonLocked, want: prunepolicy.LockedWorktree},
+		{name: "main", gitReason: git.ReasonMainWorktree, want: prunepolicy.MainWorktree},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetPruneMergedCommand(t)
+			pruneJSON = true
+			candidate := commandMergedCandidate("/worktrees/"+tc.name, commandMergedHead)
+			setPruneMergedInventory(candidate)
+			setPruneMergedProvider(providerForCommandCandidates(candidate))
+			removePruneMergedWorktree = func(candidate pruneMergedCandidate) error {
+				return &git.ConditionError{Reason: tc.gitReason, Path: candidate.Policy.Path}
+			}
+			publications := 0
+			publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+			cmd, stdout, _ := fleetTestCommand()
+
+			err := runPrune(cmd, nil)
+
+			assertExitCode(t, err, 1)
+			assert.Contains(t, stdout.String(), string(tc.want))
+			var report prunepolicy.Report
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+			require.Len(t, report.Outcomes, 1)
+			assert.Equal(t, "https://github.com/acme/widget/pull/17", report.Outcomes[0].Evidence["pr_url"])
+			assert.Zero(t, publications)
+		})
+	}
+}
+
+func TestPruneMergedRemovalConditionsIncludeBranchAndUpstream(t *testing.T) {
+	candidate := commandMergedCandidate("/worktrees/topic", commandMergedHead)
+	candidate.ExpectedGitDir = "/projects/widget/.git/worktrees/topic"
+
+	conditions := pruneMergedRemovalConditions(candidate)
+
+	assert.Equal(t, candidate.ExpectedGitDir, conditions.ExpectedGitDir)
+	assert.Equal(t, candidate.Policy.Branch, conditions.Branch)
+	assert.Equal(t, candidate.Policy.SourceRepository, conditions.UpstreamRepository)
+	assert.Equal(t, candidate.Policy.SourceBranch, conditions.UpstreamBranch)
+	assert.True(t, conditions.IncludeIgnored)
+}
+
+func TestPruneMergedMissingGenerationDoesNotAuthenticateOrPublish(t *testing.T) {
+	resetPruneMergedCommand(t)
+	candidate := commandMergedCandidate("/worktrees/legacy", commandMergedHead)
+	candidate.Policy.Generation = ""
+	setPruneMergedInventory(candidate)
+	providerCalls := 0
+	newPruneMergedProvider = func(context.Context) (prunepolicy.MergedProvider, error) {
+		providerCalls++
+		return providerForCommandCandidates(candidate), nil
+	}
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.MissingGeneration))
+	assert.Zero(t, providerCalls)
+	assert.Zero(t, publications)
+}
+
+func TestPruneMergedRemovesExactProvenance(t *testing.T) {
+	resetPruneMergedCommand(t)
+	candidate := commandMergedCandidate("/worktrees/imported", commandMergedHead)
+	record := commandMergedProvenance(candidate)
+	candidate.ProvenanceKey = record.PullRequestID
+	candidate.Policy.Provenance = &record
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	store := &fakePruneMergedProvenance{records: map[string]pullrequest.Provenance{record.PullRequestID: record}, removeResult: true}
+	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
+	cmd, _, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, record.PullRequestID, store.removedKey)
+	assert.Equal(t, record, store.removedRecord)
+}
+
+func TestAttachMergedProvenanceIgnoresMismatchedGeneration(t *testing.T) {
+	candidate := commandMergedCandidate("/worktrees/reused", "head-sha")
+	record := commandMergedProvenance(candidate)
+	record.Workspace.Generation = "fedcba9876543210fedcba9876543210"
+
+	attachMergedProvenance(&candidate, map[string]pullrequest.Provenance{
+		"stale": record,
+	})
+
+	assert.Nil(t, candidate.Policy.Provenance)
+	assert.Empty(t, candidate.ProvenanceKey)
+	assert.Nil(t, candidate.InitialOutcome)
+}
+
+func TestAttachMergedProvenanceAcceptsLegacyGeneration(t *testing.T) {
+	candidate := commandMergedCandidate("/worktrees/legacy", "head-sha")
+	record := commandMergedProvenance(candidate)
+	record.Workspace.Generation = ""
+
+	attachMergedProvenance(&candidate, map[string]pullrequest.Provenance{
+		"legacy": record,
+	})
+
+	require.NotNil(t, candidate.Policy.Provenance)
+	assert.Equal(t, record, *candidate.Policy.Provenance)
+	assert.Equal(t, "legacy", candidate.ProvenanceKey)
+}
+
+func TestPruneMergedReportsCleanupIncompleteAfterRemoval(t *testing.T) {
+	resetPruneMergedCommand(t)
+	candidate := commandMergedCandidate("/worktrees/imported", commandMergedHead)
+	record := commandMergedProvenance(candidate)
+	candidate.ProvenanceKey = record.PullRequestID
+	candidate.Policy.Provenance = &record
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	store := &fakePruneMergedProvenance{records: map[string]pullrequest.Provenance{record.PullRequestID: record}, removeResult: false}
+	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.CleanupIncomplete))
+	assert.Equal(t, 1, publications)
+}
+
+type completedWorktreeRemovalWarning struct{ message string }
+
+func (e completedWorktreeRemovalWarning) Error() string       { return e.message }
+func (completedWorktreeRemovalWarning) WorktreeRemoved() bool { return true }
+
+func TestPruneMergedCompletesBookkeepingAfterGitDeregistersWithResidualFiles(t *testing.T) {
+	resetPruneMergedCommand(t)
+	candidate := commandMergedCandidate("/worktrees/residual", commandMergedHead)
+	record := commandMergedProvenance(candidate)
+	candidate.ProvenanceKey = record.PullRequestID
+	candidate.Policy.Provenance = &record
+	candidate.RegistryExpected = true
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	reg := &fakePruneMergedRegistry{removed: true}
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
+	store := &fakePruneMergedProvenance{removeResult: true}
+	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
+	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+		return completedWorktreeRemovalWarning{message: "worktree removed, but files remain"}
+	}
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.CleanupIncomplete))
+	assert.Contains(t, stdout.String(), "files remain")
+	assert.Equal(t, 1, reg.calls)
+	assert.Equal(t, record.PullRequestID, store.removedKey)
+	assert.Equal(t, 1, publications)
+}
+
+func TestPruneMergedContinuesAfterPartialProviderFailure(t *testing.T) {
+	resetPruneMergedCommand(t)
+	failed := commandMergedCandidate("/worktrees/failed", commandMergedHead)
+	confirmed := commandMergedCandidate("/worktrees/confirmed", "89abcdef0123456789abcdef0123456789abcdef")
+	setPruneMergedInventory(failed, confirmed)
+	provider := providerForCommandCandidates(failed, confirmed)
+	provider.forCommit = func(sha string) ([]pullrequest.PullRequest, error) {
+		if sha == failed.Policy.Head {
+			return nil, pullrequest.NewError(pullrequest.CodeNetwork, "temporary", true, nil)
+		}
+		return []pullrequest.PullRequest{commandMergedPR(confirmed)}, nil
+	}
+	setPruneMergedProvider(provider)
+	var removed []string
+	removePruneMergedWorktree = func(candidate pruneMergedCandidate) error {
+		removed = append(removed, candidate.Policy.Path)
+		return nil
+	}
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.NetworkFailure))
+	assert.Contains(t, stdout.String(), string(prunepolicy.Removed))
+	assert.Equal(t, []string{confirmed.Policy.Path}, removed)
+	assert.Equal(t, 1, publications)
+}
+
+func TestPruneMergedNoopDoesNotAuthenticateOrPublish(t *testing.T) {
+	resetPruneMergedCommand(t)
+	setPruneMergedInventory()
+	providerCalls := 0
+	newPruneMergedProvider = func(context.Context) (prunepolicy.MergedProvider, error) {
+		providerCalls++
+		return nil, errors.New("must not authenticate")
+	}
+	publications := 0
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No merged worktrees found")
+	assert.Zero(t, providerCalls)
+	assert.Zero(t, publications)
+}
+
+func TestPruneMergedInventoryFailureIsExecutionError(t *testing.T) {
+	resetPruneMergedCommand(t)
+	inspectPruneMergedCandidates = func(context.Context, *models.Config, map[string]pullrequest.Provenance, []*registry.WorktreeEntry) ([]pruneMergedCandidate, error) {
+		return nil, errors.New("inventory unavailable")
+	}
+	cmd, _, stderr := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 2)
+	assert.Contains(t, stderr.String(), "inventory unavailable")
+}
+
+func TestPruneMergedInventoryReturnsStrictGlobalDiscoveryError(t *testing.T) {
+	resetPruneMergedDeps(t)
+	wantErr := errors.New("global inventory incomplete")
+	findPruneMergedGlobalPaths = func(string) ([]string, error) {
+		return nil, wantErr
+	}
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: t.TempDir()}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	assert.Nil(t, candidates)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestPruneMergedInventoryReportsUninspectableDiscoveredPathAsDoctorRequired(t *testing.T) {
+	resetPruneMergedDeps(t)
+	badPath := filepath.Join(t.TempDir(), "stale-worktree")
+	require.NoError(t, os.MkdirAll(badPath, 0o755))
+	findPruneMergedGlobalPaths = func(string) ([]string, error) {
+		return []string{badPath}, nil
+	}
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: t.TempDir()}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(context.Background(), cfg, nil, nil)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.NotNil(t, candidates[0].InitialOutcome)
+	assert.Equal(t, badPath, candidates[0].Policy.Path)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidates[0].InitialOutcome.Reason)
+	assert.Contains(t, candidates[0].InitialOutcome.Message, "could not be inspected")
+}
+
+func TestPruneMergedInventoryIncludesFinalizedRegistryWorktreeRoot(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	branch := "feature/registered-only"
+	worktreePath := filepath.Join(t.TempDir(), "registered-only")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	generation, err := git.New(repositoryRoot).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	entry := &registry.WorktreeEntry{
+		Path: worktreePath, Generation: generation, Repository: commandBaseRepo,
+	}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), &models.Config{}, nil, []*registry.WorktreeEntry{entry},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, utils.PathKey(worktreePath), utils.PathKey(candidates[0].Policy.Path))
+	assert.Equal(t, commandBaseRepo, candidates[0].Policy.ProjectRepository)
+	assert.True(t, candidates[0].RegistryExpected)
+}
+
+func TestPruneMergedInventoryExcludesRegistryWorktreeWithCreationToken(t *testing.T) {
+	entry := &registry.WorktreeEntry{
+		Path: filepath.Join(t.TempDir(), "creating"), CreationToken: "creator",
+	}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), &models.Config{}, nil, []*registry.WorktreeEntry{entry},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+}
+
+func TestPruneMergedRejectsMultipleRegistryAliasesForOneWorktree(t *testing.T) {
+	realParent := t.TempDir()
+	worktreePath := filepath.Join(realParent, "topic")
+	require.NoError(t, os.Mkdir(worktreePath, 0o755))
+	aliasParent := filepath.Join(t.TempDir(), "worktrees-link")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	generation := "0123456789abcdef0123456789abcdef"
+	candidate := pruneMergedCandidate{Policy: prunepolicy.MergedCandidate{
+		Path: worktreePath, Generation: generation,
+		ProjectRepository: commandBaseRepo, LiveRepository: commandBaseRepo,
+	}}
+	entries := []*registry.WorktreeEntry{
+		{Path: worktreePath, Generation: generation, Repository: commandBaseRepo},
+		{Path: filepath.Join(aliasParent, "topic"), Generation: generation, Repository: commandBaseRepo},
+	}
+
+	attachMergedRegistrySnapshot(&candidate, entries)
+
+	require.NotNil(t, candidate.InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidate.InitialOutcome.Reason)
+	assert.Contains(t, candidate.InitialOutcome.Message, "multiple registry")
+}
+
+func TestPruneMergedInventoryUsesReadOnlyGitFactsAndUpstreamIdentity(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/octocat/widget.git")
+	runTUITestGit(t, repositoryRoot, "remote", "add", "fork", "git@github.com:octocat/widget.git")
+	runTUITestGit(t, repositoryRoot, "remote", "add", "worktree-fork", "git@github.com:hubot/widget.git")
+	branch := "feature/local-topic"
+	worktreePath := filepath.Join(t.TempDir(), "ordinary-topic")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "config", "branch."+branch+".remote", "fork")
+	runTUITestGit(t, repositoryRoot, "config", "branch."+branch+".merge", "refs/heads/topic")
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	runTUITestGit(t, repositoryRoot, "config", "extensions.worktreeConfig", "true")
+	runTUITestGit(t, worktreePath, "config", "--worktree", "branch."+branch+".remote", "worktree-fork")
+	runTUITestGit(t, worktreePath, "config", "--worktree", "branch."+branch+".merge", "refs/heads/worktree-topic")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repositoryRoot, ".git", "info", "exclude"),
+		[]byte("valuable.local\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "valuable.local"),
+		[]byte("keep me\n"),
+		0o644,
+	))
+	generation, err := git.New(repositoryRoot).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	entry := &registry.WorktreeEntry{
+		Path: worktreePath, Generation: generation,
+		Repository: "https://github.com/octocat/widget.git",
+	}
+	cfg := &models.Config{Projects: []models.Project{{Path: repositoryRoot, Repository: commandBaseRepo}}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, []*registry.WorktreeEntry{entry},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1, "main worktrees are outside merged-prune candidate inventory")
+	var candidate *pruneMergedCandidate
+	for index := range candidates {
+		if utils.PathKey(candidates[index].Policy.Path) == utils.PathKey(worktreePath) {
+			candidate = &candidates[index]
+			break
+		}
+	}
+	require.NotNil(t, candidate, "candidates=%+v", candidates)
+	assert.Equal(t, commandBaseRepo, candidate.Policy.ProjectRepository)
+	assert.Equal(t, commandSourceRepo, candidate.Policy.LiveRepository)
+	assert.Equal(t, "github.com/hubot/widget", candidate.Policy.SourceRepository)
+	assert.Equal(t, "worktree-topic", candidate.Policy.SourceBranch)
+	assert.Equal(t, utils.CanonicalPath(repositoryRoot), candidate.Policy.MainRepositoryPath)
+	assert.Equal(t, generation, candidate.Policy.Generation)
+	assert.True(t, candidate.Policy.Dirty)
+	assert.True(t, candidate.RegistryExpected)
+	assert.Nil(t, candidate.InitialOutcome)
+}
+
+func TestPruneMergedInventoryRejectsMismatchedWorktreeBacklink(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(
+		t, repositoryRoot, "remote", "add", "origin",
+		"https://github.com/octocat/widget.git",
+	)
+	firstPath := filepath.Join(t.TempDir(), "first")
+	secondPath := filepath.Join(t.TempDir(), "second")
+	runTUITestGit(t, repositoryRoot, "worktree", "add", "-b", "first", firstPath)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", "-b", "second", secondPath)
+	_, err := git.New(repositoryRoot).ListWorktrees()
+	require.NoError(t, err)
+	secondGitDir := strings.TrimSpace(
+		runTUITestGitOutput(t, secondPath, "rev-parse", "--absolute-git-dir"),
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(firstPath, ".git"),
+		[]byte("gitdir: "+secondGitDir+"\n"),
+		0o644,
+	))
+	cfg := &models.Config{Projects: []models.Project{{
+		Path: repositoryRoot, Repository: commandBaseRepo,
+	}}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	var candidate *pruneMergedCandidate
+	for index := range candidates {
+		if utils.PathKey(candidates[index].Policy.Path) == utils.PathKey(firstPath) {
+			candidate = &candidates[index]
+			break
+		}
+	}
+	require.NotNil(t, candidate)
+	require.NotNil(t, candidate.InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidate.InitialOutcome.Reason)
+	assert.Contains(t, candidate.InitialOutcome.Message, "backlink")
+	assert.Empty(t, candidate.Policy.LiveRepository)
+	assert.Empty(t, candidate.Policy.SourceRepository)
+	assert.Empty(t, candidate.Policy.SourceBranch)
+}
+
+func TestPruneMergedInventoryRejectsDistinctRootClaimingCandidateBacklink(
+	t *testing.T,
+) {
+	for _, source := range []string{"global", "registry"} {
+		t.Run(source, func(t *testing.T) {
+			resetPruneMergedDeps(t)
+			repositoryRoot := newTUITestRepo(t)
+			runTUITestGit(
+				t, repositoryRoot, "remote", "add", "origin",
+				"https://github.com/acme/widget.git",
+			)
+			worktreePath := filepath.Join(t.TempDir(), "real-topic")
+			runTUITestGit(
+				t, repositoryRoot, "worktree", "add", "-b", "real-topic",
+				worktreePath,
+			)
+			generation, err := git.New(repositoryRoot).WorktreeGeneration(worktreePath)
+			require.NoError(t, err)
+			gitDir := strings.TrimSpace(
+				runTUITestGitOutput(t, worktreePath, "rev-parse", "--absolute-git-dir"),
+			)
+			copyPath := filepath.Join(t.TempDir(), "copied-topic")
+			require.NoError(t, os.Mkdir(copyPath, 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(copyPath, ".git"),
+				[]byte("gitdir: "+gitDir+"\n"),
+				0o644,
+			))
+			cfg := &models.Config{Projects: []models.Project{{
+				Path: repositoryRoot, Repository: commandBaseRepo,
+			}}}
+			var entries []*registry.WorktreeEntry
+			if source == "global" {
+				cfg.Worktree.BaseDir = filepath.Dir(copyPath)
+				findPruneMergedGlobalPaths = func(string) ([]string, error) {
+					return []string{copyPath}, nil
+				}
+			} else {
+				entries = []*registry.WorktreeEntry{{
+					Path: copyPath, Repository: commandBaseRepo,
+					Generation: generation,
+				}}
+			}
+
+			candidates, err := defaultInspectPruneMergedCandidates(
+				context.Background(), cfg, nil, entries,
+			)
+
+			require.NoError(t, err)
+			var candidate *pruneMergedCandidate
+			for index := range candidates {
+				if utils.PathKey(candidates[index].Policy.Path) == utils.PathKey(worktreePath) {
+					candidate = &candidates[index]
+					break
+				}
+			}
+			require.NotNil(t, candidate)
+			require.NotNil(t, candidate.InitialOutcome)
+			assert.Equal(t, prunepolicy.DoctorRequired, candidate.InitialOutcome.Reason)
+			assert.Contains(t, candidate.InitialOutcome.Message, "claimed")
+			assert.Equal(
+				t, utils.CanonicalPath(copyPath),
+				candidate.InitialOutcome.Evidence["claimants"],
+			)
+		})
+	}
+}
+
+func TestPruneMergedInventoryReadsOriginFromLinkedWorktree(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	branch := "feature/worktree-origin"
+	worktreePath := filepath.Join(t.TempDir(), "worktree-origin")
+	worktreeConfig := filepath.Join(t.TempDir(), "worktree-origin.config")
+	runTUITestGit(t, repositoryRoot, "config", "--file", worktreeConfig, "remote.origin.url", "https://github.com/hubot/widget.git")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	worktreeGitDir := strings.TrimSpace(runTUITestGitOutput(t, worktreePath, "rev-parse", "--absolute-git-dir"))
+	runTUITestGit(
+		t, repositoryRoot, "config", "--add",
+		"includeIf.gitdir:"+worktreeGitDir+".path", worktreeConfig,
+	)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/octocat/widget.git")
+	cfg := &models.Config{Projects: []models.Project{{
+		Path: repositoryRoot, Repository: commandBaseRepo,
+	}}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, commandBaseRepo, candidates[0].Policy.ProjectRepository)
+	assert.Equal(t, "github.com/hubot/widget", candidates[0].Policy.LiveRepository)
+}
+
+func TestPruneMergedInventorySupportsSeparateGitDirectory(t *testing.T) {
+	mainPath, linkedPath := newPruneMergedSeparateGitRepository(t)
+	cfg := &models.Config{Projects: []models.Project{{
+		Path: mainPath, Repository: commandBaseRepo,
+	}}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, utils.PathKey(linkedPath), utils.PathKey(candidates[0].Policy.Path))
+	assert.Equal(t, utils.PathKey(mainPath), utils.PathKey(candidates[0].RepositoryRoot))
+	assert.Equal(t, utils.PathKey(mainPath), utils.PathKey(candidates[0].Policy.MainRepositoryPath))
+}
+
+func newPruneMergedSeparateGitRepository(t *testing.T) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	mainPath := filepath.Join(base, "main-worktree")
+	linkedPath := filepath.Join(base, "linked-worktree")
+	separateGitDir := filepath.Join(base, "repository.git")
+	runTUITestGit(
+		t, "", "init", "-b", "main", "--separate-git-dir",
+		separateGitDir, mainPath,
+	)
+	runTUITestGit(t, mainPath, "config", "user.name", "Test User")
+	runTUITestGit(t, mainPath, "config", "user.email", "test@example.com")
+	runTUITestGit(
+		t, mainPath, "remote", "add", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(mainPath, "README.md"),
+		[]byte("# Separate Git directory\n"),
+		0o644,
+	))
+	runTUITestGit(t, mainPath, "add", "README.md")
+	runTUITestGit(t, mainPath, "commit", "-m", "Initial commit")
+	runTUITestGit(t, mainPath, "branch", "topic")
+	runTUITestGit(t, mainPath, "worktree", "add", linkedPath, "topic")
+	return mainPath, linkedPath
+}
+
+func TestPruneMergedSeparateGitDirectoryIncludesConfiguredLinkedIdentityClaim(
+	t *testing.T,
+) {
+	mainPath, linkedPath := newPruneMergedSeparateGitRepository(t)
+	cfg := &models.Config{Projects: []models.Project{
+		{Path: mainPath, Repository: commandBaseRepo},
+		{Path: linkedPath, Repository: "github.com/other/widget"},
+	}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.NotNil(t, candidates[0].InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidates[0].InitialOutcome.Reason)
+	assert.Contains(
+		t,
+		candidates[0].InitialOutcome.Message,
+		"conflicting configured project repository identities",
+	)
+}
+
+func TestPruneMergedConfiguredRootDoesNotFallBackToLiveOrigin(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	branch := "feature/invalid-configured-identity"
+	worktreePath := filepath.Join(t.TempDir(), "invalid-configured-identity")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	cfg := &models.Config{Projects: []models.Project{{
+		Path: repositoryRoot, Repository: filepath.Join(t.TempDir(), "local-repository"),
+	}}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Empty(t, candidates[0].Policy.ProjectRepository)
+	assert.Equal(t, commandBaseRepo, candidates[0].Policy.LiveRepository)
+	require.NotNil(t, candidates[0].InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidates[0].InitialOutcome.Reason)
+	assert.Contains(t, candidates[0].InitialOutcome.Message, "configured project repository identity")
+}
+
+func TestPruneMergedConfiguredIdentityClaimsForCanonicalPath(t *testing.T) {
+	tests := []struct {
+		name             string
+		secondRepository func(*testing.T) string
+		wantDoctor       bool
+	}{
+		{
+			name: "equivalent canonical identity",
+			secondRepository: func(*testing.T) string {
+				return "https://github.com/acme/widget.git"
+			},
+		},
+		{
+			name: "conflicting canonical identity",
+			secondRepository: func(*testing.T) string {
+				return "github.com/other/widget"
+			},
+			wantDoctor: true,
+		},
+		{
+			name: "invalid competing identity",
+			secondRepository: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "local-repository")
+			},
+			wantDoctor: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repositoryRoot := newTUITestRepo(t)
+			runTUITestGit(
+				t, repositoryRoot, "remote", "add", "origin",
+				"https://github.com/acme/widget.git",
+			)
+			branch := "feature/duplicate-configured-identity"
+			worktreePath := filepath.Join(t.TempDir(), "duplicate-configured-identity")
+			runTUITestGit(t, repositoryRoot, "branch", branch)
+			runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+			cfg := &models.Config{Projects: []models.Project{
+				{Path: repositoryRoot, Repository: commandBaseRepo},
+				{
+					Path:       filepath.Join(repositoryRoot, "."),
+					Repository: tt.secondRepository(t),
+				},
+			}}
+
+			candidates, err := defaultInspectPruneMergedCandidates(
+				context.Background(), cfg, nil, nil,
+			)
+
+			require.NoError(t, err)
+			require.Len(t, candidates, 1)
+			if tt.wantDoctor {
+				require.NotNil(t, candidates[0].InitialOutcome)
+				assert.Equal(
+					t,
+					prunepolicy.DoctorRequired,
+					candidates[0].InitialOutcome.Reason,
+				)
+				assert.Contains(
+					t,
+					candidates[0].InitialOutcome.Message,
+					"conflicting configured project repository identities",
+				)
+				return
+			}
+			assert.Nil(t, candidates[0].InitialOutcome)
+			assert.Equal(t, commandBaseRepo, candidates[0].Policy.ProjectRepository)
+		})
+	}
+}
+
+func TestPruneMergedConflictingConfiguredIdentitiesForOneCommonRepository(
+	t *testing.T,
+) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(
+		t, repositoryRoot, "remote", "add", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	branch := "feature/common-repository-conflict"
+	worktreePath := filepath.Join(t.TempDir(), "common-repository-conflict")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	cfg := &models.Config{Projects: []models.Project{
+		{Path: repositoryRoot, Repository: commandBaseRepo},
+		{Path: worktreePath, Repository: "github.com/other/widget"},
+	}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.NotNil(t, candidates[0].InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidates[0].InitialOutcome.Reason)
+	assert.Contains(
+		t,
+		candidates[0].InitialOutcome.Message,
+		"conflicting configured project repository identities",
+	)
+}
+
+func TestPruneMergedUnconfiguredCandidateRequiresDoctorWhenConfiguredRootIsUnavailable(t *testing.T) {
+	resetPruneMergedDeps(t)
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/octocat/widget.git")
+	branch := "feature/rediscovered-fork"
+	worktreePath := filepath.Join(t.TempDir(), "rediscovered-fork")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	missingConfiguredRoot := filepath.Join(t.TempDir(), "missing-upstream")
+	findPruneMergedGlobalPaths = func(string) ([]string, error) {
+		return []string{worktreePath}, nil
+	}
+	cfg := &models.Config{
+		Projects: []models.Project{{
+			Path: missingConfiguredRoot, Repository: commandBaseRepo,
+		}},
+		Worktree: models.WorktreeConfig{BaseDir: filepath.Dir(worktreePath)},
+	}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 2)
+	byPath := make(map[string]pruneMergedCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byPath[utils.PathKey(candidate.Policy.Path)] = candidate
+	}
+	unavailable := byPath[utils.PathKey(missingConfiguredRoot)]
+	require.NotNil(t, unavailable.InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, unavailable.InitialOutcome.Reason)
+	rediscovered := byPath[utils.PathKey(worktreePath)]
+	assert.Equal(t, "github.com/octocat/widget", rediscovered.Policy.ProjectRepository)
+	require.NotNil(t, rediscovered.InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, rediscovered.InitialOutcome.Reason)
+	assert.Contains(t, rediscovered.InitialOutcome.Message, "configured project")
+}
+
+func TestPruneMergedUnconfiguredCandidateRequiresDoctorWhenConfiguredPathIsEmpty(
+	t *testing.T,
+) {
+	resetPruneMergedDeps(t)
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(
+		t, repositoryRoot, "remote", "add", "origin",
+		"https://github.com/octocat/widget.git",
+	)
+	branch := "feature/empty-configured-path"
+	worktreePath := filepath.Join(t.TempDir(), "empty-configured-path")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	findPruneMergedGlobalPaths = func(string) ([]string, error) {
+		return []string{worktreePath}, nil
+	}
+	cfg := &models.Config{
+		Projects: []models.Project{{
+			Path: " \t", Repository: commandBaseRepo,
+		}},
+		Worktree: models.WorktreeConfig{BaseDir: filepath.Dir(worktreePath)},
+	}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "github.com/octocat/widget", candidates[0].Policy.ProjectRepository)
+	require.NotNil(t, candidates[0].InitialOutcome)
+	assert.Equal(t, prunepolicy.DoctorRequired, candidates[0].InitialOutcome.Reason)
+	assert.Contains(t, candidates[0].InitialOutcome.Message, "configured project")
+}
+
+func TestPruneMergedConfiguredCandidateRemainsEligibleWhenAnotherConfiguredRootIsUnavailable(t *testing.T) {
+	repositoryRoot := newTUITestRepo(t)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/octocat/widget.git")
+	branch := "feature/healthy-configured"
+	worktreePath := filepath.Join(t.TempDir(), "healthy-configured")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	missingConfiguredRoot := filepath.Join(t.TempDir(), "missing-project")
+	cfg := &models.Config{Projects: []models.Project{
+		{Path: missingConfiguredRoot, Repository: "github.com/acme/missing"},
+		{Path: repositoryRoot, Repository: commandBaseRepo},
+	}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 2)
+	byPath := make(map[string]pruneMergedCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byPath[utils.PathKey(candidate.Policy.Path)] = candidate
+	}
+	healthy := byPath[utils.PathKey(worktreePath)]
+	assert.Equal(t, commandBaseRepo, healthy.Policy.ProjectRepository)
+	assert.Equal(t, "github.com/octocat/widget", healthy.Policy.LiveRepository)
+	assert.Nil(t, healthy.InitialOutcome)
+}
+
+func TestPruneMergedInventoryStripsCredentialsFromWorktreeGitProcesses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test probe uses a POSIX executable script")
+	}
+	repositoryRoot := newTUITestRepo(t)
+	branch := "feature/credential-probe"
+	worktreePath := filepath.Join(t.TempDir(), "credential-probe")
+	runTUITestGit(t, repositoryRoot, "branch", branch)
+	runTUITestGit(t, repositoryRoot, "worktree", "add", worktreePath, branch)
+	probeOutput := filepath.Join(t.TempDir(), "probe-output")
+	probeScript := filepath.Join(t.TempDir(), "fsmonitor-probe")
+	require.NoError(t, os.WriteFile(probeScript, []byte(
+		"#!/bin/sh\n"+
+			"printf '%s|%s' \"${KWT_GITHUB_TOKEN-unset}\" \"${CUSTOM_FLEET_TOKEN-unset}\" > \"$KWT_PROBE_OUTPUT\"\n",
+	), 0o755))
+	runTUITestGit(t, repositoryRoot, "config", "core.fsmonitor", probeScript)
+	_, err := git.New(repositoryRoot).EnsureWorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	t.Setenv("KWT_PROBE_OUTPUT", probeOutput)
+	t.Setenv("KWT_GITHUB_TOKEN", "github-secret")
+	t.Setenv("CUSTOM_FLEET_TOKEN", "fleet-secret")
+	cfg := &models.Config{
+		Projects: []models.Project{{Path: repositoryRoot, Repository: commandBaseRepo}},
+		Fleet:    models.FleetConfig{TokenEnv: "CUSTOM_FLEET_TOKEN"},
+	}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	probeContents, err := os.ReadFile(probeOutput)
+	require.NoError(t, err, "configured fsmonitor probe was not invoked")
+	assert.Equal(t, "unset|unset", string(probeContents))
+	require.NoError(t, os.WriteFile(probeOutput, []byte("not-invoked"), 0o600))
+
+	require.NoError(t, defaultValidatePruneMergedWorktree(candidates[0]))
+	probeContents, err = os.ReadFile(probeOutput)
+	require.NoError(t, err)
+	assert.Equal(t, "unset|unset", string(probeContents))
+	require.NoError(t, os.WriteFile(probeOutput, []byte("not-invoked"), 0o600))
+
+	require.NoError(t, defaultRemovePruneMergedWorktree(candidates[0]))
+	probeContents, err = os.ReadFile(probeOutput)
+	require.NoError(t, err)
+	assert.Equal(t, "unset|unset", string(probeContents))
+	assert.NoDirExists(t, worktreePath)
+}
+
+func TestPruneMergedGlobalInventoryDerivesBaseFromEachWorktreeOrigin(t *testing.T) {
+	resetPruneMergedDeps(t)
+	repositoryRoot := newTUITestRepo(t)
+	globalBase := t.TempDir()
+	firstPath := filepath.Join(globalBase, "first-origin")
+	secondPath := filepath.Join(globalBase, "second-origin")
+	firstConfig := filepath.Join(t.TempDir(), "first-origin.config")
+	secondConfig := filepath.Join(t.TempDir(), "second-origin.config")
+	runTUITestGit(t, repositoryRoot, "config", "--file", firstConfig, "remote.origin.url", "https://github.com/octocat/widget.git")
+	runTUITestGit(t, repositoryRoot, "config", "--file", secondConfig, "remote.origin.url", "https://github.com/hubot/widget.git")
+	runTUITestGit(t, repositoryRoot, "branch", "feature/first-origin")
+	runTUITestGit(t, repositoryRoot, "branch", "feature/second-origin")
+	runTUITestGit(t, repositoryRoot, "worktree", "add", firstPath, "feature/first-origin")
+	runTUITestGit(t, repositoryRoot, "worktree", "add", secondPath, "feature/second-origin")
+	firstGitDir := strings.TrimSpace(runTUITestGitOutput(t, firstPath, "rev-parse", "--absolute-git-dir"))
+	secondGitDir := strings.TrimSpace(runTUITestGitOutput(t, secondPath, "rev-parse", "--absolute-git-dir"))
+	runTUITestGit(
+		t, repositoryRoot, "config", "--add",
+		"includeIf.gitdir:"+firstGitDir+".path", firstConfig,
+	)
+	runTUITestGit(
+		t, repositoryRoot, "config", "--add",
+		"includeIf.gitdir:"+secondGitDir+".path", secondConfig,
+	)
+	runTUITestGit(t, repositoryRoot, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	findPruneMergedGlobalPaths = func(string) ([]string, error) {
+		return []string{firstPath, secondPath}, nil
+	}
+	cfg := &models.Config{Worktree: models.WorktreeConfig{BaseDir: globalBase}}
+
+	candidates, err := defaultInspectPruneMergedCandidates(
+		context.Background(), cfg, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 2)
+	byPath := make(map[string]pruneMergedCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byPath[utils.PathKey(candidate.Policy.Path)] = candidate
+	}
+	assert.Equal(t, "github.com/octocat/widget", byPath[utils.PathKey(firstPath)].Policy.LiveRepository)
+	assert.Equal(t, "github.com/octocat/widget", byPath[utils.PathKey(firstPath)].Policy.ProjectRepository)
+	assert.Equal(t, "github.com/hubot/widget", byPath[utils.PathKey(secondPath)].Policy.LiveRepository)
+	assert.Equal(t, "github.com/hubot/widget", byPath[utils.PathKey(secondPath)].Policy.ProjectRepository)
+}
+
+func resetPruneMergedCommand(t *testing.T) {
+	t.Helper()
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	resetPruneMergedDeps(t)
+	pruneMerged = true
+	loadPruneMergedConfig = func() (*models.Config, error) { return &models.Config{}, nil }
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) {
+		return &fakePruneMergedRegistry{removed: true}, nil
+	}
+	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore {
+		return &fakePruneMergedProvenance{removeResult: true}
+	}
+	removePruneMergedWorktree = func(pruneMergedCandidate) error { return nil }
+}
+
+func resetPruneMergedDeps(t *testing.T) {
+	t.Helper()
+	oldLoad := loadPruneMergedConfig
+	oldRegistry := openPruneMergedRegistry
+	oldStore := openPruneMergedProvenanceStore
+	oldInspect := inspectPruneMergedCandidates
+	oldProvider := newPruneMergedProvider
+	oldValidate := validatePruneMergedWorktree
+	oldRemove := removePruneMergedWorktree
+	oldFindGlobalPaths := findPruneMergedGlobalPaths
+	t.Cleanup(func() {
+		loadPruneMergedConfig = oldLoad
+		openPruneMergedRegistry = oldRegistry
+		openPruneMergedProvenanceStore = oldStore
+		inspectPruneMergedCandidates = oldInspect
+		newPruneMergedProvider = oldProvider
+		validatePruneMergedWorktree = oldValidate
+		removePruneMergedWorktree = oldRemove
+		findPruneMergedGlobalPaths = oldFindGlobalPaths
+	})
+}
+
+func setPruneMergedInventory(candidates ...pruneMergedCandidate) {
+	inspectPruneMergedCandidates = func(context.Context, *models.Config, map[string]pullrequest.Provenance, []*registry.WorktreeEntry) ([]pruneMergedCandidate, error) {
+		return candidates, nil
+	}
+}
+
+func setPruneMergedProvider(provider prunepolicy.MergedProvider) {
+	newPruneMergedProvider = func(context.Context) (prunepolicy.MergedProvider, error) { return provider, nil }
+}
+
+func commandMergedCandidate(path, head string) pruneMergedCandidate {
+	return pruneMergedCandidate{
+		RepositoryRoot: "/projects/widget",
+		Policy: prunepolicy.MergedCandidate{
+			Path: path, Branch: "topic-local", Head: head, Generation: "0123456789abcdef0123456789abcdef",
+			MainRepositoryPath: "/projects/widget",
+			ProjectRepository:  commandBaseRepo, LiveRepository: commandBaseRepo,
+			SourceRepository: commandSourceRepo, SourceBranch: "topic",
+		},
+	}
+}
+
+func commandMergedProvenance(candidate pruneMergedCandidate) pullrequest.Provenance {
+	return pullrequest.Provenance{
+		PullRequestID: pullrequest.OpaqueID(commandBaseRepo, 17), Provider: "github",
+		Repository: commandBaseRepo, Number: 17,
+		URL: "https://github.com/acme/widget/pull/17", HeadSHA: candidate.Policy.Head,
+		SourceRepo: commandSourceRepo, SourceBranch: candidate.Policy.SourceBranch,
+		Project: pullrequest.Project{Identity: commandBaseRepo, Path: candidate.RepositoryRoot},
+		Workspace: pullrequest.Workspace{
+			ID: "workspace-17", Repository: commandBaseRepo,
+			Branch: candidate.Policy.Branch, Path: candidate.Policy.Path, State: "ready",
+		},
+	}
+}
+
+func providerForCommandCandidates(candidates ...pruneMergedCandidate) *fakePruneMergedProvider {
+	byHead := make(map[string]pruneMergedCandidate, len(candidates))
+	byNumber := make(map[int]pruneMergedCandidate)
+	for _, candidate := range candidates {
+		byHead[candidate.Policy.Head] = candidate
+		if candidate.Policy.Provenance != nil {
+			byNumber[candidate.Policy.Provenance.Number] = candidate
+		}
+	}
+	return &fakePruneMergedProvider{
+		forCommit: func(sha string) ([]pullrequest.PullRequest, error) {
+			candidate, ok := byHead[sha]
+			if !ok {
+				return nil, nil
+			}
+			return []pullrequest.PullRequest{commandMergedPR(candidate)}, nil
+		},
+		get: func(number int) (pullrequest.PullRequest, error) {
+			candidate, ok := byNumber[number]
+			if !ok {
+				return pullrequest.PullRequest{}, fmt.Errorf("unexpected PR #%d", number)
+			}
+			return commandMergedPR(candidate), nil
+		},
+	}
+}
+
+func commandMergedPR(candidate pruneMergedCandidate) pullrequest.PullRequest {
+	mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	return pullrequest.PullRequest{
+		ID: pullrequest.OpaqueID(commandBaseRepo, 17), Provider: "github",
+		Repository: commandRepository(commandBaseRepo), Number: 17,
+		URL: "https://github.com/acme/widget/pull/17", Title: "Topic", Author: "octocat",
+		Source: pullrequest.Branch{Name: candidate.Policy.SourceBranch, Repository: commandRepository(candidate.Policy.SourceRepository)},
+		Target: pullrequest.Branch{Name: "main", Repository: commandRepository(commandBaseRepo)},
+		State:  "closed", HeadSHA: candidate.Policy.Head, MergedAt: &mergedAt,
+	}
+}
+
+func commandRepository(identity string) pullrequest.Repository {
+	if identity == commandSourceRepo {
+		return pullrequest.Repository{Provider: "github", Identity: identity, Host: "github.com", Owner: "octocat", Name: "widget"}
+	}
+	return pullrequest.Repository{Provider: "github", Identity: identity, Host: "github.com", Owner: "acme", Name: "widget"}
+}

--- a/internal/cmd/prune_merged_test.go
+++ b/internal/cmd/prune_merged_test.go
@@ -30,10 +30,13 @@ const (
 )
 
 type fakePruneMergedRegistry struct {
-	removed bool
-	err     error
-	calls   int
-	entries []*registry.WorktreeEntry
+	removed       bool
+	err           error
+	calls         int
+	entries       []*registry.WorktreeEntry
+	creationBusy  bool
+	creationCalls int
+	entryMatches  func(string, *registry.WorktreeEntry) (bool, error)
 }
 
 func (r *fakePruneMergedRegistry) List() []*registry.WorktreeEntry { return r.entries }
@@ -43,8 +46,28 @@ func (r *fakePruneMergedRegistry) UnregisterIfGeneration(string, string) (bool, 
 	return r.removed, r.err
 }
 
+func (r *fakePruneMergedRegistry) AcquireCreation(string) (func() error, bool, error) {
+	r.creationCalls++
+	if r.creationBusy {
+		return nil, false, nil
+	}
+	return func() error { return nil }, true, nil
+}
+
+func (r *fakePruneMergedRegistry) EntryMatches(
+	path string,
+	expected *registry.WorktreeEntry,
+) (bool, error) {
+	if r.entryMatches == nil {
+		return true, nil
+	}
+	return r.entryMatches(path, expected)
+}
+
 type fakePruneMergedProvenance struct {
 	records       map[string]pullrequest.Provenance
+	viewRecords   func(int) map[string]pullrequest.Provenance
+	viewCalls     int
 	removeResult  bool
 	removeErr     error
 	removedKey    string
@@ -54,8 +77,13 @@ type fakePruneMergedProvenance struct {
 func (s *fakePruneMergedProvenance) View(
 	_ context.Context, fn func(map[string]pullrequest.Provenance) error,
 ) error {
-	records := make(map[string]pullrequest.Provenance, len(s.records))
-	for key, value := range s.records {
+	s.viewCalls++
+	current := s.records
+	if s.viewRecords != nil {
+		current = s.viewRecords(s.viewCalls)
+	}
+	records := make(map[string]pullrequest.Provenance, len(current))
+	for key, value := range current {
 		records[key] = value
 	}
 	return fn(records)
@@ -165,6 +193,88 @@ func TestPruneMergedDryRunMapsRevalidationChanges(t *testing.T) {
 	assert.Equal(t, prunepolicy.DirtyWorktree, report.Outcomes[0].Reason)
 	assert.Equal(t, "https://github.com/acme/widget/pull/17", report.Outcomes[0].Evidence["pr_url"])
 	assert.Empty(t, stderr.String())
+	assert.Zero(t, removed)
+}
+
+func TestPruneMergedDoesNotRemoveWhileCandidateCreationIsActive(t *testing.T) {
+	resetPruneMergedCommand(t)
+	pruneJSON = true
+	candidate := commandMergedCandidate("/worktrees/creating", commandMergedHead)
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	reg := &fakePruneMergedRegistry{creationBusy: true}
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
+	removed := 0
+	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+		removed++
+		return nil
+	}
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), "creation")
+	assert.Equal(t, 1, reg.creationCalls)
+	assert.Zero(t, removed)
+}
+
+func TestPruneMergedDoesNotRemoveWhenRegistryOwnershipAppearsAfterSnapshot(
+	t *testing.T,
+) {
+	resetPruneMergedCommand(t)
+	pruneJSON = true
+	candidate := commandMergedCandidate("/worktrees/newly-registered", commandMergedHead)
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	reg := &fakePruneMergedRegistry{
+		entryMatches: func(string, *registry.WorktreeEntry) (bool, error) {
+			return false, nil
+		},
+	}
+	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
+	removed := 0
+	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+		removed++
+		return nil
+	}
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), "ownership")
+	assert.Zero(t, removed)
+}
+
+func TestPruneMergedDoesNotRemoveWhenProvenanceAppearsAfterSnapshot(t *testing.T) {
+	resetPruneMergedCommand(t)
+	pruneJSON = true
+	candidate := commandMergedCandidate("/worktrees/newly-imported", commandMergedHead)
+	record := commandMergedProvenance(candidate)
+	setPruneMergedInventory(candidate)
+	setPruneMergedProvider(providerForCommandCandidates(candidate))
+	store := &fakePruneMergedProvenance{
+		viewRecords: func(call int) map[string]pullrequest.Provenance {
+			if call == 1 {
+				return nil
+			}
+			return map[string]pullrequest.Provenance{record.PullRequestID: record}
+		},
+	}
+	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
+	removed := 0
+	removePruneMergedWorktree = func(pruneMergedCandidate) error {
+		removed++
+		return nil
+	}
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), "ownership")
+	assert.Equal(t, 2, store.viewCalls)
 	assert.Zero(t, removed)
 }
 
@@ -433,7 +543,10 @@ func TestPruneMergedCompletesBookkeepingAfterGitDeregistersWithResidualFiles(t *
 	setPruneMergedProvider(providerForCommandCandidates(candidate))
 	reg := &fakePruneMergedRegistry{removed: true}
 	openPruneMergedRegistry = func() (pruneMergedRegistry, error) { return reg, nil }
-	store := &fakePruneMergedProvenance{removeResult: true}
+	store := &fakePruneMergedProvenance{
+		records:      map[string]pullrequest.Provenance{record.PullRequestID: record},
+		removeResult: true,
+	}
 	openPruneMergedProvenanceStore = func() pruneMergedProvenanceStore { return store }
 	removePruneMergedWorktree = func(pruneMergedCandidate) error {
 		return completedWorktreeRemovalWarning{message: "worktree removed, but files remain"}

--- a/internal/cmd/prune_test.go
+++ b/internal/cmd/prune_test.go
@@ -80,6 +80,7 @@ func TestPruneHelpDescribesExplicitPoliciesAndMigration(t *testing.T) {
 	assert.Contains(t, help, "clean worktrees")
 	assert.Contains(t, help, "bare kwt prune")
 	assert.Contains(t, help, "kwt doctor --fix")
+	assert.Contains(t, help, "Git 2.31")
 }
 
 func TestPruneRejectsMultiplePolicies(t *testing.T) {
@@ -106,6 +107,81 @@ func TestPruneMergedRejectsForce(t *testing.T) {
 
 	assertExitCode(t, err, 2)
 	assert.Contains(t, stderr.String(), "--force")
+}
+
+func TestPrunePoliciesRejectUnsupportedGitVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  func()
+		jsonOut bool
+	}{
+		{name: "expired human", policy: func() { pruneExpired = true }},
+		{name: "merged json", policy: func() { pruneMerged = true }, jsonOut: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetPruneCommandFlags(t)
+			tt.policy()
+			pruneJSON = tt.jsonOut
+			requireMaintenanceGitVersion = func() error {
+				return errors.New("Git 2.31 or newer is required; found Git 2.30.2")
+			}
+			cmd, stdout, stderr := fleetTestCommand()
+
+			err := runPrune(cmd, nil)
+
+			assertExitCode(t, err, 2)
+			assert.Contains(t, stderr.String(), "unsupported_git_version")
+			if tt.jsonOut {
+				var envelope maintenanceErrorEnvelope
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+				assert.Equal(t, "prune", envelope.Command)
+				assert.Equal(t, "unsupported_git_version", envelope.Error.Code)
+			} else {
+				assert.Empty(t, stdout.String())
+			}
+		})
+	}
+}
+
+func TestPruneInvalidUsageWinsOverGitVersionCheck(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func()
+		needle string
+	}{
+		{name: "policy required", setup: func() {}, needle: "policy_required"},
+		{
+			name:   "multiple policies",
+			setup:  func() { pruneExpired, pruneMerged = true, true },
+			needle: "incompatible_policies",
+		},
+		{
+			name:   "merged force",
+			setup:  func() { pruneMerged, pruneForce = true, true },
+			needle: "incompatible_flags",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetPruneCommandFlags(t)
+			tt.setup()
+			var versionChecks int
+			requireMaintenanceGitVersion = func() error {
+				versionChecks++
+				return errors.New("unsupported Git")
+			}
+			cmd, _, stderr := fleetTestCommand()
+
+			err := runPrune(cmd, nil)
+
+			assertExitCode(t, err, 2)
+			assert.Zero(t, versionChecks)
+			assert.Contains(t, stderr.String(), tt.needle)
+		})
+	}
 }
 
 func TestPruneExpiredMissingPathReportsDoctorRequired(t *testing.T) {
@@ -557,6 +633,7 @@ func resetPruneCommandFlags(t *testing.T) {
 	oldOpenExpiredRegistry := openPruneExpiredRegistry
 	oldValidateExpired := validatePruneExpiredWorktree
 	oldRemoveExpired := removePruneExpiredWorktree
+	oldRequireMaintenanceGitVersion := requireMaintenanceGitVersion
 	t.Cleanup(func() {
 		pruneExpired = oldPruneExpired
 		pruneMerged = oldPruneMerged
@@ -568,12 +645,14 @@ func resetPruneCommandFlags(t *testing.T) {
 		openPruneExpiredRegistry = oldOpenExpiredRegistry
 		validatePruneExpiredWorktree = oldValidateExpired
 		removePruneExpiredWorktree = oldRemoveExpired
+		requireMaintenanceGitVersion = oldRequireMaintenanceGitVersion
 	})
 	pruneExpired = false
 	pruneMerged = false
 	pruneDryRun = false
 	pruneForce = false
 	pruneJSON = false
+	requireMaintenanceGitVersion = func() error { return nil }
 }
 
 func registerExpiredWorktree(t *testing.T, path string, generation string) {

--- a/internal/cmd/prune_test.go
+++ b/internal/cmd/prune_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,143 +16,380 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/prunepolicy"
 	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
-func TestPrunePublishesAfterSuccessfulNormalPrune(t *testing.T) {
+func TestPruneRequiresPolicy(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetPruneCommandFlags(t)
+	cmd, _, stderr := fleetTestCommand()
 
-	repoPath := newTUITestRepo(t)
-	initCommandTestConfig(t, t.TempDir())
-	t.Chdir(repoPath)
-
-	var calls int
-	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
-		calls++
-	}
-
-	cmd, _, _ := fleetTestCommand()
 	err := runPrune(cmd, nil)
 
-	require.NoError(t, err)
-	assert.Equal(t, 1, calls)
+	assertExitCode(t, err, 2)
+	assert.Contains(t, stderr.String(), "kwt doctor --fix")
 }
 
-func TestPruneDoesNotPublishWhenNormalPruneFails(t *testing.T) {
+// TestPruneCmdIsolatesFromCwdConfig guards the global-scope invariant:
+// pruneCmd must not inherit root's PersistentPreRunE, which merges the caller's
+// repository-local .kwt.toml and can redirect the fleet worktree base directory.
+func TestPruneCmdIsolatesFromCwdConfig(t *testing.T) {
+	oldMerge := mergeCwdLocal
+	t.Cleanup(func() { mergeCwdLocal = oldMerge })
+	mergeCwdLocal = func() error {
+		return errors.New("repository-local configuration must not be merged")
+	}
+	require.NotNil(t, pruneCmd.PersistentPreRunE,
+		"prune must define its own PersistentPreRunE to bypass root's cwd merge")
+	require.NoError(t, pruneCmd.PersistentPreRunE(pruneCmd, nil))
+}
+
+func TestPruneInitializationFailureUsesMaintenanceErrorContract(t *testing.T) {
+	resetPruneCommandFlags(t)
+	pruneJSON = true
+	oldInitErr := configInitErr
+	configInitErr = errors.New("config unavailable")
+	t.Cleanup(func() { configInitErr = oldInitErr })
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err := pruneCmd.PersistentPreRunE(cmd, nil)
+
+	assertExitCode(t, err, 2)
+	var envelope maintenanceErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "prune", envelope.Command)
+	assert.Equal(t, "initialization_failed", envelope.Error.Code)
+	assert.Contains(t, stderr.String(), "config unavailable")
+}
+
+func TestPruneHelpDescribesExplicitPoliciesAndMigration(t *testing.T) {
+	var output bytes.Buffer
+	pruneCmd.SetOut(&output)
+	t.Cleanup(func() { pruneCmd.SetOut(nil) })
+
+	require.NoError(t, pruneCmd.Help())
+
+	help := output.String()
+	assert.Contains(t, help, "--expired")
+	assert.Contains(t, help, "--merged")
+	assert.Contains(t, help, "--dry-run")
+	assert.Contains(t, help, "--json")
+	assert.Contains(t, help, "clean worktrees")
+	assert.Contains(t, help, "bare kwt prune")
+	assert.Contains(t, help, "kwt doctor --fix")
+}
+
+func TestPruneRejectsMultiplePolicies(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetPruneCommandFlags(t)
+	pruneExpired = true
+	pruneMerged = true
+	cmd, _, stderr := fleetTestCommand()
 
-	initCommandTestConfig(t, t.TempDir())
-	t.Chdir(t.TempDir())
-
-	var calls int
-	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
-		calls++
-	}
-
-	cmd, _, _ := fleetTestCommand()
 	err := runPrune(cmd, nil)
 
-	require.Error(t, err)
-	assert.Zero(t, calls)
+	assertExitCode(t, err, 2)
+	assert.Contains(t, stderr.String(), "mutually exclusive")
 }
 
-func TestPruneExpiredPublishesOnceAfterUnregisteringExpiredEntry(t *testing.T) {
+func TestPruneMergedRejectsForce(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetPruneCommandFlags(t)
+	pruneMerged = true
+	pruneForce = true
+	cmd, _, stderr := fleetTestCommand()
 
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 2)
+	assert.Contains(t, stderr.String(), "--force")
+}
+
+func TestPruneExpiredMissingPathReportsDoctorRequired(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
 	initCommandTestConfig(t, t.TempDir())
 	pruneExpired = true
 	expiredPath := filepath.Join(t.TempDir(), "missing-expired")
-	registerExpiredWorktree(t, expiredPath)
+	registerExpiredWorktree(t, expiredPath, "0123456789abcdef0123456789abcdef")
+	cmd, stdout, _ := fleetTestCommand()
 
-	var calls int
-	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
-		calls++
-	}
-
-	cmd, _, _ := fleetTestCommand()
 	err := runPrune(cmd, nil)
 
-	require.NoError(t, err)
-	assert.Equal(t, 1, calls)
-	reg, err := registry.New()
-	require.NoError(t, err)
-	_, exists := reg.Get(expiredPath)
-	assert.False(t, exists)
-}
-
-func TestPruneExpiredDoesNotPublishOnNoop(t *testing.T) {
-	resetFleetCommandDeps(t)
-	resetPruneCommandFlags(t)
-
-	initCommandTestConfig(t, t.TempDir())
-	pruneExpired = true
-
-	var calls int
-	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
-		calls++
-	}
-
-	cmd, _, _ := fleetTestCommand()
-	err := runPrune(cmd, nil)
-
-	require.NoError(t, err)
-	assert.Zero(t, calls)
-}
-
-func TestPruneExpiredDoesNotPublishOnDryRun(t *testing.T) {
-	resetFleetCommandDeps(t)
-	resetPruneCommandFlags(t)
-
-	initCommandTestConfig(t, t.TempDir())
-	pruneExpired = true
-	pruneDryRun = true
-	expiredPath := filepath.Join(t.TempDir(), "missing-expired-dry-run")
-	registerExpiredWorktree(t, expiredPath)
-
-	var calls int
-	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
-		calls++
-	}
-
-	cmd, _, _ := fleetTestCommand()
-	err := runPrune(cmd, nil)
-
-	require.NoError(t, err)
-	assert.Zero(t, calls)
-	reg, err := registry.New()
-	require.NoError(t, err)
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.DoctorRequired))
+	assert.Contains(t, stdout.String(), "kwt doctor --fix")
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
 	_, exists := reg.Get(expiredPath)
 	assert.True(t, exists)
 }
 
-func TestPruneExpiredPreservesLiveWorktreeWithoutGeneration(t *testing.T) {
+func TestPruneExpiredMissingGenerationReportsReason(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetPruneCommandFlags(t)
-
 	repoPath := newTUITestRepo(t)
 	initCommandTestConfig(t, t.TempDir())
 	worktreePath := filepath.Join(t.TempDir(), "legacy-expired")
 	runTUITestGit(t, repoPath, "branch", "feature/legacy-expired")
-	runTUITestGit(
-		t,
-		repoPath,
-		"worktree",
-		"add",
-		worktreePath,
-		"feature/legacy-expired",
-	)
-	registerExpiredWorktree(t, worktreePath)
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/legacy-expired")
+	registerExpiredWorktree(t, worktreePath, "")
 	pruneExpired = true
-	pruneForce = true
+	cmd, stdout, _ := fleetTestCommand()
 
-	cmd, _, _ := fleetTestCommand()
 	err := runPrune(cmd, nil)
 
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.MissingGeneration))
+	assert.Contains(t, stdout.String(), "kwt doctor --fix")
+	assert.DirExists(t, worktreePath)
+}
+
+func TestPruneExpiredJSONContainsStableReasons(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	initCommandTestConfig(t, t.TempDir())
+	pruneExpired = true
+	pruneJSON = true
+	expiredPath := filepath.Join(t.TempDir(), "missing-expired")
+	registerExpiredWorktree(t, expiredPath, "0123456789abcdef0123456789abcdef")
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	var report prunepolicy.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, prunepolicy.SchemaVersion, report.SchemaVersion)
+	assert.Equal(t, "expired", report.Policy)
+	require.Len(t, report.Outcomes, 1)
+	assert.Equal(t, prunepolicy.DoctorRequired, report.Outcomes[0].Reason)
+	assert.NotContains(t, stdout.String(), "Expired worktree:")
+	assert.Empty(t, stderr.String())
+}
+
+func TestPruneExpiredForceStillRequiresGeneration(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "legacy-force")
+	runTUITestGit(t, repoPath, "branch", "feature/legacy-force")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/legacy-force")
+	registerExpiredWorktree(t, worktreePath, "")
+	pruneExpired = true
+	pruneForce = true
+	cmd, stdout, _ := fleetTestCommand()
+
+	err := runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.MissingGeneration))
+	assert.DirExists(t, worktreePath)
+}
+
+func TestPruneExpiredDryRunReportsDirtyWorktree(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "dirty-expired")
+	runTUITestGit(t, repoPath, "branch", "feature/dirty-expired")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/dirty-expired")
+	generation, err := git.New(repoPath).WorktreeGeneration(worktreePath)
 	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "dirty.txt"), []byte("dirty\n"), 0o644))
+	registerExpiredWorktree(t, worktreePath, generation)
+	pruneExpired = true
+	pruneDryRun = true
+	cmd, stdout, _ := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.DirtyWorktree))
+	assert.DirExists(t, worktreePath)
+}
+
+func TestPruneExpiredRejectsMismatchedWorktreeBacklink(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repositoryRoot := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	firstPath := filepath.Join(t.TempDir(), "expired-first")
+	secondPath := filepath.Join(t.TempDir(), "expired-second")
+	runTUITestGit(
+		t, repositoryRoot, "worktree", "add", "-b", "expired-first", firstPath,
+	)
+	runTUITestGit(
+		t, repositoryRoot, "worktree", "add", "-b", "expired-second", secondPath,
+	)
+	generation, err := git.New(repositoryRoot).WorktreeGeneration(firstPath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, firstPath, generation)
+	secondGitDir := strings.TrimSpace(
+		runTUITestGitOutput(t, secondPath, "rev-parse", "--absolute-git-dir"),
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(firstPath, ".git"),
+		[]byte("gitdir: "+secondGitDir+"\n"),
+		0o644,
+	))
+	pruneExpired = true
+	pruneDryRun = true
+	cmd, stdout, _ := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.DoctorRequired))
+	assert.Contains(t, stdout.String(), "backlink")
+	assert.DirExists(t, firstPath)
+}
+
+func TestPruneExpiredCarriesVerifiedGitDirIntoValidation(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repositoryRoot := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "expired-verified-backlink")
+	runTUITestGit(
+		t, repositoryRoot, "worktree", "add", "-b", "expired-verified-backlink",
+		worktreePath,
+	)
+	generation, err := git.New(repositoryRoot).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, worktreePath, generation)
+	expectedGitDir := strings.TrimSpace(
+		runTUITestGitOutput(t, worktreePath, "rev-parse", "--absolute-git-dir"),
+	)
+	var captured git.WorktreeRemovalConditions
+	validatePruneExpiredWorktree = func(
+		_ *git.Git, _ string, conditions git.WorktreeRemovalConditions,
+	) error {
+		captured = conditions
+		return &git.ConditionError{Reason: git.ReasonLocked, Path: worktreePath}
+	}
+	pruneExpired = true
+	pruneDryRun = true
+	cmd, _, _ := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	require.NotEmpty(t, captured.ExpectedGitDir)
+	assert.Equal(t, utils.PathKey(expectedGitDir), utils.PathKey(captured.ExpectedGitDir))
+}
+
+func TestPruneExpiredDryRunReportsLockedWorktree(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "locked-expired")
+	runTUITestGit(t, repoPath, "branch", "feature/locked-expired")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/locked-expired")
+	generation, err := git.New(repoPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, worktreePath, generation)
+	runTUITestGit(t, repoPath, "worktree", "lock", "--reason", "maintenance", worktreePath)
+	pruneExpired = true
+	pruneDryRun = true
+	pruneJSON = true
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	var report prunepolicy.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	require.Len(t, report.Outcomes, 1)
+	assert.Equal(t, prunepolicy.LockedWorktree, report.Outcomes[0].Reason)
+	assert.Empty(t, stderr.String())
+	assert.DirExists(t, worktreePath)
+}
+
+func TestPruneExpiredDryRunRevalidatesMainWorktree(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	generation, err := git.New(repoPath).WorktreeGeneration(repoPath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, repoPath, generation)
+	pruneExpired = true
+	pruneDryRun = true
+	pruneJSON = true
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	var report prunepolicy.Report
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	require.Len(t, report.Outcomes, 1)
+	assert.Equal(t, prunepolicy.MainWorktree, report.Outcomes[0].Reason)
+	assert.Empty(t, stderr.String())
+	assert.DirExists(t, repoPath)
+}
+
+func TestPruneExpiredRemovesWorktreeWithIgnoredArtifact(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "ignored-expired")
+	runTUITestGit(t, repoPath, "branch", "feature/ignored-expired")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/ignored-expired")
+	generation, err := git.New(repoPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, ".git", "info", "exclude"),
+		[]byte("build-output.local\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "build-output.local"),
+		[]byte("generated\n"),
+		0o644,
+	))
+	registerExpiredWorktree(t, worktreePath, generation)
+	pruneExpired = true
+	cmd, stdout, stderr := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout.String(), stderr.String())
+	assert.NoDirExists(t, worktreePath)
+}
+
+func TestPruneExpiredPreservesReplacementGeneration(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	repoPath := newTUITestRepo(t)
+	initCommandTestConfig(t, t.TempDir())
+	worktreePath := filepath.Join(t.TempDir(), "expired-replacement")
+	runTUITestGit(t, repoPath, "branch", "feature/expired-original")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/expired-original")
+	originalGeneration, err := git.New(repoPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, worktreePath, originalGeneration)
+	runTUITestGit(t, repoPath, "worktree", "remove", "--force", worktreePath)
+	runTUITestGit(t, repoPath, "branch", "feature/expired-replacement")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/expired-replacement")
+	_, err = git.New(repoPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	pruneExpired = true
+	pruneForce = true
+	cmd, stdout, _ := fleetTestCommand()
+
+	err = runPrune(cmd, nil)
+
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.GenerationChanged))
 	assert.DirExists(t, worktreePath)
 	reg, registryErr := registry.New()
 	require.NoError(t, registryErr)
@@ -156,103 +397,82 @@ func TestPruneExpiredPreservesLiveWorktreeWithoutGeneration(t *testing.T) {
 	assert.True(t, exists)
 }
 
-func TestPruneExpiredPreservesReplacementGeneration(t *testing.T) {
+func TestPruneExpiredPreservesWorktreeWhenExpirationChangesAfterInspection(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetPruneCommandFlags(t)
-
 	repoPath := newTUITestRepo(t)
 	initCommandTestConfig(t, t.TempDir())
-	worktreePath := filepath.Join(t.TempDir(), "expired-replacement")
-	runTUITestGit(t, repoPath, "branch", "feature/expired-original")
-	runTUITestGit(
-		t,
-		repoPath,
-		"worktree",
-		"add",
-		worktreePath,
-		"feature/expired-original",
-	)
-	originalGeneration, generationErr := git.New(repoPath).WorktreeGeneration(
-		worktreePath,
-	)
-	require.NoError(t, generationErr)
-	expiredAt := time.Now().Add(-time.Hour)
-	reg, registryErr := registry.New()
-	require.NoError(t, registryErr)
-	require.NoError(t, reg.Register(&registry.WorktreeEntry{
-		Repository: "repo",
-		Branch:     "feature/expired-original",
-		Path:       worktreePath,
-		ExpiresAt:  &expiredAt,
-		Generation: originalGeneration,
-	}))
-
-	runTUITestGit(t, repoPath, "worktree", "remove", "--force", worktreePath)
-	runTUITestGit(t, repoPath, "branch", "feature/expired-replacement")
-	runTUITestGit(
-		t,
-		repoPath,
-		"worktree",
-		"add",
-		worktreePath,
-		"feature/expired-replacement",
-	)
+	worktreePath := filepath.Join(t.TempDir(), "expiration-extended")
+	runTUITestGit(t, repoPath, "branch", "feature/expiration-extended")
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/expiration-extended")
+	generation, err := git.New(repoPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, worktreePath, generation)
 	pruneExpired = true
 	pruneForce = true
+	validatePruneExpiredWorktree = func(
+		g *git.Git, path string, conditions git.WorktreeRemovalConditions,
+	) error {
+		reg, registryErr := registry.New()
+		require.NoError(t, registryErr)
+		entry, ok := reg.Get(path)
+		require.True(t, ok)
+		future := time.Now().Add(time.Hour)
+		entry.ExpiresAt = &future
+		require.NoError(t, reg.Register(entry))
+		return g.ValidateWorktreeRemoval(path, conditions)
+	}
+	cmd, stdout, _ := fleetTestCommand()
 
-	cmd, _, _ := fleetTestCommand()
-	err := runPrune(cmd, nil)
+	err = runPrune(cmd, nil)
 
-	require.NoError(t, err)
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.ExpirationPolicyChanged))
 	assert.DirExists(t, worktreePath)
-	reloaded, registryErr := registry.New()
-	require.NoError(t, registryErr)
-	_, exists := reloaded.Get(worktreePath)
-	assert.True(t, exists)
 }
 
-func TestPruneExpiredRemovesMatchingGeneration(t *testing.T) {
+func TestPruneExpiredRemovesMatchingGenerationAndPublishesOnce(t *testing.T) {
 	resetFleetCommandDeps(t)
 	resetPruneCommandFlags(t)
-
 	repoPath := newTUITestRepo(t)
 	initCommandTestConfig(t, t.TempDir())
 	worktreePath := filepath.Join(t.TempDir(), "expired-matching")
 	runTUITestGit(t, repoPath, "branch", "feature/expired-matching")
-	runTUITestGit(
-		t,
-		repoPath,
-		"worktree",
-		"add",
-		worktreePath,
-		"feature/expired-matching",
-	)
-	generation, generationErr := git.New(repoPath).WorktreeGeneration(
-		worktreePath,
-	)
-	require.NoError(t, generationErr)
-	expiredAt := time.Now().Add(-time.Hour)
-	reg, registryErr := registry.New()
-	require.NoError(t, registryErr)
-	require.NoError(t, reg.Register(&registry.WorktreeEntry{
-		Repository: "repo",
-		Branch:     "feature/expired-matching",
-		Path:       worktreePath,
-		ExpiresAt:  &expiredAt,
-		Generation: generation,
-	}))
+	runTUITestGit(t, repoPath, "worktree", "add", worktreePath, "feature/expired-matching")
+	generation, err := git.New(repoPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	registerExpiredWorktree(t, worktreePath, generation)
 	pruneExpired = true
 	pruneForce = true
+	var publications int
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
+	cmd, stdout, _ := fleetTestCommand()
 
+	err = runPrune(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), string(prunepolicy.Removed))
+	assert.NoDirExists(t, worktreePath)
+	assert.Equal(t, 1, publications)
+	reg, registryErr := registry.New()
+	require.NoError(t, registryErr)
+	_, exists := reg.Get(worktreePath)
+	assert.False(t, exists)
+}
+
+func TestPruneExpiredNoopDoesNotPublish(t *testing.T) {
+	resetFleetCommandDeps(t)
+	resetPruneCommandFlags(t)
+	initCommandTestConfig(t, t.TempDir())
+	pruneExpired = true
+	var publications int
+	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) { publications++ }
 	cmd, _, _ := fleetTestCommand()
+
 	err := runPrune(cmd, nil)
 
 	require.NoError(t, err)
-	assert.NoDirExists(t, worktreePath)
-	reloaded, registryErr := registry.New()
-	require.NoError(t, registryErr)
-	_, exists := reloaded.Get(worktreePath)
-	assert.False(t, exists)
+	assert.Zero(t, publications)
 }
 
 func TestPruneExpiredCompletesBookkeepingAfterGitDeregistersWithResidualFiles(
@@ -311,15 +531,12 @@ exec "$REAL_GIT" "$@"
 	publishFleetBestEffortForCommand = func(*cobra.Command, *models.Config) {
 		publishCalls++
 	}
-	cmd, _, _ := fleetTestCommand()
-	output := captureStdout(t, func() {
-		err = runPrune(cmd, nil)
-	})
+	cmd, stdout, _ := fleetTestCommand()
+	err = runPrune(cmd, nil)
 
-	require.NoError(t, err)
-	assert.Contains(t, output, "worktree removed, but files remain at ")
-	assert.Contains(t, output, "Removed 1 expired worktree(s), skipped 0")
-	assert.NotContains(t, output, "Failed to remove worktree")
+	assertExitCode(t, err, 1)
+	assert.Contains(t, stdout.String(), string(prunepolicy.CleanupIncomplete))
+	assert.Contains(t, stdout.String(), "worktree removed, but files remain at ")
 	assert.Equal(t, 1, publishCalls)
 	assert.FileExists(t, filepath.Join(worktreePath, "residual"))
 	reloaded, registryErr := registry.New()
@@ -330,32 +547,42 @@ exec "$REAL_GIT" "$@"
 
 func resetPruneCommandFlags(t *testing.T) {
 	t.Helper()
-
 	oldPruneExpired := pruneExpired
+	oldPruneMerged := pruneMerged
 	oldPruneDryRun := pruneDryRun
 	oldPruneForce := pruneForce
-
+	oldPruneJSON := pruneJSON
+	oldSilenceUsage := rootCmd.SilenceUsage
+	oldSilenceErrors := rootCmd.SilenceErrors
+	oldOpenExpiredRegistry := openPruneExpiredRegistry
+	oldValidateExpired := validatePruneExpiredWorktree
+	oldRemoveExpired := removePruneExpiredWorktree
 	t.Cleanup(func() {
 		pruneExpired = oldPruneExpired
+		pruneMerged = oldPruneMerged
 		pruneDryRun = oldPruneDryRun
 		pruneForce = oldPruneForce
+		pruneJSON = oldPruneJSON
+		rootCmd.SilenceUsage = oldSilenceUsage
+		rootCmd.SilenceErrors = oldSilenceErrors
+		openPruneExpiredRegistry = oldOpenExpiredRegistry
+		validatePruneExpiredWorktree = oldValidateExpired
+		removePruneExpiredWorktree = oldRemoveExpired
 	})
-
 	pruneExpired = false
+	pruneMerged = false
 	pruneDryRun = false
 	pruneForce = false
+	pruneJSON = false
 }
 
-func registerExpiredWorktree(t *testing.T, path string) {
+func registerExpiredWorktree(t *testing.T, path string, generation string) {
 	t.Helper()
-
 	reg, err := registry.New()
 	require.NoError(t, err)
 	expiredAt := time.Now().Add(-time.Hour)
 	require.NoError(t, reg.Register(&registry.WorktreeEntry{
-		Repository: "repo",
-		Branch:     "task7/expired",
-		Path:       path,
-		ExpiresAt:  &expiredAt,
+		Repository: "repo", Branch: "expired", Path: path,
+		ExpiresAt: &expiredAt, Generation: generation,
 	}))
 }

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1484,7 +1484,10 @@ func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, lay
 	if row.Entry == nil && row.Workspace == nil {
 		return fmt.Errorf("no worktree selected")
 	}
-	if err := rejectProtectedWorkspaceOpen(ctx, rowPaneRoot(row)); err != nil {
+	if err := rejectProtectedWorkspaceOpen(
+		ctx,
+		rowPaneRoot(row),
+	); err != nil {
 		return err
 	}
 	if err := b.acknowledgeRemoteSource(rowPaneRoot(row)); err != nil {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -3528,12 +3528,14 @@ func TestTUIBackendAttachAcknowledgesRemoteSourceBeforeWorkspaceLaunch(t *testin
 func TestTUIBackendRefusesProtectedPullRequestWorkspace(t *testing.T) {
 	t.Setenv("KWT_HOME", t.TempDir())
 	workspacePath := t.TempDir()
+	liveGeneration := "0123456789abcdef0123456789abcdef"
+	stubPRWorkspaceGeneration(t, workspacePath, liveGeneration)
 	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
 		context.Background(),
 		func(records map[string]pullrequest.Provenance) error {
-			records["pr-32"] = pullrequest.Provenance{
-				Workspace: pullrequest.Workspace{Path: workspacePath},
-			}
+			records["pr-32"] = pullrequest.Provenance{Workspace: pullrequest.Workspace{
+				Path: workspacePath, Generation: liveGeneration,
+			}}
 			return nil
 		},
 	))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -37,6 +39,20 @@ func defaultAgents() map[string]string {
 		"claude":  "claude",
 		"roborev": "roborev tui",
 	}
+}
+
+func applyGlobalDefaults(target *viper.Viper) {
+	target.SetDefault("cd.launch_shell", true)
+	target.SetDefault("worktree.basedir", "~/.kwt/worktrees")
+	target.SetDefault("worktree.auto_mkdir", true)
+	target.SetDefault("finder.preview", true)
+	target.SetDefault("ui.icons", true)
+	target.SetDefault("ui.tilde_home", true)
+	target.SetDefault("naming.template", DefaultNamingTemplate)
+	target.SetDefault("naming.sanitize_chars", map[string]string{
+		"/": "-",
+		":": "-",
+	})
 }
 
 // getConfigDir returns the configuration directory path.
@@ -244,23 +260,11 @@ func Init() error {
 	viper.SetConfigType(configType)
 	viper.AddConfigPath(configDir)
 
-	viper.SetDefault("cd.launch_shell", true)
-	viper.SetDefault("worktree.basedir", "~/.kwt/worktrees")
-	viper.SetDefault("worktree.auto_mkdir", true)
-	viper.SetDefault("finder.preview", true)
-	viper.SetDefault("ui.icons", true)
-	viper.SetDefault("ui.tilde_home", true)
-
-	// Naming defaults
-	viper.SetDefault("naming.template", DefaultNamingTemplate)
-	viper.SetDefault("naming.sanitize_chars", map[string]string{
-		"/": "-",
-		":": "-",
-	})
+	applyGlobalDefaults(viper.GetViper())
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			if err := writeDefaultConfig(configPath); err != nil {
+			if _, err := (globalConfigStore{path: configPath}).ensure(defaultConfigTOML()); err != nil {
 				return fmt.Errorf("failed to create config file: %w", err)
 			}
 			if err := viper.ReadInConfig(); err != nil {
@@ -285,59 +289,35 @@ func Init() error {
 }
 
 func backfillWorkspaceConfig(configPath string) (bool, error) {
-	globalViper := viper.New()
-	globalViper.SetConfigFile(configPath)
-	globalViper.SetConfigType(configType)
-	if err := globalViper.ReadInConfig(); err != nil {
-		return false, err
-	}
+	return (globalConfigStore{path: configPath}).mutate(
+		func(globalViper *viper.Viper) (bool, error) {
+			migrated := false
+			agents := globalViper.GetStringMapString("agents")
+			if agents == nil {
+				agents = make(map[string]string)
+			}
+			for name, command := range defaultAgents() {
+				if strings.TrimSpace(agents[name]) == "" {
+					agents[name] = command
+					migrated = true
+				}
+			}
+			if migrated {
+				globalViper.Set("agents", agents)
+			}
 
-	migrated := false
-	agents := globalViper.GetStringMapString("agents")
-	if agents == nil {
-		agents = make(map[string]string)
-	}
-	for name, command := range defaultAgents() {
-		if strings.TrimSpace(agents[name]) == "" {
-			agents[name] = command
-			migrated = true
-		}
-	}
-	if migrated {
-		globalViper.Set("agents", agents)
-	}
+			if strings.TrimSpace(globalViper.GetString("naming.template")) == legacyDefaultNamingTemplate {
+				globalViper.Set("naming.template", DefaultNamingTemplate)
+				migrated = true
+			}
 
-	if strings.TrimSpace(globalViper.GetString("naming.template")) == legacyDefaultNamingTemplate {
-		globalViper.Set("naming.template", DefaultNamingTemplate)
-		migrated = true
-	}
-
-	if !globalViper.IsSet("layouts.auto_launch_on_add") {
-		globalViper.Set("layouts.auto_launch_on_add", true)
-		migrated = true
-	}
-
-	if !migrated {
-		return false, nil
-	}
-	if err := globalViper.WriteConfigAs(configPath); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func writeDefaultConfig(configPath string) (err error) {
-	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := file.Close(); err == nil {
-			err = closeErr
-		}
-	}()
-	_, err = file.WriteString(defaultConfigTOML())
-	return err
+			if !globalViper.IsSet("layouts.auto_launch_on_add") {
+				globalViper.Set("layouts.auto_launch_on_add", true)
+				migrated = true
+			}
+			return migrated, nil
+		},
+	)
 }
 
 func defaultConfigTOML() string {
@@ -688,6 +668,163 @@ func Load() (*models.Config, error) {
 	return &cfg, nil
 }
 
+// ProjectRegistration keeps the raw project value persisted in global TOML
+// alongside the independently expanded value used for filesystem inspection.
+type ProjectRegistration struct {
+	Persisted models.Project
+	Effective models.Project
+	raw       map[string]any
+}
+
+// SamePersistedEntry compares the complete raw project values used as CAS
+// tokens. Manually constructed registrations fall back to the known model.
+func (p ProjectRegistration) SamePersistedEntry(other ProjectRegistration) bool {
+	if p.raw == nil && other.raw == nil {
+		return p.Persisted == other.Persisted
+	}
+	return reflect.DeepEqual(p.raw, other.raw)
+}
+
+// GlobalSnapshot is a fresh global-only configuration view. Projects are
+// paired by their stable order in the single TOML snapshot.
+type GlobalSnapshot struct {
+	Config   *models.Config
+	Projects []ProjectRegistration
+}
+
+// LoadGlobalSnapshot re-reads global configuration without merging a
+// repository-local .kwt.toml file.
+func LoadGlobalSnapshot() (*GlobalSnapshot, error) {
+	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	globalViper, err := readGlobalViper(configPath)
+	if err != nil {
+		return nil, err
+	}
+	applyGlobalDefaults(globalViper)
+
+	var persisted models.Config
+	if err := globalViper.Unmarshal(&persisted); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal global config: %w", err)
+	}
+	effective := persisted
+	effective.Projects = slices.Clone(persisted.Projects)
+	effective.Workspaces = slices.Clone(persisted.Workspaces)
+	effective.RepositorySettings = slices.Clone(persisted.RepositorySettings)
+	if err := expandConfigPaths(&effective); err != nil {
+		return nil, err
+	}
+
+	projects := make([]ProjectRegistration, len(persisted.Projects))
+	rawProjects, err := rawProjectEntries(globalViper)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawProjects) != len(projects) {
+		return nil, fmt.Errorf(
+			"global project representations disagree: %d typed, %d raw",
+			len(projects), len(rawProjects),
+		)
+	}
+	for index := range persisted.Projects {
+		projects[index] = ProjectRegistration{
+			Persisted: persisted.Projects[index],
+			Effective: effective.Projects[index],
+			raw:       cloneStringMap(rawProjects[index]),
+		}
+	}
+	return &GlobalSnapshot{Config: &effective, Projects: projects}, nil
+}
+
+// CompareAndSwapProject replaces or removes exactly one raw persisted project
+// entry. Expanded path equality is intentionally not used as a concurrency
+// token because it would collapse distinct user edits and symlink spellings.
+func CompareAndSwapProject(
+	expected ProjectRegistration,
+	replacement *models.Project,
+) (bool, error) {
+	var copiedReplacement *models.Project
+	if replacement != nil {
+		copied := *replacement
+		copiedReplacement = &copied
+	}
+	var projects []map[string]any
+	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	changed, err := (globalConfigStore{path: configPath}).mutate(
+		func(globalViper *viper.Viper) (bool, error) {
+			var err error
+			projects, err = rawProjectEntries(globalViper)
+			if err != nil {
+				return false, err
+			}
+			var persisted []models.Project
+			if err := globalViper.UnmarshalKey("projects", &persisted); err != nil {
+				return false, fmt.Errorf("failed to read projects: %w", err)
+			}
+			if len(persisted) != len(projects) {
+				return false, fmt.Errorf(
+					"global project representations disagree: %d typed, %d raw",
+					len(persisted),
+					len(projects),
+				)
+			}
+			match := -1
+			matches := 0
+			for index := range projects {
+				if reflect.DeepEqual(projects[index], expected.raw) {
+					match = index
+					matches++
+				}
+			}
+			if matches != 1 {
+				return false, nil
+			}
+			if copiedReplacement == nil {
+				projects = append(projects[:match], projects[match+1:]...)
+			} else {
+				for index := range persisted {
+					if index != match && sameProjectPath(
+						persisted[index].Path,
+						copiedReplacement.Path,
+					) {
+						return false, nil
+					}
+				}
+				updated := cloneStringMap(projects[match])
+				updated["repository"] = copiedReplacement.Repository
+				updated["name"] = copiedReplacement.Name
+				updated["path"] = copiedReplacement.Path
+				updated["last_touched"] = copiedReplacement.LastTouched
+				projects[match] = updated
+			}
+			globalViper.Set("projects", projects)
+			return true, nil
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		viper.Set("projects", projects)
+	}
+	return changed, nil
+}
+
+func rawProjectEntries(source *viper.Viper) ([]map[string]any, error) {
+	var projects []map[string]any
+	if err := source.UnmarshalKey("projects", &projects); err != nil {
+		return nil, fmt.Errorf("failed to read raw projects: %w", err)
+	}
+	return projects, nil
+}
+
+func cloneStringMap(source map[string]any) map[string]any {
+	result := make(map[string]any, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+
 // expandConfigPaths expands all path fields in the configuration.
 func expandConfigPaths(cfg *models.Config) error {
 	expandedPath, err := utils.ExpandPath(cfg.Worktree.BaseDir)
@@ -787,46 +924,54 @@ func RegisterProject(project models.Project) error {
 	}
 	project.LastTouched = time.Now().UTC().Format(time.RFC3339)
 
-	configDir := getConfigDir()
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
-	}
-
-	globalViper := viper.New()
-	globalViper.SetConfigName(configName)
-	globalViper.SetConfigType(configType)
-	globalViper.AddConfigPath(configDir)
-	if err := globalViper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return fmt.Errorf("failed to read config: %w", err)
-		}
-	}
-
-	var projects []models.Project
-	if err := globalViper.UnmarshalKey("projects", &projects); err != nil {
-		return fmt.Errorf("failed to read projects: %w", err)
-	}
-
-	updated := false
-	for i := range projects {
-		if sameProject(projects[i], project) {
-			projects[i] = project
-			updated = true
-			break
-		}
-	}
-	if !updated {
-		projects = append(projects, project)
-	}
-
-	globalViper.Set("projects", projects)
-	configPath := filepath.Join(configDir, configName+"."+configType)
-	if err := globalViper.WriteConfigAs(configPath); err != nil {
+	var projects []map[string]any
+	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	if _, err := (globalConfigStore{path: configPath}).mutate(
+		func(globalViper *viper.Viper) (bool, error) {
+			var persisted []models.Project
+			if err := globalViper.UnmarshalKey("projects", &persisted); err != nil {
+				return false, fmt.Errorf("failed to read projects: %w", err)
+			}
+			var err error
+			projects, err = rawProjectEntries(globalViper)
+			if err != nil {
+				return false, err
+			}
+			if len(projects) != len(persisted) {
+				return false, fmt.Errorf(
+					"project representations disagree: %d typed, %d raw",
+					len(persisted), len(projects),
+				)
+			}
+			updated := false
+			for i := range persisted {
+				if sameProject(persisted[i], project) {
+					projects[i] = updateRawProject(projects[i], project)
+					updated = true
+					break
+				}
+			}
+			if !updated {
+				projects = append(projects, updateRawProject(nil, project))
+			}
+			globalViper.Set("projects", projects)
+			return true, nil
+		},
+	); err != nil {
 		return err
 	}
 
 	viper.Set("projects", projects)
 	return nil
+}
+
+func updateRawProject(raw map[string]any, project models.Project) map[string]any {
+	updated := cloneStringMap(raw)
+	updated["repository"] = project.Repository
+	updated["name"] = project.Name
+	updated["path"] = project.Path
+	updated["last_touched"] = project.LastTouched
+	return updated
 }
 
 func normalizeProjectPath(path string) (string, error) {
@@ -872,23 +1017,19 @@ func sameProjectPath(existingPath, nextPath string) bool {
 	if err != nil {
 		nextNormalized = filepath.Clean(nextPath)
 	}
-	return existingNormalized == nextNormalized
+	return utils.PathKey(existingNormalized) == utils.PathKey(nextNormalized)
 }
 
 // SetGlobal sets a configuration value and writes to the global config file only.
 // This uses a separate viper instance to avoid writing merged local settings.
 func SetGlobal(key string, value any) error {
-	globalViper := viper.New()
-	globalViper.SetConfigName(configName)
-	globalViper.SetConfigType(configType)
-	globalViper.AddConfigPath(getConfigDir())
-
-	// Read only global config (ignore error if file doesn't exist)
-	_ = globalViper.ReadInConfig()
-	globalViper.Set(key, value)
-
 	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
-	if err := globalViper.WriteConfigAs(configPath); err != nil {
+	if _, err := (globalConfigStore{path: configPath}).mutate(
+		func(globalViper *viper.Viper) (bool, error) {
+			globalViper.Set(key, value)
+			return true, nil
+		},
+	); err != nil {
 		return err
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -994,6 +995,84 @@ func TestRegisterProjectUpdatesExistingProject(t *testing.T) {
 	require.Len(t, cfg.Projects, 1)
 	assert.Equal(t, "kwt-renamed", cfg.Projects[0].Name)
 	assert.Equal(t, wantSecondPath, cfg.Projects[0].Path)
+}
+
+func TestRegisterProjectPreservesUnknownProjectFields(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	kwtHome := t.TempDir()
+	t.Setenv("KWT_HOME", kwtHome)
+	firstPath := t.TempDir()
+	secondPath := t.TempDir()
+	replacementPath := t.TempDir()
+	configPath := filepath.Join(kwtHome, "config.toml")
+	contents := fmt.Sprintf(`[[projects]]
+repository = "github.com/example/widget"
+name = "widget"
+path = %q
+last_touched = "2026-08-01T00:00:00Z"
+future_policy = "retain"
+
+[[projects]]
+repository = "github.com/example/other"
+name = "other"
+path = %q
+last_touched = "2026-08-01T00:00:00Z"
+future_policy = "untouched"
+`, firstPath, secondPath)
+	require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+
+	require.NoError(t, RegisterProject(models.Project{
+		Repository: "github.com/example/widget",
+		Name:       "widget-renamed",
+		Path:       replacementPath,
+	}))
+	wantReplacementPath, err := filepath.EvalSymlinks(replacementPath)
+	require.NoError(t, err)
+
+	stored, err := readGlobalViper(configPath)
+	require.NoError(t, err)
+	projects, err := rawProjectEntries(stored)
+	require.NoError(t, err)
+	require.Len(t, projects, 2)
+	assert.Equal(t, "retain", projects[0]["future_policy"])
+	assert.Equal(t, "widget-renamed", projects[0]["name"])
+	assert.Equal(t, wantReplacementPath, projects[0]["path"])
+	assert.Equal(t, "untouched", projects[1]["future_policy"])
+}
+
+func TestRegisterProjectAppendsWithoutDiscardingUnknownFields(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+
+	kwtHome := t.TempDir()
+	t.Setenv("KWT_HOME", kwtHome)
+	existingPath := t.TempDir()
+	newPath := t.TempDir()
+	configPath := filepath.Join(kwtHome, "config.toml")
+	contents := fmt.Sprintf(`[[projects]]
+repository = "github.com/example/existing"
+name = "existing"
+path = %q
+last_touched = "2026-08-01T00:00:00Z"
+future_policy = "retain"
+`, existingPath)
+	require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+
+	require.NoError(t, RegisterProject(models.Project{
+		Repository: "github.com/example/new",
+		Name:       "new",
+		Path:       newPath,
+	}))
+
+	stored, err := readGlobalViper(configPath)
+	require.NoError(t, err)
+	projects, err := rawProjectEntries(stored)
+	require.NoError(t, err)
+	require.Len(t, projects, 2)
+	assert.Equal(t, "retain", projects[0]["future_policy"])
+	assert.Equal(t, "github.com/example/new", projects[1]["repository"])
 }
 
 func TestRegisterProjectMatchesCaseInsensitiveRepositoryIdentity(t *testing.T) {

--- a/internal/config/global_store.go
+++ b/internal/config/global_store.go
@@ -102,36 +102,32 @@ func writeGlobalViperAtomically(path string, current *viper.Viper) (err error) {
 }
 
 func globalConfigWriteTarget(path string) (string, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return path, nil
+	targetPath := filepath.Clean(path)
+	seen := make(map[string]struct{})
+	for {
+		if _, ok := seen[targetPath]; ok {
+			return "", fmt.Errorf("resolve global config symlink: cycle at %s", targetPath)
 		}
-		return "", fmt.Errorf("inspect global config path: %w", err)
+		seen[targetPath] = struct{}{}
+		info, err := os.Lstat(targetPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return targetPath, nil
+			}
+			return "", fmt.Errorf("inspect global config path: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return targetPath, nil
+		}
+		linkTarget, err := os.Readlink(targetPath)
+		if err != nil {
+			return "", fmt.Errorf("read global config symlink: %w", err)
+		}
+		if !filepath.IsAbs(linkTarget) {
+			linkTarget = filepath.Join(filepath.Dir(targetPath), linkTarget)
+		}
+		targetPath = filepath.Clean(linkTarget)
 	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		return path, nil
-	}
-	linkTarget, err := os.Readlink(path)
-	if err != nil {
-		return "", fmt.Errorf("read global config symlink: %w", err)
-	}
-	if !filepath.IsAbs(linkTarget) {
-		linkTarget = filepath.Join(filepath.Dir(path), linkTarget)
-	}
-	linkTarget = filepath.Clean(linkTarget)
-	resolved, err := filepath.EvalSymlinks(linkTarget)
-	if err == nil {
-		return resolved, nil
-	}
-	if !os.IsNotExist(err) {
-		return "", fmt.Errorf("resolve global config symlink: %w", err)
-	}
-	resolvedParent, parentErr := filepath.EvalSymlinks(filepath.Dir(linkTarget))
-	if parentErr != nil {
-		return "", fmt.Errorf("resolve global config symlink target directory: %w", parentErr)
-	}
-	return filepath.Join(resolvedParent, filepath.Base(linkTarget)), nil
 }
 
 func writeGlobalConfigAtomically(

--- a/internal/config/global_store.go
+++ b/internal/config/global_store.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gofrs/flock"
+	"github.com/spf13/viper"
+)
+
+type globalConfigStore struct {
+	path string
+}
+
+var beforeGlobalConfigPublish = func(string, string) {}
+
+func (s globalConfigStore) withLock(change func() error) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("create global config directory: %w", err)
+	}
+	lock := flock.New(s.path+".lock", flock.SetPermissions(0o600))
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("lock global config: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+	return change()
+}
+
+func (s globalConfigStore) mutate(
+	change func(*viper.Viper) (bool, error),
+) (bool, error) {
+	changed := false
+	err := s.withLock(func() error {
+		current, err := readGlobalViper(s.path)
+		if err != nil {
+			return err
+		}
+		changed, err = change(current)
+		if err != nil || !changed {
+			return err
+		}
+		return writeGlobalViperAtomically(s.path, current)
+	})
+	return changed && err == nil, err
+}
+
+func (s globalConfigStore) ensure(contents string) (bool, error) {
+	created := false
+	err := s.withLock(func() error {
+		targetPath, err := globalConfigWriteTarget(s.path)
+		if err != nil {
+			return err
+		}
+		if _, err := os.Stat(targetPath); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat global config: %w", err)
+		}
+		if err := writeGlobalConfigAtomically(targetPath, 0o600, func(file *os.File) error {
+			_, err := file.WriteString(contents)
+			return err
+		}); err != nil {
+			return err
+		}
+		created = true
+		return nil
+	})
+	return created, err
+}
+
+func readGlobalViper(path string) (*viper.Viper, error) {
+	current := viper.New()
+	current.SetConfigFile(path)
+	current.SetConfigType(configType)
+	if err := current.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok || os.IsNotExist(err) {
+			return current, nil
+		}
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+	return current, nil
+}
+
+func writeGlobalViperAtomically(path string, current *viper.Viper) (err error) {
+	targetPath, err := globalConfigWriteTarget(path)
+	if err != nil {
+		return err
+	}
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(targetPath); statErr == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("stat global config: %w", statErr)
+	}
+	return writeGlobalConfigAtomically(targetPath, mode, func(temp *os.File) error {
+		if err := current.WriteConfigTo(temp); err != nil {
+			return fmt.Errorf("write global config: %w", err)
+		}
+		return nil
+	})
+}
+
+func globalConfigWriteTarget(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return "", fmt.Errorf("inspect global config path: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return path, nil
+	}
+	linkTarget, err := os.Readlink(path)
+	if err != nil {
+		return "", fmt.Errorf("read global config symlink: %w", err)
+	}
+	if !filepath.IsAbs(linkTarget) {
+		linkTarget = filepath.Join(filepath.Dir(path), linkTarget)
+	}
+	linkTarget = filepath.Clean(linkTarget)
+	resolved, err := filepath.EvalSymlinks(linkTarget)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("resolve global config symlink: %w", err)
+	}
+	resolvedParent, parentErr := filepath.EvalSymlinks(filepath.Dir(linkTarget))
+	if parentErr != nil {
+		return "", fmt.Errorf("resolve global config symlink target directory: %w", parentErr)
+	}
+	return filepath.Join(resolvedParent, filepath.Base(linkTarget)), nil
+}
+
+func writeGlobalConfigAtomically(
+	path string,
+	mode os.FileMode,
+	write func(*os.File) error,
+) (err error) {
+	temp, err := os.CreateTemp(filepath.Dir(path), ".config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create global config temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := write(temp); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Chmod(mode); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("set global config permissions: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("sync global config: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close global config: %w", err)
+	}
+	beforeGlobalConfigPublish(tempPath, path)
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace global config: %w", err)
+	}
+	return nil
+}

--- a/internal/config/global_store_test.go
+++ b/internal/config/global_store_test.go
@@ -157,6 +157,30 @@ func TestGlobalConfigStoreEnsurePreservesDanglingSymlink(t *testing.T) {
 	assert.Equal(t, contents, string(stored))
 }
 
+func TestGlobalConfigStoreEnsurePreservesDanglingSymlinkChain(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "config.toml")
+	intermediatePath := filepath.Join(dir, "current.toml")
+	targetPath := filepath.Join(dir, "managed", "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join("managed", "config.toml"), intermediatePath))
+	require.NoError(t, os.Symlink("current.toml", linkPath))
+	contents := "[ui]\nicons = true\n"
+
+	created, err := (globalConfigStore{path: linkPath}).ensure(contents)
+
+	require.NoError(t, err)
+	assert.True(t, created)
+	for _, path := range []string{linkPath, intermediatePath} {
+		info, statErr := os.Lstat(path)
+		require.NoError(t, statErr)
+		assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	}
+	stored, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(stored))
+}
+
 func TestGlobalConfigStorePreservesConfigSymlink(t *testing.T) {
 	for _, tt := range []struct {
 		name       string

--- a/internal/config/global_store_test.go
+++ b/internal/config/global_store_test.go
@@ -1,0 +1,296 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestGlobalConfigStoreSerializesIndependentWriters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("[ui]\nicons = true\n"), 0o640))
+	first := globalConfigStore{path: path}
+	second := globalConfigStore{path: path}
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+
+	go func() {
+		_, err := first.mutate(func(current *viper.Viper) (bool, error) {
+			entered <- "first"
+			<-release
+			current.Set("ui.tilde_home", true)
+			return true, nil
+		})
+		firstDone <- err
+	}()
+	require.Equal(t, "first", <-entered)
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := second.mutate(func(current *viper.Viper) (bool, error) {
+			entered <- "second"
+			current.Set("finder.preview", false)
+			return true, nil
+		})
+		secondDone <- err
+	}()
+	select {
+	case got := <-entered:
+		t.Fatalf("second mutation entered before unlock: %s", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.Equal(t, "second", <-entered)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+
+	stored, err := readGlobalViper(path)
+	require.NoError(t, err)
+	assert.True(t, stored.GetBool("ui.icons"))
+	assert.True(t, stored.GetBool("ui.tilde_home"))
+	assert.False(t, stored.GetBool("finder.preview"))
+}
+
+func TestGlobalConfigStorePreservesModeAndUnrelatedSettings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte("[ui]\nicons = true\n\n[custom]\nvalue = \"kept\"\n"),
+		0o640,
+	))
+	require.NoError(t, os.Chmod(path, 0o640))
+
+	changed, err := (globalConfigStore{path: path}).mutate(
+		func(current *viper.Viper) (bool, error) {
+			current.Set("ui.tilde_home", true)
+			return true, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	stored, err := readGlobalViper(path)
+	require.NoError(t, err)
+	assert.Equal(t, "kept", stored.GetString("custom.value"))
+	temps, err := filepath.Glob(filepath.Join(dir, ".config-*.tmp"))
+	require.NoError(t, err)
+	assert.Empty(t, temps)
+}
+
+func TestGlobalConfigStoreDoesNotOverwriteMalformedConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	original := []byte("[ui\nicons = true\n")
+	require.NoError(t, os.WriteFile(path, original, 0o600))
+
+	called := false
+	changed, err := (globalConfigStore{path: path}).mutate(
+		func(*viper.Viper) (bool, error) {
+			called = true
+			return true, nil
+		},
+	)
+
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.False(t, called)
+	stored, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, stored)
+}
+
+func TestGlobalConfigStoreEnsurePublishesCompleteFileAtomically(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	contents := "[ui]\nicons = true\n"
+	oldHook := beforeGlobalConfigPublish
+	t.Cleanup(func() { beforeGlobalConfigPublish = oldHook })
+	var observed bool
+	beforeGlobalConfigPublish = func(tempPath, targetPath string) {
+		assert.Equal(t, path, targetPath)
+		_, statErr := os.Stat(targetPath)
+		assert.ErrorIs(t, statErr, os.ErrNotExist)
+		data, readErr := os.ReadFile(tempPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, contents, string(data))
+		observed = true
+	}
+
+	created, err := (globalConfigStore{path: path}).ensure(contents)
+
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.True(t, observed)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(data))
+}
+
+func TestGlobalConfigStoreEnsurePreservesDanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "config.toml")
+	targetPath := filepath.Join(dir, "managed", "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join("managed", "config.toml"), linkPath))
+	contents := "[ui]\nicons = true\n"
+
+	created, err := (globalConfigStore{path: linkPath}).ensure(contents)
+
+	require.NoError(t, err)
+	assert.True(t, created)
+	info, err := os.Lstat(linkPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	stored, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(stored))
+}
+
+func TestGlobalConfigStorePreservesConfigSymlink(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		targetPath func(string) string
+	}{
+		{name: "relative", targetPath: func(string) string { return "managed.toml" }},
+		{name: "absolute", targetPath: func(dir string) string { return filepath.Join(dir, "managed.toml") }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			linkPath := filepath.Join(dir, "config.toml")
+			targetValue := tt.targetPath(dir)
+			targetPath := targetValue
+			if !filepath.IsAbs(targetPath) {
+				targetPath = filepath.Join(dir, targetPath)
+			}
+			require.NoError(t, os.WriteFile(targetPath, []byte("[ui]\nicons = true\n"), 0o640))
+			require.NoError(t, os.Chmod(targetPath, 0o640))
+			require.NoError(t, os.Symlink(targetValue, linkPath))
+
+			changed, err := (globalConfigStore{path: linkPath}).mutate(
+				func(current *viper.Viper) (bool, error) {
+					current.Set("ui.tilde_home", true)
+					return true, nil
+				},
+			)
+
+			require.NoError(t, err)
+			assert.True(t, changed)
+			info, err := os.Lstat(linkPath)
+			require.NoError(t, err)
+			assert.NotZero(t, info.Mode()&os.ModeSymlink)
+			stored, err := readGlobalViper(targetPath)
+			require.NoError(t, err)
+			assert.True(t, stored.GetBool("ui.tilde_home"))
+			info, err = os.Stat(targetPath)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+		})
+	}
+}
+
+func TestGlobalConfigWritersShareOneFileLock(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*testing.T, string)
+		write   func(string) error
+	}{
+		{
+			name: "set global",
+			write: func(string) error {
+				return SetGlobal("ui.tilde_home", true)
+			},
+		},
+		{
+			name: "register project",
+			write: func(path string) error {
+				repository := filepath.Join(filepath.Dir(path), "repository")
+				if err := os.Mkdir(repository, 0o755); err != nil {
+					return err
+				}
+				return RegisterProject(models.Project{
+					Repository: "github.com/acme/widget",
+					Name:       "widget",
+					Path:       repository,
+				})
+			},
+		},
+		{
+			name: "register workspace",
+			write: func(path string) error {
+				workspace := filepath.Join(filepath.Dir(path), "workspace")
+				if err := os.Mkdir(workspace, 0o755); err != nil {
+					return err
+				}
+				_, err := RegisterWorkspace(models.Workspace{Name: "notes", Path: workspace})
+				return err
+			},
+		},
+		{
+			name: "unregister workspace",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte(
+					"[[workspaces]]\nname = \"notes\"\npath = \"/tmp/notes\"\n",
+				), 0o600))
+			},
+			write: func(string) error { return UnregisterWorkspace("notes") },
+		},
+		{
+			name: "startup migration",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte(
+					"[layouts]\nauto_launch_on_add = false\n",
+				), 0o600))
+			},
+			write: func(path string) error {
+				_, err := backfillWorkspaceConfig(path)
+				return err
+			},
+		},
+		{
+			name:  "default creation",
+			write: func(string) error { return Init() },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			configHome := t.TempDir()
+			t.Setenv("KWT_HOME", configHome)
+			path := filepath.Join(configHome, "config.toml")
+			if tt.name != "default creation" {
+				require.NoError(t, os.WriteFile(path, []byte("[ui]\nicons = true\n"), 0o600))
+			}
+			if tt.prepare != nil {
+				tt.prepare(t, path)
+			}
+
+			lock := flock.New(path+".lock", flock.SetPermissions(0o600))
+			require.NoError(t, lock.Lock())
+			done := make(chan error, 1)
+			go func() { done <- tt.write(path) }()
+			select {
+			case err := <-done:
+				_ = lock.Unlock()
+				t.Fatalf("writer completed before global config unlock: %v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+			require.NoError(t, lock.Unlock())
+			require.NoError(t, <-done)
+		})
+	}
+}

--- a/internal/config/project_snapshot_test.go
+++ b/internal/config/project_snapshot_test.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestLoadGlobalSnapshotPairsPersistedAndEffectiveProjects(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	testHome := t.TempDir()
+	t.Setenv("HOME", testHome)
+	raw := `[[projects]]
+repository = "github.com/acme/widget"
+name = "widget"
+path = "~/code/widget"
+last_touched = "before"
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configHome, "config.toml"), []byte(raw), 0o600,
+	))
+
+	snapshot, err := LoadGlobalSnapshot()
+
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	assert.Equal(t, "~/code/widget", snapshot.Projects[0].Persisted.Path)
+	assert.Equal(t,
+		filepath.Join(testHome, "code", "widget"),
+		snapshot.Projects[0].Effective.Path,
+	)
+	assert.Equal(t, "~/code/widget", snapshot.Projects[0].Persisted.Path,
+		"expanding the effective config must not mutate the persisted slice")
+	assert.Equal(t, snapshot.Projects[0].Effective, snapshot.Config.Projects[0])
+}
+
+func TestLoadGlobalSnapshotKeepsMissingSymlinkPathSpellingEffective(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	realParent := t.TempDir()
+	aliasParent := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symbolic links are not supported: %v", err)
+	}
+	missing := filepath.Join(aliasParent, "missing")
+	raw := "[[projects]]\nrepository = \"github.com/acme/widget\"\nname = \"widget\"\npath = " +
+		strconvQuote(missing) + "\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configHome, "config.toml"), []byte(raw), 0o600,
+	))
+
+	snapshot, err := LoadGlobalSnapshot()
+
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	assert.Equal(t, missing, snapshot.Projects[0].Persisted.Path)
+	assert.Equal(t, filepath.Clean(missing), snapshot.Projects[0].Effective.Path)
+}
+
+func TestCompareAndSwapProjectUsesExactPersistedEntry(t *testing.T) {
+	tests := []struct {
+		name        string
+		projects    []models.Project
+		expected    models.Project
+		replacement *models.Project
+		wantChanged bool
+		want        []models.Project
+	}{
+		{
+			name: "replace one exact raw entry",
+			projects: []models.Project{
+				{Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before"},
+				{Repository: "github.com/acme/other", Name: "other", Path: "~/other", LastTouched: "kept"},
+			},
+			expected: models.Project{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before",
+			},
+			replacement: &models.Project{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "/repos/widget", LastTouched: "before",
+			},
+			wantChanged: true,
+			want: []models.Project{
+				{Repository: "github.com/acme/widget", Name: "widget", Path: "/repos/widget", LastTouched: "before"},
+				{Repository: "github.com/acme/other", Name: "other", Path: "~/other", LastTouched: "kept"},
+			},
+		},
+		{
+			name: "remove one exact raw entry",
+			projects: []models.Project{{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before",
+			}},
+			expected: models.Project{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before",
+			},
+			wantChanged: true,
+			want:        []models.Project{},
+		},
+		{
+			name: "changed metadata is a no-op",
+			projects: []models.Project{{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "after",
+			}},
+			expected: models.Project{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before",
+			},
+			want: []models.Project{{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "after",
+			}},
+		},
+		{
+			name: "duplicate exact entries are a no-op",
+			projects: []models.Project{
+				{Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before"},
+				{Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before"},
+			},
+			expected: models.Project{
+				Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before",
+			},
+			want: []models.Project{
+				{Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before"},
+				{Repository: "github.com/acme/widget", Name: "widget", Path: "~/old/widget", LastTouched: "before"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configHome := t.TempDir()
+			t.Setenv("KWT_HOME", configHome)
+			writePersistedProjects(t, filepath.Join(configHome, "config.toml"), []models.Project{tt.expected})
+			snapshot, err := LoadGlobalSnapshot()
+			require.NoError(t, err)
+			require.Len(t, snapshot.Projects, 1)
+			writePersistedProjects(t, filepath.Join(configHome, "config.toml"), tt.projects)
+
+			changed, err := CompareAndSwapProject(snapshot.Projects[0], tt.replacement)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, changed)
+			stored, err := readGlobalViper(filepath.Join(configHome, "config.toml"))
+			require.NoError(t, err)
+			var projects []models.Project
+			require.NoError(t, stored.UnmarshalKey("projects", &projects))
+			if projects == nil {
+				projects = []models.Project{}
+			}
+			assert.Equal(t, tt.want, projects)
+		})
+	}
+}
+
+func TestCompareAndSwapProjectRejectsOccupiedCanonicalTarget(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	configPath := filepath.Join(configHome, "config.toml")
+	stale := models.Project{
+		Repository:  "github.com/acme/widget",
+		Name:        "stale-widget",
+		Path:        "/old/widget",
+		LastTouched: "before",
+	}
+	writePersistedProjects(t, configPath, []models.Project{stale})
+	snapshot, err := LoadGlobalSnapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+
+	target := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "widget-alias")
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("symbolic links are not supported: %v", err)
+	}
+	live := models.Project{
+		Repository:  "github.com/acme/widget",
+		Name:        "live-widget",
+		Path:        alias,
+		LastTouched: "concurrent",
+	}
+	writePersistedProjects(t, configPath, []models.Project{stale, live})
+	replacement := stale
+	replacement.Path = target
+
+	changed, err := CompareAndSwapProject(snapshot.Projects[0], &replacement)
+
+	require.NoError(t, err)
+	assert.False(t, changed)
+	stored, err := readGlobalViper(configPath)
+	require.NoError(t, err)
+	var projects []models.Project
+	require.NoError(t, stored.UnmarshalKey("projects", &projects))
+	assert.Equal(t, []models.Project{stale, live}, projects)
+}
+
+func TestCompareAndSwapProjectPreservesUnknownFields(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	t.Setenv("HOME", t.TempDir())
+	path := filepath.Join(configHome, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`[[projects]]
+repository = "github.com/acme/widget"
+name = "widget"
+path = "~/old/widget"
+last_touched = "before"
+future_policy = "keep-matched"
+
+[[projects]]
+repository = "github.com/acme/other"
+name = "other"
+path = "/repos/other"
+last_touched = "kept"
+future_policy = "keep-unrelated"
+`), 0o600))
+	snapshot, err := LoadGlobalSnapshot()
+	require.NoError(t, err)
+	replacement := snapshot.Projects[0].Persisted
+	replacement.Path = "/repos/widget"
+
+	changed, err := CompareAndSwapProject(snapshot.Projects[0], &replacement)
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+	stored, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(stored), "future_policy = 'keep-matched'")
+	assert.Contains(t, string(stored), "future_policy = 'keep-unrelated'")
+}
+
+func TestCompareAndSwapProjectRejectsUnknownFieldChange(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	path := filepath.Join(configHome, "config.toml")
+	original := `[[projects]]
+repository = "github.com/acme/widget"
+name = "widget"
+path = "/old/widget"
+last_touched = "before"
+future_policy = "observed"
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+	snapshot, err := LoadGlobalSnapshot()
+	require.NoError(t, err)
+	concurrent := strings.Replace(original, "observed", "concurrent", 1)
+	require.NoError(t, os.WriteFile(path, []byte(concurrent), 0o600))
+	replacement := snapshot.Projects[0].Persisted
+	replacement.Path = "/repos/widget"
+
+	changed, err := CompareAndSwapProject(snapshot.Projects[0], &replacement)
+
+	require.NoError(t, err)
+	assert.False(t, changed)
+	stored, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, concurrent, string(stored))
+}
+
+func writePersistedProjects(t *testing.T, path string, projects []models.Project) {
+	t.Helper()
+	current := viper.New()
+	current.SetConfigType(configType)
+	current.Set("projects", projects)
+	require.NoError(t, writeGlobalViperAtomically(path, current))
+}
+
+func strconvQuote(value string) string {
+	return strconv.Quote(filepath.ToSlash(value))
+}

--- a/internal/config/workspace.go
+++ b/internal/config/workspace.go
@@ -37,31 +37,37 @@ func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
 	}
 	workspace.Name = strings.TrimSpace(workspace.Name)
 
-	workspaces, globalViper, err := readGlobalWorkspaces()
-	if err != nil {
+	var workspaces []models.Workspace
+	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	if _, err := (globalConfigStore{path: configPath}).mutate(
+		func(globalViper *viper.Viper) (bool, error) {
+			if err := globalViper.UnmarshalKey("workspaces", &workspaces); err != nil {
+				return false, fmt.Errorf("failed to read workspaces: %w", err)
+			}
+			updated := false
+			for i := range workspaces {
+				if sameProjectPath(workspaces[i].Path, workspace.Path) {
+					workspaces[i] = workspace
+					updated = true
+					continue
+				}
+				if strings.EqualFold(workspaces[i].Name, workspace.Name) {
+					return false, fmt.Errorf(
+						"workspace name %q is already registered for %s; choose another with --name",
+						workspace.Name, workspaces[i].Path,
+					)
+				}
+			}
+			if !updated {
+				workspaces = append(workspaces, workspace)
+			}
+			globalViper.Set("workspaces", workspaces)
+			return true, nil
+		},
+	); err != nil {
 		return models.Workspace{}, err
 	}
-
-	updated := false
-	for i := range workspaces {
-		if sameProjectPath(workspaces[i].Path, workspace.Path) {
-			workspaces[i] = workspace
-			updated = true
-			continue
-		}
-		if strings.EqualFold(workspaces[i].Name, workspace.Name) {
-			return models.Workspace{}, fmt.Errorf(
-				"workspace name %q is already registered for %s; choose another with --name",
-				workspace.Name, workspaces[i].Path,
-			)
-		}
-	}
-	if !updated {
-		workspaces = append(workspaces, workspace)
-	}
-	if err := writeGlobalWorkspaces(globalViper, workspaces); err != nil {
-		return models.Workspace{}, err
-	}
+	viper.Set("workspaces", workspaces)
 	return workspace, nil
 }
 
@@ -69,59 +75,38 @@ func RegisterWorkspace(workspace models.Workspace) (models.Workspace, error) {
 // name. The directory itself is never touched.
 func UnregisterWorkspace(name string) error {
 	name = strings.TrimSpace(name)
-	workspaces, globalViper, err := readGlobalWorkspaces()
-	if err != nil {
-		return err
-	}
-
-	kept := workspaces[:0]
-	removed := false
-	for _, workspace := range workspaces {
-		if strings.EqualFold(workspace.Name, name) {
-			removed = true
-			continue
-		}
-		kept = append(kept, workspace)
-	}
-	if !removed {
-		if len(workspaces) == 0 {
-			return fmt.Errorf("no workspace named %q; no workspaces registered", name)
-		}
-		names := make([]string, 0, len(workspaces))
-		for _, workspace := range workspaces {
-			names = append(names, workspace.Name)
-		}
-		sort.Strings(names)
-		return fmt.Errorf("no workspace named %q; registered: %s", name, strings.Join(names, ", "))
-	}
-	return writeGlobalWorkspaces(globalViper, kept)
-}
-
-func readGlobalWorkspaces() ([]models.Workspace, *viper.Viper, error) {
-	configDir := getConfigDir()
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return nil, nil, fmt.Errorf("failed to create config directory: %w", err)
-	}
-	globalViper := viper.New()
-	globalViper.SetConfigName(configName)
-	globalViper.SetConfigType(configType)
-	globalViper.AddConfigPath(configDir)
-	if err := globalViper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return nil, nil, fmt.Errorf("failed to read config: %w", err)
-		}
-	}
 	var workspaces []models.Workspace
-	if err := globalViper.UnmarshalKey("workspaces", &workspaces); err != nil {
-		return nil, nil, fmt.Errorf("failed to read workspaces: %w", err)
-	}
-	return workspaces, globalViper, nil
-}
-
-func writeGlobalWorkspaces(globalViper *viper.Viper, workspaces []models.Workspace) error {
-	globalViper.Set("workspaces", workspaces)
 	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
-	if err := globalViper.WriteConfigAs(configPath); err != nil {
+	if _, err := (globalConfigStore{path: configPath}).mutate(
+		func(globalViper *viper.Viper) (bool, error) {
+			if err := globalViper.UnmarshalKey("workspaces", &workspaces); err != nil {
+				return false, fmt.Errorf("failed to read workspaces: %w", err)
+			}
+			kept := workspaces[:0]
+			removed := false
+			for _, workspace := range workspaces {
+				if strings.EqualFold(workspace.Name, name) {
+					removed = true
+					continue
+				}
+				kept = append(kept, workspace)
+			}
+			if !removed {
+				if len(workspaces) == 0 {
+					return false, fmt.Errorf("no workspace named %q; no workspaces registered", name)
+				}
+				names := make([]string, 0, len(workspaces))
+				for _, workspace := range workspaces {
+					names = append(names, workspace.Name)
+				}
+				sort.Strings(names)
+				return false, fmt.Errorf("no workspace named %q; registered: %s", name, strings.Join(names, ", "))
+			}
+			workspaces = kept
+			globalViper.Set("workspaces", workspaces)
+			return true, nil
+		},
+	); err != nil {
 		return err
 	}
 	viper.Set("workspaces", workspaces)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -35,79 +35,21 @@ type worktreeCandidate struct {
 	isMain bool
 }
 
+var (
+	walkGlobalWorktreePaths = filepath.Walk
+	statGlobalWorktreeGit   = os.Stat
+	readGlobalWorktreeGit   = os.ReadFile
+)
+
 // DiscoverGlobalWorktrees finds all worktrees in the configured base
 // directory. projects carries the registered projects so repository identity
 // follows the single registered-identity precedence (a registered canonical
 // identity wins over a fork origin; see worktree.RepositoryInfoWithProjects);
 // pass nil when no registry is available.
 func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*GlobalWorktreeEntry, error) {
-	if baseDir == "" {
-		return nil, fmt.Errorf("base directory not configured")
-	}
-
-	// Expand path (handles ~, env vars, and relative paths)
-	expandedPath, err := utils.ExpandPath(baseDir)
+	candidates, err := findGlobalWorktreeCandidates(baseDir, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to expand base directory path: %w", err)
-	}
-	baseDir = expandedPath
-
-	// Check if base directory exists
-	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
-		return []*GlobalWorktreeEntry{}, nil
-	}
-
-	var candidates []worktreeCandidate
-
-	err = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // Skip errors and continue walking
-		}
-
-		if !info.IsDir() {
-			return nil
-		}
-
-		// Skip .git directories themselves
-		if info.Name() == ".git" {
-			return filepath.SkipDir
-		}
-
-		gitPath := filepath.Join(path, ".git")
-		gitInfo, err := os.Stat(gitPath)
-		if err != nil {
-			return nil // No .git entry, continue
-		}
-
-		if gitInfo.IsDir() {
-			// Main worktree (.git is a directory)
-			candidates = append(candidates, worktreeCandidate{path: path, isMain: true})
-			return filepath.SkipDir // Don't descend into the repo
-		}
-
-		// Linked worktree (.git is a file)
-		gitContent, err := os.ReadFile(gitPath)
-		if err != nil {
-			return nil
-		}
-
-		gitContentStr := strings.TrimSpace(string(gitContent))
-		if !strings.HasPrefix(gitContentStr, "gitdir: ") {
-			return nil
-		}
-
-		// Skip submodules — their gitdir points to .git/modules/...
-		gitDir := strings.TrimPrefix(gitContentStr, "gitdir: ")
-		if isSubmoduleGitDir(gitDir) {
-			return nil
-		}
-
-		candidates = append(candidates, worktreeCandidate{path: path})
-		return filepath.SkipDir
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to walk directory: %w", err)
+		return nil, err
 	}
 
 	snapshots, err := snapshotCandidateWorktrees(candidates)
@@ -125,6 +67,152 @@ func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*Glob
 			return extractWorktreeInfoFromSnapshot(path, projects, snapshot)
 		},
 	), nil
+}
+
+// FindGlobalWorktreePaths returns filesystem worktree candidates without
+// snapshotting repositories or initializing durable generations.
+func FindGlobalWorktreePaths(baseDir string) ([]string, error) {
+	candidates, err := findGlobalWorktreeCandidates(baseDir, false)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		paths = append(paths, candidate.path)
+	}
+	return paths, nil
+}
+
+// FindGlobalWorktreePathsStrict returns filesystem worktree candidates only
+// when the complete configured tree can be traversed and inspected.
+func FindGlobalWorktreePathsStrict(baseDir string) ([]string, error) {
+	candidates, err := findGlobalWorktreeCandidates(baseDir, true)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		paths = append(paths, candidate.path)
+	}
+	return paths, nil
+}
+
+func findGlobalWorktreeCandidates(baseDir string, strict bool) ([]worktreeCandidate, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("base directory not configured")
+	}
+
+	// Expand path (handles ~, env vars, and relative paths)
+	expandedPath, err := utils.ExpandPath(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand base directory path: %w", err)
+	}
+	baseDir = expandedPath
+
+	// Inspect the link itself before resolving the root so strict discovery can
+	// distinguish a genuinely absent directory from a dangling configured
+	// symlink. Resolve a healthy symlink so Walk enters its target tree.
+	baseInfo, err := os.Lstat(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []worktreeCandidate{}, nil
+		}
+		if strict {
+			return nil, fmt.Errorf("inspect base directory %s: %w", baseDir, err)
+		}
+	}
+	if err == nil && baseInfo.Mode()&os.ModeSymlink != 0 {
+		resolved, resolveErr := filepath.EvalSymlinks(baseDir)
+		if resolveErr != nil {
+			if strict {
+				return nil, fmt.Errorf("resolve base directory %s: %w", baseDir, resolveErr)
+			}
+		} else {
+			baseDir = resolved
+		}
+	}
+
+	var candidates []worktreeCandidate
+
+	err = walkGlobalWorktreePaths(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if strict {
+				return err
+			}
+			return nil // Skip errors and continue walking
+		}
+
+		if !info.IsDir() {
+			return nil
+		}
+
+		// Skip .git directories themselves
+		if info.Name() == ".git" {
+			return filepath.SkipDir
+		}
+
+		gitPath := filepath.Join(path, ".git")
+		gitInfo, err := statGlobalWorktreeGit(gitPath)
+		if err != nil {
+			if strict && os.IsNotExist(err) {
+				_, linkErr := os.Lstat(gitPath)
+				if linkErr == nil {
+					return fmt.Errorf("inspect worktree metadata %s: %w", gitPath, err)
+				}
+				if !os.IsNotExist(linkErr) {
+					return fmt.Errorf("inspect worktree metadata %s: %w", gitPath, linkErr)
+				}
+			}
+			if strict && !os.IsNotExist(err) {
+				return fmt.Errorf("inspect worktree metadata %s: %w", gitPath, err)
+			}
+			return nil // No .git entry, continue
+		}
+
+		if gitInfo.IsDir() {
+			// Main worktree (.git is a directory)
+			candidates = append(candidates, worktreeCandidate{path: path, isMain: true})
+			return filepath.SkipDir // Don't descend into the repo
+		}
+
+		// Linked worktree (.git is a file)
+		gitContent, err := readGlobalWorktreeGit(gitPath)
+		if err != nil {
+			if strict {
+				return fmt.Errorf("read linked worktree metadata %s: %w", gitPath, err)
+			}
+			return nil
+		}
+
+		gitContentStr := strings.TrimSpace(string(gitContent))
+		if !strings.HasPrefix(gitContentStr, "gitdir: ") {
+			if strict {
+				return fmt.Errorf("invalid linked worktree metadata %s", gitPath)
+			}
+			return nil
+		}
+
+		// Skip submodules — their gitdir points to .git/modules/...
+		gitDir := strings.TrimSpace(strings.TrimPrefix(gitContentStr, "gitdir: "))
+		if gitDir == "" || strings.ContainsAny(gitDir, "\r\n") {
+			if strict {
+				return fmt.Errorf("invalid linked worktree metadata %s", gitPath)
+			}
+			return nil
+		}
+		if isSubmoduleGitDir(gitDir) {
+			return nil
+		}
+
+		candidates = append(candidates, worktreeCandidate{path: path})
+		return filepath.SkipDir
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	return candidates, nil
 }
 
 // DiscoverWorktree resolves one exact worktree root independently of the

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -429,15 +429,30 @@ func getCurrentCommitHash(worktreePath string) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
-// isSubmoduleGitDir checks whether a gitdir path points to a submodule
-// rather than a linked worktree. Submodule gitdirs always contain a
-// "/modules/" segment — either under .git/modules/ (submodules in the main
-// worktree) or under .git/worktrees/<name>/modules/ (submodules in a linked
-// worktree). Linked worktree gitdirs point to .git/worktrees/<name> with no
-// trailing /modules/ path.
+// isSubmoduleGitDir checks whether a gitdir path uses Git's standard submodule
+// administrative layout. Only segments after the final .git directory are
+// relevant; an ordinary repository may itself live below a directory named
+// modules.
 func isSubmoduleGitDir(gitDir string) bool {
 	normalized := filepath.ToSlash(gitDir)
-	return strings.Contains(normalized, "/modules/")
+	segments := strings.Split(normalized, "/")
+	gitIndex := -1
+	for index, segment := range segments {
+		if strings.EqualFold(segment, ".git") {
+			gitIndex = index
+		}
+	}
+	if gitIndex < 0 {
+		return false
+	}
+
+	adminPath := segments[gitIndex+1:]
+	if len(adminPath) >= 2 && strings.EqualFold(adminPath[0], "modules") {
+		return true
+	}
+	return len(adminPath) >= 4 &&
+		strings.EqualFold(adminPath[0], "worktrees") &&
+		strings.EqualFold(adminPath[2], "modules")
 }
 
 // Model converts a discovered entry into a manifest Worktree, carrying the

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -211,6 +211,24 @@ func TestFindGlobalWorktreePathsStrictTraversesSymlinkedBaseDirectory(t *testing
 	}), "FindGlobalWorktreePathsStrict() = %v, want %s", paths, worktreePath)
 }
 
+func TestFindGlobalWorktreePathsStrictIncludesRepositoryUnderModulesDirectory(
+	t *testing.T,
+) {
+	baseDir := t.TempDir()
+	repoDir := filepath.Join(t.TempDir(), "modules", "widget")
+	repo := initRepoAt(t, repoDir, "https://github.com/acme/widget.git")
+	repo.CreateBranch(t, "topic")
+	worktreePath := filepath.Join(baseDir, "topic")
+	repo.CreateWorktree(t, worktreePath, "topic")
+
+	paths, err := FindGlobalWorktreePathsStrict(baseDir)
+
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(paths, func(path string) bool {
+		return utils.PathKey(path) == utils.PathKey(worktreePath)
+	}), "FindGlobalWorktreePathsStrict() = %v, want %s", paths, worktreePath)
+}
+
 func TestFindGlobalWorktreePathsStrictRejectsDanglingBaseDirectorySymlink(
 	t *testing.T,
 ) {

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,15 +1,18 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/url"
@@ -152,6 +155,191 @@ func TestDiscoverGlobalWorktrees_NoWorktrees(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("Expected no entries, got %d", len(entries))
+	}
+}
+
+func TestFindGlobalWorktreePathsReturnsGitFilesWithoutSnapshotting(t *testing.T) {
+	baseDir := t.TempDir()
+	repoDir := filepath.Join(baseDir, "repo")
+	repo := initRepoAt(t, repoDir, "https://github.com/acme/widget.git")
+	repo.CreateBranch(t, "raw-topic")
+	worktreePath := filepath.Join(baseDir, "raw-topic")
+	repo.CreateWorktree(t, worktreePath, "raw-topic")
+	gitFile, err := os.ReadFile(filepath.Join(worktreePath, ".git"))
+	if err != nil {
+		t.Fatalf("read linked .git file: %v", err)
+	}
+	adminDir := strings.TrimSpace(strings.TrimPrefix(string(gitFile), "gitdir: "))
+	if !filepath.IsAbs(adminDir) {
+		adminDir = filepath.Join(worktreePath, adminDir)
+	}
+	generationPath := filepath.Join(adminDir, "kwt-generation")
+	if _, err := os.Stat(generationPath); !os.IsNotExist(err) {
+		t.Fatalf("generation exists before discovery: %v", err)
+	}
+
+	paths, err := FindGlobalWorktreePaths(baseDir)
+	if err != nil {
+		t.Fatalf("FindGlobalWorktreePaths() error = %v", err)
+	}
+	if !slices.ContainsFunc(paths, func(path string) bool {
+		return utils.PathKey(path) == utils.PathKey(worktreePath)
+	}) {
+		t.Fatalf("FindGlobalWorktreePaths() = %v, want %s", paths, worktreePath)
+	}
+	if _, err := os.Stat(generationPath); !os.IsNotExist(err) {
+		t.Fatalf("generation created by read-only discovery: %v", err)
+	}
+}
+
+func TestFindGlobalWorktreePathsStrictTraversesSymlinkedBaseDirectory(t *testing.T) {
+	realBase := t.TempDir()
+	repoDir := filepath.Join(realBase, "repo")
+	repo := initRepoAt(t, repoDir, "https://github.com/acme/widget.git")
+	repo.CreateBranch(t, "linked-base")
+	worktreePath := filepath.Join(realBase, "linked-base")
+	repo.CreateWorktree(t, worktreePath, "linked-base")
+
+	aliasBase := filepath.Join(t.TempDir(), "worktrees")
+	require.NoError(t, os.Symlink(realBase, aliasBase))
+
+	paths, err := FindGlobalWorktreePathsStrict(aliasBase)
+
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(paths, func(path string) bool {
+		return utils.PathKey(path) == utils.PathKey(worktreePath)
+	}), "FindGlobalWorktreePathsStrict() = %v, want %s", paths, worktreePath)
+}
+
+func TestFindGlobalWorktreePathsStrictRejectsDanglingBaseDirectorySymlink(
+	t *testing.T,
+) {
+	aliasBase := filepath.Join(t.TempDir(), "worktrees")
+	missingTarget := filepath.Join(t.TempDir(), "missing-worktrees")
+	if err := os.Symlink(missingTarget, aliasBase); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("create symlink: %v", err)
+		}
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	paths, err := FindGlobalWorktreePathsStrict(aliasBase)
+
+	require.Nil(t, paths)
+	require.ErrorContains(t, err, "resolve base directory")
+}
+
+func TestFindGlobalWorktreePathsStrictRejectsDanglingGitSymlink(t *testing.T) {
+	baseDir := t.TempDir()
+	candidatePath := filepath.Join(baseDir, "candidate")
+	require.NoError(t, os.Mkdir(candidatePath, 0o755))
+	gitPath := filepath.Join(candidatePath, ".git")
+	missingTarget := filepath.Join(t.TempDir(), "missing-admin")
+	if err := os.Symlink(missingTarget, gitPath); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("create symlink: %v", err)
+		}
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	paths, err := FindGlobalWorktreePathsStrict(baseDir)
+
+	require.Nil(t, paths)
+	require.ErrorContains(t, err, "inspect worktree metadata")
+}
+
+func TestFindGlobalWorktreePathsStrictReturnsTraversalError(t *testing.T) {
+	wantErr := errors.New("permission denied")
+	oldWalk := walkGlobalWorktreePaths
+	t.Cleanup(func() { walkGlobalWorktreePaths = oldWalk })
+	walkGlobalWorktreePaths = func(root string, walkFn filepath.WalkFunc) error {
+		return walkFn(filepath.Join(root, "blocked"), nil, wantErr)
+	}
+
+	paths, err := FindGlobalWorktreePathsStrict(t.TempDir())
+
+	if paths != nil {
+		t.Fatalf("FindGlobalWorktreePathsStrict() paths = %v, want nil", paths)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("FindGlobalWorktreePathsStrict() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestFindGlobalWorktreePathsStrictReturnsGitStatError(t *testing.T) {
+	baseDir := t.TempDir()
+	candidatePath := filepath.Join(baseDir, "candidate")
+	if err := os.Mkdir(candidatePath, 0o755); err != nil {
+		t.Fatalf("create candidate: %v", err)
+	}
+	wantErr := errors.New("git stat denied")
+	oldStat := statGlobalWorktreeGit
+	t.Cleanup(func() { statGlobalWorktreeGit = oldStat })
+	statGlobalWorktreeGit = func(path string) (os.FileInfo, error) {
+		if path == filepath.Join(candidatePath, ".git") {
+			return nil, wantErr
+		}
+		return os.Stat(path)
+	}
+
+	paths, err := FindGlobalWorktreePathsStrict(baseDir)
+
+	if paths != nil {
+		t.Fatalf("FindGlobalWorktreePathsStrict() paths = %v, want nil", paths)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("FindGlobalWorktreePathsStrict() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestFindGlobalWorktreePathsStrictReturnsGitReadError(t *testing.T) {
+	baseDir := t.TempDir()
+	candidatePath := filepath.Join(baseDir, "candidate")
+	if err := os.Mkdir(candidatePath, 0o755); err != nil {
+		t.Fatalf("create candidate: %v", err)
+	}
+	gitPath := filepath.Join(candidatePath, ".git")
+	if err := os.WriteFile(gitPath, []byte("gitdir: /repo/.git/worktrees/candidate\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	wantErr := errors.New("git read denied")
+	oldRead := readGlobalWorktreeGit
+	t.Cleanup(func() { readGlobalWorktreeGit = oldRead })
+	readGlobalWorktreeGit = func(path string) ([]byte, error) {
+		if path == gitPath {
+			return nil, wantErr
+		}
+		return os.ReadFile(path)
+	}
+
+	paths, err := FindGlobalWorktreePathsStrict(baseDir)
+
+	if paths != nil {
+		t.Fatalf("FindGlobalWorktreePathsStrict() paths = %v, want nil", paths)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("FindGlobalWorktreePathsStrict() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestFindGlobalWorktreePathsStrictReturnsMalformedGitFileError(t *testing.T) {
+	baseDir := t.TempDir()
+	candidatePath := filepath.Join(baseDir, "candidate")
+	if err := os.Mkdir(candidatePath, 0o755); err != nil {
+		t.Fatalf("create candidate: %v", err)
+	}
+	gitPath := filepath.Join(candidatePath, ".git")
+	if err := os.WriteFile(gitPath, []byte("not a gitdir\n"), 0o644); err != nil {
+		t.Fatalf("write malformed .git file: %v", err)
+	}
+
+	paths, err := FindGlobalWorktreePathsStrict(baseDir)
+
+	if paths != nil {
+		t.Fatalf("FindGlobalWorktreePathsStrict() paths = %v, want nil", paths)
+	}
+	if err == nil || !strings.Contains(err.Error(), "invalid linked worktree metadata") {
+		t.Fatalf("FindGlobalWorktreePathsStrict() error = %v, want malformed metadata error", err)
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -39,6 +39,16 @@ func (g *Git) RunCommand(args ...string) (string, error) {
 	return g.run(args...)
 }
 
+// RunCommandWithoutCredentials executes a Git command after removing the
+// named credentials from its environment. Use it for commands that may run
+// hooks or helpers selected by untrusted worktree content or configuration.
+func (g *Git) RunCommandWithoutCredentials(
+	protectedNames []string,
+	args ...string,
+) (string, error) {
+	return g.runWithoutCredentials(protectedNames, args...)
+}
+
 // RunWithContext executes a git command with context support for cancellation and timeout.
 func (g *Git) RunWithContext(ctx context.Context, args ...string) (string, error) {
 	return g.runWithContext(ctx, args...)

--- a/internal/git/git_branch.go
+++ b/internal/git/git_branch.go
@@ -10,6 +10,94 @@ import (
 	"go.kenn.io/kwt/pkg/models"
 )
 
+// BranchUpstream describes the configured source branch and its remote URL.
+type BranchUpstream struct {
+	Remote        string
+	Branch        string
+	RepositoryURL string
+}
+
+// BranchUpstream returns the exact configured upstream for a local branch.
+func (g *Git) BranchUpstream(branch string) (BranchUpstream, error) {
+	return g.branchUpstream(branch, nil)
+}
+
+// BranchUpstreamWithoutCredentials returns the configured upstream without
+// exposing the named credentials to Git configuration selected by a worktree.
+func (g *Git) BranchUpstreamWithoutCredentials(
+	branch string,
+	protectedNames []string,
+) (BranchUpstream, error) {
+	return g.branchUpstream(branch, protectedNames)
+}
+
+func (g *Git) branchUpstream(
+	branch string,
+	protectedNames []string,
+) (BranchUpstream, error) {
+	remote, err := g.runWithoutCredentials(
+		protectedNames,
+		"config", "--get", "branch."+branch+".remote",
+	)
+	if err != nil {
+		return BranchUpstream{}, fmt.Errorf(
+			"resolve branch %q upstream remote: %w",
+			branch,
+			err,
+		)
+	}
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return BranchUpstream{}, fmt.Errorf(
+			"resolve branch %q upstream remote: value is empty",
+			branch,
+		)
+	}
+	mergeRef, err := g.runWithoutCredentials(
+		protectedNames,
+		"config", "--get", "branch."+branch+".merge",
+	)
+	if err != nil {
+		return BranchUpstream{}, fmt.Errorf(
+			"resolve branch %q upstream merge ref: %w",
+			branch,
+			err,
+		)
+	}
+	mergeRef = strings.TrimSpace(mergeRef)
+	const headsPrefix = "refs/heads/"
+	if !strings.HasPrefix(mergeRef, headsPrefix) ||
+		strings.TrimPrefix(mergeRef, headsPrefix) == "" {
+		return BranchUpstream{}, fmt.Errorf(
+			"resolve branch %q upstream merge ref: expected refs/heads/ reference",
+			branch,
+		)
+	}
+	repositoryURL, err := g.runWithoutCredentials(
+		protectedNames,
+		"remote", "get-url", remote,
+	)
+	if err != nil {
+		return BranchUpstream{}, fmt.Errorf(
+			"resolve branch %q upstream remote URL: %w",
+			branch,
+			err,
+		)
+	}
+	repositoryURL = strings.TrimSpace(repositoryURL)
+	if repositoryURL == "" {
+		return BranchUpstream{}, fmt.Errorf(
+			"resolve branch %q upstream remote URL: value is empty",
+			branch,
+		)
+	}
+	return BranchUpstream{
+		Remote:        remote,
+		Branch:        strings.TrimPrefix(mergeRef, headsPrefix),
+		RepositoryURL: repositoryURL,
+	}, nil
+}
+
 // ListBranches returns a list of all branches.
 func (g *Git) ListBranches(includeRemote bool) ([]models.Branch, error) {
 	args := []string{

--- a/internal/git/git_repo.go
+++ b/internal/git/git_repo.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	gitworktree "go.kenn.io/kit/git/worktree"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -28,6 +30,14 @@ func (g *Git) GetRepositoryPath() (string, error) {
 // called from inside a worktree.
 func (g *Git) GetMainRepositoryPath() (string, error) {
 	return g.getMainRepoRoot()
+}
+
+// GetMainRepositoryPathWithoutCredentials resolves the main repository while
+// removing the named credentials from Git's environment.
+func (g *Git) GetMainRepositoryPathWithoutCredentials(
+	protectedNames []string,
+) (string, error) {
+	return g.getMainRepoRootWithoutCredentials(protectedNames)
 }
 
 // GetRepositoryURL returns the remote origin URL of the repository.
@@ -80,25 +90,95 @@ func (g *Git) GetRecentCommits(path string, limit int) ([]models.CommitInfo, err
 // getMainRepoRoot returns the main repository root directory using git-common-dir.
 // This works correctly from both the main repo and worktrees.
 func (g *Git) getMainRepoRoot() (string, error) {
-	output, err := g.run("rev-parse", "--git-common-dir")
+	return g.getMainRepoRootWithoutCredentials(nil)
+}
+
+func (g *Git) getMainRepoRootWithoutCredentials(
+	protectedNames []string,
+) (string, error) {
+	currentRootOutput, err := g.runWithoutCredentials(
+		protectedNames,
+		"rev-parse", "--show-toplevel",
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get current worktree root: %w", err)
+	}
+	gitDirOutput, err := g.runWithoutCredentials(
+		protectedNames,
+		"rev-parse", "--absolute-git-dir",
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute git dir: %w", err)
+	}
+	commonDirOutput, err := g.runWithoutCredentials(
+		protectedNames,
+		"rev-parse", "--git-common-dir",
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to get git common dir: %w", err)
 	}
-	commonDir := strings.TrimSpace(output)
-
+	commonDir := strings.TrimSpace(commonDirOutput)
 	if !filepath.IsAbs(commonDir) {
 		commonDir = filepath.Join(g.workDir, commonDir)
 	}
-
-	repoRoot := filepath.Dir(filepath.Clean(commonDir))
-
-	// Resolve symlinks to ensure consistent path comparison
-	// (e.g., macOS /var -> /private/var)
-	if resolved, err := filepath.EvalSymlinks(repoRoot); err == nil {
-		repoRoot = resolved
+	commonDir = utils.CanonicalPath(commonDir)
+	gitDir := utils.CanonicalPath(strings.TrimSpace(gitDirOutput))
+	currentRoot := utils.CanonicalPath(strings.TrimSpace(currentRootOutput))
+	if utils.PathKey(gitDir) == utils.PathKey(commonDir) {
+		return currentRoot, nil
+	}
+	if filepath.Base(commonDir) == ".git" {
+		standardRoot := utils.CanonicalPath(filepath.Dir(commonDir))
+		standardGitDir, verifyErr := New(standardRoot).
+			worktreeGitDirWithoutCredentials(standardRoot, protectedNames)
+		if verifyErr == nil &&
+			utils.PathKey(standardGitDir) == utils.PathKey(commonDir) {
+			return standardRoot, nil
+		}
 	}
 
-	return repoRoot, nil
+	output, err := g.runWithoutCredentials(
+		protectedNames,
+		"worktree", "list", "--porcelain",
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to list repository worktrees: %w", err)
+	}
+	entries := gitworktree.ParsePorcelain(output)
+	if len(entries) == 0 {
+		return "", fmt.Errorf("main worktree path is unavailable")
+	}
+	inventoryMain := utils.CanonicalPath(entries[0].Path)
+	if utils.PathKey(inventoryMain) != utils.PathKey(commonDir) {
+		return inventoryMain, nil
+	}
+	coreWorktree, coreErr := g.runWithoutCredentials(
+		protectedNames,
+		"config", "--path", "--get", "core.worktree",
+	)
+	if coreErr == nil && strings.TrimSpace(coreWorktree) != "" {
+		path := strings.TrimSpace(coreWorktree)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(commonDir, path)
+		}
+		path = utils.CanonicalPath(path)
+		gitDir, verifyErr := New(path).worktreeGitDirWithoutCredentials(
+			path,
+			protectedNames,
+		)
+		if verifyErr != nil || utils.PathKey(gitDir) != utils.PathKey(commonDir) {
+			return "", fmt.Errorf(
+				"configured core.worktree does not name the main worktree for %s",
+				commonDir,
+			)
+		}
+		return path, nil
+	}
+
+	return "", fmt.Errorf(
+		"main worktree path is unavailable for separate Git directory %s",
+		commonDir,
+	)
 }
 
 // getRootDir returns the repository root directory.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1328,6 +1328,53 @@ func TestWorktreeGitDirRejectsDuplicateAdministrativeBacklinks(t *testing.T) {
 	require.ErrorContains(t, err, "multiple administrative directories")
 }
 
+func TestWorktreeGitDirRejectsIncompleteAdministrativeInventory(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "missing gitdir file",
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.Mkdir(path, 0o700))
+			},
+		},
+		{
+			name: "malformed gitdir file",
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.Mkdir(path, 0o700))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(path, "gitdir"),
+					[]byte("not-a-worktree-backlink\n"),
+					0o600,
+				))
+			},
+		},
+		{
+			name: "unexpected non-directory entry",
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.WriteFile(path, []byte("unexpected\n"), 0o600))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewTestRepository(t)
+			g := New(repo.Path)
+			repo.CreateBranch(t, "verified-worktree")
+			worktreePath := filepath.Join(t.TempDir(), "verified-worktree")
+			repo.CreateWorktree(t, worktreePath, "verified-worktree")
+			commonDir, err := g.worktreeCommonDir(nil)
+			require.NoError(t, err)
+			tt.setup(t, filepath.Join(commonDir, "worktrees", "incomplete-entry"))
+
+			_, err = g.worktreeGitDir(worktreePath)
+
+			require.ErrorContains(t, err, "incomplete administrative inventory")
+		})
+	}
+}
+
 func TestWorktreeGenerationSupportsSeparateGitDirectory(t *testing.T) {
 	base := t.TempDir()
 	worktreePath := filepath.Join(base, "worktree")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -122,6 +123,36 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 		t.Fatalf("git %s failed: %v\nOutput: %s", strings.Join(args, " "), err, output)
 	}
 	return strings.TrimSpace(string(output))
+}
+
+func newSeparateGitDirectoryRepository(t *testing.T) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	mainPath := filepath.Join(base, "main-worktree")
+	separateGitDir := filepath.Join(base, "repository.git")
+	linkedPath := filepath.Join(base, "linked-worktree")
+	gitOutput(
+		t,
+		base,
+		"init",
+		"-b",
+		"main",
+		"--separate-git-dir",
+		separateGitDir,
+		mainPath,
+	)
+	gitOutput(t, mainPath, "config", "user.name", "Test User")
+	gitOutput(t, mainPath, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(mainPath, "README.md"),
+		[]byte("# Separate Git directory\n"),
+		0o644,
+	))
+	gitOutput(t, mainPath, "add", "README.md")
+	gitOutput(t, mainPath, "commit", "-m", "Initial commit")
+	gitOutput(t, mainPath, "branch", "topic")
+	gitOutput(t, mainPath, "worktree", "add", linkedPath, "topic")
+	return mainPath, linkedPath
 }
 
 func commitTestFile(t *testing.T, dir, name, contents, message string) {
@@ -988,6 +1019,228 @@ func TestListWorktreesKeepsGenerationStableWhenDirectoryChanges(t *testing.T) {
 	t.Fatal("worktree missing after ordinary directory change")
 }
 
+func TestInspectWorktreesDoesNotInitializeGeneration(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "raw-topic")
+	worktreePath := filepath.Join(t.TempDir(), "raw-topic")
+	repo.CreateWorktree(t, worktreePath, "raw-topic")
+	g := New(repo.Path)
+	adminDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	assert.NoFileExists(t, filepath.Join(adminDir, "kwt-generation"))
+
+	inspections, err := g.InspectWorktrees()
+	require.NoError(t, err)
+	inspection := requireWorktreeInspection(t, inspections, worktreePath)
+	assert.Equal(t, GenerationMissing, inspection.GenerationStatus)
+	assert.Empty(t, inspection.Generation)
+	assert.NoFileExists(t, filepath.Join(adminDir, "kwt-generation"))
+}
+
+func TestReadWorktreeBacklinkReturnsDirectAdministrativeDirectory(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "backlink-topic")
+	worktreePath := filepath.Join(t.TempDir(), "backlink-topic")
+	repo.CreateWorktree(t, worktreePath, "backlink-topic")
+	expected, err := New(repo.Path).worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+
+	actual, err := ReadWorktreeBacklink(worktreePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, utils.PathKey(expected), utils.PathKey(actual))
+}
+
+func TestInspectWorktreesReportsMissingDirectoryWithoutInitializing(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "missing-topic")
+	worktreePath := filepath.Join(t.TempDir(), "missing-topic")
+	repo.CreateWorktree(t, worktreePath, "missing-topic")
+	g := New(repo.Path)
+	adminDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(worktreePath))
+
+	inspections, err := g.InspectWorktrees()
+	require.NoError(t, err)
+	inspection := requireWorktreeInspection(t, inspections, worktreePath)
+	assert.False(t, inspection.Exists)
+	assert.True(t, inspection.Prunable)
+	assert.Equal(t, GenerationMissing, inspection.GenerationStatus)
+	assert.NoFileExists(t, filepath.Join(adminDir, "kwt-generation"))
+}
+
+func TestInspectWorktreesReturnsIncompleteInventoryForWorktreeStatError(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "inaccessible-topic")
+	worktreePath := filepath.Join(t.TempDir(), "inaccessible-topic")
+	repo.CreateWorktree(t, worktreePath, "inaccessible-topic")
+	g := New(repo.Path)
+	wantErr := errors.New("worktree path is inaccessible")
+	originalStat := inspectWorktreeStat
+	inspectWorktreeStat = func(path string) (os.FileInfo, error) {
+		if comparableWorktreePath(path) == comparableWorktreePath(worktreePath) {
+			return nil, wantErr
+		}
+		return os.Stat(path)
+	}
+	t.Cleanup(func() { inspectWorktreeStat = originalStat })
+
+	_, err := g.InspectWorktrees()
+
+	require.Error(t, err)
+	assert.True(t, IsIncompleteInventory(err))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestInspectWorktreesReturnsIncompleteInventoryForDotGitReadError(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "unreadable-backlink")
+	worktreePath := filepath.Join(t.TempDir(), "unreadable-backlink")
+	repo.CreateWorktree(t, worktreePath, "unreadable-backlink")
+	g := New(repo.Path)
+	wantErr := errors.New("backlink is unreadable")
+	originalRead := inspectDotGitRead
+	inspectDotGitRead = func(path string) ([]byte, error) {
+		if comparableWorktreePath(path) ==
+			comparableWorktreePath(filepath.Join(worktreePath, ".git")) {
+			return nil, wantErr
+		}
+		return os.ReadFile(path)
+	}
+	t.Cleanup(func() { inspectDotGitRead = originalRead })
+
+	_, err := g.InspectWorktrees()
+
+	require.Error(t, err)
+	assert.True(t, IsIncompleteInventory(err))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestInspectWorktreesReturnsIncompleteInventoryForDotGitStatError(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "unstatable-backlink")
+	worktreePath := filepath.Join(t.TempDir(), "unstatable-backlink")
+	repo.CreateWorktree(t, worktreePath, "unstatable-backlink")
+	g := New(repo.Path)
+	wantErr := errors.New("backlink metadata is inaccessible")
+	originalStat := inspectWorktreeStat
+	inspectWorktreeStat = func(path string) (os.FileInfo, error) {
+		if comparableWorktreePath(path) ==
+			comparableWorktreePath(filepath.Join(worktreePath, ".git")) {
+			return nil, wantErr
+		}
+		return os.Stat(path)
+	}
+	t.Cleanup(func() { inspectWorktreeStat = originalStat })
+
+	_, err := g.InspectWorktrees()
+
+	require.Error(t, err)
+	assert.True(t, IsIncompleteInventory(err))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestWorktreeInspectionJSONUsesSnakeCaseFields(t *testing.T) {
+	encoded, err := json.Marshal(WorktreeInspection{
+		Path:             "/worktrees/topic",
+		GenerationStatus: GenerationValid,
+		IsMain:           true,
+		LockedReason:     "maintenance",
+	})
+	require.NoError(t, err)
+
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &fields))
+	assert.Equal(t, "/worktrees/topic", fields["path"])
+	assert.Equal(t, string(GenerationValid), fields["generation_status"])
+	assert.Equal(t, true, fields["is_main"])
+	assert.Equal(t, "maintenance", fields["locked_reason"])
+	assert.NotContains(t, fields, "Path")
+}
+
+func requireWorktreeInspection(
+	t *testing.T,
+	inspections []WorktreeInspection,
+	path string,
+) WorktreeInspection {
+	t.Helper()
+	for _, inspection := range inspections {
+		if comparableWorktreePath(inspection.Path) == comparableWorktreePath(path) {
+			return inspection
+		}
+	}
+	t.Fatalf("worktree inspection missing for %s", path)
+	return WorktreeInspection{}
+}
+
+func TestBranchUpstream(t *testing.T) {
+	tests := []struct {
+		name       string
+		remote     string
+		remoteURL  string
+		mergeRef   string
+		wantBranch string
+	}{
+		{
+			name:       "same repository",
+			remote:     "origin",
+			remoteURL:  "https://github.com/acme/widget.git",
+			mergeRef:   "refs/heads/topic",
+			wantBranch: "topic",
+		},
+		{
+			name:       "fork remote",
+			remote:     "fork",
+			remoteURL:  "git@github.com:alice/widget.git",
+			mergeRef:   "refs/heads/topic",
+			wantBranch: "topic",
+		},
+		{
+			name:       "slash remote name",
+			remote:     "fork/alice",
+			remoteURL:  "ssh://git@github.com/alice/widget.git",
+			mergeRef:   "refs/heads/team/topic",
+			wantBranch: "team/topic",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewTestRepository(t)
+			require.NoError(t, repo.run("config", "branch.topic.remote", tt.remote))
+			require.NoError(t, repo.run("config", "branch.topic.merge", tt.mergeRef))
+			require.NoError(t, repo.run("config", "remote."+tt.remote+".url", tt.remoteURL))
+
+			got, err := New(repo.Path).BranchUpstream("topic")
+			require.NoError(t, err)
+			assert.Equal(t, tt.remote, got.Remote)
+			assert.Equal(t, tt.wantBranch, got.Branch)
+			assert.Equal(t, tt.remoteURL, got.RepositoryURL)
+		})
+	}
+}
+
+func TestBranchUpstreamResolvesInsteadOfURL(t *testing.T) {
+	repo := NewTestRepository(t)
+	require.NoError(t, repo.run("config", "branch.topic.remote", "origin"))
+	require.NoError(t, repo.run("config", "branch.topic.merge", "refs/heads/topic"))
+	require.NoError(t, repo.run("config", "remote.origin.url", "gh:acme/widget.git"))
+	require.NoError(t, repo.run("config", "url.https://github.com/.insteadOf", "gh:"))
+
+	got, err := New(repo.Path).BranchUpstream("topic")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/acme/widget.git", got.RepositoryURL)
+}
+
+func TestBranchUpstreamRejectsMissingUpstream(t *testing.T) {
+	repo := NewTestRepository(t)
+
+	_, err := New(repo.Path).BranchUpstream("topic")
+
+	require.ErrorContains(t, err, "upstream remote")
+}
+
 func TestListWorktreesDoesNotAdoptGenerationFromAnotherRepository(t *testing.T) {
 	repoA := NewTestRepository(t)
 	repoB := NewTestRepository(t)
@@ -1016,6 +1269,117 @@ func TestListWorktreesDoesNotAdoptGenerationFromAnotherRepository(t *testing.T) 
 	_, err = New(repoA.Path).ListWorktrees()
 
 	require.ErrorContains(t, err, "belongs to a different repository")
+}
+
+func TestReadWorktreeGenerationRejectsAnotherWorktreeAdministrativeDirectory(
+	t *testing.T,
+) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "first-worktree")
+	repo.CreateBranch(t, "second-worktree")
+	firstPath := filepath.Join(t.TempDir(), "first-worktree")
+	secondPath := filepath.Join(t.TempDir(), "second-worktree")
+	repo.CreateWorktree(t, firstPath, "first-worktree")
+	repo.CreateWorktree(t, secondPath, "second-worktree")
+	firstGeneration, err := g.WorktreeGeneration(firstPath)
+	require.NoError(t, err)
+	secondGeneration, err := g.WorktreeGeneration(secondPath)
+	require.NoError(t, err)
+	require.NotEqual(t, firstGeneration, secondGeneration)
+	secondAdminDir, err := g.worktreeGitDir(secondPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(firstPath, ".git"),
+		[]byte("gitdir: "+secondAdminDir+"\n"),
+		0o600,
+	))
+
+	generation, err := g.ReadWorktreeGeneration(firstPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, firstGeneration, generation)
+}
+
+func TestWorktreeGitDirRejectsDuplicateAdministrativeBacklinks(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	repo.CreateBranch(t, "duplicate-backlink")
+	worktreePath := filepath.Join(t.TempDir(), "duplicate-backlink")
+	repo.CreateWorktree(t, worktreePath, "duplicate-backlink")
+	_, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	commonDir, err := g.worktreeCommonDir(nil)
+	require.NoError(t, err)
+	duplicateAdminDir := filepath.Join(
+		commonDir,
+		"worktrees",
+		"duplicate-backlink-claim",
+	)
+	require.NoError(t, os.Mkdir(duplicateAdminDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(duplicateAdminDir, "gitdir"),
+		[]byte(filepath.Join(worktreePath, ".git")+"\n"),
+		0o600,
+	))
+
+	_, err = g.worktreeGitDir(worktreePath)
+
+	require.ErrorContains(t, err, "multiple administrative directories")
+}
+
+func TestWorktreeGenerationSupportsSeparateGitDirectory(t *testing.T) {
+	base := t.TempDir()
+	worktreePath := filepath.Join(base, "worktree")
+	separateGitDir := filepath.Join(base, "repository.git")
+	gitOutput(
+		t,
+		base,
+		"init",
+		"--separate-git-dir",
+		separateGitDir,
+		worktreePath,
+	)
+	g := New(worktreePath)
+
+	generation, err := g.WorktreeGeneration(worktreePath)
+
+	require.NoError(t, err)
+	require.NoError(t, ValidateWorktreeGeneration(generation))
+	repeated, err := g.WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	assert.Equal(t, generation, repeated)
+}
+
+func TestWorktreeGenerationRejectsSeparateGitDirectoryDuplicateClaim(
+	t *testing.T,
+) {
+	base := t.TempDir()
+	worktreePath := filepath.Join(base, "worktree")
+	separateGitDir := filepath.Join(base, "repository.git")
+	gitOutput(
+		t,
+		base,
+		"init",
+		"--separate-git-dir",
+		separateGitDir,
+		worktreePath,
+	)
+	duplicateAdminDir := filepath.Join(
+		separateGitDir,
+		"worktrees",
+		"duplicate-main-claim",
+	)
+	require.NoError(t, os.MkdirAll(duplicateAdminDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(duplicateAdminDir, "gitdir"),
+		[]byte(filepath.Join(worktreePath, ".git")+"\n"),
+		0o600,
+	))
+
+	_, err := New(worktreePath).WorktreeGeneration(worktreePath)
+
+	require.ErrorContains(t, err, "multiple Git directory claims")
 }
 
 func TestWorktreeGenerationRecoversFromRelativeAdministrativeGitDir(
@@ -1191,6 +1555,417 @@ func TestRemoveWorktreeRejectsChangedGeneration(t *testing.T) {
 
 	require.ErrorContains(t, err, "generation changed")
 	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveWorktreeCheckedRejectsDirtyWorktree(t *testing.T) {
+	repo, g, worktreePath, conditions := checkedRemovalFixture(t, "dirty")
+	lock := lockWorktreeMutationsForTest(t, repo.Path)
+	result := make(chan error, 1)
+	go func() {
+		result <- g.RemoveWorktreeChecked(worktreePath, false, conditions)
+	}()
+	assertRemovalWaitsForLock(t, result)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "untracked.txt"),
+		[]byte("dirty\n"),
+		0o644,
+	))
+	require.NoError(t, lock.Unlock())
+
+	err := receiveRemovalResult(t, result)
+	var conditionErr *ConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Equal(t, ReasonDirty, conditionErr.Reason)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveWorktreeCheckedRejectsIgnoredUntrackedFileWhenRequested(t *testing.T) {
+	repo, g, worktreePath, conditions := checkedRemovalFixture(t, "ignored")
+	conditions.IncludeIgnored = true
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo.Path, ".git", "info", "exclude"),
+		[]byte("valuable.local\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, "valuable.local"),
+		[]byte("keep me\n"),
+		0o644,
+	))
+
+	err := g.RemoveWorktreeChecked(worktreePath, false, conditions)
+
+	var conditionErr *ConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Equal(t, ReasonDirty, conditionErr.Reason)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveWorktreeCheckedRejectsChangedHead(t *testing.T) {
+	repo, g, worktreePath, conditions := checkedRemovalFixture(t, "head")
+	lock := lockWorktreeMutationsForTest(t, repo.Path)
+	result := make(chan error, 1)
+	go func() {
+		result <- g.RemoveWorktreeChecked(worktreePath, false, conditions)
+	}()
+	assertRemovalWaitsForLock(t, result)
+	commitTestFile(t, worktreePath, "advanced.txt", "advanced\n", "advance head")
+	require.NoError(t, lock.Unlock())
+
+	err := receiveRemovalResult(t, result)
+	var conditionErr *ConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Equal(t, ReasonHeadChanged, conditionErr.Reason)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveWorktreeCheckedRejectsRepositoryIdentityChange(t *testing.T) {
+	_, g, worktreePath, conditions := checkedRemovalFixture(t, "identity")
+	gitOutput(
+		t,
+		worktreePath,
+		"remote",
+		"set-url",
+		"origin",
+		"https://github.com/other/widget.git",
+	)
+
+	err := g.RemoveWorktreeChecked(worktreePath, false, conditions)
+
+	var conditionErr *ConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Equal(t, ReasonRepositoryChanged, conditionErr.Reason)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveWorktreeCheckedRejectsChangedBacklink(t *testing.T) {
+	repo, g, worktreePath, conditions := checkedRemovalFixture(t, "backlink")
+	expectedGitDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	conditions.ExpectedGitDir = expectedGitDir
+	repo.CreateBranch(t, "backlink-sibling")
+	siblingPath := filepath.Join(t.TempDir(), "backlink-sibling")
+	repo.CreateWorktree(t, siblingPath, "backlink-sibling")
+	siblingGitDir, err := g.worktreeGitDir(siblingPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreePath, ".git"),
+		[]byte("gitdir: "+siblingGitDir+"\n"),
+		0o644,
+	))
+
+	err = g.RemoveWorktreeChecked(worktreePath, false, conditions)
+
+	var conditionErr *ConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Equal(t, ReasonBacklinkChanged, conditionErr.Reason)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemoveWorktreeCheckedRejectsChangedBranchAndUpstream(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		wantReason ConditionReason
+		mutate     func(*testing.T, *TestRepository, string, string)
+	}{
+		{
+			name:       "local branch",
+			wantReason: ReasonBranchChanged,
+			mutate: func(t *testing.T, _ *TestRepository, path, _ string) {
+				gitOutput(t, path, "checkout", "-b", "replacement-branch")
+			},
+		},
+		{
+			name:       "upstream repository",
+			wantReason: ReasonUpstreamRepositoryChanged,
+			mutate: func(t *testing.T, _ *TestRepository, path, _ string) {
+				gitOutput(t, path, "remote", "set-url", "source", "https://github.com/hubot/widget.git")
+			},
+		},
+		{
+			name:       "upstream branch",
+			wantReason: ReasonUpstreamBranchChanged,
+			mutate: func(t *testing.T, _ *TestRepository, path, branch string) {
+				gitOutput(t, path, "config", "branch."+branch+".merge", "refs/heads/replacement-topic")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, g, worktreePath, conditions := checkedRemovalFixture(t, "upstream-"+strings.ReplaceAll(tc.name, " ", "-"))
+			branch := "checked-upstream-" + strings.ReplaceAll(tc.name, " ", "-")
+			gitOutput(t, repo.Path, "remote", "add", "source", "https://github.com/octocat/widget.git")
+			gitOutput(t, worktreePath, "config", "branch."+branch+".remote", "source")
+			gitOutput(t, worktreePath, "config", "branch."+branch+".merge", "refs/heads/topic")
+			conditions.Branch = branch
+			conditions.UpstreamRepository = "github.com/octocat/widget"
+			conditions.UpstreamBranch = "topic"
+			tc.mutate(t, repo, worktreePath, branch)
+
+			err := g.RemoveWorktreeChecked(worktreePath, false, conditions)
+
+			var conditionErr *ConditionError
+			require.ErrorAs(t, err, &conditionErr)
+			assert.Equal(t, tc.wantReason, conditionErr.Reason)
+			assert.DirExists(t, worktreePath)
+		})
+	}
+}
+
+func TestRemoveWorktreeCheckedRejectsChangedGeneration(t *testing.T) {
+	_, g, worktreePath, conditions := checkedRemovalFixture(t, "generation")
+	conditions.Generation = strings.Repeat("a", 32)
+
+	err := g.RemoveWorktreeChecked(worktreePath, false, conditions)
+
+	var conditionErr *ConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Equal(t, ReasonGenerationChanged, conditionErr.Reason)
+	assert.DirExists(t, worktreePath)
+}
+
+func checkedRemovalFixture(
+	t *testing.T,
+	suffix string,
+) (*TestRepository, *Git, string, WorktreeRemovalConditions) {
+	t.Helper()
+	repo := NewTestRepository(t)
+	gitOutput(
+		t,
+		repo.Path,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/acme/widget.git",
+	)
+	branch := "checked-" + suffix
+	repo.CreateBranch(t, branch)
+	worktreePath := filepath.Join(t.TempDir(), branch)
+	repo.CreateWorktree(t, worktreePath, branch)
+	g := New(repo.Path)
+	worktrees, err := g.ListWorktrees()
+	require.NoError(t, err)
+	var generation string
+	for _, worktree := range worktrees {
+		if comparableWorktreePath(worktree.Path) == comparableWorktreePath(worktreePath) {
+			generation = worktree.Generation
+			break
+		}
+	}
+	require.NotEmpty(t, generation)
+	expectedGitDir, err := g.worktreeGitDir(worktreePath)
+	require.NoError(t, err)
+	return repo, g, worktreePath, WorktreeRemovalConditions{
+		ExpectedGitDir:     expectedGitDir,
+		Generation:         generation,
+		Head:               gitOutput(t, worktreePath, "rev-parse", "HEAD"),
+		RepositoryIdentity: "github.com/acme/widget",
+		RequireClean:       true,
+	}
+}
+
+func lockWorktreeMutationsForTest(t *testing.T, repositoryPath string) *flock.Flock {
+	t.Helper()
+	lock := flock.New(
+		filepath.Join(repositoryPath, ".git", worktreeMutationLockName),
+		flock.SetPermissions(0o600),
+	)
+	require.NoError(t, lock.Lock())
+	t.Cleanup(func() { _, _ = lock.TryLock(); _ = lock.Unlock() })
+	return lock
+}
+
+func assertRemovalWaitsForLock(t *testing.T, result <-chan error) {
+	t.Helper()
+	select {
+	case err := <-result:
+		t.Fatalf("checked removal completed while mutation lock was held: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func receiveRemovalResult(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("checked removal did not resume after mutation lock release")
+		return nil
+	}
+}
+
+func TestMaintainWorktreesRepairsBeforeImmediatePrune(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "live-linked")
+	livePath := filepath.Join(t.TempDir(), "live-linked")
+	repo.CreateWorktree(t, livePath, "live-linked")
+	repo.CreateBranch(t, "missing-linked")
+	missingPath := filepath.Join(t.TempDir(), "missing-linked")
+	repo.CreateWorktree(t, missingPath, "missing-linked")
+	require.NoError(t, os.RemoveAll(missingPath))
+	movedPath := filepath.Join(t.TempDir(), "moved-main")
+	require.NoError(t, os.Rename(repo.Path, movedPath))
+	g := New(movedPath)
+	before, err := g.InspectWorktrees()
+	require.NoError(t, err)
+	require.Len(t, before, 3)
+	expected := make([]WorktreeStructuralCondition, 0, len(before))
+	for _, inspection := range before {
+		expected = append(expected, WorktreeStructuralCondition{
+			Path:         inspection.Path,
+			GitDir:       inspection.GitDir,
+			DotGitTarget: inspection.DotGitTarget,
+			Generation:   inspection.Generation,
+			Exists:       inspection.Exists,
+		})
+	}
+
+	after, err := g.MaintainWorktrees(WorktreeMaintenanceRequest{
+		Expected:        expected,
+		RepairBacklinks: true,
+		PruneMissing:    true,
+	})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, gitOutput(t, livePath, "status", "--short", "--branch"))
+	for _, inspection := range after {
+		assert.NotEqual(
+			t,
+			comparableWorktreePath(missingPath),
+			comparableWorktreePath(inspection.Path),
+		)
+	}
+}
+
+func TestMaintainWorktreesRepairsOnlyExpectedBacklinks(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "expected-repair")
+	expectedPath := filepath.Join(t.TempDir(), "expected-repair")
+	repo.CreateWorktree(t, expectedPath, "expected-repair")
+	repo.CreateBranch(t, "manual-repair")
+	manualPath := filepath.Join(t.TempDir(), "manual-repair")
+	repo.CreateWorktree(t, manualPath, "manual-repair")
+	movedPath := filepath.Join(t.TempDir(), "moved-main")
+	require.NoError(t, os.Rename(repo.Path, movedPath))
+	g := New(movedPath)
+	before, err := g.InspectWorktrees()
+	require.NoError(t, err)
+	expectedInspection := requireWorktreeInspection(t, before, expectedPath)
+	manualInspection := requireWorktreeInspection(t, before, manualPath)
+	require.NotEqual(t, expectedInspection.GitDir, expectedInspection.DotGitTarget)
+	require.NotEqual(t, manualInspection.GitDir, manualInspection.DotGitTarget)
+
+	_, err = g.MaintainWorktrees(WorktreeMaintenanceRequest{
+		Expected: []WorktreeStructuralCondition{{
+			Path:         expectedInspection.Path,
+			GitDir:       expectedInspection.GitDir,
+			DotGitTarget: expectedInspection.DotGitTarget,
+			Generation:   expectedInspection.Generation,
+			Exists:       expectedInspection.Exists,
+		}},
+		RepairBacklinks: true,
+	})
+
+	require.ErrorContains(t, err, "unexpected repairable worktree")
+	after, inspectErr := g.InspectWorktrees()
+	require.NoError(t, inspectErr)
+	repaired := requireWorktreeInspection(t, after, expectedPath)
+	manual := requireWorktreeInspection(t, after, manualPath)
+	assert.Equal(t, expectedInspection.DotGitTarget, repaired.DotGitTarget)
+	assert.Equal(t, manualInspection.DotGitTarget, manual.DotGitTarget)
+}
+
+func TestMaintainWorktreesRejectsPruneWhenAnyPrunableRecordIsUnexpected(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "expected-missing")
+	expectedPath := filepath.Join(t.TempDir(), "expected-missing")
+	repo.CreateWorktree(t, expectedPath, "expected-missing")
+	repo.CreateBranch(t, "unexpected-missing")
+	unexpectedPath := filepath.Join(t.TempDir(), "unexpected-missing")
+	repo.CreateWorktree(t, unexpectedPath, "unexpected-missing")
+	require.NoError(t, os.RemoveAll(expectedPath))
+	require.NoError(t, os.RemoveAll(unexpectedPath))
+	g := New(repo.Path)
+	before, err := g.InspectWorktrees()
+	require.NoError(t, err)
+	expectedInspection := requireWorktreeInspection(t, before, expectedPath)
+	require.True(t, expectedInspection.Prunable)
+	require.True(t, requireWorktreeInspection(t, before, unexpectedPath).Prunable)
+
+	_, err = g.MaintainWorktrees(WorktreeMaintenanceRequest{
+		Expected: []WorktreeStructuralCondition{{
+			Path:         expectedInspection.Path,
+			GitDir:       expectedInspection.GitDir,
+			DotGitTarget: expectedInspection.DotGitTarget,
+			Generation:   expectedInspection.Generation,
+			Exists:       expectedInspection.Exists,
+		}},
+		PruneMissing: true,
+	})
+
+	require.ErrorContains(t, err, "unexpected prunable worktree")
+	after, inspectErr := g.InspectWorktrees()
+	require.NoError(t, inspectErr)
+	requireWorktreeInspection(t, after, expectedPath)
+	requireWorktreeInspection(t, after, unexpectedPath)
+}
+
+func TestValidatePruneScopeRejectsChangedExpectedRecord(t *testing.T) {
+	expected := WorktreeStructuralCondition{
+		Path: "/worktrees/missing", GitDir: "/repo/.git/worktrees/missing",
+		Generation: "0123456789abcdef0123456789abcdef", Exists: false,
+	}
+	tests := []struct {
+		name   string
+		change func(*WorktreeInspection)
+	}{
+		{
+			name: "git directory changed",
+			change: func(inspection *WorktreeInspection) {
+				inspection.GitDir = "/repo/.git/worktrees/replacement"
+			},
+		},
+		{
+			name: "generation changed",
+			change: func(inspection *WorktreeInspection) {
+				inspection.Generation = "fedcba9876543210fedcba9876543210"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspection := WorktreeInspection{
+				Path: expected.Path, GitDir: expected.GitDir,
+				Generation: expected.Generation, Exists: false, Prunable: true,
+			}
+			tt.change(&inspection)
+
+			err := validatePruneScope(
+				[]WorktreeInspection{inspection},
+				[]WorktreeStructuralCondition{expected},
+			)
+
+			require.ErrorContains(t, err, "structural state changed")
+		})
+	}
+}
+
+func TestMaintainWorktreesRejectsActiveCreationReservation(t *testing.T) {
+	repo := NewTestRepository(t)
+	g := New(repo.Path)
+	reservation, err := g.reserveWorktreeCreation(
+		filepath.Join(t.TempDir(), "creating-worktree"),
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reservation.release()) })
+
+	_, err = g.MaintainWorktrees(WorktreeMaintenanceRequest{
+		RepairBacklinks: true,
+		PruneMissing:    true,
+	})
+
+	require.ErrorContains(t, err, "worktree creation in progress")
 }
 
 func TestRemoveWorktreeCleansDirectoryAfterGitDeregistersWorktree(t *testing.T) {
@@ -2350,6 +3125,66 @@ func TestGetMainRepositoryPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetMainRepositoryPathResolvesSeparateGitDirectoryMain(t *testing.T) {
+	mainPath, _ := newSeparateGitDirectoryRepository(t)
+
+	got, err := New(mainPath).GetMainRepositoryPath()
+
+	require.NoError(t, err)
+	assert.Equal(t, utils.PathKey(mainPath), utils.PathKey(got))
+}
+
+func TestGetMainRepositoryPathRejectsUnresolvedSeparateGitDirectoryLinkedWorktree(
+	t *testing.T,
+) {
+	_, linkedPath := newSeparateGitDirectoryRepository(t)
+
+	_, err := New(linkedPath).GetMainRepositoryPath()
+
+	require.ErrorContains(t, err, "main worktree path")
+}
+
+func TestGetMainRepositoryPathUsesCoreWorktreeForSeparateGitDirectoryLinkedWorktree(
+	t *testing.T,
+) {
+	mainPath, linkedPath := newSeparateGitDirectoryRepository(t)
+	_, err := New(mainPath).RunCommand("config", "core.worktree", mainPath)
+	require.NoError(t, err)
+
+	got, err := New(linkedPath).GetMainRepositoryPath()
+
+	require.NoError(t, err)
+	assert.Equal(t, utils.PathKey(mainPath), utils.PathKey(got))
+}
+
+func TestGetMainRepositoryPathRejectsUnrelatedCoreWorktree(t *testing.T) {
+	mainPath, linkedPath := newSeparateGitDirectoryRepository(t)
+	unrelatedPath := t.TempDir()
+	_, err := New(mainPath).RunCommand(
+		"config",
+		"core.worktree",
+		unrelatedPath,
+	)
+	require.NoError(t, err)
+
+	_, err = New(linkedPath).GetMainRepositoryPath()
+
+	require.ErrorContains(t, err, "configured core.worktree")
+}
+
+func TestInspectWorktreesNormalizesSeparateGitDirectoryMain(t *testing.T) {
+	mainPath, linkedPath := newSeparateGitDirectoryRepository(t)
+
+	inspections, err := New(mainPath).InspectWorktrees()
+
+	require.NoError(t, err)
+	require.Len(t, inspections, 2)
+	mainInspection := requireWorktreeInspection(t, inspections, mainPath)
+	linkedInspection := requireWorktreeInspection(t, inspections, linkedPath)
+	assert.True(t, mainInspection.IsMain)
+	assert.False(t, linkedInspection.IsMain)
 }
 
 func TestListWorktrees_IsMainFromWorktree(t *testing.T) {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -1702,9 +1702,20 @@ func (g *Git) worktreeGitDirWithoutCredentials(
 					gitDirInfo.IsDir() {
 					if utils.PathKey(gitDir) == utils.PathKey(commonDir) {
 						directCommonClaim = true
-					} else if !worktreeAdminDirMatchesPath(gitDir, commonDir, dotGitPath) {
-						pointsOutsideCommon = utils.PathKey(filepath.Dir(gitDir)) !=
-							utils.PathKey(filepath.Join(commonDir, "worktrees"))
+					} else {
+						matchesPath, matchErr := worktreeAdminDirMatchesPath(
+							gitDir, commonDir, dotGitPath,
+						)
+						if matchErr != nil {
+							return "", fmt.Errorf(
+								"resolve worktree Git directory: incomplete administrative inventory: %w",
+								matchErr,
+							)
+						}
+						if !matchesPath {
+							pointsOutsideCommon = utils.PathKey(filepath.Dir(gitDir)) !=
+								utils.PathKey(filepath.Join(commonDir, "worktrees"))
+						}
 					}
 				}
 			}
@@ -1724,10 +1735,22 @@ func (g *Git) worktreeGitDirWithoutCredentials(
 	matches := make([]string, 0, 1)
 	for _, entry := range entries {
 		if !entry.IsDir() {
-			continue
+			return "", fmt.Errorf(
+				"resolve worktree Git directory: incomplete administrative inventory: unexpected entry %s",
+				filepath.Join(commonDir, "worktrees", entry.Name()),
+			)
 		}
 		adminDir := filepath.Join(commonDir, "worktrees", entry.Name())
-		if worktreeAdminDirMatchesPath(adminDir, commonDir, dotGitPath) {
+		matchesPath, matchErr := worktreeAdminDirMatchesPath(
+			adminDir, commonDir, dotGitPath,
+		)
+		if matchErr != nil {
+			return "", fmt.Errorf(
+				"resolve worktree Git directory: incomplete administrative inventory: %w",
+				matchErr,
+			)
+		}
+		if matchesPath {
 			matches = append(matches, adminDir)
 		}
 	}
@@ -1756,22 +1779,31 @@ func worktreeAdminDirMatchesPath(
 	adminDir string,
 	commonDir string,
 	dotGitPath string,
-) bool {
+) (bool, error) {
 	if utils.PathKey(filepath.Dir(adminDir)) !=
 		utils.PathKey(filepath.Join(commonDir, "worktrees")) {
-		return false
+		return false, nil
 	}
-	gitDirFile, err := os.ReadFile(filepath.Join(adminDir, "gitdir"))
+	gitDirPath := filepath.Join(adminDir, "gitdir")
+	gitDirFile, err := os.ReadFile(gitDirPath)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("read administrative backlink %s: %w", gitDirPath, err)
 	}
 	registeredDotGit := strings.TrimSpace(string(gitDirFile))
+	if registeredDotGit == "" {
+		return false, fmt.Errorf("administrative backlink %s is empty", gitDirPath)
+	}
 	if !filepath.IsAbs(registeredDotGit) {
 		registeredDotGit = filepath.Join(adminDir, registeredDotGit)
 	}
-	return filepath.Base(registeredDotGit) == ".git" &&
-		comparableWorktreePath(filepath.Dir(registeredDotGit)) ==
-			comparableWorktreePath(filepath.Dir(dotGitPath))
+	if filepath.Base(registeredDotGit) != ".git" {
+		return false, fmt.Errorf(
+			"administrative backlink %s does not identify a worktree .git file",
+			gitDirPath,
+		)
+	}
+	return comparableWorktreePath(filepath.Dir(registeredDotGit)) ==
+		comparableWorktreePath(filepath.Dir(dotGitPath)), nil
 }
 
 func comparableWorktreePath(path string) string {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -264,6 +264,21 @@ func (g *Git) InspectWorktreesWithoutCredentials(
 	return inspections, err
 }
 
+// HasExactWorktreeRoot reports whether path identifies exactly one worktree in
+// an inspected repository inventory. Git accepts paths below a worktree root,
+// so callers must use this check before treating an arbitrary path as an
+// inventory root.
+func HasExactWorktreeRoot(inspections []WorktreeInspection, path string) bool {
+	matches := 0
+	key := utils.PathKey(path)
+	for _, inspection := range inspections {
+		if utils.PathKey(inspection.Path) == key {
+			matches++
+		}
+	}
+	return matches == 1
+}
+
 func (g *Git) inspectWorktreesLocked(
 	excludedPath string,
 	immediateExpiry bool,

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -1508,10 +1508,18 @@ func (g *Git) requireWorktreeGenerationWithoutCredentials(
 		protectedNames,
 	)
 	if err != nil {
-		return fmt.Errorf("worktree generation changed for %s", path)
+		return fmt.Errorf(
+			"worktree generation changed for %s: %w",
+			path,
+			&ConditionError{Reason: ReasonGenerationChanged, Path: path},
+		)
 	}
 	if generation != expected {
-		return fmt.Errorf("worktree generation changed for %s", path)
+		return fmt.Errorf(
+			"worktree generation changed for %s: %w",
+			path,
+			&ConditionError{Reason: ReasonGenerationChanged, Path: path},
+		)
 	}
 	return nil
 }

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -9,9 +9,11 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gofrs/flock"
 	gitworktree "go.kenn.io/kit/git/worktree"
+	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
@@ -20,6 +22,11 @@ const (
 	worktreeMutationLockName        = "kwt-worktree.lock"
 	worktreeCreationLockName        = "kwt-worktree-create.lock"
 	worktreeCreationReservationName = "kwt-worktree-create.path"
+)
+
+var (
+	inspectWorktreeStat = os.Stat
+	inspectDotGitRead   = os.ReadFile
 )
 
 type worktreeCreationReservation struct {
@@ -56,6 +63,95 @@ func (e *incompleteWorktreeRemovalError) WorktreeRemoved() bool {
 func WorktreeWasRemoved(err error) bool {
 	var removed interface{ WorktreeRemoved() bool }
 	return errors.As(err, &removed) && removed.WorktreeRemoved()
+}
+
+// GenerationStatus describes whether a durable kwt worktree generation was
+// observed without changing repository state.
+type GenerationStatus string
+
+const (
+	GenerationValid      GenerationStatus = "valid"
+	GenerationMissing    GenerationStatus = "missing"
+	GenerationInvalid    GenerationStatus = "invalid"
+	GenerationUnreadable GenerationStatus = "unreadable"
+)
+
+// WorktreeInspection is a read-only snapshot of one Git worktree record.
+type WorktreeInspection struct {
+	Path             string           `json:"path"`
+	Branch           string           `json:"branch"`
+	Head             string           `json:"head"`
+	Generation       string           `json:"generation"`
+	GitDir           string           `json:"git_dir"`
+	DotGitTarget     string           `json:"dot_git_target"`
+	GenerationStatus GenerationStatus `json:"generation_status"`
+	IsMain           bool             `json:"is_main"`
+	Exists           bool             `json:"exists"`
+	Locked           bool             `json:"locked"`
+	Prunable         bool             `json:"prunable"`
+	LockedReason     string           `json:"locked_reason"`
+	PrunableReason   string           `json:"prunable_reason"`
+	GitDirError      string           `json:"git_dir_error"`
+	CreatedAt        time.Time        `json:"created_at"`
+}
+
+// ConditionReason identifies a checked-removal precondition that changed.
+type ConditionReason string
+
+const (
+	ReasonBacklinkChanged           ConditionReason = "backlink_changed"
+	ReasonGenerationChanged         ConditionReason = "generation_changed"
+	ReasonHeadChanged               ConditionReason = "head_changed"
+	ReasonRepositoryChanged         ConditionReason = "repository_identity_changed"
+	ReasonBranchChanged             ConditionReason = "branch_changed"
+	ReasonUpstreamRepositoryChanged ConditionReason = "upstream_repository_changed"
+	ReasonUpstreamBranchChanged     ConditionReason = "upstream_branch_changed"
+	ReasonDirty                     ConditionReason = "dirty_worktree"
+	ReasonLocked                    ConditionReason = "locked_worktree"
+	ReasonMainWorktree              ConditionReason = "main_worktree"
+)
+
+// WorktreeRemovalConditions are re-evaluated inside the worktree mutation
+// lock immediately before removal.
+type WorktreeRemovalConditions struct {
+	ExpectedGitDir     string
+	Generation         string
+	Head               string
+	RepositoryIdentity string
+	Branch             string
+	UpstreamRepository string
+	UpstreamBranch     string
+	RequireClean       bool
+	IncludeIgnored     bool
+	ProtectedNames     []string
+}
+
+// ConditionError reports why a checked worktree removal was preserved.
+type ConditionError struct {
+	Reason ConditionReason
+	Path   string
+}
+
+func (e *ConditionError) Error() string {
+	return fmt.Sprintf("worktree %s for %s", e.Reason, e.Path)
+}
+
+// WorktreeStructuralCondition captures facts that must remain unchanged
+// before a structural repair/prune transaction runs.
+type WorktreeStructuralCondition struct {
+	Path         string
+	GitDir       string
+	DotGitTarget string
+	Generation   string
+	Exists       bool
+}
+
+// WorktreeMaintenanceRequest serializes backlink repair before immediate
+// native pruning for one repository.
+type WorktreeMaintenanceRequest struct {
+	Expected        []WorktreeStructuralCondition
+	RepairBacklinks bool
+	PruneMissing    bool
 }
 
 // IncompleteInventoryError reports a repository whose worktree inventory
@@ -107,69 +203,195 @@ func (g *Git) ListWorktrees() ([]models.Worktree, error) {
 		if !creationActive {
 			reservedPath = ""
 		}
-		worktrees, err = g.listWorktrees(reservedPath)
-		return err
+		inspections, err := g.inspectWorktreesLocked(reservedPath, false, nil)
+		if err != nil {
+			return err
+		}
+		worktrees = make([]models.Worktree, 0, len(inspections))
+		for _, inspection := range inspections {
+			generation, generationErr := g.WorktreeGeneration(inspection.Path)
+			if generationErr != nil {
+				return &IncompleteInventoryError{
+					Path: inspection.Path,
+					Err: fmt.Errorf(
+						"initialize worktree generation: %w",
+						generationErr,
+					),
+				}
+			}
+			worktrees = append(worktrees, models.Worktree{
+				Path:       inspection.Path,
+				Branch:     inspection.Branch,
+				CommitHash: inspection.Head,
+				IsMain:     inspection.IsMain,
+				Prunable:   inspection.Prunable,
+				CreatedAt:  inspection.CreatedAt,
+				Generation: generation,
+			})
+		}
+		return nil
 	})
 	return worktrees, err
 }
 
-func (g *Git) listWorktrees(excludedPath string) ([]models.Worktree, error) {
-	output, err := g.run("worktree", "list", "--porcelain")
+// InspectWorktrees returns repository worktree facts without initializing a
+// missing generation or running Git through a linked worktree path.
+func (g *Git) InspectWorktrees() ([]WorktreeInspection, error) {
+	return g.InspectWorktreesWithoutCredentials(nil)
+}
+
+// InspectWorktreesWithoutCredentials returns repository worktree facts while
+// removing the named credentials from every Git process it starts.
+func (g *Git) InspectWorktreesWithoutCredentials(
+	protectedNames []string,
+) ([]WorktreeInspection, error) {
+	var inspections []WorktreeInspection
+	err := g.withWorktreeMutationLock(protectedNames, func() error {
+		reservedPath, creationActive, err := g.activeWorktreeCreation(protectedNames)
+		if err != nil {
+			return err
+		}
+		if !creationActive {
+			reservedPath = ""
+		}
+		inspections, err = g.inspectWorktreesLocked(
+			reservedPath,
+			true,
+			protectedNames,
+		)
+		return err
+	})
+	return inspections, err
+}
+
+func (g *Git) inspectWorktreesLocked(
+	excludedPath string,
+	immediateExpiry bool,
+	protectedNames []string,
+) ([]WorktreeInspection, error) {
+	args := []string{"worktree", "list", "--porcelain"}
+	if immediateExpiry {
+		args = append(args, "--expire", "now")
+	}
+	output, err := g.runWithoutCredentials(protectedNames, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
 	entries := gitworktree.ParsePorcelain(output)
-	worktrees := make([]models.Worktree, 0, len(entries))
+	inspections := make([]WorktreeInspection, 0, len(entries))
 	excluded := ""
 	if excludedPath != "" {
 		excluded = comparableWorktreePath(excludedPath)
+	}
+	mainDir, mainDirErr := g.getMainRepoRootWithoutCredentials(protectedNames)
+	if mainDirErr != nil {
+		return nil, fmt.Errorf("resolve main worktree path: %w", mainDirErr)
+	}
+	if len(entries) != 0 {
+		entries[0].Path = mainDir
 	}
 	for _, entry := range entries {
 		if excluded != "" && comparableWorktreePath(entry.Path) == excluded {
 			continue
 		}
-		worktree := models.Worktree{
-			Path: entry.Path, Branch: entry.Branch, CommitHash: entry.Head,
-			Prunable: entry.Prunable,
+		branch := entry.Branch
+		if branch == "" {
+			branch = "HEAD"
 		}
-		if worktree.Branch == "" {
-			worktree.Branch = g.getCurrentBranch(worktree.Path)
-		}
-		if info, statErr := os.Stat(worktree.Path); statErr == nil {
-			worktree.CreatedAt = info.ModTime()
-		}
-		generation, generationErr := g.WorktreeGeneration(worktree.Path)
-		if generationErr != nil {
+		dotGitTarget, dotGitErr := readDotGitTarget(entry.Path)
+		if dotGitErr != nil {
 			return nil, &IncompleteInventoryError{
-				Path: worktree.Path,
-				Err: fmt.Errorf(
-					"initialize worktree generation: %w",
-					generationErr,
-				),
+				Path: entry.Path,
+				Err:  fmt.Errorf("inspect worktree backlink: %w", dotGitErr),
 			}
 		}
-		worktree.Generation = generation
-		worktrees = append(worktrees, worktree)
-	}
-
-	if len(worktrees) > 0 {
-		mainDir, err := g.getMainRepoRoot()
-		if err == nil {
-			for i := range worktrees {
-				resolvedPath := worktrees[i].Path
-				if resolved, err := filepath.EvalSymlinks(resolvedPath); err == nil {
-					resolvedPath = resolved
-				}
-				if resolvedPath == mainDir {
-					worktrees[i].IsMain = true
-					break
-				}
+		inspection := WorktreeInspection{
+			Path:             entry.Path,
+			Branch:           branch,
+			Head:             entry.Head,
+			DotGitTarget:     dotGitTarget,
+			Locked:           entry.Locked,
+			LockedReason:     entry.LockedReason,
+			Prunable:         entry.Prunable,
+			PrunableReason:   entry.PrunableReason,
+			GenerationStatus: GenerationUnreadable,
+		}
+		if info, statErr := inspectWorktreeStat(entry.Path); statErr == nil {
+			inspection.Exists = true
+			inspection.CreatedAt = info.ModTime()
+		} else if !os.IsNotExist(statErr) {
+			return nil, &IncompleteInventoryError{
+				Path: entry.Path,
+				Err:  fmt.Errorf("inspect worktree path: %w", statErr),
 			}
 		}
+		if utils.PathKey(entry.Path) == utils.PathKey(mainDir) {
+			inspection.IsMain = true
+		}
+		gitDir, gitDirErr := g.worktreeGitDirWithoutCredentials(
+			entry.Path,
+			protectedNames,
+		)
+		if gitDirErr != nil {
+			inspection.GitDirError = gitDirErr.Error()
+		} else {
+			inspection.GitDir = gitDir
+			inspection.Generation, inspection.GenerationStatus =
+				inspectGenerationFile(gitDir)
+		}
+		inspections = append(inspections, inspection)
 	}
 
-	return worktrees, nil
+	return inspections, nil
+}
+
+func inspectGenerationFile(gitDir string) (string, GenerationStatus) {
+	data, err := os.ReadFile(filepath.Join(gitDir, "kwt-generation"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", GenerationMissing
+		}
+		return "", GenerationUnreadable
+	}
+	generation := strings.TrimSpace(string(data))
+	if ValidateWorktreeGeneration(generation) != nil {
+		return generation, GenerationInvalid
+	}
+	return generation, GenerationValid
+}
+
+// ReadWorktreeBacklink returns the administrative directory claimed directly
+// by path's .git entry without consulting Git or changing repository state.
+func ReadWorktreeBacklink(path string) (string, error) {
+	return readDotGitTarget(path)
+}
+
+func readDotGitTarget(path string) (string, error) {
+	dotGitPath := filepath.Join(path, ".git")
+	info, err := inspectWorktreeStat(dotGitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if info.IsDir() {
+		return filepath.Clean(dotGitPath), nil
+	}
+	data, err := inspectDotGitRead(dotGitPath)
+	if err != nil {
+		return "", err
+	}
+	target := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(target, "gitdir: ") {
+		return "", nil
+	}
+	target = strings.TrimSpace(strings.TrimPrefix(target, "gitdir: "))
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(path, target)
+	}
+	return filepath.Clean(target), nil
 }
 
 // AddWorktree creates a new worktree.
@@ -856,8 +1078,353 @@ func (g *Git) RemoveWorktree(
 				return err
 			}
 		}
-		return g.removeWorktree(path, force, ifGeneration != "")
+		return g.removeWorktree(path, force, ifGeneration != "", nil)
 	})
+}
+
+// RemoveWorktreeChecked removes a live worktree only while all supplied local
+// identity and safety facts still hold inside the mutation lock.
+func (g *Git) RemoveWorktreeChecked(
+	path string,
+	force bool,
+	conditions WorktreeRemovalConditions,
+) error {
+	if ValidateWorktreeGeneration(conditions.Generation) != nil {
+		return &ConditionError{Reason: ReasonGenerationChanged, Path: path}
+	}
+	return g.withWorktreeMutationLock(conditions.ProtectedNames, func() error {
+		if err := g.rejectActiveWorktreeCreation(conditions.ProtectedNames); err != nil {
+			return err
+		}
+		if err := g.validateWorktreeRemovalLocked(path, conditions); err != nil {
+			return err
+		}
+		return g.removeWorktree(path, force, true, conditions.ProtectedNames)
+	})
+}
+
+// RemoveWorktreeCheckedAfterClaim validates under the worktree mutation lock,
+// then lets the caller atomically claim its policy record around the supplied
+// lock-owned removal. Callers must invoke remove synchronously at most once.
+func (g *Git) RemoveWorktreeCheckedAfterClaim(
+	path string,
+	force bool,
+	conditions WorktreeRemovalConditions,
+	claim func(remove func() error) (bool, error),
+) (bool, error) {
+	if ValidateWorktreeGeneration(conditions.Generation) != nil {
+		return false, &ConditionError{Reason: ReasonGenerationChanged, Path: path}
+	}
+	removed := false
+	err := g.withWorktreeMutationLock(conditions.ProtectedNames, func() error {
+		if err := g.rejectActiveWorktreeCreation(conditions.ProtectedNames); err != nil {
+			return err
+		}
+		if err := g.validateWorktreeRemovalLocked(path, conditions); err != nil {
+			return err
+		}
+		var err error
+		removed, err = claim(func() error {
+			return g.removeWorktree(path, force, true, conditions.ProtectedNames)
+		})
+		return err
+	})
+	return removed, err
+}
+
+// ValidateWorktreeRemoval checks the same lock-scoped preconditions as
+// RemoveWorktreeChecked without removing the worktree. It supports truthful
+// dry-run policy output without weakening the real removal path.
+func (g *Git) ValidateWorktreeRemoval(
+	path string,
+	conditions WorktreeRemovalConditions,
+) error {
+	if ValidateWorktreeGeneration(conditions.Generation) != nil {
+		return &ConditionError{Reason: ReasonGenerationChanged, Path: path}
+	}
+	return g.withWorktreeMutationLock(conditions.ProtectedNames, func() error {
+		if err := g.rejectActiveWorktreeCreation(conditions.ProtectedNames); err != nil {
+			return err
+		}
+		return g.validateWorktreeRemovalLocked(path, conditions)
+	})
+}
+
+func (g *Git) validateWorktreeRemovalLocked(
+	path string,
+	conditions WorktreeRemovalConditions,
+) error {
+	if err := g.validateWorktreeRemovalInventoryLocked(
+		path,
+		conditions.ProtectedNames,
+	); err != nil {
+		return err
+	}
+	if conditions.ExpectedGitDir != "" {
+		dotGitTarget, dotGitErr := readDotGitTarget(path)
+		verifiedGitDir, gitDirErr := g.worktreeGitDirWithoutCredentials(
+			path,
+			conditions.ProtectedNames,
+		)
+		if dotGitErr != nil || gitDirErr != nil ||
+			utils.PathKey(dotGitTarget) != utils.PathKey(conditions.ExpectedGitDir) ||
+			utils.PathKey(verifiedGitDir) != utils.PathKey(conditions.ExpectedGitDir) {
+			return &ConditionError{Reason: ReasonBacklinkChanged, Path: path}
+		}
+	}
+	if err := g.requireWorktreeGenerationWithoutCredentials(
+		path,
+		conditions.Generation,
+		conditions.ProtectedNames,
+	); err != nil {
+		return &ConditionError{Reason: ReasonGenerationChanged, Path: path}
+	}
+	if conditions.Head != "" {
+		head, err := g.runWithoutCredentials(
+			conditions.ProtectedNames,
+			"-C", path, "rev-parse", "HEAD",
+		)
+		if err != nil {
+			return fmt.Errorf("inspect worktree HEAD for %s: %w", path, err)
+		}
+		if strings.TrimSpace(head) != conditions.Head {
+			return &ConditionError{Reason: ReasonHeadChanged, Path: path}
+		}
+	}
+	if conditions.RepositoryIdentity != "" {
+		remote, err := g.runWithoutCredentials(
+			conditions.ProtectedNames,
+			"-C", path, "remote", "get-url", "origin",
+		)
+		if err != nil {
+			return &ConditionError{Reason: ReasonRepositoryChanged, Path: path}
+		}
+		identity, ok := repositoryurl.CanonicalRepositoryIdentityFromRemote(
+			strings.TrimSpace(remote),
+		)
+		if !ok || repositoryurl.FoldRepositoryIdentity(identity) !=
+			repositoryurl.FoldRepositoryIdentity(conditions.RepositoryIdentity) {
+			return &ConditionError{Reason: ReasonRepositoryChanged, Path: path}
+		}
+	}
+	currentBranch := ""
+	if conditions.Branch != "" || conditions.UpstreamRepository != "" ||
+		conditions.UpstreamBranch != "" {
+		branch, err := g.runWithoutCredentials(
+			conditions.ProtectedNames,
+			"-C", path, "symbolic-ref", "--quiet", "--short", "HEAD",
+		)
+		if err != nil {
+			return &ConditionError{Reason: ReasonBranchChanged, Path: path}
+		}
+		currentBranch = strings.TrimSpace(branch)
+		if conditions.Branch != "" && currentBranch != conditions.Branch {
+			return &ConditionError{Reason: ReasonBranchChanged, Path: path}
+		}
+	}
+	if conditions.UpstreamRepository != "" || conditions.UpstreamBranch != "" {
+		upstream, err := New(path).BranchUpstreamWithoutCredentials(
+			currentBranch,
+			conditions.ProtectedNames,
+		)
+		if err != nil {
+			return &ConditionError{Reason: ReasonUpstreamRepositoryChanged, Path: path}
+		}
+		if conditions.UpstreamRepository != "" {
+			identity, ok := repositoryurl.CanonicalRepositoryIdentityFromRemote(
+				upstream.RepositoryURL,
+			)
+			if !ok || repositoryurl.FoldRepositoryIdentity(identity) !=
+				repositoryurl.FoldRepositoryIdentity(conditions.UpstreamRepository) {
+				return &ConditionError{Reason: ReasonUpstreamRepositoryChanged, Path: path}
+			}
+		}
+		if conditions.UpstreamBranch != "" && upstream.Branch != conditions.UpstreamBranch {
+			return &ConditionError{Reason: ReasonUpstreamBranchChanged, Path: path}
+		}
+	}
+	if conditions.RequireClean {
+		args := []string{
+			"-C",
+			path,
+			"status",
+			"--porcelain",
+			"--untracked-files=normal",
+		}
+		if conditions.IncludeIgnored {
+			args = append(args, "--ignored")
+		}
+		status, err := g.runWithoutCredentials(conditions.ProtectedNames, args...)
+		if err != nil {
+			return fmt.Errorf("inspect worktree status for %s: %w", path, err)
+		}
+		if strings.TrimSpace(status) != "" {
+			return &ConditionError{Reason: ReasonDirty, Path: path}
+		}
+	}
+	return nil
+}
+
+func (g *Git) validateWorktreeRemovalInventoryLocked(
+	path string,
+	protectedNames []string,
+) error {
+	output, err := g.runWithoutCredentials(
+		protectedNames,
+		"worktree", "list", "--porcelain", "--expire", "now",
+	)
+	if err != nil {
+		return fmt.Errorf("inspect worktree inventory for %s: %w", path, err)
+	}
+	wanted := comparableWorktreePath(path)
+	found := false
+	for _, entry := range gitworktree.ParsePorcelain(output) {
+		if comparableWorktreePath(entry.Path) != wanted {
+			continue
+		}
+		found = true
+		if entry.Locked {
+			return &ConditionError{Reason: ReasonLocked, Path: path}
+		}
+		break
+	}
+	if !found {
+		return &ConditionError{Reason: ReasonGenerationChanged, Path: path}
+	}
+	mainRoot, err := g.getMainRepoRootWithoutCredentials(protectedNames)
+	if err != nil {
+		return fmt.Errorf("inspect main worktree for %s: %w", path, err)
+	}
+	if comparableWorktreePath(mainRoot) == wanted {
+		return &ConditionError{Reason: ReasonMainWorktree, Path: path}
+	}
+	return nil
+}
+
+// MaintainWorktrees revalidates one repository snapshot, repairs backlinks,
+// then prunes confirmed-missing administrative records under one lock.
+func (g *Git) MaintainWorktrees(
+	request WorktreeMaintenanceRequest,
+) ([]WorktreeInspection, error) {
+	var final []WorktreeInspection
+	err := g.withWorktreeMutationLock(nil, func() error {
+		if err := g.rejectActiveWorktreeCreation(nil); err != nil {
+			return err
+		}
+		current, err := g.inspectWorktreesLocked("", true, nil)
+		if err != nil {
+			return err
+		}
+		if err := validateStructuralConditions(current, request.Expected); err != nil {
+			return err
+		}
+		if request.RepairBacklinks {
+			if err := validateRepairScope(current, request.Expected); err != nil {
+				return err
+			}
+			if _, err := g.run("worktree", "repair"); err != nil {
+				return fmt.Errorf("repair worktree backlinks: %w", err)
+			}
+			current, err = g.inspectWorktreesLocked("", true, nil)
+			if err != nil {
+				return fmt.Errorf("inspect repaired worktrees: %w", err)
+			}
+		}
+		if request.PruneMissing {
+			if err := validatePruneScope(current, request.Expected); err != nil {
+				return err
+			}
+			if _, err := g.run("worktree", "prune", "--expire", "now"); err != nil {
+				return fmt.Errorf("prune missing worktrees: %w", err)
+			}
+		}
+		final, err = g.inspectWorktreesLocked("", true, nil)
+		return err
+	})
+	return final, err
+}
+
+func validateRepairScope(
+	current []WorktreeInspection,
+	expected []WorktreeStructuralCondition,
+) error {
+	expectedRepair := make(map[string]bool, len(expected))
+	for _, condition := range expected {
+		if condition.Exists &&
+			comparableWorktreePath(condition.DotGitTarget) !=
+				comparableWorktreePath(condition.GitDir) {
+			expectedRepair[comparableWorktreePath(condition.Path)] = true
+		}
+	}
+	for _, inspection := range current {
+		if inspection.Exists &&
+			comparableWorktreePath(inspection.DotGitTarget) !=
+				comparableWorktreePath(inspection.GitDir) &&
+			!expectedRepair[comparableWorktreePath(inspection.Path)] {
+			return fmt.Errorf(
+				"unexpected repairable worktree %s prevents repository-wide repair",
+				inspection.Path,
+			)
+		}
+	}
+	return nil
+}
+
+func validatePruneScope(
+	current []WorktreeInspection,
+	expected []WorktreeStructuralCondition,
+) error {
+	expectedMissing := make(map[string]WorktreeStructuralCondition, len(expected))
+	for _, condition := range expected {
+		if !condition.Exists {
+			expectedMissing[comparableWorktreePath(condition.Path)] = condition
+		}
+	}
+	for _, inspection := range current {
+		if !inspection.Prunable {
+			continue
+		}
+		condition, expected := expectedMissing[comparableWorktreePath(inspection.Path)]
+		if !expected {
+			return fmt.Errorf(
+				"unexpected prunable worktree %s prevents repository-wide metadata pruning",
+				inspection.Path,
+			)
+		}
+		if utils.PathKey(inspection.GitDir) != utils.PathKey(condition.GitDir) ||
+			filepath.Clean(inspection.DotGitTarget) != filepath.Clean(condition.DotGitTarget) ||
+			inspection.Generation != condition.Generation || inspection.Exists {
+			return fmt.Errorf(
+				"worktree structural state changed for %s before repository-wide metadata pruning",
+				inspection.Path,
+			)
+		}
+	}
+	return nil
+}
+
+func validateStructuralConditions(
+	current []WorktreeInspection,
+	expected []WorktreeStructuralCondition,
+) error {
+	byPath := make(map[string]WorktreeInspection, len(current))
+	for _, inspection := range current {
+		byPath[comparableWorktreePath(inspection.Path)] = inspection
+	}
+	for _, condition := range expected {
+		inspection, ok := byPath[comparableWorktreePath(condition.Path)]
+		if !ok ||
+			utils.PathKey(inspection.GitDir) != utils.PathKey(condition.GitDir) ||
+			filepath.Clean(inspection.DotGitTarget) != filepath.Clean(condition.DotGitTarget) ||
+			inspection.Generation != condition.Generation ||
+			inspection.Exists != condition.Exists {
+			return fmt.Errorf(
+				"worktree structural state changed for %s",
+				condition.Path,
+			)
+		}
+	}
+	return nil
 }
 
 // WithWorktreeGeneration runs operation while the selected worktree still
@@ -878,21 +1445,29 @@ func (g *Git) WithWorktreeGeneration(
 	})
 }
 
-func (g *Git) removeWorktree(path string, force bool, conditional bool) error {
+func (g *Git) removeWorktree(
+	path string,
+	force bool,
+	conditional bool,
+	protectedNames []string,
+) error {
 	canonicalPath := utils.CanonicalPath(path)
 	registryGit := g
-	if mainRoot, err := g.getMainRepoRoot(); err == nil {
+	if mainRoot, err := g.getMainRepoRootWithoutCredentials(protectedNames); err == nil {
 		registryGit = New(mainRoot)
 	}
-	wasRegistered, _ := registryGit.hasRegisteredWorktree(canonicalPath)
+	wasRegistered, _ := registryGit.hasRegisteredWorktree(canonicalPath, protectedNames)
 
 	args := []string{"worktree", "remove"}
 	if force {
 		args = append(args, "--force")
 	}
 	args = append(args, path)
-	if _, err := registryGit.run(args...); err != nil {
-		stillRegistered, listErr := registryGit.hasRegisteredWorktree(canonicalPath)
+	if _, err := registryGit.runWithoutCredentials(protectedNames, args...); err != nil {
+		stillRegistered, listErr := registryGit.hasRegisteredWorktree(
+			canonicalPath,
+			protectedNames,
+		)
 		if wasRegistered && listErr == nil && !stillRegistered {
 			if conditional {
 				return &incompleteWorktreeRemovalError{
@@ -920,7 +1495,18 @@ func (g *Git) removeWorktree(path string, force bool, conditional bool) error {
 }
 
 func (g *Git) requireWorktreeGeneration(path string, expected string) error {
-	generation, err := g.readWorktreeGeneration(path)
+	return g.requireWorktreeGenerationWithoutCredentials(path, expected, nil)
+}
+
+func (g *Git) requireWorktreeGenerationWithoutCredentials(
+	path string,
+	expected string,
+	protectedNames []string,
+) error {
+	generation, err := g.readWorktreeGenerationWithoutCredentials(
+		path,
+		protectedNames,
+	)
 	if err != nil {
 		return fmt.Errorf("worktree generation changed for %s", path)
 	}
@@ -952,6 +1538,12 @@ func (g *Git) initializeWorktreeGenerationValue(
 		return nil
 	})
 	return generation, err
+}
+
+// EnsureWorktreeGeneration returns the selected worktree's durable identity,
+// creating it while repository worktree mutations are excluded when needed.
+func (g *Git) EnsureWorktreeGeneration(path string) (string, error) {
+	return g.initializeWorktreeGenerationValue(path, nil)
 }
 
 // WorktreeGeneration returns a durable identity stored in the worktree's Git
@@ -1007,7 +1599,14 @@ func (g *Git) ReadWorktreeGeneration(path string) (string, error) {
 }
 
 func (g *Git) readWorktreeGeneration(path string) (string, error) {
-	gitDir, err := g.worktreeGitDir(path)
+	return g.readWorktreeGenerationWithoutCredentials(path, nil)
+}
+
+func (g *Git) readWorktreeGenerationWithoutCredentials(
+	path string,
+	protectedNames []string,
+) (string, error) {
+	gitDir, err := g.worktreeGitDirWithoutCredentials(path, protectedNames)
 	if err != nil {
 		return "", err
 	}
@@ -1035,7 +1634,14 @@ func ValidateWorktreeGeneration(generation string) error {
 }
 
 func (g *Git) worktreeGitDir(path string) (string, error) {
-	commonDir, commonDirErr := g.worktreeCommonDir(nil)
+	return g.worktreeGitDirWithoutCredentials(path, nil)
+}
+
+func (g *Git) worktreeGitDirWithoutCredentials(
+	path string,
+	protectedNames []string,
+) (string, error) {
+	commonDir, commonDirErr := g.worktreeCommonDir(protectedNames)
 	if commonDirErr != nil {
 		return "", fmt.Errorf(
 			"resolve worktree Git directory: %w",
@@ -1044,16 +1650,19 @@ func (g *Git) worktreeGitDir(path string) (string, error) {
 	}
 
 	dotGitPath := filepath.Join(path, ".git")
+	directCommonClaim := false
+	pointsOutsideCommon := false
 	info, err := os.Stat(dotGitPath)
 	if err == nil {
 		if info.IsDir() {
 			if utils.PathKey(dotGitPath) == utils.PathKey(commonDir) {
-				return commonDir, nil
+				directCommonClaim = true
+			} else {
+				return "", fmt.Errorf(
+					"resolve worktree Git directory: %s belongs to a different repository",
+					path,
+				)
 			}
-			return "", fmt.Errorf(
-				"resolve worktree Git directory: %s belongs to a different repository",
-				path,
-			)
 		}
 		data, readErr := os.ReadFile(dotGitPath)
 		if readErr == nil {
@@ -1068,50 +1677,78 @@ func (g *Git) worktreeGitDir(path string) (string, error) {
 				gitDir = filepath.Clean(gitDir)
 				if gitDirInfo, statErr := os.Stat(gitDir); statErr == nil &&
 					gitDirInfo.IsDir() {
-					if worktreeGitDirBelongsToCommon(gitDir, commonDir) {
-						return gitDir, nil
+					if utils.PathKey(gitDir) == utils.PathKey(commonDir) {
+						directCommonClaim = true
+					} else if !worktreeAdminDirMatchesPath(gitDir, commonDir, dotGitPath) {
+						pointsOutsideCommon = utils.PathKey(filepath.Dir(gitDir)) !=
+							utils.PathKey(filepath.Join(commonDir, "worktrees"))
 					}
-					return "", fmt.Errorf(
-						"resolve worktree Git directory: %s belongs to a different repository",
-						path,
-					)
 				}
 			}
 		}
 	}
+	if pointsOutsideCommon {
+		return "", fmt.Errorf(
+			"resolve worktree Git directory: %s belongs to a different repository",
+			path,
+		)
+	}
 
 	entries, readDirErr := os.ReadDir(filepath.Join(commonDir, "worktrees"))
-	if readDirErr != nil {
+	if readDirErr != nil && !os.IsNotExist(readDirErr) {
 		return "", fmt.Errorf("resolve worktree Git directory: %w", readDirErr)
 	}
-	canonicalPath := comparableWorktreePath(path)
+	matches := make([]string, 0, 1)
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		adminDir := filepath.Join(commonDir, "worktrees", entry.Name())
-		gitDirFile, readErr := os.ReadFile(filepath.Join(adminDir, "gitdir"))
-		if readErr != nil {
-			continue
+		if worktreeAdminDirMatchesPath(adminDir, commonDir, dotGitPath) {
+			matches = append(matches, adminDir)
 		}
-		registeredDotGit := strings.TrimSpace(string(gitDirFile))
-		if !filepath.IsAbs(registeredDotGit) {
-			registeredDotGit = filepath.Join(adminDir, registeredDotGit)
+	}
+	if directCommonClaim {
+		if len(matches) != 0 {
+			return "", fmt.Errorf(
+				"resolve worktree Git directory: multiple Git directory claims map to %s",
+				path,
+			)
 		}
-		registeredPath := filepath.Dir(registeredDotGit)
-		if comparableWorktreePath(registeredPath) == canonicalPath {
-			return adminDir, nil
-		}
+		return commonDir, nil
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"resolve worktree Git directory: multiple administrative directories map to %s",
+			path,
+		)
 	}
 	return "", fmt.Errorf("resolve worktree Git directory: worktree not found")
 }
 
-func worktreeGitDirBelongsToCommon(gitDir string, commonDir string) bool {
-	if utils.PathKey(gitDir) == utils.PathKey(commonDir) {
-		return true
+func worktreeAdminDirMatchesPath(
+	adminDir string,
+	commonDir string,
+	dotGitPath string,
+) bool {
+	if utils.PathKey(filepath.Dir(adminDir)) !=
+		utils.PathKey(filepath.Join(commonDir, "worktrees")) {
+		return false
 	}
-	return utils.PathKey(filepath.Dir(gitDir)) ==
-		utils.PathKey(filepath.Join(commonDir, "worktrees"))
+	gitDirFile, err := os.ReadFile(filepath.Join(adminDir, "gitdir"))
+	if err != nil {
+		return false
+	}
+	registeredDotGit := strings.TrimSpace(string(gitDirFile))
+	if !filepath.IsAbs(registeredDotGit) {
+		registeredDotGit = filepath.Join(adminDir, registeredDotGit)
+	}
+	return filepath.Base(registeredDotGit) == ".git" &&
+		comparableWorktreePath(filepath.Dir(registeredDotGit)) ==
+			comparableWorktreePath(filepath.Dir(dotGitPath))
 }
 
 func comparableWorktreePath(path string) string {
@@ -1270,8 +1907,14 @@ func (g *Git) withWorktreeMutationLock(
 	return operation()
 }
 
-func (g *Git) hasRegisteredWorktree(canonicalPath string) (bool, error) {
-	output, err := g.run("worktree", "list", "--porcelain")
+func (g *Git) hasRegisteredWorktree(
+	canonicalPath string,
+	protectedNames []string,
+) (bool, error) {
+	output, err := g.runWithoutCredentials(
+		protectedNames,
+		"worktree", "list", "--porcelain",
+	)
 	if err != nil {
 		return false, err
 	}

--- a/internal/git/version.go
+++ b/internal/git/version.go
@@ -1,0 +1,55 @@
+package git
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var gitVersionPattern = regexp.MustCompile(`^git version ([0-9]+)\.([0-9]+)(?:\.([0-9]+))?`)
+
+// RequireVersion verifies that the installed Git is at least major.minor.
+func RequireVersion(major, minor int) error {
+	output, err := New("").RunCommand("version")
+	if err != nil {
+		return fmt.Errorf("determine Git version: %w", err)
+	}
+	return requireVersionOutput(output, major, minor)
+}
+
+func requireVersionOutput(output string, major, minor int) error {
+	trimmed := strings.TrimSpace(output)
+	match := gitVersionPattern.FindStringSubmatch(trimmed)
+	if match == nil {
+		return fmt.Errorf("unexpected Git version output %q", trimmed)
+	}
+
+	installedMajor, err := strconv.Atoi(match[1])
+	if err != nil {
+		return fmt.Errorf("parse Git major version %q: %w", match[1], err)
+	}
+	installedMinor, err := strconv.Atoi(match[2])
+	if err != nil {
+		return fmt.Errorf("parse Git minor version %q: %w", match[2], err)
+	}
+	installedPatch := 0
+	if match[3] != "" {
+		installedPatch, err = strconv.Atoi(match[3])
+		if err != nil {
+			return fmt.Errorf("parse Git patch version %q: %w", match[3], err)
+		}
+	}
+
+	if installedMajor < major || (installedMajor == major && installedMinor < minor) {
+		return fmt.Errorf(
+			"Git %d.%d or newer is required; found Git %d.%d.%d",
+			major,
+			minor,
+			installedMajor,
+			installedMinor,
+			installedPatch,
+		)
+	}
+	return nil
+}

--- a/internal/git/version_test.go
+++ b/internal/git/version_test.go
@@ -1,0 +1,73 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireVersionOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		major      int
+		minor      int
+		wantErr    bool
+		errorParts []string
+	}{
+		{
+			name:   "general minimum",
+			output: "git version 2.20.0\n",
+			major:  2,
+			minor:  20,
+		},
+		{
+			name:       "maintenance version too old",
+			output:     "git version 2.30.2\n",
+			major:      2,
+			minor:      31,
+			wantErr:    true,
+			errorParts: []string{"2.31", "2.30.2"},
+		},
+		{
+			name:   "maintenance minimum",
+			output: "git version 2.31.0\n",
+			major:  2,
+			minor:  31,
+		},
+		{
+			name:   "newer major",
+			output: "git version 3.0.0\n",
+			major:  2,
+			minor:  31,
+		},
+		{
+			name:   "windows suffix",
+			output: "git version 2.55.0.windows.3\n",
+			major:  2,
+			minor:  31,
+		},
+		{
+			name:       "malformed output",
+			output:     "git unknown\n",
+			major:      2,
+			minor:      31,
+			wantErr:    true,
+			errorParts: []string{"unexpected Git version output", "git unknown"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireVersionOutput(tt.output, tt.major, tt.minor)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, part := range tt.errorParts {
+				require.ErrorContains(t, err, part)
+			}
+		})
+	}
+}

--- a/internal/maintenance/fix.go
+++ b/internal/maintenance/fix.go
@@ -1,0 +1,335 @@
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/kwt/internal/config"
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+// RegistryMutator is the narrow registry surface needed after Git maintenance
+// releases its repository lock.
+type RegistryMutator interface {
+	UnregisterIfGeneration(string, string) (bool, error)
+	CompareAndSwap(string, *registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error)
+	CompareAndSwapAliases([]*registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error)
+	AcquireCreation(string) (func() error, bool, error)
+}
+
+// ProjectMutator is the narrow configuration surface used after Git and
+// registry maintenance have released their locks.
+type ProjectMutator interface {
+	CompareAndSwapProject(config.ProjectRegistration, *models.Project) (bool, error)
+}
+
+// Fixer applies only findings whose inspection established unique ownership.
+type Fixer struct {
+	Registry               RegistryMutator
+	RegistryEntries        []*registry.WorktreeEntry
+	MaintainRepository     func(string, gitadapter.WorktreeMaintenanceRequest) ([]gitadapter.WorktreeInspection, error)
+	PathExists             func(string) (bool, error)
+	Projects               ProjectMutator
+	InspectRepository      func(string) (RepositorySnapshot, error)
+	WithWorktreeGeneration func(string, string, func() error) error
+}
+
+// Fix repairs backlinks before native metadata pruning per repository, then
+// conditionally removes unchanged stale registry entries after Git unlocks.
+func (f *Fixer) Fix(ctx context.Context, report Report) error {
+	f.setDefaults()
+	entries := make(map[string]*registry.WorktreeEntry, len(f.RegistryEntries))
+	for _, entry := range f.RegistryEntries {
+		if entry == nil {
+			continue
+		}
+		entries[pathKey(entry.Path)] = entry
+	}
+	for _, repositoryReport := range report.Repositories {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		blocked := make(map[string]bool)
+		structural := make(map[string]FindingCode)
+		var repairBacklinks bool
+		var repairBacklinksBlocked bool
+		var pruneMissing bool
+		var pruneMissingBlocked bool
+		for _, finding := range repositoryReport.Findings {
+			key := pathKey(finding.Path)
+			switch finding.Code {
+			case AmbiguousWorktreeBacklink:
+				blocked[key] = true
+				repairBacklinksBlocked = true
+			case RepositoryIdentityMismatch:
+				blocked[key] = true
+			case BrokenWorktreeBacklink:
+				if finding.Fixable {
+					repairBacklinks = true
+					structural[key] = finding.Code
+				} else {
+					repairBacklinksBlocked = true
+				}
+			case MissingWorktreeDirectory:
+				if finding.Fixable {
+					pruneMissing = true
+					structural[key] = finding.Code
+				} else {
+					pruneMissingBlocked = true
+				}
+			}
+		}
+		if repairBacklinksBlocked {
+			repairBacklinks = false
+			for path, code := range structural {
+				if code == BrokenWorktreeBacklink {
+					delete(structural, path)
+				}
+			}
+		}
+		if pruneMissingBlocked {
+			pruneMissing = false
+			for path, code := range structural {
+				if code == MissingWorktreeDirectory {
+					delete(structural, path)
+				}
+			}
+		}
+		if repairBacklinks || pruneMissing {
+			request := gitadapter.WorktreeMaintenanceRequest{
+				RepairBacklinks: repairBacklinks,
+				PruneMissing:    pruneMissing,
+			}
+			for _, inspection := range repositoryReport.Worktrees {
+				if _, ok := structural[pathKey(inspection.Path)]; !ok {
+					continue
+				}
+				request.Expected = append(request.Expected, gitadapter.WorktreeStructuralCondition{
+					Path:         inspection.Path,
+					GitDir:       inspection.GitDir,
+					DotGitTarget: inspection.DotGitTarget,
+					Generation:   inspection.Generation,
+					Exists:       inspection.Exists,
+				})
+			}
+			if _, err := f.MaintainRepository(repositoryReport.Root, request); err != nil {
+				return fmt.Errorf("maintain worktrees for %s: %w", repositoryReport.Root, err)
+			}
+		}
+
+		for _, finding := range repositoryReport.Findings {
+			condition := finding.RegistryAliasRepair
+			if finding.Code != DuplicateRegistryEntry || !finding.Fixable ||
+				condition == nil || f.Registry == nil {
+				continue
+			}
+			if condition.Retained == nil {
+				confirmedAbsent := true
+				for _, entry := range condition.Expected {
+					if entry == nil {
+						confirmedAbsent = false
+						break
+					}
+					exists, err := f.PathExists(entry.Path)
+					if err != nil {
+						return fmt.Errorf(
+							"recheck stale registry alias path %s: %w",
+							entry.Path,
+							err,
+						)
+					}
+					if exists {
+						confirmedAbsent = false
+						break
+					}
+				}
+				if !confirmedAbsent {
+					continue
+				}
+			}
+			if _, err := f.Registry.CompareAndSwapAliases(
+				condition.Expected,
+				condition.Retained,
+			); err != nil {
+				return fmt.Errorf(
+					"collapse duplicate registry aliases for %s: %w",
+					finding.Path,
+					err,
+				)
+			}
+		}
+
+		inspections := make(map[string]gitadapter.WorktreeInspection, len(repositoryReport.Worktrees))
+		for _, inspection := range repositoryReport.Worktrees {
+			inspections[pathKey(inspection.Path)] = inspection
+		}
+		for _, finding := range repositoryReport.Findings {
+			key := pathKey(finding.Path)
+			if finding.Code != RegistryGenerationMismatch || !finding.Fixable || blocked[key] {
+				continue
+			}
+			entry := entries[key]
+			inspection, ok := inspections[key]
+			if entry == nil || entry.Generation != "" || !ok || f.Registry == nil ||
+				inspection.GenerationStatus != gitadapter.GenerationValid {
+				continue
+			}
+			if err := f.withInactiveCreation(entry, func() error {
+				err := f.WithWorktreeGeneration(entry.Path, inspection.Generation, func() error {
+					exists, err := f.PathExists(entry.Path)
+					if err != nil {
+						return fmt.Errorf("recheck registry generation path %s: %w", entry.Path, err)
+					}
+					if !exists {
+						return nil
+					}
+					replacement := *entry
+					replacement.Generation = inspection.Generation
+					replacement.CreationToken = ""
+					replacement.ExpiresAt = nil
+					if _, err := f.Registry.CompareAndSwap(entry.Path, entry, &replacement); err != nil {
+						return fmt.Errorf("reconcile registry generation for %s: %w", entry.Path, err)
+					}
+					return nil
+				})
+				var conditionErr *gitadapter.ConditionError
+				if errors.As(err, &conditionErr) && conditionErr.Reason == gitadapter.ReasonGenerationChanged {
+					return nil
+				}
+				return err
+			}); err != nil {
+				return err
+			}
+		}
+
+		for _, finding := range repositoryReport.Findings {
+			if finding.Code != StaleRegistryEntry || !finding.Fixable ||
+				blocked[pathKey(finding.Path)] {
+				continue
+			}
+			entry := entries[pathKey(finding.Path)]
+			if entry == nil || f.Registry == nil {
+				continue
+			}
+			if err := f.withInactiveCreation(entry, func() error {
+				exists, err := f.PathExists(entry.Path)
+				if err != nil {
+					return fmt.Errorf("recheck stale registry path %s: %w", entry.Path, err)
+				}
+				if exists {
+					return nil
+				}
+				if entry.CreationToken == "" && gitadapter.ValidateWorktreeGeneration(entry.Generation) == nil {
+					if _, err := f.Registry.UnregisterIfGeneration(entry.Path, entry.Generation); err != nil {
+						return fmt.Errorf("unregister stale worktree %s: %w", entry.Path, err)
+					}
+					return nil
+				}
+				if _, err := f.Registry.CompareAndSwap(entry.Path, entry, nil); err != nil {
+					return fmt.Errorf("remove stale legacy registry entry %s: %w", entry.Path, err)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	if f.Projects == nil {
+		return nil
+	}
+	for _, repositoryReport := range report.Repositories {
+		for _, finding := range repositoryReport.Findings {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			condition := finding.ProjectRepair
+			if !finding.Fixable || condition == nil {
+				continue
+			}
+			exists, err := f.PathExists(finding.Path)
+			if err != nil {
+				return fmt.Errorf("recheck configured project path %s: %w", finding.Path, err)
+			}
+			if exists {
+				continue
+			}
+
+			switch condition.Action {
+			case RemoveProject:
+				if _, err := f.Projects.CompareAndSwapProject(condition.Expected, nil); err != nil {
+					return fmt.Errorf("remove stale project registration %s: %w", finding.Path, err)
+				}
+			case RelocateProject:
+				target, err := f.InspectRepository(condition.TargetRoot)
+				if err != nil {
+					return fmt.Errorf("recheck project relocation target %s: %w", condition.TargetRoot, err)
+				}
+				targetIdentity, identityOK := repairableProjectIdentity(target.RepositoryIdentity)
+				if pathKey(target.Root) != pathKey(condition.TargetRoot) ||
+					pathKey(target.CommonDir) != pathKey(condition.TargetCommonDir) ||
+					!identityOK || !repositoryIdentityMatchesAny(targetIdentity, condition.TargetRepository) {
+					continue
+				}
+				replacement := condition.Expected.Persisted
+				replacement.Path = condition.TargetRoot
+				replacement.Repository = condition.TargetRepository
+				if _, err := f.Projects.CompareAndSwapProject(condition.Expected, &replacement); err != nil {
+					return fmt.Errorf("relocate project registration %s: %w", finding.Path, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (f *Fixer) withInactiveCreation(
+	entry *registry.WorktreeEntry,
+	change func() error,
+) error {
+	if entry.CreationToken == "" {
+		return change()
+	}
+	release, acquired, err := f.Registry.AcquireCreation(entry.Path)
+	if err != nil {
+		return fmt.Errorf("inspect registry creation ownership for %s: %w", entry.Path, err)
+	}
+	if !acquired {
+		return nil
+	}
+	changeErr := change()
+	releaseErr := release()
+	if changeErr != nil {
+		return changeErr
+	}
+	if releaseErr != nil {
+		return fmt.Errorf("release registry creation ownership for %s: %w", entry.Path, releaseErr)
+	}
+	return nil
+}
+
+func (f *Fixer) setDefaults() {
+	if f.MaintainRepository == nil {
+		f.MaintainRepository = func(
+			root string,
+			request gitadapter.WorktreeMaintenanceRequest,
+		) ([]gitadapter.WorktreeInspection, error) {
+			return gitadapter.New(root).MaintainWorktrees(request)
+		}
+	}
+	if f.PathExists == nil {
+		f.PathExists = pathExists
+	}
+	if f.InspectRepository == nil {
+		inspector := &Inspector{Config: &models.Config{}}
+		inspector.setDefaults()
+		f.InspectRepository = inspector.inspectRepository
+	}
+	if f.WithWorktreeGeneration == nil {
+		f.WithWorktreeGeneration = func(path, expected string, operation func() error) error {
+			return gitadapter.New(path).WithWorktreeGeneration(path, expected, operation)
+		}
+	}
+}

--- a/internal/maintenance/fix_test.go
+++ b/internal/maintenance/fix_test.go
@@ -506,6 +506,55 @@ func TestFixerDoesNotAdoptGenerationAfterWorktreeReplacement(t *testing.T) {
 	assert.False(t, swapped)
 }
 
+func TestFixerIgnoresGenerationChangeFromRealGitAdapter(t *testing.T) {
+	const (
+		inspectedGeneration   = "0123456789abcdef0123456789abcdef"
+		replacementGeneration = "fedcba9876543210fedcba9876543210"
+	)
+	repositoryPath := newMaintenanceTestRepository(t)
+	worktreePath := filepath.Join(t.TempDir(), "replacement")
+	g := gitadapter.New(repositoryPath)
+	_, err := g.RunCommand("branch", "replacement")
+	require.NoError(t, err)
+	_, err = g.RunCommand("worktree", "add", worktreePath, "replacement")
+	require.NoError(t, err)
+	gitDir, err := gitadapter.ReadWorktreeBacklink(worktreePath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(gitDir, "kwt-generation"),
+		[]byte(replacementGeneration+"\n"),
+		0o600,
+	))
+	entry := &registry.WorktreeEntry{Path: worktreePath}
+	report := Report{Repositories: []RepositoryReport{{
+		Worktrees: []gitadapter.WorktreeInspection{{
+			Path: worktreePath, Exists: true, Generation: inspectedGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}},
+		Findings: []Finding{{
+			Code: RegistryGenerationMismatch, Path: worktreePath, Fixable: true,
+		}},
+	}}}
+	var swapped bool
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{compareAndSwap: func(
+			string,
+			*registry.WorktreeEntry,
+			*registry.WorktreeEntry,
+		) (bool, error) {
+			swapped = true
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{entry},
+		PathExists:      func(string) (bool, error) { return true, nil },
+	}
+
+	err = fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.False(t, swapped)
+}
+
 func TestFixerAdoptsGenerationThroughSymlinkedRegistryPath(t *testing.T) {
 	gitGeneration := "0123456789abcdef0123456789abcdef"
 	realParent := t.TempDir()

--- a/internal/maintenance/fix_test.go
+++ b/internal/maintenance/fix_test.go
@@ -1,0 +1,765 @@
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/config"
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestFixerRepairsBeforePruningAndRegistryCleanup(t *testing.T) {
+	generation := "0123456789abcdef0123456789abcdef"
+	entry := &registry.WorktreeEntry{
+		Path: "/worktrees/missing", Repository: "github.com/acme/widget",
+		Generation: generation,
+	}
+	var calls []string
+	store := &fakeRegistryMutator{
+		unregister: func(path, gotGeneration string) (bool, error) {
+			calls = append(calls, "unregister")
+			assert.Equal(t, entry.Path, path)
+			assert.Equal(t, generation, gotGeneration)
+			return true, nil
+		},
+	}
+	fixer := &Fixer{
+		Registry:        store,
+		RegistryEntries: []*registry.WorktreeEntry{entry},
+		MaintainRepository: func(root string, request gitadapter.WorktreeMaintenanceRequest) ([]gitadapter.WorktreeInspection, error) {
+			calls = append(calls, "maintain")
+			assert.Equal(t, "/repos/widget", root)
+			assert.True(t, request.RepairBacklinks)
+			assert.True(t, request.PruneMissing)
+			require.Len(t, request.Expected, 2)
+			return nil, nil
+		},
+		PathExists: func(string) (bool, error) { return false, nil },
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Root: "/repos/widget",
+		Worktrees: []gitadapter.WorktreeInspection{
+			{Path: "/worktrees/broken", GitDir: "/repos/widget/.git/worktrees/broken", DotGitTarget: "/old/widget/.git/worktrees/broken", Exists: true},
+			{Path: "/worktrees/missing", GitDir: "/repos/widget/.git/worktrees/missing", Generation: generation, Exists: false},
+		},
+		Findings: []Finding{
+			{Code: BrokenWorktreeBacklink, Path: "/worktrees/broken", Fixable: true},
+			{Code: MissingWorktreeDirectory, Path: "/worktrees/missing", Fixable: true},
+			{Code: StaleRegistryEntry, Path: "/worktrees/missing", Fixable: true},
+		},
+	}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"maintain", "unregister"}, calls)
+}
+
+func TestFixerSkipsRepositoryPruneWhenAnyMissingRecordIsNotFixable(t *testing.T) {
+	var mutationCalls int
+	fixer := &Fixer{
+		MaintainRepository: func(string, gitadapter.WorktreeMaintenanceRequest) ([]gitadapter.WorktreeInspection, error) {
+			mutationCalls++
+			return nil, nil
+		},
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Root: "/repos/widget",
+		Worktrees: []gitadapter.WorktreeInspection{
+			{Path: "/worktrees/fixable", Exists: false, Prunable: true},
+			{Path: "/worktrees/ambiguous", Exists: false, Prunable: true},
+		},
+		Findings: []Finding{
+			{Code: MissingWorktreeDirectory, Path: "/worktrees/fixable", Fixable: true},
+			{Code: AmbiguousWorktreeBacklink, Path: "/worktrees/ambiguous", Fixable: false},
+			{Code: MissingWorktreeDirectory, Path: "/worktrees/ambiguous", Fixable: false},
+		},
+	}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Zero(t, mutationCalls)
+}
+
+func TestFixerSkipsBacklinkRepairButContinuesOtherSafeCleanup(t *testing.T) {
+	generation := "0123456789abcdef0123456789abcdef"
+	entry := &registry.WorktreeEntry{
+		Path: "/worktrees/stale", Generation: generation,
+	}
+	var calls []string
+	fixer := &Fixer{
+		Registry:        &fakeRegistryMutator{unregister: func(string, string) (bool, error) { calls = append(calls, "unregister"); return true, nil }},
+		RegistryEntries: []*registry.WorktreeEntry{entry},
+		MaintainRepository: func(_ string, request gitadapter.WorktreeMaintenanceRequest) ([]gitadapter.WorktreeInspection, error) {
+			if request.RepairBacklinks {
+				return nil, errors.New("unexpected partial backlink repair")
+			}
+			calls = append(calls, "prune")
+			require.True(t, request.PruneMissing)
+			require.Len(t, request.Expected, 1)
+			assert.Equal(t, "/worktrees/missing", request.Expected[0].Path)
+			return nil, nil
+		},
+		PathExists: func(string) (bool, error) { return false, nil },
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Root: "/repos/widget",
+		Worktrees: []gitadapter.WorktreeInspection{
+			{Path: "/worktrees/fixable-backlink", Exists: true},
+			{Path: "/worktrees/ambiguous-backlink", Exists: true},
+			{Path: "/worktrees/missing", Generation: generation, Exists: false},
+		},
+		Findings: []Finding{
+			{Code: BrokenWorktreeBacklink, Path: "/worktrees/fixable-backlink", Fixable: true},
+			{Code: AmbiguousWorktreeBacklink, Path: "/worktrees/ambiguous-backlink", Fixable: false},
+			{Code: MissingWorktreeDirectory, Path: "/worktrees/missing", Fixable: true},
+			{Code: StaleRegistryEntry, Path: entry.Path, Fixable: true},
+		},
+	}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prune", "unregister"}, calls)
+}
+
+func TestFixerDeletesGenerationlessStaleRegistryEntryByFullEntryCAS(t *testing.T) {
+	observed := &registry.WorktreeEntry{
+		Path: "/worktrees/legacy", Repository: "github.com/acme/widget", Branch: "legacy",
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{{
+		Code: StaleRegistryEntry, Path: observed.Path, Fixable: true,
+	}}}}}
+
+	t.Run("unchanged entry", func(t *testing.T) {
+		var removed bool
+		fixer := &Fixer{
+			Registry: &fakeRegistryMutator{compareAndSwap: func(path string, expected, replacement *registry.WorktreeEntry) (bool, error) {
+				assert.Equal(t, observed.Path, path)
+				assert.Equal(t, observed, expected)
+				assert.Nil(t, replacement)
+				removed = true
+				return true, nil
+			}},
+			RegistryEntries: []*registry.WorktreeEntry{observed},
+			PathExists:      func(string) (bool, error) { return false, nil },
+		}
+
+		err := fixer.Fix(context.Background(), report)
+
+		require.NoError(t, err)
+		assert.True(t, removed)
+	})
+
+	t.Run("concurrent replacement", func(t *testing.T) {
+		replacement := *observed
+		replacement.Branch = "replacement"
+		current := &replacement
+		fixer := &Fixer{
+			Registry: &fakeRegistryMutator{compareAndSwap: func(_ string, expected, _ *registry.WorktreeEntry) (bool, error) {
+				assert.Equal(t, observed, expected)
+				return false, nil
+			}},
+			RegistryEntries: []*registry.WorktreeEntry{observed},
+			PathExists:      func(string) (bool, error) { return false, nil },
+		}
+
+		err := fixer.Fix(context.Background(), report)
+
+		require.NoError(t, err)
+		assert.Equal(t, "replacement", current.Branch)
+	})
+
+	t.Run("active creation", func(t *testing.T) {
+		creating := *observed
+		creating.CreationToken = "creation-owner"
+		var compared bool
+		fixer := &Fixer{
+			Registry: &fakeRegistryMutator{
+				acquireCreation: func(string) (func() error, bool, error) {
+					return nil, false, nil
+				},
+				compareAndSwap: func(string, *registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error) {
+					compared = true
+					return true, nil
+				},
+			},
+			RegistryEntries: []*registry.WorktreeEntry{&creating},
+			PathExists:      func(string) (bool, error) { return false, nil },
+		}
+
+		err := fixer.Fix(context.Background(), report)
+
+		require.NoError(t, err)
+		assert.False(t, compared)
+	})
+}
+
+func TestFixerCleansAbandonedCreationUnderPathLock(t *testing.T) {
+	entry := &registry.WorktreeEntry{
+		Path: "/worktrees/abandoned", Branch: "topic", CreationToken: "abandoned",
+	}
+	var calls []string
+	store := &fakeRegistryMutator{
+		acquireCreation: func(path string) (func() error, bool, error) {
+			assert.Equal(t, entry.Path, path)
+			calls = append(calls, "lock")
+			return func() error { calls = append(calls, "unlock"); return nil }, true, nil
+		},
+		compareAndSwap: func(path string, expected, replacement *registry.WorktreeEntry) (bool, error) {
+			calls = append(calls, "remove")
+			assert.Equal(t, entry.Path, path)
+			assert.Equal(t, entry, expected)
+			assert.Nil(t, replacement)
+			return true, nil
+		},
+	}
+	fixer := &Fixer{
+		Registry: store, RegistryEntries: []*registry.WorktreeEntry{entry},
+		PathExists: func(string) (bool, error) { return false, nil },
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{{
+		Code: StaleRegistryEntry, Path: entry.Path, Fixable: true,
+	}}}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"lock", "remove", "unlock"}, calls)
+}
+
+func TestFixerPreservesNonemptyRegistryGenerationMismatch(t *testing.T) {
+	gitGeneration := "0123456789abcdef0123456789abcdef"
+	observed := &registry.WorktreeEntry{
+		Path:       "/worktrees/topic",
+		Repository: "github.com/acme/widget",
+		Branch:     "topic",
+		Generation: "fedcba9876543210fedcba9876543210",
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Worktrees: []gitadapter.WorktreeInspection{{
+			Path:             observed.Path,
+			Exists:           true,
+			Generation:       gitGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}},
+		Findings: []Finding{{
+			Code: RegistryGenerationMismatch, Path: observed.Path, Fixable: true,
+		}},
+	}}}
+	var swapped bool
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{compareAndSwap: func(string, *registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error) {
+			swapped = true
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{observed},
+		PathExists:      func(string) (bool, error) { return true, nil },
+		WithWorktreeGeneration: func(_ string, _ string, operation func() error) error {
+			return operation()
+		},
+	}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.False(t, swapped)
+}
+
+func TestFixerCollapsesOnlyCompleteEquivalentRegistryAliasGroup(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	worktreePath := t.TempDir()
+	aliasPath := filepath.Dir(worktreePath) + string(os.PathSeparator) + "." +
+		string(os.PathSeparator) + filepath.Base(worktreePath)
+	first := &registry.WorktreeEntry{
+		Path: worktreePath, Repository: "github.com/acme/widget",
+		Branch: "feature/topic", Generation: generation,
+	}
+	second := *first
+	second.Path = aliasPath
+	stale := &registry.WorktreeEntry{
+		Path: filepath.Join(t.TempDir(), "stale"), Generation: generation,
+	}
+	aliasCalls := 0
+	staleCalls := 0
+	mutator := &fakeRegistryMutator{
+		compareAliases: func(
+			expected []*registry.WorktreeEntry,
+			retained *registry.WorktreeEntry,
+		) (bool, error) {
+			aliasCalls++
+			assert.Equal(t, []*registry.WorktreeEntry{first, &second}, expected)
+			assert.Equal(t, first, retained)
+			return true, nil
+		},
+		unregister: func(path, gotGeneration string) (bool, error) {
+			staleCalls++
+			assert.Equal(t, stale.Path, path)
+			assert.Equal(t, stale.Generation, gotGeneration)
+			return true, nil
+		},
+	}
+	condition := &RegistryAliasRepairCondition{
+		Expected: []*registry.WorktreeEntry{first, &second},
+		Retained: first,
+	}
+	fixer := &Fixer{
+		Registry:        mutator,
+		RegistryEntries: []*registry.WorktreeEntry{first, &second, stale},
+		PathExists: func(path string) (bool, error) {
+			return path != stale.Path, nil
+		},
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{
+		{
+			Code: DuplicateRegistryEntry, Path: first.Path, Fixable: true,
+			RegistryAliasRepair: condition,
+		},
+		{Code: StaleRegistryEntry, Path: stale.Path, Fixable: true},
+		{
+			Code: DuplicateRegistryEntry, Path: "/manual", Fixable: false,
+			RegistryAliasRepair: condition,
+		},
+	}}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, aliasCalls)
+	assert.Equal(t, 1, staleCalls)
+}
+
+func TestFixerRemovesCompleteMissingRegistryAliasGroup(t *testing.T) {
+	realParent := t.TempDir()
+	worktreePath := filepath.Join(realParent, "missing-worktree")
+	aliasPath := realParent + string(os.PathSeparator) + "." +
+		string(os.PathSeparator) + "missing-worktree"
+	first := &registry.WorktreeEntry{
+		Path: worktreePath, Repository: "github.com/acme/widget",
+		Branch: "feature/topic",
+	}
+	second := *first
+	second.Path = aliasPath
+	aliasCalls := 0
+	singleEntryCalls := 0
+	mutator := &fakeRegistryMutator{
+		compareAliases: func(
+			expected []*registry.WorktreeEntry,
+			retained *registry.WorktreeEntry,
+		) (bool, error) {
+			aliasCalls++
+			assert.Equal(t, []*registry.WorktreeEntry{first, &second}, expected)
+			assert.Nil(t, retained)
+			return true, nil
+		},
+		compareAndSwap: func(
+			string,
+			*registry.WorktreeEntry,
+			*registry.WorktreeEntry,
+		) (bool, error) {
+			singleEntryCalls++
+			return true, nil
+		},
+		unregister: func(string, string) (bool, error) {
+			singleEntryCalls++
+			return true, nil
+		},
+	}
+	condition := &RegistryAliasRepairCondition{
+		Expected: []*registry.WorktreeEntry{first, &second},
+	}
+	fixer := &Fixer{
+		Registry:        mutator,
+		RegistryEntries: []*registry.WorktreeEntry{first, &second},
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{{
+		Code: DuplicateRegistryEntry, Path: first.Path, Fixable: true,
+		RegistryAliasRepair: condition,
+	}}}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, aliasCalls)
+	assert.Zero(t, singleEntryCalls)
+}
+
+func TestFixerPreservesMissingRegistryAliasGroupWhenPathReappears(t *testing.T) {
+	first := &registry.WorktreeEntry{
+		Path: "/worktrees/reused", Repository: "github.com/acme/widget",
+		Branch: "feature/topic",
+	}
+	second := *first
+	second.Path = "/worktrees/./reused"
+	aliasCalls := 0
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{compareAliases: func(
+			[]*registry.WorktreeEntry,
+			*registry.WorktreeEntry,
+		) (bool, error) {
+			aliasCalls++
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{first, &second},
+		PathExists: func(string) (bool, error) {
+			return true, nil
+		},
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{{
+		Code: DuplicateRegistryEntry, Path: first.Path, Fixable: true,
+		RegistryAliasRepair: &RegistryAliasRepairCondition{
+			Expected: []*registry.WorktreeEntry{first, &second},
+		},
+	}}}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Zero(t, aliasCalls)
+}
+
+func TestFixerAdoptsGenerationlessRegistryEntryWithoutExpiration(t *testing.T) {
+	gitGeneration := "0123456789abcdef0123456789abcdef"
+	expiresAt := time.Now().Add(-time.Hour)
+	observed := &registry.WorktreeEntry{
+		Path:       "/worktrees/legacy",
+		Repository: "github.com/acme/widget",
+		Branch:     "legacy",
+		Generation: "",
+		ExpiresAt:  &expiresAt,
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Worktrees: []gitadapter.WorktreeInspection{{
+			Path:             observed.Path,
+			Exists:           true,
+			Generation:       gitGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}},
+		Findings: []Finding{{
+			Code: RegistryGenerationMismatch, Path: observed.Path, Fixable: true,
+		}},
+	}}}
+	var swapped bool
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{compareAndSwap: func(path string, expected, replacement *registry.WorktreeEntry) (bool, error) {
+			assert.Equal(t, observed.Path, path)
+			assert.Equal(t, observed, expected)
+			require.NotNil(t, replacement)
+			assert.Equal(t, gitGeneration, replacement.Generation)
+			assert.Nil(t, replacement.ExpiresAt)
+			assert.Equal(t, observed.Branch, replacement.Branch)
+			swapped = true
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{observed},
+		PathExists:      func(string) (bool, error) { return true, nil },
+		WithWorktreeGeneration: func(_ string, _ string, operation func() error) error {
+			return operation()
+		},
+	}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.True(t, swapped)
+}
+
+func TestFixerDoesNotAdoptGenerationAfterWorktreeReplacement(t *testing.T) {
+	inspectedGeneration := "0123456789abcdef0123456789abcdef"
+	entry := &registry.WorktreeEntry{Path: "/worktrees/replaced"}
+	report := Report{Repositories: []RepositoryReport{{
+		Worktrees: []gitadapter.WorktreeInspection{{
+			Path: entry.Path, Exists: true, Generation: inspectedGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}},
+		Findings: []Finding{{
+			Code: RegistryGenerationMismatch, Path: entry.Path, Fixable: true,
+		}},
+	}}}
+	var swapped bool
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{compareAndSwap: func(string, *registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error) {
+			swapped = true
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{entry},
+		PathExists:      func(string) (bool, error) { return true, nil },
+		WithWorktreeGeneration: func(path, expected string, operation func() error) error {
+			assert.Equal(t, entry.Path, path)
+			assert.Equal(t, inspectedGeneration, expected)
+			return &gitadapter.ConditionError{Reason: gitadapter.ReasonGenerationChanged, Path: path}
+		},
+	}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.False(t, swapped)
+}
+
+func TestFixerAdoptsGenerationThroughSymlinkedRegistryPath(t *testing.T) {
+	gitGeneration := "0123456789abcdef0123456789abcdef"
+	realParent := t.TempDir()
+	realPath := filepath.Join(realParent, "workspace")
+	require.NoError(t, os.Mkdir(realPath, 0o755))
+	aliasParent := filepath.Join(t.TempDir(), "worktrees-link")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	entry := &registry.WorktreeEntry{
+		Path: filepath.Join(aliasParent, "workspace"), Branch: "topic",
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Worktrees: []gitadapter.WorktreeInspection{{
+			Path:             realPath,
+			Exists:           true,
+			Generation:       gitGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}},
+		Findings: []Finding{{
+			Code: RegistryGenerationMismatch, Path: entry.Path, Fixable: true,
+		}},
+	}}}
+	var swapped bool
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{compareAndSwap: func(path string, expected, replacement *registry.WorktreeEntry) (bool, error) {
+			assert.Equal(t, entry.Path, path)
+			assert.Equal(t, entry, expected)
+			require.NotNil(t, replacement)
+			assert.Equal(t, gitGeneration, replacement.Generation)
+			swapped = true
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{entry},
+		PathExists:      func(string) (bool, error) { return true, nil },
+		WithWorktreeGeneration: func(_ string, _ string, operation func() error) error {
+			return operation()
+		},
+	}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.True(t, swapped)
+}
+
+func TestFixerPreservesAmbiguousFinding(t *testing.T) {
+	var mutationCalls int
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{},
+		MaintainRepository: func(string, gitadapter.WorktreeMaintenanceRequest) ([]gitadapter.WorktreeInspection, error) {
+			mutationCalls++
+			return nil, nil
+		},
+		PathExists: func(string) (bool, error) {
+			mutationCalls++
+			return false, nil
+		},
+	}
+	report := Report{Repositories: []RepositoryReport{{
+		Root: "/repos/widget",
+		Findings: []Finding{{
+			Code: AmbiguousWorktreeBacklink, Path: "/worktrees/topic", Fixable: false,
+		}},
+	}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Zero(t, mutationCalls)
+}
+
+func TestFixerRepairsProjectAfterRegistryCleanup(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	expected := models.Project{
+		Repository: "https://github.com/acme/widget.git", Name: "Widget",
+		Path: "~/old/widget", LastTouched: "2026-08-01T12:00:00Z",
+	}
+	entry := &registry.WorktreeEntry{Path: "/worktrees/stale", Generation: generation}
+	condition := &ProjectRepairCondition{
+		Action: RelocateProject, Expected: config.ProjectRegistration{Persisted: expected},
+		TargetRoot: "/repos/widget", TargetCommonDir: "/repos/widget/.git",
+		TargetRepository: "github.com/acme/widget",
+	}
+	var calls []string
+	fixer := &Fixer{
+		Registry: &fakeRegistryMutator{unregister: func(string, string) (bool, error) {
+			calls = append(calls, "registry")
+			return true, nil
+		}},
+		RegistryEntries: []*registry.WorktreeEntry{entry},
+		Projects: &fakeProjectMutator{compareAndSwap: func(got config.ProjectRegistration, replacement *models.Project) (bool, error) {
+			calls = append(calls, "project")
+			assert.Equal(t, expected, got.Persisted)
+			require.NotNil(t, replacement)
+			assert.Equal(t, models.Project{
+				Repository: "github.com/acme/widget", Name: "Widget",
+				Path: "/repos/widget", LastTouched: "2026-08-01T12:00:00Z",
+			}, *replacement)
+			return true, nil
+		}},
+		InspectRepository: func(path string) (RepositorySnapshot, error) {
+			calls = append(calls, "inspect")
+			assert.Equal(t, condition.TargetRoot, path)
+			return RepositorySnapshot{
+				Root: condition.TargetRoot, CommonDir: condition.TargetCommonDir,
+				RepositoryIdentity: condition.TargetRepository,
+			}, nil
+		},
+		PathExists: func(path string) (bool, error) {
+			return path != entry.Path && path != "/old/widget", nil
+		},
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{
+		{Code: StaleRegistryEntry, Path: entry.Path, Fixable: true},
+		{Code: ProjectPathMoved, Path: "/old/widget", Fixable: true, ProjectRepair: condition},
+	}}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"registry", "inspect", "project"}, calls)
+}
+
+func TestFixerRevalidatesProjectRepair(t *testing.T) {
+	base := ProjectRepairCondition{
+		Action: RelocateProject,
+		Expected: config.ProjectRegistration{Persisted: models.Project{
+			Repository: "github.com/acme/widget", Path: "/old/widget",
+		}},
+		TargetRoot: "/repos/widget", TargetCommonDir: "/repos/widget/.git",
+		TargetRepository: "github.com/acme/widget",
+	}
+	tests := []struct {
+		name       string
+		oldExists  bool
+		statErr    error
+		snapshot   RepositorySnapshot
+		inspectErr error
+		wantErr    string
+	}{
+		{name: "old path recreated", oldExists: true},
+		{name: "target root changed", snapshot: RepositorySnapshot{Root: "/repos/replacement", CommonDir: base.TargetCommonDir, RepositoryIdentity: base.TargetRepository}},
+		{name: "target common directory changed", snapshot: RepositorySnapshot{Root: base.TargetRoot, CommonDir: "/repos/other/.git", RepositoryIdentity: base.TargetRepository}},
+		{name: "target identity changed", snapshot: RepositorySnapshot{Root: base.TargetRoot, CommonDir: base.TargetCommonDir, RepositoryIdentity: "github.com/other/widget"}},
+		{name: "old path access failure", statErr: errors.New("permission denied"), wantErr: "recheck configured project path"},
+		{name: "target inspection failure", inspectErr: errors.New("repository unavailable"), wantErr: "recheck project relocation target"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := base
+			var mutations int
+			fixer := &Fixer{
+				Projects: &fakeProjectMutator{compareAndSwap: func(config.ProjectRegistration, *models.Project) (bool, error) {
+					mutations++
+					return true, nil
+				}},
+				PathExists: func(string) (bool, error) { return tt.oldExists, tt.statErr },
+				InspectRepository: func(string) (RepositorySnapshot, error) {
+					return tt.snapshot, tt.inspectErr
+				},
+			}
+			report := Report{Repositories: []RepositoryReport{{Findings: []Finding{{
+				Code: ProjectPathMoved, Path: "/old/widget", Fixable: true,
+				ProjectRepair: &condition,
+			}}}}}
+
+			err := fixer.Fix(context.Background(), report)
+
+			assert.Zero(t, mutations)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFixerRemovesOnlyFixableStaleProjectByCAS(t *testing.T) {
+	expected := models.Project{Repository: "github.com/acme/widget", Path: "~/old/widget"}
+	var calls int
+	fixer := &Fixer{
+		Projects: &fakeProjectMutator{compareAndSwap: func(got config.ProjectRegistration, replacement *models.Project) (bool, error) {
+			calls++
+			assert.Equal(t, expected, got.Persisted)
+			assert.Nil(t, replacement)
+			return false, nil
+		}},
+		PathExists: func(string) (bool, error) { return false, nil },
+	}
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{
+		{Code: StaleProjectRegistration, Path: "/old/widget", Fixable: true, ProjectRepair: &ProjectRepairCondition{Action: RemoveProject, Expected: config.ProjectRegistration{Persisted: expected}}},
+		{Code: AmbiguousProjectRelocation, Path: "/other/widget", Fixable: false},
+	}}}}
+
+	err := fixer.Fix(context.Background(), report)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+type fakeRegistryMutator struct {
+	unregister      func(string, string) (bool, error)
+	compareAndSwap  func(string, *registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error)
+	compareAliases  func([]*registry.WorktreeEntry, *registry.WorktreeEntry) (bool, error)
+	acquireCreation func(string) (func() error, bool, error)
+}
+
+type fakeProjectMutator struct {
+	compareAndSwap func(config.ProjectRegistration, *models.Project) (bool, error)
+}
+
+func (f *fakeProjectMutator) CompareAndSwapProject(
+	expected config.ProjectRegistration,
+	replacement *models.Project,
+) (bool, error) {
+	if f.compareAndSwap == nil {
+		return false, nil
+	}
+	return f.compareAndSwap(expected, replacement)
+}
+
+func (f *fakeRegistryMutator) UnregisterIfGeneration(path, generation string) (bool, error) {
+	if f.unregister == nil {
+		return false, nil
+	}
+	return f.unregister(path, generation)
+}
+
+func (f *fakeRegistryMutator) CompareAndSwap(
+	path string,
+	expected *registry.WorktreeEntry,
+	replacement *registry.WorktreeEntry,
+) (bool, error) {
+	if f.compareAndSwap == nil {
+		return false, nil
+	}
+	return f.compareAndSwap(path, expected, replacement)
+}
+
+func (f *fakeRegistryMutator) CompareAndSwapAliases(
+	expected []*registry.WorktreeEntry,
+	retained *registry.WorktreeEntry,
+) (bool, error) {
+	if f.compareAliases == nil {
+		return false, nil
+	}
+	return f.compareAliases(expected, retained)
+}
+
+func (f *fakeRegistryMutator) AcquireCreation(path string) (func() error, bool, error) {
+	if f.acquireCreation == nil {
+		return func() error { return nil }, true, nil
+	}
+	return f.acquireCreation(path)
+}

--- a/internal/maintenance/inspect.go
+++ b/internal/maintenance/inspect.go
@@ -92,6 +92,15 @@ func (i *Inspector) Inspect(ctx context.Context) (Report, error) {
 			i.addUnreachableProject(reports, project, message)
 			continue
 		}
+		if !gitadapter.HasExactWorktreeRoot(snapshot.Worktrees, project.Path) {
+			inventoryComplete = false
+			i.addUnreachableProject(
+				reports,
+				project,
+				"configured project path is not an exact Git worktree root",
+			)
+			continue
+		}
 		report := mergeSnapshot(reports, snapshot)
 		mergeLiveRepositoryIdentities(liveRepositoryIdentities, snapshot)
 		addConfiguredRepositoryClaim(
@@ -152,6 +161,17 @@ func (i *Inspector) Inspect(ctx context.Context) (Report, error) {
 			})
 			continue
 		}
+		if !gitadapter.HasExactWorktreeRoot(snapshot.Worktrees, path) {
+			inventoryComplete = false
+			report := reportForKey(reports, "unreachable:"+pathKey(path))
+			report.Root = path
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: path,
+				Message:     "global inventory path is not an exact Git worktree root",
+				Remediation: "Review or remove the invalid path and rerun kwt doctor.",
+			})
+			continue
+		}
 		mergeSnapshot(reports, snapshot)
 		mergeLiveRepositoryIdentities(liveRepositoryIdentities, snapshot)
 	}
@@ -189,6 +209,10 @@ func (i *Inspector) Inspect(ctx context.Context) (Report, error) {
 				Message:     message,
 				Remediation: "Restore access to the registered worktree and rerun kwt doctor.",
 			})
+			continue
+		}
+		if !gitadapter.HasExactWorktreeRoot(snapshot.Worktrees, entry.Path) {
+			inventoryComplete = false
 			continue
 		}
 		mergeSnapshot(reports, snapshot)

--- a/internal/maintenance/inspect.go
+++ b/internal/maintenance/inspect.go
@@ -1,0 +1,1182 @@
+package maintenance
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/discovery"
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
+	repositoryurl "go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/internal/worktree"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+// Inspector gathers local facts and classifies consistency findings. Its
+// injectable functions keep tests deterministic and the package provider-free.
+type Inspector struct {
+	Config               *models.Config
+	ProjectRegistrations []config.ProjectRegistration
+	RegistryEntries      []*registry.WorktreeEntry
+	InspectRepository    func(string) (RepositorySnapshot, error)
+	FindGlobalPaths      func(string) ([]string, error)
+	ReadDotGitTarget     func(string) (string, error)
+	PathExists           func(string) (bool, error)
+	CreationActive       func(string) (bool, error)
+}
+
+// NewInspector creates an inspector backed by the repository's real local Git
+// and filesystem implementations.
+func NewInspector(
+	cfg *models.Config,
+	entries []*registry.WorktreeEntry,
+	registrations []config.ProjectRegistration,
+) *Inspector {
+	inspector := &Inspector{
+		Config: cfg, ProjectRegistrations: registrations, RegistryEntries: entries,
+	}
+	inspector.setDefaults()
+	return inspector
+}
+
+// Inspect returns a stable report without changing Git, registry, or
+// provenance state.
+func (i *Inspector) Inspect(ctx context.Context) (Report, error) {
+	if err := ctx.Err(); err != nil {
+		return Report{}, err
+	}
+	i.setDefaults()
+	reports := make(map[string]*RepositoryReport)
+	liveRepositoryIdentities := make(map[string]string)
+	configuredClaims := make(map[string]*configuredRepositoryClaims)
+	inventoryComplete := true
+
+	registrations := append([]config.ProjectRegistration(nil), i.ProjectRegistrations...)
+	sort.Slice(registrations, func(left, right int) bool {
+		if registrations[left].Effective.Path == registrations[right].Effective.Path {
+			return registrations[left].Effective.Name < registrations[right].Effective.Name
+		}
+		return registrations[left].Effective.Path < registrations[right].Effective.Path
+	})
+	missingProjects := make([]config.ProjectRegistration, 0)
+	for _, registration := range registrations {
+		if err := ctx.Err(); err != nil {
+			return Report{}, err
+		}
+		project := registration.Effective
+		exists, statErr := i.PathExists(project.Path)
+		if statErr != nil {
+			inventoryComplete = false
+			i.addUnreachableProject(reports, project, fmt.Sprintf("configured project path could not be inspected: %v", statErr))
+			continue
+		}
+		if !exists {
+			missingProjects = append(missingProjects, registration)
+			continue
+		}
+		snapshot, err := i.InspectRepository(project.Path)
+		if err != nil || snapshot.CommonDir == "" {
+			inventoryComplete = false
+			message := "configured project could not be inspected"
+			if err != nil {
+				message = fmt.Sprintf("configured project could not be inspected: %v", err)
+			}
+			i.addUnreachableProject(reports, project, message)
+			continue
+		}
+		report := mergeSnapshot(reports, snapshot)
+		mergeLiveRepositoryIdentities(liveRepositoryIdentities, snapshot)
+		addConfiguredRepositoryClaim(
+			configuredClaims,
+			pathKey(snapshot.CommonDir),
+			project.Repository,
+		)
+		appendProjectName(report, project.Name)
+		if report.RepositoryIdentity == "" {
+			report.RepositoryIdentity = configuredRepositoryIdentity(project.Repository)
+		}
+	}
+	classifyConfiguredRepositoryClaims(reports, configuredClaims)
+
+	globalPaths := []string(nil)
+	if strings.TrimSpace(i.Config.Worktree.BaseDir) != "" {
+		var err error
+		globalPaths, err = i.FindGlobalPaths(i.Config.Worktree.BaseDir)
+		if err != nil {
+			return Report{}, fmt.Errorf("discover global worktree paths: %w", err)
+		}
+	}
+	claims := make(map[string][]string)
+	for _, path := range globalPaths {
+		if err := ctx.Err(); err != nil {
+			return Report{}, err
+		}
+		target, targetErr := i.ReadDotGitTarget(path)
+		if targetErr != nil || target == "" {
+			inventoryComplete = false
+			report := reportForKey(reports, "unreachable:"+pathKey(path))
+			report.Root = path
+			message := "global worktree .git entry could not be inspected"
+			if targetErr != nil {
+				message = fmt.Sprintf("global worktree .git entry could not be inspected: %v", targetErr)
+			}
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: path,
+				Message: message, Fixable: false,
+				Remediation: "Restore access to the linked worktree metadata and rerun kwt doctor.",
+			})
+			continue
+		}
+		addClaim(claims, target, path)
+		snapshot, err := i.InspectRepository(path)
+		if err != nil || snapshot.CommonDir == "" {
+			inventoryComplete = false
+			report := reportForKey(reports, "unreachable:"+pathKey(path))
+			report.Root = path
+			message := "global worktree repository could not be inspected"
+			if err != nil {
+				message = fmt.Sprintf("global worktree repository could not be inspected: %v", err)
+			}
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: path,
+				Message: message, Fixable: false,
+				Remediation: "Restore access to the linked repository and rerun kwt doctor.",
+			})
+			continue
+		}
+		mergeSnapshot(reports, snapshot)
+		mergeLiveRepositoryIdentities(liveRepositoryIdentities, snapshot)
+	}
+	for _, entry := range i.RegistryEntries {
+		if entry == nil {
+			continue
+		}
+		active, activeErr := i.registryCreationActive(entry)
+		if activeErr != nil {
+			inventoryComplete = false
+			continue
+		}
+		if active {
+			continue
+		}
+		exists, statErr := i.PathExists(entry.Path)
+		if statErr != nil {
+			inventoryComplete = false
+			continue
+		}
+		if !exists {
+			continue
+		}
+		snapshot, err := i.InspectRepository(entry.Path)
+		if err != nil || snapshot.CommonDir == "" {
+			inventoryComplete = false
+			report := reportForKey(reports, "registry-path:"+pathKey(entry.Path))
+			report.Root = entry.Path
+			message := "live registry path could not be inspected as a Git repository"
+			if err != nil {
+				message = fmt.Sprintf("live registry path could not be inspected as a Git repository: %v", err)
+			}
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: entry.Path,
+				Message:     message,
+				Remediation: "Restore access to the registered worktree and rerun kwt doctor.",
+			})
+			continue
+		}
+		mergeSnapshot(reports, snapshot)
+		mergeLiveRepositoryIdentities(liveRepositoryIdentities, snapshot)
+	}
+	for _, report := range reports {
+		for _, inspection := range report.Worktrees {
+			if inspection.DotGitTarget != "" {
+				addClaim(claims, inspection.DotGitTarget, inspection.Path)
+			}
+		}
+	}
+	i.classifyMissingProjects(reports, missingProjects, inventoryComplete)
+
+	for _, report := range reports {
+		i.classifyRepository(report, claims)
+	}
+	i.classifyRegistry(reports, liveRepositoryIdentities)
+
+	result := Report{SchemaVersion: SchemaVersion, Command: "doctor"}
+	for _, report := range reports {
+		sort.Strings(report.ProjectNames)
+		sort.Slice(report.Worktrees, func(left, right int) bool {
+			return pathKey(report.Worktrees[left].Path) < pathKey(report.Worktrees[right].Path)
+		})
+		sort.Slice(report.Findings, func(left, right int) bool {
+			if pathKey(report.Findings[left].Path) == pathKey(report.Findings[right].Path) {
+				return report.Findings[left].Code < report.Findings[right].Code
+			}
+			return pathKey(report.Findings[left].Path) < pathKey(report.Findings[right].Path)
+		})
+		result.Repositories = append(result.Repositories, *report)
+	}
+	sort.Slice(result.Repositories, func(left, right int) bool {
+		leftKey := result.Repositories[left].CommonDir + "\x00" + result.Repositories[left].Root
+		rightKey := result.Repositories[right].CommonDir + "\x00" + result.Repositories[right].Root
+		return leftKey < rightKey
+	})
+	result.Summary.Repositories = len(result.Repositories)
+	for _, report := range result.Repositories {
+		for _, finding := range report.Findings {
+			result.Summary.Findings++
+			if finding.Fixable {
+				result.Summary.FixableFindings++
+			} else {
+				result.Summary.ManualFindings++
+			}
+		}
+	}
+	result.Summary.Healthy = result.Summary.Findings == 0
+	return result, nil
+}
+
+type configuredRepositoryClaims struct {
+	identities map[string]string
+	invalid    int
+}
+
+func addConfiguredRepositoryClaim(
+	claimsByRepository map[string]*configuredRepositoryClaims,
+	repositoryKey string,
+	raw string,
+) {
+	claims := claimsByRepository[repositoryKey]
+	if claims == nil {
+		claims = &configuredRepositoryClaims{identities: make(map[string]string)}
+		claimsByRepository[repositoryKey] = claims
+	}
+	identity, ok := repairableProjectIdentity(raw)
+	if !ok {
+		claims.invalid++
+		return
+	}
+	claims.identities[repositoryurl.FoldRepositoryIdentity(identity)] = identity
+}
+
+func classifyConfiguredRepositoryClaims(
+	reports map[string]*RepositoryReport,
+	claimsByRepository map[string]*configuredRepositoryClaims,
+) {
+	for repositoryKey, claims := range claimsByRepository {
+		if claims.invalid == 0 && len(claims.identities) < 2 {
+			continue
+		}
+		report := reports[repositoryKey]
+		if report == nil {
+			continue
+		}
+		identities := make([]string, 0, len(claims.identities))
+		for _, identity := range claims.identities {
+			identities = append(identities, identity)
+		}
+		sort.Strings(identities)
+		evidence := make(map[string]string)
+		if len(identities) != 0 {
+			evidence["configured_repositories"] = strings.Join(identities, "\n")
+		}
+		if claims.invalid != 0 {
+			evidence["invalid_claim_count"] = fmt.Sprintf("%d", claims.invalid)
+		}
+		addFinding(report, Finding{
+			Code: RepositoryIdentityMismatch, Severity: SeverityError,
+			Path:        report.Root,
+			Message:     "configured projects for this repository have invalid or conflicting repository identities",
+			Remediation: "Update the project registrations to use one canonical network repository identity, then rerun kwt doctor.",
+			Evidence:    evidence,
+		})
+	}
+}
+
+func (i *Inspector) addUnreachableProject(
+	reports map[string]*RepositoryReport,
+	project models.Project,
+	message string,
+) {
+	report := reportForKey(reports, "unreachable:"+pathKey(project.Path))
+	report.Root = project.Path
+	report.RepositoryIdentity = configuredRepositoryIdentity(project.Repository)
+	appendProjectName(report, project.Name)
+	addFinding(report, Finding{
+		Code: ProjectUnreachable, Severity: SeverityError, Path: project.Path,
+		Message:     message,
+		Remediation: "Restore access to the configured repository path or update the project registration.",
+	})
+}
+
+type projectRelocationCandidate struct {
+	root       string
+	commonDir  string
+	repository string
+}
+
+func (i *Inspector) classifyMissingProjects(
+	reports map[string]*RepositoryReport,
+	registrations []config.ProjectRegistration,
+	inventoryComplete bool,
+) {
+	if !inventoryComplete {
+		for _, registration := range registrations {
+			project := registration.Effective
+			report := reportForKey(reports, "unreachable:"+pathKey(project.Path))
+			report.Root = project.Path
+			appendProjectName(report, project.Name)
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: project.Path,
+				Message:     "configured project is absent but repository inventory is incomplete",
+				Remediation: "Restore access to every repository reported as unreachable, then rerun kwt doctor before changing this registration.",
+				Evidence:    map[string]string{"old_path": project.Path},
+			})
+		}
+		return
+	}
+	registeredProjectPaths := make(map[string]string, len(i.ProjectRegistrations))
+	for _, registration := range i.ProjectRegistrations {
+		path := registration.Effective.Path
+		if path != "" {
+			registeredProjectPaths[pathKey(path)] = path
+		}
+	}
+	duplicates := make([]bool, len(registrations))
+	for left := range registrations {
+		for right := left + 1; right < len(registrations); right++ {
+			if registrations[left].SamePersistedEntry(registrations[right]) {
+				duplicates[left] = true
+				duplicates[right] = true
+			}
+		}
+	}
+	candidatesByIdentity := make(map[string][]projectRelocationCandidate)
+	seen := make(map[string]bool)
+	for _, report := range reports {
+		if report.CommonDir == "" || report.Root == "" || report.RepositoryIdentity == "" {
+			continue
+		}
+		identity, ok := repairableProjectIdentity(report.RepositoryIdentity)
+		if !ok {
+			continue
+		}
+		candidateKey := pathKey(report.CommonDir)
+		if seen[candidateKey] {
+			continue
+		}
+		seen[candidateKey] = true
+		folded := repositoryurl.FoldRepositoryIdentity(identity)
+		candidatesByIdentity[folded] = append(candidatesByIdentity[folded], projectRelocationCandidate{
+			root: report.Root, commonDir: report.CommonDir, repository: identity,
+		})
+	}
+	matchingTargets := func(registration config.ProjectRegistration) []projectRelocationCandidate {
+		identity, ok := repairableProjectIdentity(registration.Persisted.Repository)
+		if !ok {
+			return nil
+		}
+		matches := append([]projectRelocationCandidate(nil),
+			candidatesByIdentity[repositoryurl.FoldRepositoryIdentity(identity)]...)
+		sort.Slice(matches, func(left, right int) bool {
+			return pathKey(matches[left].root) < pathKey(matches[right].root)
+		})
+		return matches
+	}
+	targetClaimants := make(map[string]int)
+	for index, registration := range registrations {
+		if duplicates[index] {
+			continue
+		}
+		matches := matchingTargets(registration)
+		if len(matches) != 1 {
+			continue
+		}
+		target := matches[0]
+		if registeredPath, ok := registeredProjectPaths[pathKey(target.root)]; ok &&
+			pathKey(registeredPath) != pathKey(registration.Effective.Path) {
+			continue
+		}
+		targetClaimants[pathKey(target.root)]++
+	}
+
+	for index, registration := range registrations {
+		project := registration.Effective
+		report := reportForKey(reports, "unreachable:"+pathKey(project.Path))
+		report.Root = project.Path
+		appendProjectName(report, project.Name)
+		if duplicates[index] {
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: project.Path,
+				Message:     "configured project is absent but its persisted registration is duplicated",
+				Remediation: "Remove or consolidate the duplicate project registrations manually, then rerun kwt doctor.",
+			})
+			continue
+		}
+		identity, ok := repairableProjectIdentity(registration.Persisted.Repository)
+		if !ok {
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: project.Path,
+				Message:     "configured project is absent and its stored repository identity is not safe for automatic matching",
+				Remediation: "Update or remove this project registration manually, then rerun kwt doctor.",
+			})
+			continue
+		}
+		report.RepositoryIdentity = identity
+		matches := matchingTargets(registration)
+		switch len(matches) {
+		case 0:
+			addFinding(report, Finding{
+				Code: StaleProjectRegistration, Severity: SeverityWarning, Path: project.Path,
+				Message:     "configured project path is absent and no matching live repository was found",
+				Remediation: "Run kwt doctor --fix to remove the unchanged stale project registration.",
+				Fixable:     true,
+				Evidence:    map[string]string{"old_path": project.Path},
+				ProjectRepair: &ProjectRepairCondition{
+					Action: RemoveProject, Expected: registration,
+				},
+			})
+		case 1:
+			target := matches[0]
+			if registeredPath, ok := registeredProjectPaths[pathKey(target.root)]; ok &&
+				pathKey(registeredPath) != pathKey(project.Path) {
+				addFinding(report, Finding{
+					Code: StaleProjectRegistration, Severity: SeverityWarning, Path: project.Path,
+					Message:     "configured project path is absent and the matching live repository is already registered",
+					Remediation: "Run kwt doctor --fix to remove the unchanged stale duplicate registration.",
+					Fixable:     true,
+					Evidence: map[string]string{
+						"old_path": project.Path, "registered_path": target.root,
+					},
+					ProjectRepair: &ProjectRepairCondition{
+						Action: RemoveProject, Expected: registration,
+					},
+				})
+				continue
+			}
+			if targetClaimants[pathKey(target.root)] > 1 {
+				addFinding(report, Finding{
+					Code: AmbiguousProjectRelocation, Severity: SeverityError, Path: project.Path,
+					Message:     "multiple missing project registrations match the same live repository target",
+					Remediation: "Choose which project registration should own the live repository, update the others manually, then rerun kwt doctor.",
+					Evidence: map[string]string{
+						"old_path": project.Path, "candidate_paths": target.root,
+					},
+				})
+				continue
+			}
+			addFinding(report, Finding{
+				Code: ProjectPathMoved, Severity: SeverityWarning, Path: project.Path,
+				Message:     "configured project path is absent and one matching live repository was found",
+				Remediation: "Run kwt doctor --fix to update the unchanged project registration.",
+				Fixable:     true,
+				Evidence: map[string]string{
+					"old_path": project.Path, "new_path": target.root,
+				},
+				ProjectRepair: &ProjectRepairCondition{
+					Action: RelocateProject, Expected: registration,
+					TargetRoot: target.root, TargetCommonDir: target.commonDir,
+					TargetRepository: target.repository,
+				},
+			})
+		default:
+			paths := make([]string, 0, len(matches))
+			for _, match := range matches {
+				paths = append(paths, match.root)
+			}
+			addFinding(report, Finding{
+				Code: AmbiguousProjectRelocation, Severity: SeverityError, Path: project.Path,
+				Message:     "configured project path is absent and multiple matching live repositories were found",
+				Remediation: "Choose the intended repository path and update the project registration manually.",
+				Evidence: map[string]string{
+					"old_path": project.Path, "candidate_paths": strings.Join(paths, "\n"),
+				},
+			})
+		}
+	}
+}
+
+func repairableProjectIdentity(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if repositoryurl.IsPathFallbackIdentity(raw) ||
+		strings.HasPrefix(strings.ToLower(raw), "file:") {
+		return "", false
+	}
+	identity, ok := repositoryurl.CanonicalRepositoryIdentity(raw)
+	if !ok || repositoryurl.IsPathFallbackIdentity(identity) {
+		return "", false
+	}
+	return identity, true
+}
+
+func (i *Inspector) classifyRepository(
+	report *RepositoryReport,
+	claims map[string][]string,
+) {
+	for _, inspection := range report.Worktrees {
+		exists, statErr := i.PathExists(inspection.Path)
+		if statErr != nil {
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: inspection.Path,
+				Message:     fmt.Sprintf("worktree path could not be inspected: %v", statErr),
+				Remediation: "Restore filesystem access and rerun kwt doctor.",
+			})
+			continue
+		}
+		if inspection.GitDirError != "" {
+			addFinding(report, Finding{
+				Code: AmbiguousWorktreeBacklink, Severity: SeverityError,
+				Path:        inspection.Path,
+				Message:     "Git worktree administrative ownership could not be determined",
+				Remediation: "Review the competing Git administrative records, resolve the ambiguity manually, then rerun kwt doctor.",
+				Evidence: map[string]string{
+					"git_dir_error": inspection.GitDirError,
+				},
+			})
+			continue
+		}
+		claimants := claimantPaths(claims, inspection)
+		ambiguous := false
+		for _, claimant := range claimants {
+			if pathKey(claimant) != pathKey(inspection.Path) {
+				ambiguous = true
+				break
+			}
+		}
+		if len(claimants) > 1 {
+			ambiguous = true
+		}
+		if ambiguous {
+			addFinding(report, Finding{
+				Code: AmbiguousWorktreeBacklink, Severity: SeverityError, Path: inspection.Path,
+				Message:     "multiple filesystem paths claim the same Git worktree administrative record",
+				Remediation: "Choose the intended worktree path, remove or repair the conflicting copies manually, then rerun kwt doctor.",
+				Evidence:    map[string]string{"claimants": strings.Join(claimants, ",")},
+			})
+		} else if !inspection.IsMain && exists && inspection.GitDir != "" &&
+			(inspection.DotGitTarget == "" || pathKey(inspection.DotGitTarget) != pathKey(inspection.GitDir)) {
+			addFinding(report, Finding{
+				Code: BrokenWorktreeBacklink, Severity: SeverityWarning, Path: inspection.Path,
+				Message:     "linked worktree points to an outdated Git administrative directory",
+				Remediation: "Run kwt doctor --fix to repair the verified backlink.",
+				Fixable:     true,
+				Evidence: map[string]string{
+					"current_target":  inspection.DotGitTarget,
+					"expected_target": inspection.GitDir,
+				},
+			})
+		}
+		if !exists {
+			addFinding(report, Finding{
+				Code: MissingWorktreeDirectory, Severity: SeverityWarning, Path: inspection.Path,
+				Message:     "Git records a worktree path that is confirmed absent",
+				Remediation: "Run kwt doctor --fix to prune the stale Git administrative record.",
+				Fixable:     inspection.Prunable && !inspection.Locked && inspection.GitDir != "" && !ambiguous,
+				Evidence:    map[string]string{"git_dir": inspection.GitDir},
+			})
+			continue
+		}
+		if inspection.GenerationStatus != gitadapter.GenerationValid {
+			addFinding(report, Finding{
+				Code: MissingGeneration, Severity: SeverityWarning, Path: inspection.Path,
+				Message:     "live worktree has no valid durable kwt generation",
+				Remediation: fmt.Sprintf("Run kwt list from %s to initialize the Git generation, then run kwt doctor --fix to reconcile registry metadata.", report.Root),
+				Evidence:    map[string]string{"generation_status": string(inspection.GenerationStatus)},
+			})
+		}
+	}
+}
+
+func (i *Inspector) classifyRegistry(
+	reports map[string]*RepositoryReport,
+	liveRepositoryIdentities map[string]string,
+) {
+	byPath := make(map[string]*RepositoryReport)
+	inspectionByPath := make(map[string]gitadapter.WorktreeInspection)
+	byIdentity := make(map[string][]*RepositoryReport)
+	for _, report := range reports {
+		if report.RepositoryIdentity != "" {
+			identity := repositoryurl.FoldRepositoryIdentity(report.RepositoryIdentity)
+			byIdentity[identity] = append(byIdentity[identity], report)
+		}
+		for _, inspection := range report.Worktrees {
+			byPath[pathKey(inspection.Path)] = report
+			inspectionByPath[pathKey(inspection.Path)] = inspection
+		}
+	}
+	registryReports := make(map[string]*RepositoryReport)
+	reportForRegistryEntry := func(entry *registry.WorktreeEntry) *RepositoryReport {
+		key := pathKey(entry.Path)
+		if report := registryReports[key]; report != nil {
+			return report
+		}
+		if report := byPath[key]; report != nil {
+			registryReports[key] = report
+			return report
+		}
+		registryIdentity, registryIdentityOK :=
+			repositoryurl.CanonicalRepositoryIdentity(entry.Repository)
+		if registryIdentityOK {
+			matches := byIdentity[repositoryurl.FoldRepositoryIdentity(registryIdentity)]
+			if len(matches) == 1 {
+				registryReports[key] = matches[0]
+				return matches[0]
+			}
+		}
+		report := reportForKey(reports, "registry-path:"+key)
+		report.Root = entry.Path
+		if registryIdentityOK && report.RepositoryIdentity == "" {
+			report.RepositoryIdentity = registryIdentity
+			identity := repositoryurl.FoldRepositoryIdentity(registryIdentity)
+			byIdentity[identity] = append(byIdentity[identity], report)
+		}
+		registryReports[key] = report
+		return report
+	}
+	type registryInspectionState struct {
+		active bool
+		err    error
+	}
+	states := make(map[*registry.WorktreeEntry]registryInspectionState, len(i.RegistryEntries))
+	groups := make(map[string][]*registry.WorktreeEntry)
+	for _, entry := range i.RegistryEntries {
+		if entry == nil {
+			continue
+		}
+		active, err := i.registryCreationActive(entry)
+		states[entry] = registryInspectionState{active: active, err: err}
+		key := pathKey(entry.Path)
+		groups[key] = append(groups[key], entry)
+	}
+	deferredGroups := make(map[string]bool)
+	handledDuplicateGroups := make(map[string]bool)
+	for key, entries := range groups {
+		if len(entries) < 2 {
+			continue
+		}
+		for _, entry := range entries {
+			state := states[entry]
+			if state.active || state.err != nil {
+				deferredGroups[key] = true
+				break
+			}
+		}
+		if deferredGroups[key] {
+			continue
+		}
+		sort.Slice(entries, func(left, right int) bool {
+			return literalPathKey(entries[left].Path) < literalPathKey(entries[right].Path)
+		})
+		retained := entries[0]
+		inspection, matched := inspectionByPath[key]
+		if matched && inspection.Exists {
+			inspectionPathKey := literalPathKey(inspection.Path)
+			for _, entry := range entries {
+				if literalPathKey(entry.Path) == inspectionPathKey {
+					retained = entry
+					break
+				}
+			}
+		}
+		existsKnown := matched
+		exists := matched && inspection.Exists
+		if !matched {
+			present, absent := 0, 0
+			for _, entry := range entries {
+				entryExists, err := i.PathExists(entry.Path)
+				if err != nil {
+					present, absent = 0, 0
+					break
+				}
+				if entryExists {
+					present++
+				} else {
+					absent++
+				}
+			}
+			switch {
+			case present == len(entries):
+				existsKnown, exists = true, true
+			case absent == len(entries):
+				existsKnown, exists = true, false
+			}
+		}
+		equivalent := equivalentRegistryAliases(entries)
+		severity := SeverityError
+		message := "multiple registry paths resolve to the same path but cannot be safely reconciled"
+		remediation := "Restore complete filesystem access, review the conflicting registry records, and rerun kwt doctor."
+		fixable := false
+		var repair *RegistryAliasRepairCondition
+		switch {
+		case !existsKnown:
+		case !exists:
+			message = "multiple registry paths resolve to the same confirmed-absent worktree but their policy metadata differs"
+			remediation = "Review the conflicting stale registry records and remove only the policies that are no longer needed."
+			if equivalent {
+				severity = SeverityWarning
+				message = "multiple equivalent registry paths resolve to the same confirmed-absent worktree"
+				remediation = "Run kwt doctor --fix to remove the complete unchanged stale alias group."
+				fixable = true
+				repair = &RegistryAliasRepairCondition{
+					Expected: cloneRegistryEntries(entries),
+				}
+			}
+		case matched:
+			message = "multiple registry paths resolve to the same live worktree but their policy metadata differs"
+			remediation = "Review the conflicting registry records and keep only the intended policy before rerunning kwt doctor."
+			if equivalent {
+				severity = SeverityWarning
+				message = "multiple equivalent registry paths resolve to the same live worktree"
+				remediation = "Run kwt doctor --fix to collapse the unchanged aliases to one registry record."
+				fixable = true
+				repair = &RegistryAliasRepairCondition{
+					Expected: cloneRegistryEntries(entries),
+					Retained: cloneRegistryEntry(retained),
+				}
+			}
+		default:
+			message = "multiple registry paths resolve to an existing path that is not a verified live Git worktree"
+			remediation = "Restore or remove the worktree metadata, then rerun kwt doctor before changing the registry records."
+		}
+		paths := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			paths = append(paths, entry.Path)
+		}
+		report := reportForRegistryEntry(retained)
+		addFinding(report, Finding{
+			Code: DuplicateRegistryEntry, Severity: severity, Path: retained.Path,
+			Message: message, Remediation: remediation, Fixable: fixable,
+			Evidence:            map[string]string{"paths": strings.Join(paths, "\n")},
+			RegistryAliasRepair: repair,
+		})
+		handledDuplicateGroups[key] = true
+	}
+	for _, entry := range i.RegistryEntries {
+		if entry == nil {
+			continue
+		}
+		state := states[entry]
+		active, activeErr := state.active, state.err
+		if activeErr != nil {
+			report := reportForKey(reports, "registry-path:"+pathKey(entry.Path))
+			report.Root = entry.Path
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: entry.Path,
+				Message:     fmt.Sprintf("registry creation ownership could not be inspected: %v", activeErr),
+				Remediation: "Restore access to the registry creation lock and rerun kwt doctor.",
+			})
+			continue
+		}
+		key := pathKey(entry.Path)
+		if active || deferredGroups[key] || handledDuplicateGroups[key] {
+			continue
+		}
+		registryIdentity, registryIdentityOK :=
+			repositoryurl.CanonicalRepositoryIdentity(entry.Repository)
+		report := reportForRegistryEntry(entry)
+		exists, err := i.PathExists(entry.Path)
+		if err != nil {
+			addFinding(report, Finding{
+				Code: ProjectUnreachable, Severity: SeverityError, Path: entry.Path,
+				Message:     fmt.Sprintf("registry path could not be inspected: %v", err),
+				Remediation: "Restore filesystem access and rerun kwt doctor.",
+			})
+			continue
+		}
+		if !exists {
+			addFinding(report, Finding{
+				Code: StaleRegistryEntry, Severity: SeverityWarning, Path: entry.Path,
+				Message:     "kwt registry records a path that is confirmed absent",
+				Remediation: "Run kwt doctor --fix to remove the unchanged stale registry record.",
+				Fixable:     true,
+				Evidence:    map[string]string{"generation": entry.Generation},
+			})
+		}
+		inspection, matchedInspection := inspectionByPath[pathKey(entry.Path)]
+		if exists && !matchedInspection {
+			addFinding(report, Finding{
+				Code: UnverifiedRegistryEntry, Severity: SeverityError, Path: entry.Path,
+				Message:     "registry path exists but is not a verified Git worktree",
+				Remediation: "Restore valid worktree metadata or remove this registry policy manually, then rerun kwt doctor.",
+				Evidence:    map[string]string{"generation": entry.Generation},
+			})
+			continue
+		}
+		if exists && matchedInspection &&
+			inspection.GenerationStatus == gitadapter.GenerationValid &&
+			entry.Generation != inspection.Generation {
+			fixable := entry.Generation == ""
+			severity := SeverityWarning
+			message := "generation-less registry record does not yet name the verified live Git worktree generation"
+			remediation := "Run kwt doctor --fix to adopt the live generation and clear inherited expiration policy."
+			if !fixable {
+				severity = SeverityError
+				message = "registry and live Git generations identify different worktrees at the same path"
+				remediation = "Review the replacement conflict and remove or recreate the stale registry record manually; kwt will not transfer its policy metadata."
+			}
+			addFinding(report, Finding{
+				Code: RegistryGenerationMismatch, Severity: severity, Path: entry.Path,
+				Message:     message,
+				Remediation: remediation,
+				Fixable:     fixable,
+				Evidence: map[string]string{
+					"registry_generation": entry.Generation,
+					"git_generation":      inspection.Generation,
+				},
+			})
+		} else if entry.Generation == "" {
+			remediation := "Review this unmatched legacy registry record and either register or remove it manually."
+			if !exists {
+				remediation = "Run kwt doctor --fix to compare-and-delete this unchanged legacy registry record."
+			} else if matchedInspection {
+				remediation = fmt.Sprintf("Run kwt list from %s to initialize the Git generation, then run kwt doctor --fix to reconcile the registry.", report.Root)
+			}
+			addFinding(report, Finding{
+				Code: MissingGeneration, Severity: SeverityWarning, Path: entry.Path,
+				Message:     "registry record has no durable kwt generation",
+				Remediation: remediation,
+			})
+		}
+		if matched := byPath[pathKey(entry.Path)]; matched != nil &&
+			entry.Repository != "" &&
+			(!registryIdentityOK || !repositoryIdentityMatchesAny(
+				registryIdentity,
+				matched.RepositoryIdentity,
+				liveRepositoryIdentities[pathKey(entry.Path)],
+			)) {
+			registryEvidence := "[redacted]"
+			if registryIdentityOK {
+				registryEvidence = registryIdentity
+			}
+			evidence := map[string]string{"registry_repository": registryEvidence}
+			if matched.RepositoryIdentity != "" {
+				evidence["configured_repository"] = matched.RepositoryIdentity
+			}
+			if liveIdentity := liveRepositoryIdentities[pathKey(entry.Path)]; liveIdentity != "" {
+				evidence["live_repository"] = liveIdentity
+			}
+			addFinding(matched, Finding{
+				Code: RepositoryIdentityMismatch, Severity: SeverityError, Path: entry.Path,
+				Message:     "registry repository identity does not match the configured project or live worktree origin",
+				Remediation: "Review the registry and configured project identities before changing either record.",
+				Evidence:    evidence,
+			})
+		}
+	}
+}
+
+func equivalentRegistryAliases(entries []*registry.WorktreeEntry) bool {
+	if len(entries) < 2 {
+		return false
+	}
+	first := entries[0]
+	firstRepository, ok := repositoryurl.CanonicalRepositoryIdentity(first.Repository)
+	if !ok || first.CreationToken != "" {
+		return false
+	}
+	for _, entry := range entries[1:] {
+		repositoryIdentity, identityOK := repositoryurl.CanonicalRepositoryIdentity(
+			entry.Repository,
+		)
+		if !identityOK || entry.CreationToken != "" ||
+			repositoryurl.FoldRepositoryIdentity(repositoryIdentity) !=
+				repositoryurl.FoldRepositoryIdentity(firstRepository) ||
+			entry.Branch != first.Branch || entry.Hash != first.Hash ||
+			entry.IsMain != first.IsMain ||
+			!entry.RegisteredAt.Equal(first.RegisteredAt) ||
+			!sameRegistryTime(entry.ExpiresAt, first.ExpiresAt) ||
+			entry.Generation != first.Generation ||
+			entry.UnreviewedRemoteSource != first.UnreviewedRemoteSource {
+			return false
+		}
+	}
+	return true
+}
+
+func sameRegistryTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Equal(*right)
+}
+
+func cloneRegistryEntries(entries []*registry.WorktreeEntry) []*registry.WorktreeEntry {
+	cloned := make([]*registry.WorktreeEntry, 0, len(entries))
+	for _, entry := range entries {
+		cloned = append(cloned, cloneRegistryEntry(entry))
+	}
+	return cloned
+}
+
+func cloneRegistryEntry(entry *registry.WorktreeEntry) *registry.WorktreeEntry {
+	if entry == nil {
+		return nil
+	}
+	cloned := *entry
+	if entry.ExpiresAt != nil {
+		expiresAt := *entry.ExpiresAt
+		cloned.ExpiresAt = &expiresAt
+	}
+	return &cloned
+}
+
+func literalPathKey(path string) string {
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	path = filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(filepath.ToSlash(path))
+	}
+	return path
+}
+
+func (i *Inspector) setDefaults() {
+	if i.Config == nil {
+		i.Config = &models.Config{}
+	}
+	if i.ProjectRegistrations == nil {
+		i.ProjectRegistrations = make([]config.ProjectRegistration, len(i.Config.Projects))
+		for index := range i.Config.Projects {
+			i.ProjectRegistrations[index] = config.ProjectRegistration{
+				Persisted: i.Config.Projects[index], Effective: i.Config.Projects[index],
+			}
+		}
+	}
+	if i.InspectRepository == nil {
+		i.InspectRepository = i.inspectRepository
+	}
+	if i.FindGlobalPaths == nil {
+		i.FindGlobalPaths = discovery.FindGlobalWorktreePathsStrict
+	}
+	if i.ReadDotGitTarget == nil {
+		i.ReadDotGitTarget = readDotGitTarget
+	}
+	if i.PathExists == nil {
+		i.PathExists = pathExists
+	}
+	if i.CreationActive == nil {
+		i.CreationActive = func(string) (bool, error) { return true, nil }
+	}
+}
+
+func (i *Inspector) registryCreationActive(entry *registry.WorktreeEntry) (bool, error) {
+	if entry.CreationToken == "" {
+		return false, nil
+	}
+	return i.CreationActive(entry.Path)
+}
+
+func (i *Inspector) inspectRepository(path string) (RepositorySnapshot, error) {
+	g := gitadapter.New(path)
+	root, err := g.GetMainRepositoryPath()
+	if err != nil {
+		return RepositorySnapshot{}, err
+	}
+	commonDir, err := g.RunCommand("rev-parse", "--git-common-dir")
+	if err != nil {
+		return RepositorySnapshot{}, err
+	}
+	commonDir = strings.TrimSpace(commonDir)
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(path, commonDir)
+	}
+	rootGit := gitadapter.New(root)
+	worktrees, err := rootGit.InspectWorktrees()
+	if err != nil {
+		return RepositorySnapshot{}, err
+	}
+	identity := ""
+	for _, project := range i.Config.Projects {
+		if pathKey(project.Path) == pathKey(root) {
+			identity = configuredRepositoryIdentity(project.Repository)
+			if identity != "" {
+				break
+			}
+		}
+	}
+	if identity == "" {
+		if remote, remoteErr := rootGit.GetRepositoryURL(); remoteErr == nil {
+			identity, _ = repositoryurl.CanonicalRepositoryIdentityFromRemote(remote)
+		}
+	}
+	if identity == "" {
+		if info, localErr := worktree.RepositoryInfoFromLocalPath(root); localErr == nil {
+			identity = info.FullPath
+		}
+	}
+	liveIdentities := make(map[string]string)
+	for _, inspection := range worktrees {
+		remote, remoteErr := gitadapter.New(inspection.Path).GetRepositoryURL()
+		if remoteErr != nil {
+			continue
+		}
+		liveIdentity, ok := repositoryurl.CanonicalRepositoryIdentityFromRemote(remote)
+		if ok {
+			liveIdentities[pathKey(inspection.Path)] = liveIdentity
+		}
+	}
+	return RepositorySnapshot{
+		Root: root, CommonDir: utils.CanonicalPath(commonDir),
+		RepositoryIdentity: identity, LiveRepositoryIdentities: liveIdentities,
+		Worktrees: worktrees,
+	}, nil
+}
+
+func configuredRepositoryIdentity(raw string) string {
+	identity, _ := repositoryurl.CanonicalRepositoryIdentity(raw)
+	return identity
+}
+
+func repositoryIdentityMatchesAny(identity string, candidates ...string) bool {
+	folded := repositoryurl.FoldRepositoryIdentity(identity)
+	for _, candidate := range candidates {
+		if candidate != "" && folded == repositoryurl.FoldRepositoryIdentity(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeLiveRepositoryIdentities(
+	destination map[string]string,
+	snapshot RepositorySnapshot,
+) {
+	for path, identity := range snapshot.LiveRepositoryIdentities {
+		destination[pathKey(path)] = identity
+	}
+}
+
+func mergeSnapshot(
+	reports map[string]*RepositoryReport,
+	snapshot RepositorySnapshot,
+) *RepositoryReport {
+	key := pathKey(snapshot.CommonDir)
+	report := reportForKey(reports, key)
+	if report.CommonDir == "" {
+		report.CommonDir = utils.CanonicalPath(snapshot.CommonDir)
+		report.Root = snapshot.Root
+		report.RepositoryIdentity = snapshot.RepositoryIdentity
+		report.Worktrees = append([]gitadapter.WorktreeInspection(nil), snapshot.Worktrees...)
+	}
+	return report
+}
+
+func reportForKey(
+	reports map[string]*RepositoryReport,
+	key string,
+) *RepositoryReport {
+	if report := reports[key]; report != nil {
+		return report
+	}
+	report := &RepositoryReport{}
+	reports[key] = report
+	return report
+}
+
+func appendProjectName(report *RepositoryReport, name string) {
+	if name == "" {
+		return
+	}
+	for _, existing := range report.ProjectNames {
+		if existing == name {
+			return
+		}
+	}
+	report.ProjectNames = append(report.ProjectNames, name)
+}
+
+func addFinding(report *RepositoryReport, finding Finding) {
+	for _, existing := range report.Findings {
+		if existing.Code == finding.Code && pathKey(existing.Path) == pathKey(finding.Path) {
+			return
+		}
+	}
+	report.Findings = append(report.Findings, finding)
+}
+
+func addClaim(claims map[string][]string, target string, path string) {
+	key := pathKey(target)
+	for _, existing := range claims[key] {
+		if pathKey(existing) == pathKey(path) {
+			return
+		}
+	}
+	claims[key] = append(claims[key], path)
+	sort.Strings(claims[key])
+}
+
+func claimantPaths(
+	claims map[string][]string,
+	inspection gitadapter.WorktreeInspection,
+) []string {
+	unique := make(map[string]string)
+	for _, target := range []string{inspection.DotGitTarget, inspection.GitDir} {
+		if target == "" {
+			continue
+		}
+		for _, claimant := range claims[pathKey(target)] {
+			unique[pathKey(claimant)] = claimant
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for _, claimant := range unique {
+		result = append(result, claimant)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func readDotGitTarget(path string) (string, error) {
+	dotGit := filepath.Join(path, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return filepath.Clean(dotGit), nil
+	}
+	data, err := os.ReadFile(dotGit)
+	if err != nil {
+		return "", err
+	}
+	target := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(target, "gitdir: ") {
+		return "", fmt.Errorf("invalid .git file")
+	}
+	target = strings.TrimSpace(strings.TrimPrefix(target, "gitdir: "))
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(path, target)
+	}
+	return filepath.Clean(target), nil
+}
+
+func pathExists(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			return true, nil
+		}
+		if _, targetErr := os.Stat(path); targetErr != nil {
+			if os.IsNotExist(targetErr) {
+				return false, fmt.Errorf("path is a dangling symbolic link: %w", targetErr)
+			}
+			return false, targetErr
+		}
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func pathKey(path string) string {
+	return registry.PathKey(path)
+}

--- a/internal/maintenance/inspect.go
+++ b/internal/maintenance/inspect.go
@@ -185,6 +185,7 @@ func (i *Inspector) Inspect(ctx context.Context) (Report, error) {
 			continue
 		}
 		if active {
+			inventoryComplete = false
 			continue
 		}
 		exists, statErr := i.PathExists(entry.Path)

--- a/internal/maintenance/inspect_test.go
+++ b/internal/maintenance/inspect_test.go
@@ -62,7 +62,10 @@ func TestInspectorClassifiesLocalFindings(t *testing.T) {
 				"/copies/topic":    "/old/widget/.git/worktrees/topic",
 			},
 			exists: map[string]bool{"/worktrees/topic": true, "/copies/topic": true},
-			want:   []FindingCode{AmbiguousWorktreeBacklink},
+			want: []FindingCode{
+				AmbiguousWorktreeBacklink,
+				ProjectUnreachable,
+			},
 		},
 		{
 			name:     "missing path",
@@ -753,7 +756,19 @@ func TestInspectorReportsConfiguredRepositoryIdentityClaims(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snapshot := repositorySnapshot("/repos/widget")
+			snapshot := repositorySnapshot(
+				"/repos/widget",
+				gitadapter.WorktreeInspection{
+					Path: "/configured/widget-a", Exists: true,
+					Generation:       projectInspectionGeneration,
+					GenerationStatus: gitadapter.GenerationValid,
+				},
+				gitadapter.WorktreeInspection{
+					Path: "/configured/widget-b", Exists: true,
+					Generation:       projectInspectionGeneration,
+					GenerationStatus: gitadapter.GenerationValid,
+				},
+			)
 			inspector := fakeInspector(
 				[]models.Project{
 					{
@@ -863,7 +878,19 @@ func TestInspectRepositorySupportsSeparateGitDirectory(t *testing.T) {
 }
 
 func TestInspectorDeduplicatesProjectsByCommonDirectory(t *testing.T) {
-	snapshot := repositorySnapshot("/repos/widget")
+	snapshot := repositorySnapshot(
+		"/repos/widget",
+		gitadapter.WorktreeInspection{
+			Path: "/aliases/zeta", Exists: true,
+			Generation:       projectInspectionGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		},
+		gitadapter.WorktreeInspection{
+			Path: "/aliases/alpha", Exists: true,
+			Generation:       projectInspectionGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		},
+	)
 	inspector := fakeInspector(
 		[]models.Project{
 			{Name: "zeta", Repository: "github.com/acme/widget", Path: "/aliases/zeta"},
@@ -964,6 +991,22 @@ func TestInspectorReportsUnreadableGlobalDotGit(t *testing.T) {
 }
 
 func repositorySnapshot(root string, worktrees ...gitadapter.WorktreeInspection) RepositorySnapshot {
+	hasMain := false
+	for _, inspection := range worktrees {
+		if pathKey(inspection.Path) == pathKey(root) {
+			hasMain = true
+			break
+		}
+	}
+	if !hasMain {
+		worktrees = append([]gitadapter.WorktreeInspection{{
+			Path: root, IsMain: true, Exists: true,
+			GitDir:           filepath.Join(root, ".git"),
+			DotGitTarget:     filepath.Join(root, ".git"),
+			Generation:       projectInspectionGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}}, worktrees...)
+	}
 	return RepositorySnapshot{
 		Root:               root,
 		CommonDir:          root + "/.git",

--- a/internal/maintenance/inspect_test.go
+++ b/internal/maintenance/inspect_test.go
@@ -1,0 +1,1094 @@
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestInspectorClassifiesLocalFindings(t *testing.T) {
+	validGeneration := "0123456789abcdef0123456789abcdef"
+	tests := []struct {
+		name       string
+		projects   []models.Project
+		registry   []*registry.WorktreeEntry
+		snapshots  map[string]RepositorySnapshot
+		inspectErr map[string]error
+		global     []string
+		targets    map[string]string
+		exists     map[string]bool
+		want       []FindingCode
+	}{
+		{
+			name:     "moved main",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/moved/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/moved/widget": repositorySnapshot("/moved/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/topic", GitDir: "/moved/widget/.git/worktrees/topic",
+					DotGitTarget: "/old/widget/.git/worktrees/topic", Exists: true,
+					Generation: validGeneration, GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			global:  []string{"/worktrees/topic"},
+			targets: map[string]string{"/worktrees/topic": "/old/widget/.git/worktrees/topic"},
+			exists:  map[string]bool{"/worktrees/topic": true},
+			want:    []FindingCode{BrokenWorktreeBacklink},
+		},
+		{
+			name:     "copied claimant",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/moved/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/moved/widget": repositorySnapshot("/moved/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/topic", GitDir: "/moved/widget/.git/worktrees/topic",
+					DotGitTarget: "/old/widget/.git/worktrees/topic", Exists: true,
+					Generation: validGeneration, GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			global: []string{"/worktrees/topic", "/copies/topic"},
+			targets: map[string]string{
+				"/worktrees/topic": "/old/widget/.git/worktrees/topic",
+				"/copies/topic":    "/old/widget/.git/worktrees/topic",
+			},
+			exists: map[string]bool{"/worktrees/topic": true, "/copies/topic": true},
+			want:   []FindingCode{AmbiguousWorktreeBacklink},
+		},
+		{
+			name:     "missing path",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/missing", GitDir: "/repos/widget/.git/worktrees/missing",
+					Exists: false, Prunable: true, Generation: validGeneration,
+					GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			exists: map[string]bool{"/worktrees/missing": false},
+			want:   []FindingCode{MissingWorktreeDirectory},
+		},
+		{
+			name:     "legacy registry",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget"),
+			},
+			registry: []*registry.WorktreeEntry{{
+				Path: "/worktrees/stale", Repository: "github.com/acme/widget", Generation: validGeneration,
+			}},
+			exists: map[string]bool{"/worktrees/stale": false},
+			want:   []FindingCode{StaleRegistryEntry},
+		},
+		{
+			name:     "active registry creation",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget"),
+			},
+			registry: []*registry.WorktreeEntry{{
+				Path: "/worktrees/creating", Repository: "github.com/acme/widget",
+				CreationToken: "creation-owner",
+			}},
+			exists: map[string]bool{"/worktrees/creating": false},
+			want:   nil,
+		},
+		{
+			name:     "live missing generation",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/legacy", GitDir: "/repos/widget/.git/worktrees/legacy",
+					DotGitTarget: "/repos/widget/.git/worktrees/legacy", Exists: true,
+					GenerationStatus: gitadapter.GenerationMissing,
+				}),
+			},
+			global:  []string{"/worktrees/legacy"},
+			targets: map[string]string{"/worktrees/legacy": "/repos/widget/.git/worktrees/legacy"},
+			exists:  map[string]bool{"/worktrees/legacy": true},
+			want:    []FindingCode{MissingGeneration},
+		},
+		{
+			name:     "live registry missing generation",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/legacy", GitDir: "/repos/widget/.git/worktrees/legacy",
+					DotGitTarget: "/repos/widget/.git/worktrees/legacy", Exists: true,
+					Generation: validGeneration, GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			registry: []*registry.WorktreeEntry{{
+				Path: "/worktrees/legacy", Repository: "github.com/acme/widget",
+			}},
+			global:  []string{"/worktrees/legacy"},
+			targets: map[string]string{"/worktrees/legacy": "/repos/widget/.git/worktrees/legacy"},
+			exists:  map[string]bool{"/worktrees/legacy": true},
+			want:    []FindingCode{RegistryGenerationMismatch},
+		},
+		{
+			name:     "live registry generation differs from Git",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/topic", GitDir: "/repos/widget/.git/worktrees/topic",
+					DotGitTarget: "/repos/widget/.git/worktrees/topic", Exists: true,
+					Generation: validGeneration, GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			registry: []*registry.WorktreeEntry{{
+				Path: "/worktrees/topic", Repository: "github.com/acme/widget",
+				Generation: "fedcba9876543210fedcba9876543210",
+			}},
+			global:  []string{"/worktrees/topic"},
+			targets: map[string]string{"/worktrees/topic": "/repos/widget/.git/worktrees/topic"},
+			exists:  map[string]bool{"/worktrees/topic": true},
+			want:    []FindingCode{RegistryGenerationMismatch},
+		},
+		{
+			name:     "wrong repository",
+			projects: []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			snapshots: map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/topic", GitDir: "/repos/widget/.git/worktrees/topic",
+					DotGitTarget: "/repos/widget/.git/worktrees/topic", Exists: true,
+					Generation: validGeneration, GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			registry: []*registry.WorktreeEntry{{
+				Path: "/worktrees/topic", Repository: "github.com/other/widget", Generation: validGeneration,
+			}},
+			global:  []string{"/worktrees/topic"},
+			targets: map[string]string{"/worktrees/topic": "/repos/widget/.git/worktrees/topic"},
+			exists:  map[string]bool{"/worktrees/topic": true},
+			want:    []FindingCode{RepositoryIdentityMismatch},
+		},
+		{
+			name:       "unreachable project",
+			projects:   []models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/missing/widget"}},
+			inspectErr: map[string]error{"/missing/widget": errors.New("permission denied")},
+			want:       []FindingCode{ProjectUnreachable},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector := fakeInspector(tt.projects, tt.registry, tt.snapshots, tt.inspectErr, tt.global, tt.targets, tt.exists)
+
+			report, err := inspector.Inspect(context.Background())
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, findingCodes(report))
+		})
+	}
+}
+
+func TestInspectorReportsGitDirInspectionAmbiguity(t *testing.T) {
+	const path = "/worktrees/topic"
+	const gitDirError = "multiple Git administrative directories claim the worktree"
+	inspector := fakeInspector(
+		[]models.Project{{
+			Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget",
+		}},
+		nil,
+		map[string]RepositorySnapshot{
+			"/repos/widget": repositorySnapshot(
+				"/repos/widget",
+				gitadapter.WorktreeInspection{
+					Path: path, Exists: true, GitDirError: gitDirError,
+					GenerationStatus: gitadapter.GenerationMissing,
+				},
+			),
+		},
+		nil, nil, nil, map[string]bool{path: true},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, report.Repositories, 1)
+	require.Len(t, report.Repositories[0].Findings, 1)
+	finding := report.Repositories[0].Findings[0]
+	assert.Equal(t, AmbiguousWorktreeBacklink, finding.Code)
+	assert.False(t, finding.Fixable)
+	assert.Equal(t, gitDirError, finding.Evidence["git_dir_error"])
+}
+
+func TestInspectorTreatsDanglingSymlinksAsUnreachable(t *testing.T) {
+	t.Run("configured project", func(t *testing.T) {
+		path := newDanglingInspectionSymlink(t)
+		inspector := NewInspector(&models.Config{Projects: []models.Project{{
+			Name: "widget", Repository: "github.com/acme/widget", Path: path,
+		}}}, nil, nil)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		assert.Contains(t, findingCodes(report), ProjectUnreachable)
+		assert.NotContains(t, findingCodes(report), StaleProjectRegistration)
+	})
+
+	t.Run("registry path", func(t *testing.T) {
+		path := newDanglingInspectionSymlink(t)
+		inspector := NewInspector(
+			&models.Config{},
+			[]*registry.WorktreeEntry{{
+				Path: path, Repository: "github.com/acme/widget",
+				Generation: "0123456789abcdef0123456789abcdef",
+			}},
+			nil,
+		)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		assert.Contains(t, findingCodes(report), ProjectUnreachable)
+		assert.NotContains(t, findingCodes(report), StaleRegistryEntry)
+	})
+
+	t.Run("Git recorded worktree path", func(t *testing.T) {
+		repositoryRoot := t.TempDir()
+		path := newDanglingInspectionSymlink(t)
+		inspector := &Inspector{
+			Config: &models.Config{Projects: []models.Project{{
+				Name: "widget", Repository: "github.com/acme/widget",
+				Path: repositoryRoot,
+			}}},
+			InspectRepository: func(string) (RepositorySnapshot, error) {
+				return repositorySnapshot(repositoryRoot, gitadapter.WorktreeInspection{
+					Path: path, GitDir: filepath.Join(repositoryRoot, ".git", "worktrees", "topic"),
+					Exists: false, Prunable: true,
+					Generation:       "0123456789abcdef0123456789abcdef",
+					GenerationStatus: gitadapter.GenerationValid,
+				}), nil
+			},
+		}
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		assert.Contains(t, findingCodes(report), ProjectUnreachable)
+		assert.NotContains(t, findingCodes(report), MissingWorktreeDirectory)
+	})
+}
+
+func newDanglingInspectionSymlink(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	path := filepath.Join(base, "dangling")
+	if err := os.Symlink(filepath.Join(base, "missing-target"), path); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	return path
+}
+
+func TestInspectorOnlyAutoFixesGenerationlessRegistryMismatch(t *testing.T) {
+	const gitGeneration = "0123456789abcdef0123456789abcdef"
+	for _, tt := range []struct {
+		name               string
+		registryGeneration string
+		wantFixable        bool
+	}{
+		{name: "generationless legacy record", wantFixable: true},
+		{name: "nonempty replacement conflict", registryGeneration: "fedcba9876543210fedcba9876543210", wantFixable: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector := fakeInspector(
+				[]models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+				[]*registry.WorktreeEntry{{
+					Path: "/worktrees/topic", Repository: "github.com/acme/widget",
+					Generation: tt.registryGeneration,
+				}},
+				map[string]RepositorySnapshot{
+					"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+						Path: "/worktrees/topic", GitDir: "/repos/widget/.git/worktrees/topic",
+						DotGitTarget: "/repos/widget/.git/worktrees/topic", Exists: true,
+						Generation: gitGeneration, GenerationStatus: gitadapter.GenerationValid,
+					}),
+				},
+				nil,
+				[]string{"/worktrees/topic"},
+				map[string]string{"/worktrees/topic": "/repos/widget/.git/worktrees/topic"},
+				map[string]bool{"/worktrees/topic": true},
+			)
+
+			report, err := inspector.Inspect(context.Background())
+
+			require.NoError(t, err)
+			require.Len(t, report.Repositories, 1)
+			require.Len(t, report.Repositories[0].Findings, 1)
+			finding := report.Repositories[0].Findings[0]
+			assert.Equal(t, RegistryGenerationMismatch, finding.Code)
+			assert.Equal(t, tt.wantFixable, finding.Fixable)
+			if tt.wantFixable {
+				assert.Contains(t, finding.Remediation, "kwt doctor --fix")
+			} else {
+				assert.Contains(t, finding.Remediation, "replacement")
+			}
+		})
+	}
+}
+
+func TestInspectorReportsExistingUnverifiedRegistryPath(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	repositoryRoot := "/repos/widget"
+	registryPath := "/repos/widget/copied-metadata"
+	snapshot := repositorySnapshot(repositoryRoot, gitadapter.WorktreeInspection{
+		Path: repositoryRoot, IsMain: true, Exists: true,
+		GitDir:       filepath.Join(repositoryRoot, ".git"),
+		DotGitTarget: filepath.Join(repositoryRoot, ".git"),
+		Generation:   generation, GenerationStatus: gitadapter.GenerationValid,
+	})
+	inspector := fakeInspector(
+		[]models.Project{{
+			Name: "widget", Repository: "github.com/acme/widget", Path: repositoryRoot,
+		}},
+		[]*registry.WorktreeEntry{{
+			Path: registryPath, Repository: "github.com/acme/widget",
+			Generation: generation,
+		}},
+		map[string]RepositorySnapshot{
+			repositoryRoot: snapshot,
+			registryPath:   snapshot,
+		},
+		nil, nil, nil,
+		map[string]bool{repositoryRoot: true, registryPath: true},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, findingCodes(report), UnverifiedRegistryEntry)
+	for _, repository := range report.Repositories {
+		for _, finding := range repository.Findings {
+			if finding.Code == UnverifiedRegistryEntry {
+				assert.Equal(t, registryPath, finding.Path)
+				assert.False(t, finding.Fixable)
+				assert.Equal(t, generation, finding.Evidence["generation"])
+			}
+		}
+	}
+}
+
+func TestInspectorClassifiesDuplicateRegistryAliases(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	worktreePath := t.TempDir()
+	aliasPath := filepath.Dir(worktreePath) + string(os.PathSeparator) + "." +
+		string(os.PathSeparator) + filepath.Base(worktreePath)
+	registeredAt := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	expiresAt := registeredAt.Add(24 * time.Hour)
+	base := registry.WorktreeEntry{
+		Repository:   "github.com/acme/widget",
+		Branch:       "feature/topic",
+		Path:         worktreePath,
+		Hash:         "abc123",
+		RegisteredAt: registeredAt,
+		ExpiresAt:    &expiresAt,
+		Generation:   generation,
+	}
+	tests := []struct {
+		name        string
+		changeAlias func(*registry.WorktreeEntry)
+		wantFinding bool
+		wantFixable bool
+	}{
+		{name: "equivalent aliases", wantFinding: true, wantFixable: true},
+		{
+			name: "different expiration", wantFinding: true,
+			changeAlias: func(entry *registry.WorktreeEntry) {
+				other := expiresAt.Add(time.Hour)
+				entry.ExpiresAt = &other
+			},
+		},
+		{
+			name: "different generation", wantFinding: true,
+			changeAlias: func(entry *registry.WorktreeEntry) {
+				entry.Generation = "fedcba9876543210fedcba9876543210"
+			},
+		},
+		{
+			name: "active creation owner defers group",
+			changeAlias: func(entry *registry.WorktreeEntry) {
+				entry.CreationToken = "active-owner"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := base
+			second := base
+			second.Path = aliasPath
+			if tt.changeAlias != nil {
+				tt.changeAlias(&second)
+			}
+			inspector := fakeInspector(
+				nil,
+				[]*registry.WorktreeEntry{&first, &second},
+				map[string]RepositorySnapshot{
+					worktreePath: repositorySnapshot(worktreePath, gitadapter.WorktreeInspection{
+						Path: worktreePath, Exists: true, Generation: generation,
+						GenerationStatus: gitadapter.GenerationValid,
+					}),
+				},
+				nil, nil, nil,
+				map[string]bool{worktreePath: true, aliasPath: true},
+			)
+
+			report, err := inspector.Inspect(context.Background())
+
+			require.NoError(t, err)
+			var duplicates []Finding
+			for _, repositoryReport := range report.Repositories {
+				for _, finding := range repositoryReport.Findings {
+					if finding.Code == DuplicateRegistryEntry {
+						duplicates = append(duplicates, finding)
+					}
+				}
+			}
+			if !tt.wantFinding {
+				assert.Empty(t, duplicates)
+				return
+			}
+			require.Len(t, duplicates, 1)
+			finding := duplicates[0]
+			assert.Equal(t, tt.wantFixable, finding.Fixable)
+			assert.Contains(t, finding.Evidence["paths"], worktreePath)
+			assert.Contains(t, finding.Evidence["paths"], aliasPath)
+			if tt.wantFixable {
+				require.NotNil(t, finding.RegistryAliasRepair)
+				require.Len(t, finding.RegistryAliasRepair.Expected, 2)
+				assert.Equal(t, worktreePath, finding.RegistryAliasRepair.Retained.Path)
+			} else {
+				assert.Nil(t, finding.RegistryAliasRepair)
+			}
+		})
+	}
+}
+
+func TestInspectorClassifiesMissingDuplicateRegistryAliases(t *testing.T) {
+	realParent := t.TempDir()
+	aliasParent := filepath.Join(t.TempDir(), "worktrees-link")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	worktreePath := filepath.Join(
+		realParent,
+		"missing-parent",
+		"missing-worktree",
+	)
+	aliasPath := filepath.Join(
+		aliasParent,
+		"missing-parent",
+		"missing-worktree",
+	)
+	registeredAt := time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC)
+	base := registry.WorktreeEntry{
+		Repository: "github.com/acme/widget", Branch: "feature/topic",
+		Path: worktreePath, RegisteredAt: registeredAt,
+	}
+	tests := []struct {
+		name        string
+		changeAlias func(*registry.WorktreeEntry)
+		wantFixable bool
+	}{
+		{name: "equivalent group", wantFixable: true},
+		{
+			name: "conflicting group",
+			changeAlias: func(entry *registry.WorktreeEntry) {
+				entry.Branch = "feature/other"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := base
+			second := base
+			second.Path = aliasPath
+			if tt.changeAlias != nil {
+				tt.changeAlias(&second)
+			}
+			inspector := fakeInspector(
+				nil,
+				[]*registry.WorktreeEntry{&first, &second},
+				nil, nil, nil, nil,
+				map[string]bool{worktreePath: false, aliasPath: false},
+			)
+
+			report, err := inspector.Inspect(context.Background())
+
+			require.NoError(t, err)
+			var duplicates []Finding
+			var stale []Finding
+			for _, repositoryReport := range report.Repositories {
+				for _, finding := range repositoryReport.Findings {
+					switch finding.Code {
+					case DuplicateRegistryEntry:
+						duplicates = append(duplicates, finding)
+					case StaleRegistryEntry:
+						stale = append(stale, finding)
+					}
+				}
+			}
+			require.Len(t, duplicates, 1)
+			assert.Empty(t, stale)
+			finding := duplicates[0]
+			assert.Equal(t, tt.wantFixable, finding.Fixable)
+			assert.Contains(t, finding.Evidence["paths"], worktreePath)
+			assert.Contains(t, finding.Evidence["paths"], aliasPath)
+			if tt.wantFixable {
+				require.NotNil(t, finding.RegistryAliasRepair)
+				require.Len(t, finding.RegistryAliasRepair.Expected, 2)
+				assert.Nil(t, finding.RegistryAliasRepair.Retained)
+			} else {
+				assert.Nil(t, finding.RegistryAliasRepair)
+			}
+		})
+	}
+}
+
+func TestInspectorCanonicalizesLegacyRegistryRepositoryURL(t *testing.T) {
+	const (
+		secret     = "credential-must-not-appear"
+		generation = "0123456789abcdef0123456789abcdef"
+	)
+	inspector := fakeInspector(
+		[]models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+		[]*registry.WorktreeEntry{{
+			Path:       "/worktrees/topic",
+			Repository: "https://user:" + secret + "@github.com/acme/widget.git",
+			Generation: generation,
+		}},
+		map[string]RepositorySnapshot{
+			"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+				Path: "/worktrees/topic", Exists: true, Generation: generation,
+				GenerationStatus: gitadapter.GenerationValid,
+			}),
+		},
+		nil, nil, nil,
+		map[string]bool{"/worktrees/topic": true},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, findingCodes(report))
+	encoded, err := json.Marshal(report)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), secret)
+}
+
+func TestInspectorAcceptsOriginBasedExpirationForConfiguredUpstream(t *testing.T) {
+	const (
+		upstream = "github.com/acme/widget"
+		fork     = "github.com/octocat/widget"
+	)
+	repositoryPath := newMaintenanceTestRepository(t)
+	g := gitadapter.New(repositoryPath)
+	_, err := g.RunCommand("remote", "set-url", "origin", "https://github.com/octocat/widget.git")
+	require.NoError(t, err)
+	_, err = g.RunCommand("branch", "feature/expiring")
+	require.NoError(t, err)
+	worktreePath := filepath.Join(t.TempDir(), "expiring")
+	_, err = g.RunCommand("worktree", "add", worktreePath, "feature/expiring")
+	require.NoError(t, err)
+	generation, err := g.WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	inspector := NewInspector(
+		&models.Config{Projects: []models.Project{{
+			Name: "widget", Path: repositoryPath, Repository: upstream,
+		}}},
+		[]*registry.WorktreeEntry{{
+			Path: worktreePath, Repository: fork, Generation: generation,
+		}},
+		nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	assert.NotContains(t, findingCodes(report), RepositoryIdentityMismatch)
+}
+
+func TestInspectorRedactsUnparseableRegistryRepository(t *testing.T) {
+	const (
+		secret     = "credential-must-not-appear"
+		generation = "0123456789abcdef0123456789abcdef"
+	)
+	rawRepository := "ext::command --token=" + secret
+
+	t.Run("standalone registry report", func(t *testing.T) {
+		inspector := fakeInspector(
+			nil,
+			[]*registry.WorktreeEntry{{Path: "/worktrees/stale", Repository: rawRepository}},
+			nil, nil, nil, nil,
+			map[string]bool{"/worktrees/stale": false},
+		)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		encoded, err := json.Marshal(report)
+		require.NoError(t, err)
+		assert.NotContains(t, string(encoded), secret)
+		assert.NotContains(t, string(encoded), rawRepository)
+	})
+
+	t.Run("mismatch evidence", func(t *testing.T) {
+		inspector := fakeInspector(
+			[]models.Project{{Name: "widget", Repository: "github.com/acme/widget", Path: "/repos/widget"}},
+			[]*registry.WorktreeEntry{{
+				Path: "/worktrees/topic", Repository: rawRepository, Generation: generation,
+			}},
+			map[string]RepositorySnapshot{
+				"/repos/widget": repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+					Path: "/worktrees/topic", Exists: true, Generation: generation,
+					GenerationStatus: gitadapter.GenerationValid,
+				}),
+			},
+			nil, nil, nil,
+			map[string]bool{"/worktrees/topic": true},
+		)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		require.Len(t, report.Repositories, 1)
+		require.Len(t, report.Repositories[0].Findings, 1)
+		finding := report.Repositories[0].Findings[0]
+		assert.Equal(t, RepositoryIdentityMismatch, finding.Code)
+		assert.Equal(t, "[redacted]", finding.Evidence["registry_repository"])
+		encoded, err := json.Marshal(report)
+		require.NoError(t, err)
+		assert.NotContains(t, string(encoded), secret)
+	})
+}
+
+func TestInspectorSanitizesConfiguredRepositoryIdentity(t *testing.T) {
+	const secret = "configured-credential-must-not-appear"
+
+	t.Run("reachable credential URL is canonicalized", func(t *testing.T) {
+		repositoryPath := newMaintenanceTestRepository(t)
+		inspector := NewInspector(&models.Config{Projects: []models.Project{{
+			Name: "widget", Path: repositoryPath,
+			Repository: "https://user:" + secret + "@github.com/acme/widget.git",
+		}}}, nil, nil)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		require.Len(t, report.Repositories, 1)
+		assert.Equal(t, "github.com/acme/widget", report.Repositories[0].RepositoryIdentity)
+		assertReportOmits(t, report, secret)
+	})
+
+	t.Run("reachable malformed identity falls back to origin", func(t *testing.T) {
+		repositoryPath := newMaintenanceTestRepository(t)
+		inspector := NewInspector(&models.Config{Projects: []models.Project{{
+			Name: "widget", Path: repositoryPath,
+			Repository: "ext::command --token=" + secret,
+		}}}, nil, nil)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		require.Len(t, report.Repositories, 1)
+		assert.Equal(t, "github.com/acme/widget", report.Repositories[0].RepositoryIdentity)
+		assertReportOmits(t, report, secret)
+	})
+
+	t.Run("unreachable malformed identity is omitted", func(t *testing.T) {
+		inspector := fakeInspector(
+			[]models.Project{{
+				Name: "widget", Path: "/missing/widget",
+				Repository: "ext::command --token=" + secret,
+			}},
+			nil, nil,
+			map[string]error{"/missing/widget": errors.New("permission denied")},
+			nil, nil, nil,
+		)
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		require.Len(t, report.Repositories, 1)
+		assert.Empty(t, report.Repositories[0].RepositoryIdentity)
+		assertReportOmits(t, report, secret)
+	})
+}
+
+func TestInspectorReportsConfiguredRepositoryIdentityClaims(t *testing.T) {
+	const secret = "configured-claim-secret-must-not-appear"
+	tests := []struct {
+		name             string
+		repository       string
+		want             bool
+		wantRepositories string
+		wantInvalid      string
+	}{
+		{
+			name:       "equivalent canonical identity",
+			repository: "https://github.com/acme/widget.git",
+		},
+		{
+			name:             "conflicting canonical identity",
+			repository:       "github.com/other/widget",
+			want:             true,
+			wantRepositories: "github.com/acme/widget\ngithub.com/other/widget",
+		},
+		{
+			name:       "invalid competing identity",
+			repository: "ext::command --token=" + secret,
+			want:       true, wantRepositories: "github.com/acme/widget",
+			wantInvalid: "1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := repositorySnapshot("/repos/widget")
+			inspector := fakeInspector(
+				[]models.Project{
+					{
+						Name: "widget-a", Repository: "github.com/acme/widget",
+						Path: "/configured/widget-a",
+					},
+					{
+						Name: "widget-b", Repository: tt.repository,
+						Path: "/configured/widget-b",
+					},
+				},
+				nil,
+				map[string]RepositorySnapshot{
+					"/configured/widget-a": snapshot,
+					"/configured/widget-b": snapshot,
+				},
+				nil, nil, nil, nil,
+			)
+
+			report, err := inspector.Inspect(context.Background())
+
+			require.NoError(t, err)
+			require.Len(t, report.Repositories, 1)
+			if tt.want {
+				require.Len(t, report.Repositories[0].Findings, 1)
+				finding := report.Repositories[0].Findings[0]
+				assert.Equal(t, RepositoryIdentityMismatch, finding.Code)
+				assert.False(t, finding.Fixable)
+				assert.Equal(
+					t, tt.wantRepositories,
+					finding.Evidence["configured_repositories"],
+				)
+				assert.Equal(t, tt.wantInvalid, finding.Evidence["invalid_claim_count"])
+			} else {
+				assert.Empty(t, report.Repositories[0].Findings)
+			}
+			assertReportOmits(t, report, secret)
+		})
+	}
+}
+
+func TestInspectRepositoryUsesMainRepositoryIdentityForLinkedRoot(t *testing.T) {
+	repositoryPath := newMaintenanceTestRepository(t)
+	g := gitadapter.New(repositoryPath)
+	_, err := g.RunCommand("branch", "linked-origin")
+	require.NoError(t, err)
+	worktreePath := filepath.Join(t.TempDir(), "linked-origin")
+	_, err = g.RunCommand("worktree", "add", worktreePath, "linked-origin")
+	require.NoError(t, err)
+	_, err = g.RunCommand("remote", "remove", "origin")
+	require.NoError(t, err)
+	linkedGitDir, err := gitadapter.New(worktreePath).RunCommand(
+		"rev-parse", "--absolute-git-dir",
+	)
+	require.NoError(t, err)
+	linkedConfig := filepath.Join(t.TempDir(), "linked.config")
+	_, err = g.RunCommand(
+		"config", "--file", linkedConfig,
+		"remote.origin.url", "https://github.com/hubot/widget.git",
+	)
+	require.NoError(t, err)
+	_, err = g.RunCommand(
+		"config", "--add",
+		"includeIf.gitdir:"+strings.TrimSpace(linkedGitDir)+".path", linkedConfig,
+	)
+	require.NoError(t, err)
+	_, err = g.RunCommand(
+		"remote", "add", "origin", "https://github.com/acme/widget.git",
+	)
+	require.NoError(t, err)
+
+	inspector := NewInspector(&models.Config{}, nil, nil)
+	snapshot, err := inspector.inspectRepository(worktreePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/acme/widget", snapshot.RepositoryIdentity)
+	assert.Equal(
+		t,
+		"github.com/hubot/widget",
+		snapshot.LiveRepositoryIdentities[pathKey(worktreePath)],
+	)
+}
+
+func TestInspectRepositorySupportsSeparateGitDirectory(t *testing.T) {
+	mainPath, linkedPath := newMaintenanceSeparateGitRepository(t)
+	inspector := NewInspector(&models.Config{Projects: []models.Project{{
+		Name: "widget", Path: mainPath, Repository: "github.com/acme/widget",
+	}}}, nil, nil)
+
+	snapshot, err := inspector.inspectRepository(mainPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, pathKey(mainPath), pathKey(snapshot.Root))
+	require.Len(t, snapshot.Worktrees, 2)
+	mainFound := false
+	linkedFound := false
+	for _, inspection := range snapshot.Worktrees {
+		switch pathKey(inspection.Path) {
+		case pathKey(mainPath):
+			mainFound = inspection.IsMain
+		case pathKey(linkedPath):
+			linkedFound = !inspection.IsMain
+		}
+	}
+	assert.True(t, mainFound)
+	assert.True(t, linkedFound)
+}
+
+func TestInspectorDeduplicatesProjectsByCommonDirectory(t *testing.T) {
+	snapshot := repositorySnapshot("/repos/widget")
+	inspector := fakeInspector(
+		[]models.Project{
+			{Name: "zeta", Repository: "github.com/acme/widget", Path: "/aliases/zeta"},
+			{Name: "alpha", Repository: "github.com/acme/widget", Path: "/aliases/alpha"},
+		},
+		nil,
+		map[string]RepositorySnapshot{
+			"/aliases/zeta":  snapshot,
+			"/aliases/alpha": snapshot,
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, report.Repositories, 1)
+	assert.Equal(t, []string{"alpha", "zeta"}, report.Repositories[0].ProjectNames)
+}
+
+func TestInspectorInventoriesRepositoryFromGlobalLinkedWorktree(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	linkedPath := "/worktrees/topic"
+	inspector := fakeInspector(
+		nil,
+		nil,
+		map[string]RepositorySnapshot{
+			linkedPath: repositorySnapshot("/repos/widget", gitadapter.WorktreeInspection{
+				Path: linkedPath, GitDir: "/repos/widget/.git/worktrees/topic",
+				DotGitTarget: "/repos/widget/.git/worktrees/topic", Exists: true,
+				Generation: generation, GenerationStatus: gitadapter.GenerationValid,
+			}),
+		},
+		nil,
+		[]string{linkedPath},
+		map[string]string{linkedPath: "/repos/widget/.git/worktrees/topic"},
+		map[string]bool{linkedPath: true},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, report.Repositories, 1)
+	assert.Equal(t, "/repos/widget/.git", report.Repositories[0].CommonDir)
+	assert.Empty(t, report.Repositories[0].Findings)
+}
+
+func TestInspectorReportsUninspectableGlobalLinkedWorktree(t *testing.T) {
+	linkedPath := "/worktrees/topic"
+	inspector := fakeInspector(
+		nil,
+		nil,
+		nil,
+		map[string]error{linkedPath: errors.New("linked repository unavailable")},
+		[]string{linkedPath},
+		map[string]string{linkedPath: "/repos/widget/.git/worktrees/topic"},
+		map[string]bool{linkedPath: true},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, report.Repositories, 1)
+	assert.Equal(t, linkedPath, report.Repositories[0].Root)
+	require.Len(t, report.Repositories[0].Findings, 1)
+	assert.Equal(t, ProjectUnreachable, report.Repositories[0].Findings[0].Code)
+	assert.Contains(t, report.Repositories[0].Findings[0].Message, "linked repository unavailable")
+}
+
+func TestInspectorReportsUnreadableGlobalDotGit(t *testing.T) {
+	linkedPath := "/worktrees/topic"
+	inspector := &Inspector{
+		Config: &models.Config{Worktree: models.WorktreeConfig{BaseDir: "/worktrees"}},
+		FindGlobalPaths: func(string) ([]string, error) {
+			return []string{linkedPath}, nil
+		},
+		ReadDotGitTarget: func(string) (string, error) {
+			return "", errors.New("permission denied")
+		},
+		InspectRepository: func(string) (RepositorySnapshot, error) {
+			t.Fatal("repository inspection must not run without a readable .git entry")
+			return RepositorySnapshot{}, nil
+		},
+		PathExists: func(string) (bool, error) { return true, nil },
+	}
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, report.Repositories, 1)
+	require.Len(t, report.Repositories[0].Findings, 1)
+	finding := report.Repositories[0].Findings[0]
+	assert.Equal(t, ProjectUnreachable, finding.Code)
+	assert.Contains(t, finding.Message, "permission denied")
+}
+
+func repositorySnapshot(root string, worktrees ...gitadapter.WorktreeInspection) RepositorySnapshot {
+	return RepositorySnapshot{
+		Root:               root,
+		CommonDir:          root + "/.git",
+		RepositoryIdentity: "github.com/acme/widget",
+		Worktrees:          worktrees,
+	}
+}
+
+func newMaintenanceTestRepository(t *testing.T) string {
+	t.Helper()
+	repositoryPath := t.TempDir()
+	g := gitadapter.New(repositoryPath)
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.name", "Test User"},
+		{"config", "user.email", "test@example.com"},
+		{"remote", "add", "origin", "https://github.com/acme/widget.git"},
+	} {
+		_, err := g.RunCommand(args...)
+		require.NoError(t, err)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("test\n"), 0o644))
+	_, err := g.RunCommand("add", "README.md")
+	require.NoError(t, err)
+	_, err = g.RunCommand("commit", "-m", "initial")
+	require.NoError(t, err)
+	return repositoryPath
+}
+
+func newMaintenanceSeparateGitRepository(t *testing.T) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	mainPath := filepath.Join(base, "main-worktree")
+	linkedPath := filepath.Join(base, "linked-worktree")
+	separateGitDir := filepath.Join(base, "repository.git")
+	_, err := gitadapter.New(base).RunCommand(
+		"init", "-b", "main", "--separate-git-dir", separateGitDir, mainPath,
+	)
+	require.NoError(t, err)
+	g := gitadapter.New(mainPath)
+	for _, args := range [][]string{
+		{"config", "user.name", "Test User"},
+		{"config", "user.email", "test@example.com"},
+		{"remote", "add", "origin", "https://github.com/acme/widget.git"},
+	} {
+		_, err := g.RunCommand(args...)
+		require.NoError(t, err)
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(mainPath, "README.md"),
+		[]byte("test\n"),
+		0o644,
+	))
+	_, err = g.RunCommand("add", "README.md")
+	require.NoError(t, err)
+	_, err = g.RunCommand("commit", "-m", "initial")
+	require.NoError(t, err)
+	_, err = g.RunCommand("branch", "topic")
+	require.NoError(t, err)
+	_, err = g.RunCommand("worktree", "add", linkedPath, "topic")
+	require.NoError(t, err)
+	return mainPath, linkedPath
+}
+
+func assertReportOmits(t *testing.T, report Report, value string) {
+	t.Helper()
+	encoded, err := json.Marshal(report)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), value)
+}
+
+func fakeInspector(
+	projects []models.Project,
+	entries []*registry.WorktreeEntry,
+	snapshots map[string]RepositorySnapshot,
+	inspectErr map[string]error,
+	global []string,
+	targets map[string]string,
+	exists map[string]bool,
+) *Inspector {
+	return &Inspector{
+		Config:          &models.Config{Projects: projects, Worktree: models.WorktreeConfig{BaseDir: "/worktrees"}},
+		RegistryEntries: entries,
+		InspectRepository: func(path string) (RepositorySnapshot, error) {
+			if err := inspectErr[path]; err != nil {
+				return RepositorySnapshot{}, err
+			}
+			if snapshot, ok := snapshots[path]; ok {
+				return snapshot, nil
+			}
+			target := targets[path]
+			for _, snapshot := range snapshots {
+				for _, inspection := range snapshot.Worktrees {
+					if pathKey(inspection.Path) == pathKey(path) ||
+						(target != "" && (pathKey(inspection.GitDir) == pathKey(target) ||
+							pathKey(inspection.DotGitTarget) == pathKey(target))) {
+						return snapshot, nil
+					}
+				}
+			}
+			return RepositorySnapshot{}, nil
+		},
+		FindGlobalPaths: func(string) ([]string, error) {
+			return append([]string(nil), global...), nil
+		},
+		ReadDotGitTarget: func(path string) (string, error) {
+			return targets[path], nil
+		},
+		PathExists: func(path string) (bool, error) {
+			value, ok := exists[path]
+			if !ok {
+				return true, nil
+			}
+			return value, nil
+		},
+	}
+}
+
+func findingCodes(report Report) []FindingCode {
+	var codes []FindingCode
+	for _, repository := range report.Repositories {
+		for _, finding := range repository.Findings {
+			codes = append(codes, finding.Code)
+		}
+	}
+	sort.Slice(codes, func(i, j int) bool { return codes[i] < codes[j] })
+	return codes
+}

--- a/internal/maintenance/project_inspect_test.go
+++ b/internal/maintenance/project_inspect_test.go
@@ -1,0 +1,546 @@
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/config"
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+const projectInspectionGeneration = "0123456789abcdef0123456789abcdef"
+
+func TestInspectorClassifiesMissingProjectRegistrations(t *testing.T) {
+	tests := []struct {
+		name           string
+		registration   config.ProjectRegistration
+		targets        map[string]RepositorySnapshot
+		globalPaths    []string
+		pathExists     map[string]bool
+		pathErrors     map[string]error
+		inspectErrors  map[string]error
+		wantCode       FindingCode
+		wantFixable    bool
+		wantEvidence   map[string]string
+		wantCandidates []string
+	}{
+		{
+			name:         "unique visible repository relocates",
+			registration: projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget"),
+			targets: map[string]RepositorySnapshot{
+				"/worktrees/widget-topic": projectTargetSnapshot("/repos/widget", "/worktrees/widget-topic"),
+			},
+			globalPaths: []string{"/worktrees/widget-topic"},
+			pathExists:  map[string]bool{"/old/widget": false},
+			wantCode:    ProjectPathMoved,
+			wantFixable: true,
+			wantEvidence: map[string]string{
+				"old_path": "/old/widget", "new_path": "/repos/widget",
+			},
+		},
+		{
+			name:         "no visible repository removes stale registration",
+			registration: projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget"),
+			pathExists:   map[string]bool{"/old/widget": false},
+			wantCode:     StaleProjectRegistration,
+			wantFixable:  true,
+		},
+		{
+			name:         "distinct live clones are ambiguous",
+			registration: projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget"),
+			targets: map[string]RepositorySnapshot{
+				"/worktrees/one": projectTargetSnapshot("/repos/widget-one", "/worktrees/one"),
+				"/worktrees/two": projectTargetSnapshot("/repos/widget-two", "/worktrees/two"),
+			},
+			globalPaths:    []string{"/worktrees/two", "/worktrees/one"},
+			pathExists:     map[string]bool{"/old/widget": false},
+			wantCode:       AmbiguousProjectRelocation,
+			wantCandidates: []string{"/repos/widget-one", "/repos/widget-two"},
+		},
+		{
+			name:         "duplicate roots for one common directory stay unique",
+			registration: projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget"),
+			targets: map[string]RepositorySnapshot{
+				"/worktrees/one": projectTargetSnapshot("/repos/widget", "/worktrees/one"),
+				"/worktrees/two": projectTargetSnapshot("/repos/widget", "/worktrees/two"),
+			},
+			globalPaths: []string{"/worktrees/two", "/worktrees/one"},
+			pathExists:  map[string]bool{"/old/widget": false},
+			wantCode:    ProjectPathMoved,
+			wantFixable: true,
+		},
+		{
+			name:         "permission error remains manual",
+			registration: projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget"),
+			pathErrors:   map[string]error{"/old/widget": errors.New("permission denied")},
+			wantCode:     ProjectUnreachable,
+		},
+		{
+			name:         "existing non repository remains manual",
+			registration: projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget"),
+			pathExists:   map[string]bool{"/old/widget": true},
+			inspectErrors: map[string]error{
+				"/old/widget": errors.New("not a git repository"),
+			},
+			wantCode: ProjectUnreachable,
+		},
+		{
+			name:         "absolute path repository identity remains manual",
+			registration: projectRegistration("/old/widget", "~/old/widget", "/old/widget"),
+			pathExists:   map[string]bool{"/old/widget": false},
+			wantCode:     ProjectUnreachable,
+		},
+		{
+			name:         "local fallback identity remains manual",
+			registration: projectRegistration("local/old/widget", "~/old/widget", "/old/widget"),
+			pathExists:   map[string]bool{"/old/widget": false},
+			wantCode:     ProjectUnreachable,
+		},
+		{
+			name:         "file scheme identity remains manual",
+			registration: projectRegistration("file:acme/widget", "~/old/widget", "/old/widget"),
+			pathExists:   map[string]bool{"/old/widget": false},
+			wantCode:     ProjectUnreachable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector := projectRepairInspector(
+				[]config.ProjectRegistration{tt.registration}, nil,
+				tt.targets, tt.globalPaths, tt.pathExists, tt.pathErrors, tt.inspectErrors,
+			)
+
+			report, err := inspector.Inspect(context.Background())
+
+			require.NoError(t, err)
+			finding, repository := requireFindingCode(t, report, tt.wantCode)
+			assert.Equal(t, tt.wantFixable, finding.Fixable)
+			assert.Equal(t, tt.registration.Effective.Path, repository.Root)
+			for key, want := range tt.wantEvidence {
+				assert.Equal(t, want, finding.Evidence[key])
+			}
+			if len(tt.wantCandidates) > 0 {
+				assert.Equal(t, tt.wantCandidates, splitEvidencePaths(finding.Evidence["candidate_paths"]))
+			}
+			if tt.wantFixable {
+				require.NotNil(t, finding.ProjectRepair)
+				assert.Equal(t, tt.registration, finding.ProjectRepair.Expected)
+			} else {
+				assert.Nil(t, finding.ProjectRepair)
+			}
+		})
+	}
+}
+
+func TestInspectorUsesLiveRegistryPathAsProjectRelocationTarget(t *testing.T) {
+	registration := projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget")
+	entry := &registry.WorktreeEntry{
+		Path: "/repos/widget", Repository: "github.com/acme/widget",
+		Generation: projectInspectionGeneration,
+	}
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{registration}, []*registry.WorktreeEntry{entry},
+		map[string]RepositorySnapshot{
+			entry.Path: projectTargetSnapshot("/repos/widget", entry.Path),
+		},
+		nil,
+		map[string]bool{registration.Effective.Path: false, entry.Path: true},
+		nil, nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	finding, _ := requireFindingCode(t, report, ProjectPathMoved)
+	assert.Equal(t, "/repos/widget", finding.Evidence["new_path"])
+}
+
+func TestInspectorKeepsMissingProjectManualWhenGlobalInventoryIsIncomplete(
+	t *testing.T,
+) {
+	registration := projectRegistration(
+		"github.com/acme/widget", "~/old/widget", "/old/widget",
+	)
+	unreachablePath := "/worktrees/unreachable"
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{registration}, nil, nil,
+		[]string{unreachablePath},
+		map[string]bool{registration.Effective.Path: false, unreachablePath: true},
+		nil,
+		map[string]error{unreachablePath: errors.New("not a git repository")},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	finding := requireProjectFindingAtPath(t, report, registration.Effective.Path)
+	assert.Equal(t, ProjectUnreachable, finding.Code)
+	assert.False(t, finding.Fixable)
+	assert.Nil(t, finding.ProjectRepair)
+	assert.Contains(t, finding.Message, "inventory is incomplete")
+}
+
+func TestInspectorKeepsMissingProjectManualWhenRegistryInventoryIsIncomplete(
+	t *testing.T,
+) {
+	registration := projectRegistration(
+		"github.com/acme/widget", "~/old/widget", "/old/widget",
+	)
+	entry := &registry.WorktreeEntry{
+		Path: "/worktrees/unreachable", Repository: "github.com/acme/widget",
+		Generation: projectInspectionGeneration,
+	}
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{registration},
+		[]*registry.WorktreeEntry{entry},
+		nil, nil,
+		map[string]bool{registration.Effective.Path: false, entry.Path: true},
+		nil,
+		map[string]error{entry.Path: errors.New("not a git repository")},
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	finding := requireProjectFindingAtPath(t, report, registration.Effective.Path)
+	assert.Equal(t, ProjectUnreachable, finding.Code)
+	assert.False(t, finding.Fixable)
+	assert.Nil(t, finding.ProjectRepair)
+	assert.Contains(t, finding.Message, "inventory is incomplete")
+}
+
+func TestInspectorRemovesMissingDuplicateOfRegisteredLiveProject(t *testing.T) {
+	stale := projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget")
+	live := projectRegistration("github.com/acme/widget", "/repos/widget", "/repos/widget")
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{stale, live}, nil,
+		map[string]RepositorySnapshot{
+			live.Effective.Path: projectTargetSnapshot(live.Effective.Path, live.Effective.Path),
+		},
+		nil,
+		map[string]bool{stale.Effective.Path: false, live.Effective.Path: true},
+		nil, nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	finding, _ := requireFindingCode(t, report, StaleProjectRegistration)
+	assert.Equal(t, stale.Effective.Path, finding.Path)
+	require.NotNil(t, finding.ProjectRepair)
+	assert.Equal(t, RemoveProject, finding.ProjectRepair.Action)
+	assert.Equal(t, live.Effective.Path, finding.Evidence["registered_path"])
+	assert.NotContains(t, findingCodes(report), ProjectPathMoved)
+
+	projects := []models.Project{stale.Persisted, live.Persisted}
+	fixer := &Fixer{
+		Projects: &fakeProjectMutator{compareAndSwap: func(
+			expected config.ProjectRegistration,
+			replacement *models.Project,
+		) (bool, error) {
+			require.Nil(t, replacement)
+			for index := range projects {
+				if projects[index] == expected.Persisted {
+					projects = append(projects[:index], projects[index+1:]...)
+					return true, nil
+				}
+			}
+			return false, nil
+		}},
+		PathExists: func(path string) (bool, error) {
+			return path == live.Effective.Path, nil
+		},
+	}
+
+	require.NoError(t, fixer.Fix(context.Background(), report))
+	require.Len(t, projects, 1)
+	assert.Equal(t, live.Persisted, projects[0])
+}
+
+func TestInspectorReportsMultipleRegistrationsClaimingOneRelocationTargetAsManual(t *testing.T) {
+	first := projectRegistration(
+		"github.com/acme/widget",
+		"~/old/widget-one",
+		"/old/widget-one",
+	)
+	first.Persisted.Name = "widget-one"
+	first.Effective.Name = "widget-one"
+	second := projectRegistration(
+		"https://github.com/acme/widget.git",
+		"~/old/widget-two",
+		"/old/widget-two",
+	)
+	second.Persisted.Name = "widget-two"
+	second.Effective.Name = "widget-two"
+	targetPath := "/repos/widget"
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{first, second}, nil,
+		map[string]RepositorySnapshot{
+			targetPath: projectTargetSnapshot(targetPath, targetPath),
+		},
+		[]string{targetPath},
+		map[string]bool{
+			first.Effective.Path:  false,
+			second.Effective.Path: false,
+			targetPath:            true,
+		},
+		nil, nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	var ambiguous []Finding
+	for _, repository := range report.Repositories {
+		for _, finding := range repository.Findings {
+			if finding.Code == AmbiguousProjectRelocation {
+				ambiguous = append(ambiguous, finding)
+			}
+			assert.NotEqual(t, ProjectPathMoved, finding.Code)
+		}
+	}
+	require.Len(t, ambiguous, 2)
+	for _, finding := range ambiguous {
+		assert.False(t, finding.Fixable)
+		assert.Nil(t, finding.ProjectRepair)
+		assert.Equal(t, targetPath, finding.Evidence["candidate_paths"])
+	}
+}
+
+func TestInspectorReportsDuplicateMissingProjectRegistrationAsManual(t *testing.T) {
+	registration := projectRegistration("github.com/acme/widget", "~/old/widget", "/old/widget")
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{registration, registration}, nil, nil, nil,
+		map[string]bool{registration.Effective.Path: false}, nil, nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	finding, _ := requireFindingCode(t, report, ProjectUnreachable)
+	assert.False(t, finding.Fixable)
+	assert.Contains(t, finding.Message, "duplicate")
+	assert.NotContains(t, findingCodes(report), StaleProjectRegistration)
+}
+
+func TestInspectorDoesNotArbitrarilyJoinRegistryEntryToOneOfMultipleClones(t *testing.T) {
+	entryPath := "/worktrees/missing"
+	registrations := []config.ProjectRegistration{
+		projectRegistration("github.com/acme/widget", "/repos/one", "/repos/one"),
+		projectRegistration("github.com/acme/widget", "/repos/two", "/repos/two"),
+	}
+	inspector := projectRepairInspector(
+		registrations,
+		[]*registry.WorktreeEntry{{
+			Path: entryPath, Repository: "github.com/acme/widget",
+			Generation: projectInspectionGeneration,
+		}},
+		map[string]RepositorySnapshot{
+			"/repos/one": projectTargetSnapshot("/repos/one", "/repos/one"),
+			"/repos/two": projectTargetSnapshot("/repos/two", "/repos/two"),
+		},
+		nil,
+		map[string]bool{entryPath: false},
+		nil, nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	finding, owner := requireFindingCode(t, report, StaleRegistryEntry)
+	assert.Equal(t, entryPath, finding.Path)
+	assert.Equal(t, entryPath, owner.Root)
+	assert.Empty(t, owner.ProjectNames)
+}
+
+func TestInspectorDoesNotInventoryRegistryEntryOwnedByCreation(t *testing.T) {
+	entry := &registry.WorktreeEntry{
+		Path: "/repos/creating", Repository: "github.com/acme/widget",
+		CreationToken: "creator",
+	}
+	inspector := projectRepairInspector(
+		nil, []*registry.WorktreeEntry{entry}, nil, nil,
+		map[string]bool{entry.Path: true}, nil, nil,
+	)
+	inspector.InspectRepository = func(path string) (RepositorySnapshot, error) {
+		return RepositorySnapshot{}, fmt.Errorf("active creation path inspected: %s", path)
+	}
+	inspector.CreationActive = func(string) (bool, error) { return true, nil }
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, report.Summary.Healthy)
+}
+
+func TestInspectorIncludesAbandonedCreationRegistryEntries(t *testing.T) {
+	t.Run("missing path", func(t *testing.T) {
+		entry := &registry.WorktreeEntry{
+			Path: "/worktrees/abandoned", Repository: "github.com/acme/widget",
+			CreationToken: "abandoned",
+		}
+		inspector := projectRepairInspector(
+			nil, []*registry.WorktreeEntry{entry}, nil, nil,
+			map[string]bool{entry.Path: false}, nil, nil,
+		)
+		inspector.CreationActive = func(string) (bool, error) { return false, nil }
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		finding, _ := requireFindingCode(t, report, StaleRegistryEntry)
+		assert.True(t, finding.Fixable)
+	})
+
+	t.Run("materialized path", func(t *testing.T) {
+		entry := &registry.WorktreeEntry{
+			Path: "/repos/widget", Repository: "github.com/acme/widget",
+			CreationToken: "abandoned",
+		}
+		inspector := projectRepairInspector(
+			nil, []*registry.WorktreeEntry{entry},
+			map[string]RepositorySnapshot{entry.Path: projectTargetSnapshot(entry.Path, entry.Path)},
+			nil, map[string]bool{entry.Path: true}, nil, nil,
+		)
+		inspector.CreationActive = func(string) (bool, error) { return false, nil }
+
+		report, err := inspector.Inspect(context.Background())
+
+		require.NoError(t, err)
+		finding, _ := requireFindingCode(t, report, RegistryGenerationMismatch)
+		assert.True(t, finding.Fixable)
+	})
+}
+
+func TestProjectRepairConditionIsExcludedFromJSON(t *testing.T) {
+	rawMarker := "raw-project-marker"
+	report := Report{Repositories: []RepositoryReport{{Findings: []Finding{{
+		Code: ProjectPathMoved, Path: "/old/widget", Fixable: true,
+		ProjectRepair: &ProjectRepairCondition{
+			Action:   RelocateProject,
+			Expected: config.ProjectRegistration{Persisted: models.Project{Name: rawMarker}},
+		},
+	}}}}}
+
+	encoded, err := json.Marshal(report)
+
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), rawMarker)
+	assert.NotContains(t, string(encoded), "project_repair")
+}
+
+func projectRepairInspector(
+	registrations []config.ProjectRegistration,
+	entries []*registry.WorktreeEntry,
+	snapshots map[string]RepositorySnapshot,
+	globalPaths []string,
+	exists map[string]bool,
+	pathErrors map[string]error,
+	inspectErrors map[string]error,
+) *Inspector {
+	effectiveProjects := make([]models.Project, len(registrations))
+	for index := range registrations {
+		effectiveProjects[index] = registrations[index].Effective
+	}
+	return &Inspector{
+		Config: &models.Config{
+			Projects: effectiveProjects,
+			Worktree: models.WorktreeConfig{BaseDir: "/worktrees"},
+		},
+		ProjectRegistrations: registrations,
+		RegistryEntries:      entries,
+		InspectRepository: func(path string) (RepositorySnapshot, error) {
+			if err := inspectErrors[path]; err != nil {
+				return RepositorySnapshot{}, err
+			}
+			if snapshot, ok := snapshots[path]; ok {
+				return snapshot, nil
+			}
+			return RepositorySnapshot{}, errors.New("repository snapshot missing")
+		},
+		FindGlobalPaths: func(string) ([]string, error) {
+			return append([]string(nil), globalPaths...), nil
+		},
+		ReadDotGitTarget: func(path string) (string, error) {
+			return filepath.Join(path, ".git"), nil
+		},
+		PathExists: func(path string) (bool, error) {
+			if err := pathErrors[path]; err != nil {
+				return false, err
+			}
+			value, ok := exists[path]
+			if !ok {
+				return true, nil
+			}
+			return value, nil
+		},
+	}
+}
+
+func projectRegistration(repository, persistedPath, effectivePath string) config.ProjectRegistration {
+	return config.ProjectRegistration{
+		Persisted: models.Project{
+			Repository: repository, Name: "widget", Path: persistedPath, LastTouched: "before",
+		},
+		Effective: models.Project{
+			Repository: repository, Name: "widget", Path: effectivePath, LastTouched: "before",
+		},
+	}
+}
+
+func projectTargetSnapshot(root, inspectionPath string) RepositorySnapshot {
+	return RepositorySnapshot{
+		Root: root, CommonDir: filepath.Join(root, ".git"),
+		RepositoryIdentity: "github.com/acme/widget",
+		Worktrees: []gitadapter.WorktreeInspection{{
+			Path: inspectionPath, Exists: true, IsMain: inspectionPath == root,
+			Generation:       projectInspectionGeneration,
+			GenerationStatus: gitadapter.GenerationValid,
+		}},
+	}
+}
+
+func requireFindingCode(t *testing.T, report Report, code FindingCode) (*Finding, *RepositoryReport) {
+	t.Helper()
+	for repositoryIndex := range report.Repositories {
+		for findingIndex := range report.Repositories[repositoryIndex].Findings {
+			finding := &report.Repositories[repositoryIndex].Findings[findingIndex]
+			if finding.Code == code {
+				return finding, &report.Repositories[repositoryIndex]
+			}
+		}
+	}
+	t.Fatalf("finding %s not found in %+v", code, report.Repositories)
+	return nil, nil
+}
+
+func requireProjectFindingAtPath(t *testing.T, report Report, path string) *Finding {
+	t.Helper()
+	for repositoryIndex := range report.Repositories {
+		for findingIndex := range report.Repositories[repositoryIndex].Findings {
+			finding := &report.Repositories[repositoryIndex].Findings[findingIndex]
+			if pathKey(finding.Path) == pathKey(path) {
+				return finding
+			}
+		}
+	}
+	t.Fatalf("finding for %s not found in %+v", path, report.Repositories)
+	return nil
+}
+
+func splitEvidencePaths(value string) []string {
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, "\n")
+}

--- a/internal/maintenance/project_inspect_test.go
+++ b/internal/maintenance/project_inspect_test.go
@@ -412,6 +412,36 @@ func TestInspectorDoesNotInventoryRegistryEntryOwnedByCreation(t *testing.T) {
 	assert.True(t, report.Summary.Healthy)
 }
 
+func TestInspectorDefersMissingProjectRepairDuringActiveCreation(t *testing.T) {
+	registration := projectRegistration(
+		"github.com/acme/widget", "~/old/widget", "/old/widget",
+	)
+	entry := &registry.WorktreeEntry{
+		Path: "/repos/creating", Repository: "github.com/acme/widget",
+		CreationToken: "creator",
+	}
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{registration},
+		[]*registry.WorktreeEntry{entry},
+		nil,
+		nil,
+		map[string]bool{registration.Effective.Path: false, entry.Path: true},
+		nil,
+		nil,
+	)
+	inspector.InspectRepository = func(path string) (RepositorySnapshot, error) {
+		return RepositorySnapshot{}, fmt.Errorf("active creation path inspected: %s", path)
+	}
+	inspector.CreationActive = func(string) (bool, error) { return true, nil }
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, findingCodes(report), ProjectUnreachable)
+	assert.NotContains(t, findingCodes(report), ProjectPathMoved)
+	assert.NotContains(t, findingCodes(report), StaleProjectRegistration)
+}
+
 func TestInspectorIncludesAbandonedCreationRegistryEntries(t *testing.T) {
 	t.Run("missing path", func(t *testing.T) {
 		entry := &registry.WorktreeEntry{

--- a/internal/maintenance/project_inspect_test.go
+++ b/internal/maintenance/project_inspect_test.go
@@ -363,6 +363,35 @@ func TestInspectorDoesNotArbitrarilyJoinRegistryEntryToOneOfMultipleClones(t *te
 	assert.Empty(t, owner.ProjectNames)
 }
 
+func TestInspectorDoesNotUseRegistrySubdirectoryForProjectRelocation(t *testing.T) {
+	registration := projectRegistration(
+		"github.com/acme/widget", "~/old/widget", "/old/widget",
+	)
+	repositoryRoot := "/repos/widget"
+	registryPath := "/repos/widget/nested"
+	inspector := projectRepairInspector(
+		[]config.ProjectRegistration{registration},
+		[]*registry.WorktreeEntry{{
+			Path: registryPath, Repository: "github.com/acme/widget",
+			Generation: projectInspectionGeneration,
+		}},
+		map[string]RepositorySnapshot{
+			registryPath: projectTargetSnapshot(repositoryRoot, repositoryRoot),
+		},
+		nil,
+		map[string]bool{registration.Effective.Path: false, registryPath: true},
+		nil,
+		nil,
+	)
+
+	report, err := inspector.Inspect(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, findingCodes(report), UnverifiedRegistryEntry)
+	assert.NotContains(t, findingCodes(report), ProjectPathMoved)
+	assert.NotContains(t, findingCodes(report), StaleProjectRegistration)
+}
+
 func TestInspectorDoesNotInventoryRegistryEntryOwnedByCreation(t *testing.T) {
 	entry := &registry.WorktreeEntry{
 		Path: "/repos/creating", Repository: "github.com/acme/widget",

--- a/internal/maintenance/types.go
+++ b/internal/maintenance/types.go
@@ -1,0 +1,111 @@
+// Package maintenance inspects and repairs local worktree consistency without
+// consulting pull-request providers.
+package maintenance
+
+import (
+	"go.kenn.io/kwt/internal/config"
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/registry"
+)
+
+const SchemaVersion = 1
+
+type FindingCode string
+
+const (
+	BrokenWorktreeBacklink     FindingCode = "broken_worktree_backlink"
+	AmbiguousWorktreeBacklink  FindingCode = "ambiguous_worktree_backlink"
+	MissingWorktreeDirectory   FindingCode = "missing_worktree_directory"
+	StaleRegistryEntry         FindingCode = "stale_registry_entry"
+	UnverifiedRegistryEntry    FindingCode = "unverified_registry_entry"
+	MissingGeneration          FindingCode = "missing_generation"
+	RegistryGenerationMismatch FindingCode = "registry_generation_mismatch"
+	DuplicateRegistryEntry     FindingCode = "duplicate_registry_entry"
+	ProjectUnreachable         FindingCode = "project_unreachable"
+	RepositoryIdentityMismatch FindingCode = "repository_identity_mismatch"
+	ProjectPathMoved           FindingCode = "project_path_moved"
+	StaleProjectRegistration   FindingCode = "stale_project_registration"
+	AmbiguousProjectRelocation FindingCode = "ambiguous_project_relocation"
+)
+
+type ProjectRepairAction string
+
+const (
+	RelocateProject ProjectRepairAction = "relocate"
+	RemoveProject   ProjectRepairAction = "remove"
+)
+
+// ProjectRepairCondition carries the raw compare-and-swap token and the live
+// target facts that the fixer must revalidate. It is deliberately excluded
+// from reports because the persisted project may contain sensitive values.
+type ProjectRepairCondition struct {
+	Action           ProjectRepairAction
+	Expected         config.ProjectRegistration
+	TargetRoot       string
+	TargetCommonDir  string
+	TargetRepository string
+}
+
+// RegistryAliasRepairCondition carries the complete observed alias group for
+// one atomic registry compare-and-swap. A nil Retained entry removes a
+// confirmed-absent group. It is excluded from serialized reports.
+type RegistryAliasRepairCondition struct {
+	Expected []*registry.WorktreeEntry
+	Retained *registry.WorktreeEntry
+}
+
+type Severity string
+
+const (
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+type Finding struct {
+	Code                FindingCode                   `json:"code"`
+	Severity            Severity                      `json:"severity"`
+	Path                string                        `json:"path,omitempty"`
+	Message             string                        `json:"message"`
+	Remediation         string                        `json:"remediation"`
+	Fixable             bool                          `json:"fixable"`
+	Evidence            map[string]string             `json:"evidence,omitempty"`
+	ProjectRepair       *ProjectRepairCondition       `json:"-"`
+	RegistryAliasRepair *RegistryAliasRepairCondition `json:"-"`
+}
+
+type RepositoryReport struct {
+	Root               string                          `json:"root,omitempty"`
+	CommonDir          string                          `json:"common_dir,omitempty"`
+	RepositoryIdentity string                          `json:"repository_identity,omitempty"`
+	ProjectNames       []string                        `json:"project_names,omitempty"`
+	Worktrees          []gitadapter.WorktreeInspection `json:"worktrees,omitempty"`
+	Findings           []Finding                       `json:"findings"`
+}
+
+type Summary struct {
+	Healthy         bool `json:"healthy"`
+	Repositories    int  `json:"repositories"`
+	Findings        int  `json:"findings"`
+	FixableFindings int  `json:"fixable_findings"`
+	ManualFindings  int  `json:"manual_findings"`
+	FixedFindings   int  `json:"fixed_findings,omitempty"`
+}
+
+type Report struct {
+	SchemaVersion int                `json:"schema_version"`
+	Command       string             `json:"command"`
+	Fix           bool               `json:"fix"`
+	Fixed         []RepositoryReport `json:"fixed,omitempty"`
+	Repositories  []RepositoryReport `json:"repositories"`
+	Summary       Summary            `json:"summary"`
+}
+
+// RepositorySnapshot is the provider-free local state for one Git common
+// directory before findings are classified.
+type RepositorySnapshot struct {
+	Root                     string
+	CommonDir                string
+	RepositoryIdentity       string
+	LiveRepositoryIdentities map[string]string
+	Worktrees                []gitadapter.WorktreeInspection
+}

--- a/internal/prunepolicy/merged.go
+++ b/internal/prunepolicy/merged.go
@@ -67,6 +67,7 @@ func evaluateMergedCandidate(
 	if !ok || strings.TrimSpace(candidate.SourceBranch) == "" {
 		return mergedOutcome(candidate, SourceRepositoryUnavailable, "configured upstream does not identify a source repository and branch")
 	}
+	observedProjectRepository := candidate.ProjectRepository
 	observedSourceRepository := candidate.SourceRepository
 	resolvedBase, err := provider.ResolveRepository(ctx, requestedBase)
 	if err != nil {
@@ -92,6 +93,7 @@ func evaluateMergedCandidate(
 			provider,
 			candidate,
 			base,
+			observedProjectRepository,
 			observedSourceRepository,
 		)
 	}
@@ -122,12 +124,13 @@ func evaluateImportedMerged(
 	provider MergedProvider,
 	candidate MergedCandidate,
 	base pullrequest.Repository,
+	observedProjectRepository string,
 	observedSourceRepository string,
 ) Outcome {
 	record := *candidate.Provenance
 	if !strings.EqualFold(record.Provider, "github") || record.Number <= 0 ||
 		!provenancePullRequestIDMatches(record) ||
-		!provenanceRepositoryMatches(record, candidate.ProjectRepository) ||
+		!provenanceRepositoryMatches(record, observedProjectRepository) ||
 		!provenanceRepositoryMatches(record, record.Project.Identity) ||
 		!provenanceRepositoryMatches(record, record.Workspace.Repository) ||
 		strings.TrimSpace(candidate.MainRepositoryPath) == "" ||

--- a/internal/prunepolicy/merged.go
+++ b/internal/prunepolicy/merged.go
@@ -1,0 +1,361 @@
+package prunepolicy
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	gitadapter "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/utils"
+)
+
+// MergedProvider supplies provider evidence without owning prune policy.
+type MergedProvider interface {
+	ResolveRepository(context.Context, pullrequest.Repository) (pullrequest.Repository, error)
+	Get(context.Context, pullrequest.Repository, int) (pullrequest.PullRequest, error)
+	ListForCommit(context.Context, pullrequest.Repository, string) ([]pullrequest.PullRequest, error)
+	ListByHead(context.Context, pullrequest.Repository, string, string) ([]pullrequest.PullRequest, error)
+}
+
+// MergedCandidate is the complete local snapshot used for provider preflight.
+type MergedCandidate struct {
+	Path               string
+	Branch             string
+	Head               string
+	Generation         string
+	MainRepositoryPath string
+	ProjectRepository  string
+	LiveRepository     string
+	SourceRepository   string
+	SourceBranch       string
+	Dirty              bool
+	IsMain             bool
+	Provenance         *pullrequest.Provenance
+}
+
+// EvaluateMerged classifies candidates without changing local or provider state.
+func EvaluateMerged(
+	ctx context.Context, provider MergedProvider, candidates []MergedCandidate,
+) []Outcome {
+	outcomes := make([]Outcome, 0, len(candidates))
+	for _, candidate := range candidates {
+		outcomes = append(outcomes, evaluateMergedCandidate(ctx, provider, candidate))
+	}
+	return outcomes
+}
+
+func evaluateMergedCandidate(
+	ctx context.Context, provider MergedProvider, candidate MergedCandidate,
+) Outcome {
+	switch {
+	case candidate.IsMain:
+		return mergedOutcome(candidate, MainWorktree, "main worktree is never pruned")
+	case gitadapter.ValidateWorktreeGeneration(candidate.Generation) != nil:
+		return mergedOutcome(candidate, MissingGeneration, "worktree has no valid generation")
+	case candidate.Dirty:
+		return mergedOutcome(candidate, DirtyWorktree, "worktree has uncommitted changes")
+	case strings.TrimSpace(candidate.LiveRepository) == "":
+		return mergedOutcome(candidate, RepositoryChanged, "worktree origin repository identity is unavailable")
+	}
+	requestedBase, ok := githubRepository(candidate.ProjectRepository)
+	if !ok {
+		return mergedOutcome(candidate, DoctorRequired, "project repository identity is unavailable")
+	}
+	requestedSource, ok := githubRepository(candidate.SourceRepository)
+	if !ok || strings.TrimSpace(candidate.SourceBranch) == "" {
+		return mergedOutcome(candidate, SourceRepositoryUnavailable, "configured upstream does not identify a source repository and branch")
+	}
+	observedSourceRepository := candidate.SourceRepository
+	resolvedBase, err := provider.ResolveRepository(ctx, requestedBase)
+	if err != nil {
+		return providerFailure(candidate, err)
+	}
+	base, ok := githubRepository(resolvedBase.Identity)
+	if !ok {
+		return mergedOutcome(candidate, RepositoryChanged, "resolved project repository identity is unavailable")
+	}
+	resolvedSource, err := provider.ResolveRepository(ctx, requestedSource)
+	if err != nil {
+		return providerFailure(candidate, err)
+	}
+	source, ok := githubRepository(resolvedSource.Identity)
+	if !ok {
+		return mergedOutcome(candidate, SourceRepositoryUnavailable, "resolved upstream repository identity is unavailable")
+	}
+	candidate.ProjectRepository = base.Identity
+	candidate.SourceRepository = source.Identity
+	if candidate.Provenance != nil {
+		return evaluateImportedMerged(
+			ctx,
+			provider,
+			candidate,
+			base,
+			observedSourceRepository,
+		)
+	}
+	prs, err := provider.ListForCommit(ctx, base, candidate.Head)
+	if err != nil {
+		return providerFailure(candidate, err)
+	}
+	exact, mismatch := exactOrdinaryMatches(candidate, prs)
+	switch len(exact) {
+	case 1:
+		return pullRequestOutcome(candidate, exact[0])
+	case 0:
+		if mismatch != "" {
+			return mergedOutcome(candidate, mismatch, mismatchMessage(mismatch))
+		}
+	default:
+		return ambiguousOutcome(candidate, exact)
+	}
+	prs, err = provider.ListByHead(ctx, base, source.Owner, candidate.SourceBranch)
+	if err != nil {
+		return providerFailure(candidate, err)
+	}
+	return diagnoseSourceHead(candidate, prs)
+}
+
+func evaluateImportedMerged(
+	ctx context.Context,
+	provider MergedProvider,
+	candidate MergedCandidate,
+	base pullrequest.Repository,
+	observedSourceRepository string,
+) Outcome {
+	record := *candidate.Provenance
+	if !strings.EqualFold(record.Provider, "github") || record.Number <= 0 ||
+		!provenancePullRequestIDMatches(record) ||
+		!provenanceRepositoryMatches(record, candidate.ProjectRepository) ||
+		!provenanceRepositoryMatches(record, record.Project.Identity) ||
+		!provenanceRepositoryMatches(record, record.Workspace.Repository) ||
+		strings.TrimSpace(candidate.MainRepositoryPath) == "" ||
+		strings.TrimSpace(record.Project.Path) == "" ||
+		utils.PathKey(record.Project.Path) != utils.PathKey(candidate.MainRepositoryPath) ||
+		utils.PathKey(record.Workspace.Path) != utils.PathKey(candidate.Path) ||
+		record.Workspace.Branch != candidate.Branch ||
+		(record.Workspace.Generation != "" &&
+			record.Workspace.Generation != candidate.Generation) {
+		return mergedOutcome(candidate, DoctorRequired, "pull-request provenance does not match the live workspace")
+	}
+	if !provenanceSourceRepositoryMatches(record, observedSourceRepository) {
+		return mergedOutcome(candidate, SourceRepositoryMismatch, mismatchMessage(SourceRepositoryMismatch))
+	}
+	if record.SourceBranch != candidate.SourceBranch {
+		return mergedOutcome(candidate, SourceBranchMismatch, mismatchMessage(SourceBranchMismatch))
+	}
+	if record.HeadSHA != candidate.Head {
+		return mergedOutcome(candidate, HeadAdvancedAfterPR, mismatchMessage(HeadAdvancedAfterPR))
+	}
+	pr, err := provider.Get(ctx, base, record.Number)
+	if err != nil {
+		return providerFailure(candidate, err)
+	}
+	if pr.Number != record.Number ||
+		!pullrequest.EqualRepositoryIdentity(pr.Repository.Identity, candidate.ProjectRepository) {
+		return mergedOutcome(candidate, RepositoryChanged, "provider pull request does not match the recorded repository")
+	}
+	if !strings.EqualFold(pr.Provider, record.Provider) {
+		return mergedOutcome(candidate, DoctorRequired, "provider pull request does not match recorded provenance")
+	}
+	if !pullrequest.EqualRepositoryIdentity(
+		candidate.SourceRepository,
+		pr.Source.Repository.Identity,
+	) {
+		return mergedOutcome(candidate, SourceRepositoryMismatch, mismatchMessage(SourceRepositoryMismatch))
+	}
+	if pr.Source.Name != record.SourceBranch {
+		return mergedOutcome(candidate, SourceBranchMismatch, mismatchMessage(SourceBranchMismatch))
+	}
+	if pr.HeadSHA != record.HeadSHA {
+		return mergedOutcome(candidate, HeadAdvancedAfterPR, mismatchMessage(HeadAdvancedAfterPR))
+	}
+	return pullRequestOutcome(candidate, pr)
+}
+
+func exactOrdinaryMatches(
+	candidate MergedCandidate, prs []pullrequest.PullRequest,
+) ([]pullrequest.PullRequest, Reason) {
+	var exact []pullrequest.PullRequest
+	var mismatch Reason
+	for _, pr := range prs {
+		if !pullrequest.EqualRepositoryIdentity(pr.Repository.Identity, candidate.ProjectRepository) ||
+			pr.HeadSHA != candidate.Head {
+			continue
+		}
+		if !pullrequest.EqualRepositoryIdentity(pr.Source.Repository.Identity, candidate.SourceRepository) {
+			mismatch = SourceRepositoryMismatch
+			continue
+		}
+		if pr.Source.Name != candidate.SourceBranch {
+			if mismatch == "" {
+				mismatch = SourceBranchMismatch
+			}
+			continue
+		}
+		exact = append(exact, pr)
+	}
+	return exact, mismatch
+}
+
+func diagnoseSourceHead(candidate MergedCandidate, prs []pullrequest.PullRequest) Outcome {
+	var matches []pullrequest.PullRequest
+	var mismatch Reason
+	for _, pr := range prs {
+		if !pullrequest.EqualRepositoryIdentity(pr.Repository.Identity, candidate.ProjectRepository) {
+			continue
+		}
+		if !pullrequest.EqualRepositoryIdentity(pr.Source.Repository.Identity, candidate.SourceRepository) {
+			mismatch = SourceRepositoryMismatch
+			continue
+		}
+		if pr.Source.Name != candidate.SourceBranch {
+			if mismatch == "" {
+				mismatch = SourceBranchMismatch
+			}
+			continue
+		}
+		matches = append(matches, pr)
+	}
+	if len(matches) > 1 {
+		return ambiguousOutcome(candidate, matches)
+	}
+	if len(matches) == 1 {
+		if matches[0].MergedAt == nil {
+			return pullRequestOutcome(candidate, matches[0])
+		}
+		outcome := mergedOutcome(candidate, HeadAdvancedAfterPR, mismatchMessage(HeadAdvancedAfterPR))
+		addPullRequestEvidence(&outcome, matches[0])
+		return outcome
+	}
+	if mismatch != "" {
+		return mergedOutcome(candidate, mismatch, mismatchMessage(mismatch))
+	}
+	return mergedOutcome(candidate, NoAssociatedPR, "no pull request is associated with the worktree HEAD or source branch")
+}
+
+func pullRequestOutcome(candidate MergedCandidate, pr pullrequest.PullRequest) Outcome {
+	reason := EligibleMerged
+	message := "worktree has one explicitly merged pull request"
+	if pr.MergedAt == nil {
+		reason = PRNotMerged
+		message = "associated pull request is not merged"
+	}
+	outcome := mergedOutcome(candidate, reason, message)
+	addPullRequestEvidence(&outcome, pr)
+	return outcome
+}
+
+func ambiguousOutcome(candidate MergedCandidate, prs []pullrequest.PullRequest) Outcome {
+	outcome := mergedOutcome(candidate, AmbiguousPRMatch, "multiple pull requests match the worktree identity")
+	outcome.Evidence["match_count"] = strconv.Itoa(len(prs))
+	return outcome
+}
+
+func providerFailure(candidate MergedCandidate, err error) Outcome {
+	reason := NetworkFailure
+	code := pullrequest.CodeNetwork
+	retryable := false
+	var typed *pullrequest.Error
+	if errors.As(err, &typed) {
+		code = typed.Code
+		retryable = typed.Retryable
+		switch typed.Code {
+		case pullrequest.CodeAuthentication:
+			reason = AuthenticationFailed
+		case pullrequest.CodeNetwork:
+			reason = NetworkFailure
+		default:
+			reason = ProviderFailure
+		}
+	}
+	message := "pull-request provider could not classify the candidate"
+	remediation := "Check network connectivity and retry merged pruning."
+	switch reason {
+	case AuthenticationFailed:
+		message = "pull-request provider authentication failed"
+		remediation = "Refresh GitHub authentication and retry merged pruning."
+	case ProviderFailure:
+		message = "pull-request provider returned an unusable result"
+		remediation = "Review the provider error code, resolve the provider issue, and retry merged pruning."
+	}
+	outcome := mergedOutcome(candidate, reason, message)
+	outcome.Remediation = remediation
+	outcome.Evidence["provider_error_code"] = string(code)
+	outcome.Evidence["retryable"] = strconv.FormatBool(retryable)
+	return outcome
+}
+
+func mergedOutcome(candidate MergedCandidate, reason Reason, message string) Outcome {
+	return Outcome{
+		Path: candidate.Path, Branch: candidate.Branch, Reason: reason, Message: message,
+		Evidence: map[string]string{"head_sha": candidate.Head},
+	}
+}
+
+func addPullRequestEvidence(outcome *Outcome, pr pullrequest.PullRequest) {
+	outcome.Evidence["pr_number"] = strconv.Itoa(pr.Number)
+	outcome.Evidence["pr_url"] = pr.URL
+	outcome.Evidence["pr_head_sha"] = pr.HeadSHA
+}
+
+func mismatchMessage(reason Reason) string {
+	switch reason {
+	case HeadAdvancedAfterPR:
+		return "source branch has advanced after the associated pull request head"
+	case SourceRepositoryMismatch:
+		return "associated pull request source repository does not match the configured upstream"
+	case SourceBranchMismatch:
+		return "associated pull request source branch does not match the configured upstream"
+	default:
+		return string(reason)
+	}
+}
+
+func provenanceRepositoryMatches(record pullrequest.Provenance, identity string) bool {
+	if pullrequest.EqualRepositoryIdentity(record.Repository, identity) {
+		return true
+	}
+	for _, alias := range record.RepositoryAliases {
+		if pullrequest.EqualRepositoryIdentity(alias, identity) {
+			return true
+		}
+	}
+	return false
+}
+
+func provenancePullRequestIDMatches(record pullrequest.Provenance) bool {
+	if record.PullRequestID == pullrequest.OpaqueID(record.Repository, record.Number) {
+		return true
+	}
+	for _, alias := range record.RepositoryAliases {
+		if record.PullRequestID == pullrequest.OpaqueID(alias, record.Number) {
+			return true
+		}
+	}
+	return false
+}
+
+func provenanceSourceRepositoryMatches(record pullrequest.Provenance, identity string) bool {
+	if pullrequest.EqualRepositoryIdentity(record.SourceRepo, identity) {
+		return true
+	}
+	return provenanceRepositoryMatches(record, record.SourceRepo) &&
+		provenanceRepositoryMatches(record, identity)
+}
+
+func githubRepository(identity string) (pullrequest.Repository, bool) {
+	identity = pullrequest.NormalizeRepositoryIdentity(identity)
+	const prefix = "github.com/"
+	if !strings.HasPrefix(identity, prefix) {
+		return pullrequest.Repository{}, false
+	}
+	owner, name, ok := strings.Cut(strings.TrimPrefix(identity, prefix), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return pullrequest.Repository{}, false
+	}
+	return pullrequest.Repository{
+		Provider: "github", Identity: identity, Host: "github.com", Owner: owner, Name: name,
+	}, true
+}

--- a/internal/prunepolicy/merged_test.go
+++ b/internal/prunepolicy/merged_test.go
@@ -1,0 +1,560 @@
+package prunepolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/pullrequest"
+)
+
+const (
+	mergedHead     = "0123456789abcdef0123456789abcdef01234567"
+	advancedHead   = "89abcdef0123456789abcdef0123456789abcdef"
+	baseRepository = "github.com/acme/widget"
+	forkRepository = "github.com/octocat/widget"
+)
+
+type fakeMergedProvider struct {
+	resolve      func(pullrequest.Repository) (pullrequest.Repository, error)
+	get          func(pullrequest.Repository, int) (pullrequest.PullRequest, error)
+	byCommit     func(pullrequest.Repository, string) ([]pullrequest.PullRequest, error)
+	byHead       func(pullrequest.Repository, string, string) ([]pullrequest.PullRequest, error)
+	getCalls     int
+	commitCalls  int
+	headCalls    int
+	resolveCalls int
+}
+
+func (p *fakeMergedProvider) ResolveRepository(_ context.Context, repository pullrequest.Repository) (pullrequest.Repository, error) {
+	p.resolveCalls++
+	if p.resolve == nil {
+		return repository, nil
+	}
+	return p.resolve(repository)
+}
+
+func (p *fakeMergedProvider) Get(_ context.Context, repository pullrequest.Repository, number int) (pullrequest.PullRequest, error) {
+	p.getCalls++
+	if p.get == nil {
+		return pullrequest.PullRequest{}, errors.New("unexpected Get call")
+	}
+	return p.get(repository, number)
+}
+
+func (p *fakeMergedProvider) ListForCommit(_ context.Context, repository pullrequest.Repository, sha string) ([]pullrequest.PullRequest, error) {
+	p.commitCalls++
+	if p.byCommit == nil {
+		return nil, errors.New("unexpected ListForCommit call")
+	}
+	return p.byCommit(repository, sha)
+}
+
+func (p *fakeMergedProvider) ListByHead(_ context.Context, repository pullrequest.Repository, owner, branch string) ([]pullrequest.PullRequest, error) {
+	p.headCalls++
+	if p.byHead == nil {
+		return nil, errors.New("unexpected ListByHead call")
+	}
+	return p.byHead(repository, owner, branch)
+}
+
+func TestEvaluateMerged(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate MergedCandidate
+		provider  *fakeMergedProvider
+		want      Reason
+	}{
+		{name: "imported exact merged", candidate: importedMergedCandidate(), provider: providerForImported(exactMergedPR(forkRepository)), want: EligibleMerged},
+		{name: "imported transferred repository aliases", candidate: importedTransferredCandidate(), provider: providerForImported(exactMergedPR(forkRepository)), want: EligibleMerged},
+		{name: "imported transferred same repository source", candidate: importedTransferredSourceCandidate(), provider: providerForImported(exactMergedPR(baseRepository)), want: EligibleMerged},
+		{name: "imported stale URL after transfer", candidate: importedWithStaleURL(), provider: providerForImported(exactMergedPR(forkRepository)), want: EligibleMerged},
+		{name: "imported opaque ID mismatch", candidate: importedWithOpaqueIDMismatch(), provider: &fakeMergedProvider{}, want: DoctorRequired},
+		{name: "imported provenance head mismatch", candidate: importedWithHeadMismatch(), provider: &fakeMergedProvider{}, want: HeadAdvancedAfterPR},
+		{name: "imported provenance workspace mismatch", candidate: importedWithWorkspaceMismatch(), provider: &fakeMergedProvider{}, want: DoctorRequired},
+		{name: "imported provenance generation mismatch", candidate: importedWithGenerationMismatch(), provider: &fakeMergedProvider{}, want: DoctorRequired},
+		{name: "imported provenance project path mismatch", candidate: importedWithProjectPathMismatch(), provider: &fakeMergedProvider{}, want: DoctorRequired},
+		{name: "ordinary same repo", candidate: ordinaryCandidate(baseRepository), provider: providerForCommit(exactMergedPR(baseRepository)), want: EligibleMerged},
+		{name: "ordinary fork", candidate: ordinaryCandidate(forkRepository), provider: providerForCommit(exactMergedPR(forkRepository)), want: EligibleMerged},
+		{name: "ordinary fork origin with configured base", candidate: withForkOrigin(ordinaryCandidate(forkRepository)), provider: providerForCommit(exactMergedPR(forkRepository)), want: EligibleMerged},
+		{name: "imported fork origin with configured base", candidate: withForkOrigin(importedMergedCandidate()), provider: providerForImported(exactMergedPR(forkRepository)), want: EligibleMerged},
+		{name: "missing generation", candidate: withoutGeneration(), provider: &fakeMergedProvider{}, want: MissingGeneration},
+		{name: "invalid generation", candidate: withInvalidGeneration(), provider: &fakeMergedProvider{}, want: MissingGeneration},
+		{name: "dirty", candidate: dirtyMerged(), provider: &fakeMergedProvider{}, want: DirtyWorktree},
+		{name: "main worktree", candidate: mainWorktree(), provider: &fakeMergedProvider{}, want: MainWorktree},
+		{name: "head advanced", candidate: advancedCandidate(), provider: providerForAdvancedBranch(), want: HeadAdvancedAfterPR},
+		{name: "no PR", candidate: ordinaryCandidate(forkRepository), provider: providerEmpty(), want: NoAssociatedPR},
+		{name: "closed not merged", candidate: ordinaryCandidate(forkRepository), provider: providerForCommit(closedPR(forkRepository)), want: PRNotMerged},
+		{name: "source unavailable", candidate: noUpstream(), provider: &fakeMergedProvider{}, want: SourceRepositoryUnavailable},
+		{name: "source repo mismatch", candidate: ordinaryCandidate(forkRepository), provider: providerForCommit(exactMergedPR("github.com/hubot/widget")), want: SourceRepositoryMismatch},
+		{name: "branch mismatch", candidate: ordinaryCandidate(forkRepository), provider: providerForCommit(prWithBranch(exactMergedPR(forkRepository), "other")), want: SourceBranchMismatch},
+		{name: "ambiguous", candidate: ordinaryCandidate(forkRepository), provider: providerForCommit(exactMergedPR(forkRepository), prWithNumber(exactMergedPR(forkRepository), 18)), want: AmbiguousPRMatch},
+		{name: "authentication", candidate: ordinaryCandidate(forkRepository), provider: providerWithError(pullrequest.NewError(pullrequest.CodeAuthentication, "auth failed", false, nil)), want: AuthenticationFailed},
+		{name: "network", candidate: ordinaryCandidate(forkRepository), provider: providerWithError(pullrequest.NewError(pullrequest.CodeNetwork, "network failed", true, nil)), want: NetworkFailure},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			outcomes := EvaluateMerged(context.Background(), tc.provider, []MergedCandidate{tc.candidate})
+
+			require.Len(t, outcomes, 1)
+			assert.Equal(t, tc.want, outcomes[0].Reason)
+			assert.Equal(t, tc.candidate.Path, outcomes[0].Path)
+			assert.Equal(t, tc.candidate.Branch, outcomes[0].Branch)
+			if tc.want == EligibleMerged {
+				assert.Equal(t, "17", outcomes[0].Evidence["pr_number"])
+				assert.Equal(t, "https://github.com/acme/widget/pull/17", outcomes[0].Evidence["pr_url"])
+				assert.Equal(t, mergedHead, outcomes[0].Evidence["pr_head_sha"])
+			}
+			if tc.want == AuthenticationFailed || tc.want == NetworkFailure {
+				assert.NotEmpty(t, outcomes[0].Evidence["provider_error_code"])
+			}
+			if tc.want == NetworkFailure {
+				assert.Equal(t, "true", outcomes[0].Evidence["retryable"])
+			}
+		})
+	}
+}
+
+func TestEvaluateMergedMapsProviderFailuresToStableReasons(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantReason   Reason
+		wantEvidence pullrequest.ErrorCode
+	}{
+		{
+			name: "authentication",
+			err: pullrequest.NewError(
+				pullrequest.CodeAuthentication, "authentication failed", false, nil,
+			),
+			wantReason: AuthenticationFailed, wantEvidence: pullrequest.CodeAuthentication,
+		},
+		{
+			name: "network",
+			err: pullrequest.NewError(
+				pullrequest.CodeNetwork, "network failed", true, nil,
+			),
+			wantReason: NetworkFailure, wantEvidence: pullrequest.CodeNetwork,
+		},
+		{
+			name: "not found",
+			err: pullrequest.NewError(
+				pullrequest.CodeNotFound, "pull request not found", false, nil,
+			),
+			wantReason: ProviderFailure, wantEvidence: pullrequest.CodeNotFound,
+		},
+		{
+			name: "malformed response",
+			err: pullrequest.NewError(
+				pullrequest.CodeMalformedResponse, "malformed response", false, nil,
+			),
+			wantReason: ProviderFailure, wantEvidence: pullrequest.CodeMalformedResponse,
+		},
+		{
+			name: "untyped failure", err: errors.New("provider unavailable"),
+			wantReason: NetworkFailure, wantEvidence: pullrequest.CodeNetwork,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcomes := EvaluateMerged(
+				context.Background(),
+				providerWithError(tt.err),
+				[]MergedCandidate{ordinaryCandidate(forkRepository)},
+			)
+
+			require.Len(t, outcomes, 1)
+			assert.Equal(t, tt.wantReason, outcomes[0].Reason)
+			assert.Equal(
+				t, string(tt.wantEvidence), outcomes[0].Evidence["provider_error_code"],
+			)
+			assert.NotEmpty(t, outcomes[0].Remediation)
+		})
+	}
+}
+
+func TestEvaluateMergedContinuesAfterProviderFailure(t *testing.T) {
+	candidates := []MergedCandidate{
+		ordinaryCandidate(forkRepository),
+		func() MergedCandidate {
+			candidate := ordinaryCandidate(forkRepository)
+			candidate.Path = "/worktrees/confirmed"
+			candidate.Head = advancedHead
+			return candidate
+		}(),
+	}
+	provider := &fakeMergedProvider{
+		byCommit: func(_ pullrequest.Repository, sha string) ([]pullrequest.PullRequest, error) {
+			if sha == mergedHead {
+				return nil, pullrequest.NewError(pullrequest.CodeNetwork, "temporary", true, nil)
+			}
+			pr := exactMergedPR(forkRepository)
+			pr.HeadSHA = advancedHead
+			return []pullrequest.PullRequest{pr}, nil
+		},
+	}
+
+	outcomes := EvaluateMerged(context.Background(), provider, candidates)
+
+	require.Len(t, outcomes, 2)
+	assert.Equal(t, NetworkFailure, outcomes[0].Reason)
+	assert.Equal(t, EligibleMerged, outcomes[1].Reason)
+}
+
+func TestEvaluateMergedResolvesTransferredRepositoryBeforeProvenanceValidation(t *testing.T) {
+	const legacyRepository = "github.com/legacy/widget"
+	candidate := importedTransferredCandidate()
+	candidate.ProjectRepository = legacyRepository
+	candidate.LiveRepository = legacyRepository
+	provider := providerForImported(exactMergedPR(forkRepository))
+	provider.resolve = func(requested pullrequest.Repository) (pullrequest.Repository, error) {
+		switch requested.Identity {
+		case legacyRepository:
+			return repository(baseRepository), nil
+		case forkRepository:
+			return repository(forkRepository), nil
+		default:
+			return pullrequest.Repository{}, fmt.Errorf("unexpected repository resolution: %s", requested.Identity)
+		}
+	}
+
+	outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+	require.Len(t, outcomes, 1)
+	assert.Equal(t, EligibleMerged, outcomes[0].Reason)
+	assert.Equal(t, 2, provider.resolveCalls)
+	assert.Equal(t, 1, provider.getCalls)
+}
+
+func TestEvaluateMergedAcceptsSymlinkEquivalentImportedWorkspacePath(t *testing.T) {
+	realPath := filepath.Join(t.TempDir(), "workspace")
+	require.NoError(t, os.Mkdir(realPath, 0o755))
+	aliasPath := filepath.Join(t.TempDir(), "workspace-link")
+	if err := os.Symlink(realPath, aliasPath); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	candidate := importedMergedCandidate()
+	candidate.Path = aliasPath
+	candidate.Provenance.Workspace.Path = realPath
+	provider := providerForImported(exactMergedPR(forkRepository))
+
+	outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+	require.Len(t, outcomes, 1)
+	assert.Equal(t, EligibleMerged, outcomes[0].Reason)
+}
+
+func TestEvaluateMergedResolvesTransferredSourceRepository(t *testing.T) {
+	const (
+		legacySource   = "github.com/legacy-fork/widget"
+		resolvedSource = "github.com/new-owner/widget"
+	)
+	resolve := func(requested pullrequest.Repository) (pullrequest.Repository, error) {
+		switch requested.Identity {
+		case baseRepository:
+			return repository(baseRepository), nil
+		case legacySource:
+			return repository(resolvedSource), nil
+		default:
+			return pullrequest.Repository{}, fmt.Errorf("unexpected repository resolution: %s", requested.Identity)
+		}
+	}
+
+	t.Run("commit match", func(t *testing.T) {
+		candidate := ordinaryCandidate(legacySource)
+		provider := providerForCommit(exactMergedPR(resolvedSource))
+		provider.resolve = resolve
+
+		outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+		require.Len(t, outcomes, 1)
+		assert.Equal(t, EligibleMerged, outcomes[0].Reason)
+		assert.Equal(t, 2, provider.resolveCalls)
+	})
+
+	t.Run("diagnostic head lookup", func(t *testing.T) {
+		candidate := ordinaryCandidate(legacySource)
+		candidate.Head = advancedHead
+		provider := &fakeMergedProvider{
+			resolve: resolve,
+			byCommit: func(pullrequest.Repository, string) ([]pullrequest.PullRequest, error) {
+				return nil, nil
+			},
+			byHead: func(_ pullrequest.Repository, owner, branch string) ([]pullrequest.PullRequest, error) {
+				assert.Equal(t, "new-owner", owner)
+				assert.Equal(t, "topic", branch)
+				return []pullrequest.PullRequest{exactMergedPR(resolvedSource)}, nil
+			},
+		}
+
+		outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+		require.Len(t, outcomes, 1)
+		assert.Equal(t, HeadAdvancedAfterPR, outcomes[0].Reason)
+		assert.Equal(t, 2, provider.resolveCalls)
+	})
+
+	t.Run("imported provenance", func(t *testing.T) {
+		candidate := importedMergedCandidate()
+		candidate.SourceRepository = legacySource
+		candidate.Provenance.SourceRepo = legacySource
+		provider := providerForImported(exactMergedPR(resolvedSource))
+		provider.resolve = resolve
+
+		outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+		require.Len(t, outcomes, 1)
+		assert.Equal(t, EligibleMerged, outcomes[0].Reason)
+		assert.Equal(t, 2, provider.resolveCalls)
+	})
+}
+
+func TestEvaluateMergedRejectsMissingLiveRepositoryWithoutProvider(t *testing.T) {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.LiveRepository = ""
+	provider := providerForCommit(exactMergedPR(forkRepository))
+
+	outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+	require.Len(t, outcomes, 1)
+	assert.Equal(t, RepositoryChanged, outcomes[0].Reason)
+	assert.Zero(t, provider.commitCalls)
+	assert.Zero(t, provider.headCalls)
+}
+
+func TestEvaluateMergedRejectsMissingUpstreamWithoutProvider(t *testing.T) {
+	candidate := noUpstream()
+	provider := &fakeMergedProvider{}
+
+	outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+	require.Len(t, outcomes, 1)
+	assert.Equal(t, SourceRepositoryUnavailable, outcomes[0].Reason)
+	assert.Zero(t, provider.resolveCalls)
+	assert.Zero(t, provider.commitCalls)
+	assert.Zero(t, provider.headCalls)
+}
+
+func TestMergedReportExitCodeTreatsNormalNonCandidatesAsSuccess(t *testing.T) {
+	for _, reason := range []Reason{NoAssociatedPR, PRNotMerged} {
+		report := Report{Outcomes: []Outcome{{Reason: reason}}}
+		assert.Equal(t, 0, report.ExitCode(), string(reason))
+	}
+	for _, reason := range []Reason{MissingGeneration, DirtyWorktree, AmbiguousPRMatch, NetworkFailure} {
+		report := Report{Outcomes: []Outcome{{Reason: reason}}}
+		assert.Equal(t, 1, report.ExitCode(), string(reason))
+	}
+}
+
+func ordinaryCandidate(sourceRepository string) MergedCandidate {
+	return MergedCandidate{
+		Path: "/worktrees/topic", Branch: "topic-local", Head: mergedHead, Generation: "0123456789abcdef0123456789abcdef",
+		ProjectRepository: baseRepository, LiveRepository: baseRepository,
+		SourceRepository: sourceRepository, SourceBranch: "topic",
+	}
+}
+
+func withForkOrigin(candidate MergedCandidate) MergedCandidate {
+	candidate.LiveRepository = forkRepository
+	return candidate
+}
+
+func importedMergedCandidate() MergedCandidate {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.MainRepositoryPath = "/projects/widget"
+	candidate.Provenance = &pullrequest.Provenance{
+		PullRequestID: pullrequest.OpaqueID(baseRepository, 17), Provider: "github",
+		Repository: baseRepository, Number: 17, URL: "https://github.com/acme/widget/pull/17",
+		HeadSHA: mergedHead, SourceRepo: forkRepository, SourceBranch: "topic",
+		Project: pullrequest.Project{Identity: baseRepository, Path: "/projects/widget"},
+		Workspace: pullrequest.Workspace{
+			ID: "workspace-17", Repository: baseRepository, Branch: candidate.Branch,
+			Path: candidate.Path, State: "ready", SessionName: "topic",
+		},
+	}
+	return candidate
+}
+
+func importedWithProjectPathMismatch() MergedCandidate {
+	candidate := importedMergedCandidate()
+	candidate.MainRepositoryPath = "/projects/replacement"
+	return candidate
+}
+
+func importedWithHeadMismatch() MergedCandidate {
+	candidate := importedMergedCandidate()
+	candidate.Head = advancedHead
+	return candidate
+}
+
+func importedTransferredCandidate() MergedCandidate {
+	candidate := importedMergedCandidate()
+	const legacyRepository = "github.com/legacy/widget"
+	candidate.Provenance.PullRequestID = pullrequest.OpaqueID(legacyRepository, 17)
+	candidate.Provenance.Repository = legacyRepository
+	candidate.Provenance.RepositoryAliases = []string{legacyRepository, baseRepository}
+	candidate.Provenance.Project.Identity = legacyRepository
+	candidate.Provenance.Workspace.Repository = legacyRepository
+	return candidate
+}
+
+func importedWithOpaqueIDMismatch() MergedCandidate {
+	candidate := importedMergedCandidate()
+	candidate.Provenance.PullRequestID = pullrequest.OpaqueID(baseRepository, 99)
+	return candidate
+}
+
+func importedTransferredSourceCandidate() MergedCandidate {
+	candidate := importedTransferredCandidate()
+	const legacyRepository = "github.com/legacy/widget"
+	candidate.SourceRepository = baseRepository
+	candidate.Provenance.SourceRepo = legacyRepository
+	return candidate
+}
+
+func importedWithStaleURL() MergedCandidate {
+	candidate := importedTransferredCandidate()
+	candidate.Provenance.URL = "https://github.com/legacy/widget/pull/17"
+	return candidate
+}
+
+func importedWithWorkspaceMismatch() MergedCandidate {
+	candidate := importedMergedCandidate()
+	candidate.Provenance.Workspace.Path = "/worktrees/other"
+	return candidate
+}
+
+func importedWithGenerationMismatch() MergedCandidate {
+	candidate := importedMergedCandidate()
+	candidate.Generation = "0123456789abcdef0123456789abcdef"
+	candidate.Provenance.Workspace.Generation = "fedcba9876543210fedcba9876543210"
+	return candidate
+}
+
+func withoutGeneration() MergedCandidate {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.Generation = ""
+	return candidate
+}
+
+func withInvalidGeneration() MergedCandidate {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.Generation = "not-a-generation"
+	return candidate
+}
+
+func dirtyMerged() MergedCandidate {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.Dirty = true
+	return candidate
+}
+
+func mainWorktree() MergedCandidate {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.IsMain = true
+	return candidate
+}
+
+func advancedCandidate() MergedCandidate {
+	candidate := ordinaryCandidate(forkRepository)
+	candidate.Head = advancedHead
+	return candidate
+}
+
+func noUpstream() MergedCandidate {
+	candidate := ordinaryCandidate("")
+	return candidate
+}
+
+func providerForImported(pr pullrequest.PullRequest) *fakeMergedProvider {
+	return &fakeMergedProvider{get: func(repository pullrequest.Repository, number int) (pullrequest.PullRequest, error) {
+		if repository.Identity != baseRepository || number != 17 {
+			return pullrequest.PullRequest{}, fmt.Errorf("unexpected imported selector %s#%d", repository.Identity, number)
+		}
+		return pr, nil
+	}}
+}
+
+func providerForCommit(prs ...pullrequest.PullRequest) *fakeMergedProvider {
+	return &fakeMergedProvider{
+		byCommit: func(_ pullrequest.Repository, _ string) ([]pullrequest.PullRequest, error) { return prs, nil },
+		byHead:   func(_ pullrequest.Repository, _, _ string) ([]pullrequest.PullRequest, error) { return nil, nil },
+	}
+}
+
+func providerForAdvancedBranch() *fakeMergedProvider {
+	return &fakeMergedProvider{
+		byCommit: func(_ pullrequest.Repository, _ string) ([]pullrequest.PullRequest, error) { return nil, nil },
+		byHead: func(_ pullrequest.Repository, owner, branch string) ([]pullrequest.PullRequest, error) {
+			if owner != "octocat" || branch != "topic" {
+				return nil, fmt.Errorf("unexpected head %s:%s", owner, branch)
+			}
+			return []pullrequest.PullRequest{exactMergedPR(forkRepository)}, nil
+		},
+	}
+}
+
+func providerEmpty() *fakeMergedProvider {
+	return &fakeMergedProvider{
+		byCommit: func(_ pullrequest.Repository, _ string) ([]pullrequest.PullRequest, error) { return nil, nil },
+		byHead:   func(_ pullrequest.Repository, _, _ string) ([]pullrequest.PullRequest, error) { return nil, nil },
+	}
+}
+
+func providerWithError(err error) *fakeMergedProvider {
+	return &fakeMergedProvider{byCommit: func(_ pullrequest.Repository, _ string) ([]pullrequest.PullRequest, error) {
+		return nil, err
+	}}
+}
+
+func exactMergedPR(sourceRepository string) pullrequest.PullRequest {
+	mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	return pullrequest.PullRequest{
+		ID: pullrequest.OpaqueID(baseRepository, 17), Provider: "github",
+		Repository: repository(baseRepository), Number: 17,
+		URL: "https://github.com/acme/widget/pull/17", Title: "Topic", Author: "octocat",
+		Source: pullrequest.Branch{Name: "topic", Repository: repository(sourceRepository)},
+		Target: pullrequest.Branch{Name: "main", Repository: repository(baseRepository)},
+		State:  "closed", HeadSHA: mergedHead, MergedAt: &mergedAt,
+	}
+}
+
+func closedPR(sourceRepository string) pullrequest.PullRequest {
+	pr := exactMergedPR(sourceRepository)
+	pr.MergedAt = nil
+	return pr
+}
+
+func prWithBranch(pr pullrequest.PullRequest, branch string) pullrequest.PullRequest {
+	pr.Source.Name = branch
+	return pr
+}
+
+func prWithNumber(pr pullrequest.PullRequest, number int) pullrequest.PullRequest {
+	pr.Number = number
+	pr.ID = pullrequest.OpaqueID(baseRepository, number)
+	pr.URL = fmt.Sprintf("https://github.com/acme/widget/pull/%d", number)
+	return pr
+}
+
+func repository(identity string) pullrequest.Repository {
+	trimmed := identity
+	if len(trimmed) > len("github.com/") && trimmed[:len("github.com/")] == "github.com/" {
+		trimmed = trimmed[len("github.com/"):]
+	}
+	owner, name := "", ""
+	for index, value := range trimmed {
+		if value == '/' {
+			owner, name = trimmed[:index], trimmed[index+1:]
+			break
+		}
+	}
+	return pullrequest.Repository{Provider: "github", Host: "github.com", Owner: owner, Name: name, Identity: identity}
+}

--- a/internal/prunepolicy/merged_test.go
+++ b/internal/prunepolicy/merged_test.go
@@ -233,6 +233,37 @@ func TestEvaluateMergedResolvesTransferredRepositoryBeforeProvenanceValidation(t
 	assert.Equal(t, 1, provider.getCalls)
 }
 
+func TestEvaluateMergedAcceptsLegacyProvenanceAfterRepositoryTransfer(t *testing.T) {
+	const legacyRepository = "github.com/legacy/widget"
+	candidate := importedMergedCandidate()
+	candidate.ProjectRepository = legacyRepository
+	candidate.LiveRepository = legacyRepository
+	candidate.Provenance.PullRequestID = pullrequest.OpaqueID(legacyRepository, 17)
+	candidate.Provenance.Repository = legacyRepository
+	candidate.Provenance.RepositoryAliases = nil
+	candidate.Provenance.Project.Identity = legacyRepository
+	candidate.Provenance.Workspace.Repository = legacyRepository
+	provider := providerForImported(exactMergedPR(forkRepository))
+	provider.resolve = func(requested pullrequest.Repository) (pullrequest.Repository, error) {
+		switch requested.Identity {
+		case legacyRepository:
+			return repository(baseRepository), nil
+		case forkRepository:
+			return repository(forkRepository), nil
+		default:
+			return pullrequest.Repository{}, fmt.Errorf(
+				"unexpected repository resolution: %s", requested.Identity,
+			)
+		}
+	}
+
+	outcomes := EvaluateMerged(context.Background(), provider, []MergedCandidate{candidate})
+
+	require.Len(t, outcomes, 1)
+	assert.Equal(t, EligibleMerged, outcomes[0].Reason)
+	assert.Equal(t, 1, provider.getCalls)
+}
+
 func TestEvaluateMergedAcceptsSymlinkEquivalentImportedWorkspacePath(t *testing.T) {
 	realPath := filepath.Join(t.TempDir(), "workspace")
 	require.NoError(t, os.Mkdir(realPath, 0o755))

--- a/internal/prunepolicy/types.go
+++ b/internal/prunepolicy/types.go
@@ -1,0 +1,88 @@
+// Package prunepolicy defines stable, provider-neutral prune outcomes.
+package prunepolicy
+
+const SchemaVersion = 1
+
+type Reason string
+
+const (
+	Removed                     Reason = "removed"
+	WouldRemove                 Reason = "would_remove"
+	MissingGeneration           Reason = "missing_generation"
+	DoctorRequired              Reason = "doctor_required"
+	DirtyWorktree               Reason = "dirty_worktree"
+	EligibleMerged              Reason = "eligible_merged"
+	HeadAdvancedAfterPR         Reason = "head_advanced_after_pr"
+	NoAssociatedPR              Reason = "no_associated_pr"
+	PRNotMerged                 Reason = "pr_not_merged"
+	SourceRepositoryUnavailable Reason = "source_repository_unavailable"
+	SourceRepositoryMismatch    Reason = "source_repository_mismatch"
+	SourceBranchMismatch        Reason = "source_branch_mismatch"
+	AmbiguousPRMatch            Reason = "ambiguous_pr_match"
+	AuthenticationFailed        Reason = "authentication_failed"
+	NetworkFailure              Reason = "network_failure"
+	ProviderFailure             Reason = "provider_failure"
+	GenerationChanged           Reason = "generation_changed"
+	ExpirationPolicyChanged     Reason = "expiration_policy_changed"
+	HeadChanged                 Reason = "head_changed"
+	RepositoryChanged           Reason = "repository_identity_changed"
+	MainWorktree                Reason = "main_worktree"
+	LockedWorktree              Reason = "locked_worktree"
+	PathUnavailable             Reason = "path_unavailable"
+	RemovalFailed               Reason = "removal_failed"
+	CleanupIncomplete           Reason = "cleanup_incomplete"
+)
+
+type Outcome struct {
+	Path        string            `json:"path"`
+	Branch      string            `json:"branch,omitempty"`
+	Reason      Reason            `json:"reason"`
+	Message     string            `json:"message"`
+	Remediation string            `json:"remediation,omitempty"`
+	Evidence    map[string]string `json:"evidence,omitempty"`
+}
+
+type Summary struct {
+	Candidates  int `json:"candidates"`
+	Removed     int `json:"removed"`
+	WouldRemove int `json:"would_remove"`
+	Skipped     int `json:"skipped"`
+}
+
+type Report struct {
+	SchemaVersion int       `json:"schema_version"`
+	Command       string    `json:"command"`
+	Policy        string    `json:"policy"`
+	DryRun        bool      `json:"dry_run"`
+	Outcomes      []Outcome `json:"outcomes"`
+	Summary       Summary   `json:"summary"`
+}
+
+// Finalize derives summary counts from outcomes.
+func (r *Report) Finalize() {
+	r.Summary = Summary{Candidates: len(r.Outcomes)}
+	for _, outcome := range r.Outcomes {
+		switch outcome.Reason {
+		case Removed:
+			r.Summary.Removed++
+		case WouldRemove:
+			r.Summary.WouldRemove++
+		default:
+			r.Summary.Skipped++
+		}
+	}
+}
+
+// ExitCode returns the candidate-level status. Global inspection and usage
+// errors are classified by the command before a report exists.
+func (r Report) ExitCode() int {
+	for _, outcome := range r.Outcomes {
+		switch outcome.Reason {
+		case Removed, WouldRemove, NoAssociatedPR, PRNotMerged:
+			continue
+		default:
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/pullrequest/backend.go
+++ b/internal/pullrequest/backend.go
@@ -81,6 +81,7 @@ func (b *GitBackend) ListWorkspaces(ctx context.Context) ([]Workspace, error) {
 			Repository: b.project.Identity,
 			Branch:     candidate.Branch,
 			Path:       candidate.Path,
+			Generation: candidate.Generation,
 			State:      "ready",
 			SessionName: tmux.WorkspaceSessionName(
 				info, candidate.Branch, candidate.Path,
@@ -170,6 +171,15 @@ func (b *GitBackend) ImportPullRequest(
 			false, err,
 		)
 	}
+	generation, err := gitadapter.New(created.Path).EnsureWorktreeGeneration(created.Path)
+	if err != nil {
+		return workspace, NewError(
+			CodeWorkspaceCreation,
+			"failed to persist pull-request worktree identity",
+			false, err,
+		)
+	}
+	workspace.Generation = generation
 	return workspace, nil
 }
 

--- a/internal/pullrequest/backend.go
+++ b/internal/pullrequest/backend.go
@@ -19,22 +19,59 @@ import (
 var createMergeRequestWorktree = managedworktree.CreateWorktreeFromMergeRequest
 
 type GitBackend struct {
-	git            *gitadapter.Git
-	manager        *worktree.Manager
-	project        Project
-	gitEnvironment []string
+	git               *gitadapter.Git
+	manager           *worktree.Manager
+	project           Project
+	openCreationGuard func() (WorktreeCreationGuard, error)
+	gitEnvironment    []string
+}
+
+type WorktreeCreationGuard interface {
+	AcquireCreation(string) (func() error, bool, error)
 }
 
 func NewGitBackend(
 	g *gitadapter.Git,
 	manager *worktree.Manager,
 	project Project,
+	openCreationGuard func() (WorktreeCreationGuard, error),
 	fleetTokenEnv string,
 ) *GitBackend {
 	return &GitBackend{
 		git: g, manager: manager, project: project,
-		gitEnvironment: SafeGitEnvironment(os.Environ(), fleetTokenEnv),
+		openCreationGuard: openCreationGuard,
+		gitEnvironment:    SafeGitEnvironment(os.Environ(), fleetTokenEnv),
 	}
+}
+
+func (b *GitBackend) AcquireWorkspaceCreation(
+	ctx context.Context,
+	branch string,
+) (func() error, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if b.openCreationGuard == nil {
+		return func() error { return nil }, nil
+	}
+	creationGuard, err := b.openCreationGuard()
+	if err != nil {
+		return nil, fmt.Errorf("open pull-request workspace creation state: %w", err)
+	}
+	path, err := b.manager.PreparePathForRepository(
+		"", branch, b.project.Identity,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("prepare pull-request workspace path: %w", err)
+	}
+	release, acquired, err := creationGuard.AcquireCreation(path)
+	if err != nil {
+		return nil, fmt.Errorf("lock pull-request workspace creation: %w", err)
+	}
+	if !acquired {
+		return nil, fmt.Errorf("pull-request workspace creation is already in progress for %s", path)
+	}
+	return release, nil
 }
 
 // SafeGitEnvironment retains ordinary Git authentication context while

--- a/internal/pullrequest/backend_test.go
+++ b/internal/pullrequest/backend_test.go
@@ -49,8 +49,45 @@ func newBackendRepo(t *testing.T) (string, *GitBackend) {
 		}},
 	}
 	return repo, NewGitBackend(
-		g, worktree.New(g, cfg), testProject(), cfg.Fleet.TokenEnv,
+		g, worktree.New(g, cfg), testProject(), nil, cfg.Fleet.TokenEnv,
 	)
+}
+
+type recordingCreationGuard struct {
+	path   string
+	active bool
+}
+
+func (g *recordingCreationGuard) AcquireCreation(
+	path string,
+) (func() error, bool, error) {
+	g.path = path
+	g.active = true
+	return func() error {
+		g.active = false
+		return nil
+	}, true, nil
+}
+
+func TestGitBackendCoordinatesCreationForResolvedWorkspacePath(t *testing.T) {
+	_, backend := newBackendRepo(t)
+	guard := &recordingCreationGuard{}
+	backend.openCreationGuard = func() (WorktreeCreationGuard, error) {
+		return guard, nil
+	}
+	activeDuringOperation := false
+
+	release, err := backend.AcquireWorkspaceCreation(
+		context.Background(),
+		"pr-17-feature-widgets",
+	)
+
+	require.NoError(t, err)
+	activeDuringOperation = guard.active
+	assert.True(t, activeDuringOperation)
+	assert.Contains(t, filepath.ToSlash(guard.path), "github.com/acme/widget/pr-17-feature-widgets")
+	require.NoError(t, release())
+	assert.False(t, guard.active)
 }
 
 func configureTestPushTracking(

--- a/internal/pullrequest/backend_test.go
+++ b/internal/pullrequest/backend_test.go
@@ -127,6 +127,7 @@ func TestGitBackendDelegatesPullRequestLifecycleToKit(t *testing.T) {
 	assert.Contains(t, filepath.ToSlash(got.Path), "github.com/acme/widget/pr-17-feature-widgets")
 	assert.Equal(t, got.Path, workspace.Path)
 	assert.Equal(t, "pr-17-feature-widgets", workspace.Branch)
+	assert.NoError(t, gitadapter.ValidateWorktreeGeneration(workspace.Generation))
 	assert.NotEmpty(t, workspace.ID)
 	assert.NotEmpty(t, workspace.SessionName)
 }

--- a/internal/pullrequest/github.go
+++ b/internal/pullrequest/github.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v89/github"
 )
@@ -113,6 +114,86 @@ func (p *GitHubProvider) List(ctx context.Context, repository Repository, state 
 	return result, nil
 }
 
+func (p *GitHubProvider) ListForCommit(
+	ctx context.Context, repository Repository, sha string,
+) ([]PullRequest, error) {
+	if p == nil || p.client == nil {
+		return nil, NewError(CodeNetwork, "GitHub client is not configured", false, nil)
+	}
+	options := &github.ListOptions{PerPage: 100}
+	var result []PullRequest
+	for {
+		prs, response, err := p.client.PullRequests.ListPullRequestsWithCommit(
+			ctx, repository.Owner, repository.Name, sha, options,
+		)
+		if err != nil {
+			return nil, classifyGitHubError(err, "list pull requests for commit")
+		}
+		result, err = appendGitHubPullRequests(result, prs, repository)
+		if err != nil {
+			return nil, err
+		}
+		if response == nil || response.NextPage == 0 {
+			break
+		}
+		options.Page = response.NextPage
+	}
+	return result, nil
+}
+
+func (p *GitHubProvider) ListByHead(
+	ctx context.Context, repository Repository, sourceOwner, branch string,
+) ([]PullRequest, error) {
+	if p == nil || p.client == nil {
+		return nil, NewError(CodeNetwork, "GitHub client is not configured", false, nil)
+	}
+	options := &github.PullRequestListOptions{
+		State: "closed",
+		Head:  sourceOwner + ":" + branch,
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+	var result []PullRequest
+	for {
+		prs, response, err := p.client.PullRequests.List(
+			ctx, repository.Owner, repository.Name, options,
+		)
+		if err != nil {
+			return nil, classifyGitHubError(err, "list pull requests by head")
+		}
+		result, err = appendGitHubPullRequests(result, prs, repository)
+		if err != nil {
+			return nil, err
+		}
+		if response == nil || response.NextPage == 0 {
+			break
+		}
+		options.Page = response.NextPage
+	}
+	return result, nil
+}
+
+func appendGitHubPullRequests(
+	result []PullRequest, values []*github.PullRequest, repository Repository,
+) ([]PullRequest, error) {
+	for _, value := range values {
+		pr, err := mapGitHubPullRequest(value)
+		if err != nil {
+			var typed *Error
+			if errors.As(err, &typed) && typed.Code == CodeInaccessibleHead {
+				continue
+			}
+			return nil, err
+		}
+		if err := validateGitHubPullRequest(pr, repository, 0); err != nil {
+			return nil, err
+		}
+		result = append(result, pr)
+	}
+	return result, nil
+}
+
 func (p *GitHubProvider) Get(ctx context.Context, repository Repository, number int) (PullRequest, error) {
 	if p == nil || p.client == nil {
 		return PullRequest{}, NewError(CodeNetwork, "GitHub client is not configured", false, nil)
@@ -191,12 +272,17 @@ func mapGitHubPullRequest(value *github.PullRequest) (PullRequest, error) {
 		return PullRequest{}, NewError(CodeMalformedResponse,
 			"GitHub returned a pull request with incomplete branch information", false, nil)
 	}
+	var mergedAt *time.Time
+	if value.MergedAt != nil {
+		value := value.MergedAt.Time
+		mergedAt = &value
+	}
 	return PullRequest{
 		ID: OpaqueID(base.Identity, value.GetNumber()), Provider: "github", Repository: base,
 		Number: value.GetNumber(), URL: value.GetHTMLURL(), Title: value.GetTitle(),
 		Author: value.User.GetLogin(), Source: Branch{Name: value.Head.GetRef(), Repository: head},
 		Target: Branch{Name: value.Base.GetRef(), Repository: base}, Draft: value.GetDraft(),
-		State: value.GetState(), HeadSHA: value.Head.GetSHA(),
+		State: value.GetState(), HeadSHA: value.Head.GetSHA(), MergedAt: mergedAt,
 	}, nil
 }
 

--- a/internal/pullrequest/github_test.go
+++ b/internal/pullrequest/github_test.go
@@ -3,16 +3,193 @@ package pullrequest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGitHubProviderListsPullRequestsForCommit(t *testing.T) {
+	const headSHA = "0123456789abcdef0123456789abcdef01234567"
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/acme/widget/commits/"+headSHA+"/pulls", r.URL.Path)
+		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = io.WriteString(w, "["+testGitHubPRJSON(18, headSHA, "")+"]")
+			return
+		}
+		w.Header().Set(
+			"Link",
+			fmt.Sprintf("<%s/repos/acme/widget/commits/%s/pulls?page=2>; rel=\"next\"", serverURL, headSHA),
+		)
+		_, _ = io.WriteString(w, "["+testGitHubPRJSON(17, headSHA, "2026-08-01T12:00:00Z")+"]")
+	}))
+	defer server.Close()
+	serverURL = server.URL
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&baseURL, nil))
+	require.NoError(t, err)
+	provider := NewGitHubProvider(client)
+
+	prs, err := provider.ListForCommit(context.Background(), testGitHubRepository(), headSHA)
+
+	require.NoError(t, err)
+	require.Len(t, prs, 2)
+	require.NotNil(t, prs[0].MergedAt)
+	assert.Equal(t, "2026-08-01T12:00:00Z", prs[0].MergedAt.UTC().Format(time.RFC3339))
+	assert.Nil(t, prs[1].MergedAt)
+}
+
+func TestGitHubProviderListsClosedPullRequestsByHead(t *testing.T) {
+	const headSHA = "0123456789abcdef0123456789abcdef01234567"
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/acme/widget/pulls", r.URL.Path)
+		assert.Equal(t, "closed", r.URL.Query().Get("state"))
+		assert.Equal(t, "octocat:topic", r.URL.Query().Get("head"))
+		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = io.WriteString(w, "["+testGitHubPRJSON(18, headSHA, "")+"]")
+			return
+		}
+		w.Header().Set(
+			"Link",
+			fmt.Sprintf("<%s/repos/acme/widget/pulls?page=2>; rel=\"next\"", serverURL),
+		)
+		_, _ = io.WriteString(w, "["+testGitHubPRJSON(17, headSHA, "2026-08-01T12:00:00Z")+"]")
+	}))
+	defer server.Close()
+	serverURL = server.URL
+	baseURL := server.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&baseURL, nil))
+	require.NoError(t, err)
+	provider := NewGitHubProvider(client)
+
+	prs, err := provider.ListByHead(
+		context.Background(),
+		testGitHubRepository(),
+		"octocat",
+		"topic",
+	)
+
+	require.NoError(t, err)
+	require.Len(t, prs, 2)
+	assert.Equal(t, 17, prs[0].Number)
+	assert.Equal(t, 18, prs[1].Number)
+}
+
+func TestGitHubProviderMapsMergedTimestamp(t *testing.T) {
+	mergedAt := github.Timestamp{Time: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)}
+	value := testGitHubPullRequest(17)
+	value.MergedAt = &mergedAt
+
+	mapped, err := mapGitHubPullRequest(value)
+
+	require.NoError(t, err)
+	require.NotNil(t, mapped.MergedAt)
+	assert.Equal(t, mergedAt.Time, *mapped.MergedAt)
+	value.MergedAt = nil
+	mapped, err = mapGitHubPullRequest(value)
+	require.NoError(t, err)
+	assert.Nil(t, mapped.MergedAt)
+}
+
+func TestGitHubProviderEvidenceMethodsClassifyFailures(t *testing.T) {
+	const headSHA = "0123456789abcdef0123456789abcdef01234567"
+	for _, method := range []struct {
+		name string
+		call func(*GitHubProvider) error
+	}{
+		{name: "commit", call: func(provider *GitHubProvider) error {
+			_, err := provider.ListForCommit(context.Background(), testGitHubRepository(), headSHA)
+			return err
+		}},
+		{name: "head", call: func(provider *GitHubProvider) error {
+			_, err := provider.ListByHead(context.Background(), testGitHubRepository(), "octocat", "topic")
+			return err
+		}},
+	} {
+		for _, failure := range []struct {
+			name      string
+			status    int
+			body      string
+			headers   map[string]string
+			want      ErrorCode
+			retryable bool
+		}{
+			{name: "authentication", status: http.StatusUnauthorized, body: `{"message":"Bad credentials"}`, want: CodeAuthentication},
+			{name: "rate limit", status: http.StatusForbidden, body: `{"message":"API rate limit exceeded"}`, headers: map[string]string{"X-RateLimit-Remaining": "0"}, want: CodeNetwork, retryable: true},
+			{name: "malformed head", status: http.StatusOK, body: `[{"number":17,"head":{},"base":null}]`, want: CodeMalformedResponse},
+		} {
+			t.Run(method.name+"/"+failure.name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					for key, value := range failure.headers {
+						w.Header().Set(key, value)
+					}
+					w.WriteHeader(failure.status)
+					_, _ = io.WriteString(w, failure.body)
+				}))
+				defer server.Close()
+				baseURL := server.URL + "/"
+				client, err := github.NewClient(github.WithURLs(&baseURL, nil))
+				require.NoError(t, err)
+
+				err = method.call(NewGitHubProvider(client))
+
+				var typed *Error
+				require.ErrorAs(t, err, &typed)
+				assert.Equal(t, failure.want, typed.Code)
+				assert.Equal(t, failure.retryable, typed.Retryable)
+			})
+		}
+	}
+}
+
+func testGitHubRepository() Repository {
+	return Repository{
+		Provider: "github", Identity: "github.com/acme/widget", Host: "github.com",
+		Owner: "acme", Name: "widget",
+	}
+}
+
+func testGitHubPRJSON(number int, headSHA string, mergedAt string) string {
+	mergedJSON := "null"
+	if mergedAt != "" {
+		mergedJSON = fmt.Sprintf("%q", mergedAt)
+	}
+	return fmt.Sprintf(`{"number":%d,"html_url":"https://github.com/acme/widget/pull/%d","title":"Topic",`+
+		`"user":{"login":"octocat"},"draft":false,"state":"closed","merged_at":%s,`+
+		`"head":{"ref":"topic","sha":"%s","repo":{"name":"widget","full_name":"octocat/widget","clone_url":"https://github.com/octocat/widget.git"}},`+
+		`"base":{"ref":"main","repo":{"name":"widget","full_name":"acme/widget","clone_url":"https://github.com/acme/widget.git"}}}`,
+		number, number, mergedJSON, headSHA)
+}
+
+func testGitHubPullRequest(number int) *github.PullRequest {
+	return &github.PullRequest{
+		Number: github.Ptr(number), HTMLURL: github.Ptr(fmt.Sprintf("https://github.com/acme/widget/pull/%d", number)),
+		Title: github.Ptr("Topic"), User: &github.User{Login: github.Ptr("octocat")},
+		State: github.Ptr("closed"),
+		Head: &github.PullRequestBranch{
+			Ref: github.Ptr("topic"), SHA: github.Ptr("0123456789abcdef0123456789abcdef01234567"),
+			Repo: &github.Repository{Name: github.Ptr("widget"), FullName: github.Ptr("octocat/widget"), CloneURL: github.Ptr("https://github.com/octocat/widget.git")},
+		},
+		Base: &github.PullRequestBranch{
+			Ref:  github.Ptr("main"),
+			Repo: &github.Repository{Name: github.Ptr("widget"), FullName: github.Ptr("acme/widget"), CloneURL: github.Ptr("https://github.com/acme/widget.git")},
+		},
+	}
+}
 
 func TestResolveGitHubTokenPrefersEnvironment(t *testing.T) {
 	called := false

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -24,6 +24,10 @@ type WorkspaceBackend interface {
 	Rollback(context.Context, Workspace) error
 }
 
+type WorkspaceCreationCoordinator interface {
+	AcquireWorkspaceCreation(context.Context, string) (func() error, error)
+}
+
 type Store interface {
 	View(context.Context, func(map[string]Provenance) error) error
 	Update(context.Context, func(map[string]Provenance) error) error
@@ -121,6 +125,29 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 	}
 	pr.Source.IsFork = !EqualRepositoryIdentity(pr.Source.Repository.Identity, pr.Repository.Identity)
 	branch := importBranchName(pr)
+	if coordinator, ok := s.backend.(WorkspaceCreationCoordinator); ok {
+		release, acquireErr := coordinator.AcquireWorkspaceCreation(ctx, branch)
+		if acquireErr != nil {
+			return result, AsError(
+				acquireErr,
+				CodeWorkspaceCreation,
+				"failed to coordinate pull-request workspace creation",
+			)
+		}
+		defer func() {
+			if releaseErr := release(); releaseErr != nil {
+				err = errors.Join(
+					err,
+					NewError(
+						CodeWorkspaceCreation,
+						"failed to release pull-request workspace creation lock",
+						false,
+						releaseErr,
+					),
+				)
+			}
+		}()
+	}
 	var created *Workspace
 	cleanupReason := "workspace created but provenance could not be persisted"
 

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -272,7 +272,9 @@ func (s *Service) sameProjectClone(record Provenance, current Project) bool {
 
 func matchingProvenanceWorkspace(byPath map[string]Workspace, record Provenance) (Workspace, bool) {
 	workspace, ok := byPath[utils.CanonicalPath(record.Workspace.Path)]
-	if !ok || workspace.Branch != record.Workspace.Branch {
+	if !ok || workspace.Branch != record.Workspace.Branch ||
+		(record.Workspace.Generation != "" &&
+			workspace.Generation != record.Workspace.Generation) {
 		return Workspace{}, false
 	}
 	return workspace, true

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -162,6 +162,7 @@ func (f *fakeWorkspaceBackend) ImportPullRequest(
 		Repository:  "github.com/acme/widget",
 		Branch:      branch,
 		Path:        "/worktrees/widget/" + branch,
+		Generation:  "0123456789abcdef0123456789abcdef",
 		State:       "ready",
 		SessionName: "kwt-workspace-github-com-acme-widget-" + branch,
 	}
@@ -276,6 +277,21 @@ func TestListMarksExistingImport(t *testing.T) {
 	assert.Equal(t, &workspace, got[0].Workspace)
 }
 
+func TestImportPersistsWorkspaceGenerationInProvenance(t *testing.T) {
+	pr := testPR(61, false)
+	backend := newFakeBackend()
+	backend.workspaces = nil
+	store := newMemoryStore()
+	service := newTestService(&fakeProvider{prs: []PullRequest{pr}}, backend, store)
+
+	result, err := service.Import(context.Background(), testProject(), "61")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Workspace.Generation)
+	record := store.records[pr.ID]
+	assert.Equal(t, result.Workspace.Generation, record.Workspace.Generation)
+}
+
 func TestListMatchesCanonicalProvenancePathThroughSymlink(t *testing.T) {
 	pr := testPR(25, false)
 	realBase := t.TempDir()
@@ -321,6 +337,32 @@ func TestListDoesNotMatchProvenanceWhenLiveBranchDiffers(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.False(t, got[0].Imported)
 	assert.Nil(t, got[0].Workspace)
+}
+
+func TestListDoesNotMatchProvenanceWhenLiveGenerationDiffers(t *testing.T) {
+	pr := testPR(62, false)
+	live := Workspace{
+		ID: "ws-62", Repository: testProject().Identity,
+		Branch: "pr-62-feature-widgets", Path: "/worktrees/62", State: "ready",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	recorded := live
+	recorded.Generation = "fedcba9876543210fedcba9876543210"
+	backend := newFakeBackend()
+	backend.workspaces = []Workspace{live}
+	store := newMemoryStore()
+	store.records[pr.ID] = Provenance{
+		PullRequestID: pr.ID, Project: testProject(), Workspace: recorded,
+		HeadSHA: pr.HeadSHA, SourceRepo: pr.Source.Repository.Identity,
+		SourceBranch: pr.Source.Name,
+	}
+	service := newTestService(&fakeProvider{prs: []PullRequest{pr}}, backend, store)
+
+	got, err := service.List(context.Background(), testProject(), "open")
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.False(t, got[0].Imported)
 }
 
 func TestListDoesNotMarkImportAfterSourceBranchRename(t *testing.T) {

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -133,6 +133,33 @@ type fakeWorkspaceBackend struct {
 	importedPR         PullRequest
 }
 
+type guardedWorkspaceBackend struct {
+	*fakeWorkspaceBackend
+	guardCalls         int
+	guardActive        bool
+	rollbackUnderGuard bool
+}
+
+func (b *guardedWorkspaceBackend) Rollback(
+	ctx context.Context,
+	workspace Workspace,
+) error {
+	b.rollbackUnderGuard = b.guardActive
+	return b.fakeWorkspaceBackend.Rollback(ctx, workspace)
+}
+
+func (b *guardedWorkspaceBackend) AcquireWorkspaceCreation(
+	_ context.Context,
+	_ string,
+) (func() error, error) {
+	b.guardCalls++
+	b.guardActive = true
+	return func() error {
+		b.guardActive = false
+		return nil
+	}, nil
+}
+
 func newFakeBackend() *fakeWorkspaceBackend {
 	return &fakeWorkspaceBackend{}
 }
@@ -191,6 +218,27 @@ func (f *fakeWorkspaceBackend) Rollback(ctx context.Context, workspace Workspace
 type memoryStore struct {
 	mu      sync.Mutex
 	records map[string]Provenance
+}
+
+type guardObservingStore struct {
+	*memoryStore
+	guardActive         func() bool
+	committedUnderGuard bool
+}
+
+func (s *guardObservingStore) Update(
+	_ context.Context,
+	fn func(map[string]Provenance) error,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copy := cloneRecords(s.records)
+	if err := fn(copy); err != nil {
+		return err
+	}
+	s.committedUnderGuard = s.guardActive()
+	s.records = copy
+	return nil
 }
 
 type commitFailStore struct {
@@ -290,6 +338,36 @@ func TestImportPersistsWorkspaceGenerationInProvenance(t *testing.T) {
 	require.NotEmpty(t, result.Workspace.Generation)
 	record := store.records[pr.ID]
 	assert.Equal(t, result.Workspace.Generation, record.Workspace.Generation)
+}
+
+func TestImportHoldsWorkspaceCreationGuardThroughProvenanceCommit(t *testing.T) {
+	pr := testPR(62, false)
+	backend := &guardedWorkspaceBackend{fakeWorkspaceBackend: newFakeBackend()}
+	store := &guardObservingStore{
+		memoryStore: newMemoryStore(),
+		guardActive: func() bool { return backend.guardActive },
+	}
+	service := newTestService(&fakeProvider{prs: []PullRequest{pr}}, backend, store)
+
+	result, err := service.Import(context.Background(), testProject(), "62")
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Workspace.Path)
+	assert.Equal(t, 1, backend.guardCalls)
+	assert.True(t, store.committedUnderGuard)
+}
+
+func TestImportHoldsWorkspaceCreationGuardThroughRollback(t *testing.T) {
+	pr := testPR(63, false)
+	backend := &guardedWorkspaceBackend{fakeWorkspaceBackend: newFakeBackend()}
+	store := &commitFailStore{memoryStore: newMemoryStore()}
+	service := newTestService(&fakeProvider{prs: []PullRequest{pr}}, backend, store)
+
+	_, err := service.Import(context.Background(), testProject(), "63")
+
+	assertErrorCode(t, err, CodeWorkspaceCreation)
+	assert.Equal(t, 1, backend.guardCalls)
+	assert.True(t, backend.rollbackUnderGuard)
 }
 
 func TestListMatchesCanonicalProvenancePathThroughSymlink(t *testing.T) {

--- a/internal/pullrequest/store.go
+++ b/internal/pullrequest/store.go
@@ -59,6 +59,24 @@ func (s *FileStore) Update(ctx context.Context, fn func(map[string]Provenance) e
 	})
 }
 
+// RemoveIfMatch deletes key only when its complete persisted value still
+// matches the caller's observed provenance.
+func (s *FileStore) RemoveIfMatch(
+	ctx context.Context, key string, expected Provenance,
+) (bool, error) {
+	removed := false
+	err := s.Update(ctx, func(records map[string]Provenance) error {
+		current, ok := records[key]
+		if !ok || !reflect.DeepEqual(current, expected) {
+			return nil
+		}
+		delete(records, key)
+		removed = true
+		return nil
+	})
+	return removed, err
+}
+
 func (s *FileStore) withLock(ctx context.Context, write bool, fn func() error) error {
 	if s == nil || s.path == "" {
 		return fmt.Errorf("pull-request provenance path is empty")

--- a/internal/pullrequest/store_test.go
+++ b/internal/pullrequest/store_test.go
@@ -92,3 +92,73 @@ func TestFileStoreDoesNotRewriteUnchangedState(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, before.ModTime(), after.ModTime())
 }
+
+func TestFileStoreRemoveIfMatchDeletesObservedRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pull-requests.json")
+	store := NewFileStore(path)
+	record := Provenance{PullRequestID: "pr-17", Number: 17, HeadSHA: "head-17"}
+	require.NoError(t, store.Update(context.Background(), func(records map[string]Provenance) error {
+		records[record.PullRequestID] = record
+		return nil
+	}))
+
+	removed, err := store.RemoveIfMatch(context.Background(), record.PullRequestID, record)
+
+	require.NoError(t, err)
+	assert.True(t, removed)
+	require.NoError(t, store.View(context.Background(), func(records map[string]Provenance) error {
+		_, exists := records[record.PullRequestID]
+		assert.False(t, exists)
+		return nil
+	}))
+}
+
+func TestFileStoreRemoveIfMatchPreservesReplacement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pull-requests.json")
+	store := NewFileStore(path)
+	observed := Provenance{PullRequestID: "pr-17", Number: 17, HeadSHA: "old-head"}
+	replacement := observed
+	replacement.HeadSHA = "replacement-head"
+	require.NoError(t, store.Update(context.Background(), func(records map[string]Provenance) error {
+		records[observed.PullRequestID] = replacement
+		return nil
+	}))
+
+	removed, err := store.RemoveIfMatch(context.Background(), observed.PullRequestID, observed)
+
+	require.NoError(t, err)
+	assert.False(t, removed)
+	require.NoError(t, store.View(context.Background(), func(records map[string]Provenance) error {
+		assert.Equal(t, replacement, records[observed.PullRequestID])
+		return nil
+	}))
+}
+
+func TestFileStoreRemoveIfMatchPreservesReimportedWorkspaceGeneration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pull-requests.json")
+	store := NewFileStore(path)
+	observed := Provenance{
+		PullRequestID: "pr-17", Number: 17, HeadSHA: "same-head",
+		Workspace: Workspace{
+			Path: "/worktrees/pr-17", Branch: "pr-17",
+			Generation: "0123456789abcdef0123456789abcdef",
+		},
+	}
+	replacement := observed
+	replacement.Workspace.Generation = "fedcba9876543210fedcba9876543210"
+	require.NoError(t, store.Update(context.Background(), func(records map[string]Provenance) error {
+		records[observed.PullRequestID] = replacement
+		return nil
+	}))
+
+	removed, err := store.RemoveIfMatch(
+		context.Background(), observed.PullRequestID, observed,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, removed)
+	require.NoError(t, store.View(context.Background(), func(records map[string]Provenance) error {
+		assert.Equal(t, replacement, records[observed.PullRequestID])
+		return nil
+	}))
+}

--- a/internal/pullrequest/types.go
+++ b/internal/pullrequest/types.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 type ErrorCode string
@@ -89,6 +90,7 @@ type PullRequest struct {
 	Draft      bool       `json:"draft"`
 	State      string     `json:"state"`
 	HeadSHA    string     `json:"head_sha"`
+	MergedAt   *time.Time `json:"merged_at,omitempty"`
 	Imported   bool       `json:"imported"`
 	Workspace  *Workspace `json:"workspace,omitempty"`
 }
@@ -98,6 +100,7 @@ type Workspace struct {
 	Repository     string `json:"repository"`
 	Branch         string `json:"branch"`
 	Path           string `json:"path"`
+	Generation     string `json:"generation,omitempty"`
 	State          string `json:"state"`
 	SessionName    string `json:"session_name"`
 	TmuxSocketName string `json:"tmux_socket_name,omitempty"`

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync"
 	"time"
 
@@ -48,12 +47,10 @@ type Registry struct {
 // New creates a new registry instance.
 func New() (*Registry, error) {
 	registryDir := os.Getenv("KWT_HOME")
-	legacyPath := ""
 	if registryDir != "" {
 		if expanded, err := utils.ExpandPath(registryDir); err == nil {
 			registryDir = expanded
 		}
-		legacyPath = filepath.Join(platformRegistryDir(), "registry.json")
 	} else {
 		registryDir = platformRegistryDir()
 	}
@@ -62,12 +59,6 @@ func New() (*Registry, error) {
 	}
 
 	registryPath := filepath.Join(registryDir, "registry.json")
-	if legacyPath != "" && utils.PathKey(legacyPath) != utils.PathKey(registryPath) {
-		if err := migrateLegacyRegistry(legacyPath, registryPath); err != nil {
-			return nil, err
-		}
-	}
-
 	r := &Registry{
 		entries: make(map[string]*WorktreeEntry),
 		path:    registryPath,
@@ -87,64 +78,6 @@ func platformRegistryDir() string {
 		configDir = filepath.Join(home, ".config")
 	}
 	return filepath.Join(configDir, "kwt")
-}
-
-func migrateLegacyRegistry(legacyPath, targetPath string) error {
-	if _, err := os.Stat(targetPath); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to inspect KWT_HOME registry: %w", err)
-	}
-	if _, err := os.Stat(legacyPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to inspect legacy registry: %w", err)
-	}
-
-	lockPaths := []string{legacyPath + ".lock", targetPath + ".lock"}
-	sort.Slice(lockPaths, func(left, right int) bool {
-		return utils.PathKey(lockPaths[left]) < utils.PathKey(lockPaths[right])
-	})
-	locks := make([]*flock.Flock, 0, len(lockPaths))
-	for _, lockPath := range lockPaths {
-		if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
-			return fmt.Errorf("failed to create registry lock directory: %w", err)
-		}
-		lock := flock.New(lockPath, flock.SetPermissions(0600))
-		if err := lock.Lock(); err != nil {
-			for index := len(locks) - 1; index >= 0; index-- {
-				_ = locks[index].Unlock()
-			}
-			return fmt.Errorf("failed to lock registry migration: %w", err)
-		}
-		locks = append(locks, lock)
-	}
-	defer func() {
-		for index := len(locks) - 1; index >= 0; index-- {
-			_ = locks[index].Unlock()
-		}
-	}()
-
-	if _, err := os.Stat(targetPath); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to inspect KWT_HOME registry: %w", err)
-	}
-	if _, err := os.Stat(legacyPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to inspect legacy registry: %w", err)
-	}
-	entries, err := loadEntries(legacyPath)
-	if err != nil {
-		return fmt.Errorf("failed to migrate legacy registry: %w", err)
-	}
-	if err := saveEntries(targetPath, entries); err != nil {
-		return fmt.Errorf("failed to migrate legacy registry: %w", err)
-	}
-	return nil
 }
 
 // load reads the registry from disk.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -329,9 +329,9 @@ func (r *Registry) CompareAndSwapAliases(
 	return replaced, err
 }
 
-// RemoveIfMatchAfter runs removal and deletes a registry entry while the
-// complete observed policy record remains unchanged under the registry lock.
-// The registry entry is retained when removal fails.
+// RemoveIfMatchAfter runs removal while the complete observed registry state
+// remains unchanged under the registry lock. A nil expected value claims an
+// absent entry; a matching entry is deleted only after removal succeeds.
 func (r *Registry) RemoveIfMatchAfter(
 	path string,
 	expected *WorktreeEntry,
@@ -340,8 +340,17 @@ func (r *Registry) RemoveIfMatchAfter(
 	removed := false
 	err := r.mutateChecked(func(entries map[string]*WorktreeEntry) (bool, error) {
 		keys := matchingRegistryKeys(entries, path)
-		if expected == nil || len(keys) != 1 ||
-			!sameWorktreeEntry(entries[keys[0]], expected) {
+		if expected == nil {
+			if len(keys) != 0 {
+				return false, nil
+			}
+			if err := removal(); err != nil {
+				return false, err
+			}
+			removed = true
+			return false, nil
+		}
+		if len(keys) != 1 || !sameWorktreeEntry(entries[keys[0]], expected) {
 			return false, nil
 		}
 		if err := removal(); err != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/gofrs/flock"
+	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
 )
 
@@ -45,18 +47,26 @@ type Registry struct {
 
 // New creates a new registry instance.
 func New() (*Registry, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		home, _ := os.UserHomeDir()
-		configDir = filepath.Join(home, ".config")
+	registryDir := os.Getenv("KWT_HOME")
+	legacyPath := ""
+	if registryDir != "" {
+		if expanded, err := utils.ExpandPath(registryDir); err == nil {
+			registryDir = expanded
+		}
+		legacyPath = filepath.Join(platformRegistryDir(), "registry.json")
+	} else {
+		registryDir = platformRegistryDir()
 	}
-
-	registryDir := filepath.Join(configDir, "kwt")
 	if err := os.MkdirAll(registryDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create registry directory: %w", err)
 	}
 
 	registryPath := filepath.Join(registryDir, "registry.json")
+	if legacyPath != "" && utils.PathKey(legacyPath) != utils.PathKey(registryPath) {
+		if err := migrateLegacyRegistry(legacyPath, registryPath); err != nil {
+			return nil, err
+		}
+	}
 
 	r := &Registry{
 		entries: make(map[string]*WorktreeEntry),
@@ -68,6 +78,73 @@ func New() (*Registry, error) {
 	}
 
 	return r, nil
+}
+
+func platformRegistryDir() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		home, _ := os.UserHomeDir()
+		configDir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configDir, "kwt")
+}
+
+func migrateLegacyRegistry(legacyPath, targetPath string) error {
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect KWT_HOME registry: %w", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to inspect legacy registry: %w", err)
+	}
+
+	lockPaths := []string{legacyPath + ".lock", targetPath + ".lock"}
+	sort.Slice(lockPaths, func(left, right int) bool {
+		return utils.PathKey(lockPaths[left]) < utils.PathKey(lockPaths[right])
+	})
+	locks := make([]*flock.Flock, 0, len(lockPaths))
+	for _, lockPath := range lockPaths {
+		if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+			return fmt.Errorf("failed to create registry lock directory: %w", err)
+		}
+		lock := flock.New(lockPath, flock.SetPermissions(0600))
+		if err := lock.Lock(); err != nil {
+			for index := len(locks) - 1; index >= 0; index-- {
+				_ = locks[index].Unlock()
+			}
+			return fmt.Errorf("failed to lock registry migration: %w", err)
+		}
+		locks = append(locks, lock)
+	}
+	defer func() {
+		for index := len(locks) - 1; index >= 0; index-- {
+			_ = locks[index].Unlock()
+		}
+	}()
+
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect KWT_HOME registry: %w", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to inspect legacy registry: %w", err)
+	}
+	entries, err := loadEntries(legacyPath)
+	if err != nil {
+		return fmt.Errorf("failed to migrate legacy registry: %w", err)
+	}
+	if err := saveEntries(targetPath, entries); err != nil {
+		return fmt.Errorf("failed to migrate legacy registry: %w", err)
+	}
+	return nil
 }
 
 // load reads the registry from disk.
@@ -157,6 +234,14 @@ func saveEntries(path string, entriesByPath map[string]*WorktreeEntry) error {
 func (r *Registry) mutate(
 	change func(map[string]*WorktreeEntry) bool,
 ) error {
+	return r.mutateChecked(func(entries map[string]*WorktreeEntry) (bool, error) {
+		return change(entries), nil
+	})
+}
+
+func (r *Registry) mutateChecked(
+	change func(map[string]*WorktreeEntry) (bool, error),
+) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -173,7 +258,11 @@ func (r *Registry) mutate(
 	if err != nil {
 		return err
 	}
-	changed := change(entries)
+	changed, err := change(entries)
+	if err != nil {
+		r.entries = entries
+		return err
+	}
 	if changed {
 		if err := saveEntries(r.path, entries); err != nil {
 			return err
@@ -240,6 +329,111 @@ func (r *Registry) CompareAndSwap(
 	return replaced, err
 }
 
+// CompareAndSwapAliases collapses one complete canonical-path alias group only
+// while every stored entry still matches the inspected group. A non-nil
+// retained entry must be one of the expected entries; nil removes the complete
+// group. Active creation ownership always prevents mutation.
+func (r *Registry) CompareAndSwapAliases(
+	expected []*WorktreeEntry,
+	retained *WorktreeEntry,
+) (bool, error) {
+	if len(expected) < 2 {
+		return false, nil
+	}
+	groupPath := expected[0].Path
+	groupKey := PathKey(groupPath)
+	retainedExpected := retained == nil
+	for _, entry := range expected {
+		if entry == nil || PathKey(entry.Path) != groupKey {
+			return false, nil
+		}
+		if retained != nil && sameWorktreeEntry(entry, retained) {
+			retainedExpected = true
+		}
+	}
+	if !retainedExpected {
+		return false, nil
+	}
+
+	var copied *WorktreeEntry
+	if retained != nil {
+		value := *retained
+		copied = &value
+	}
+	replaced := false
+	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
+		keys := matchingRegistryKeys(entries, groupPath)
+		if len(keys) != len(expected) {
+			return false
+		}
+		matched := make([]bool, len(expected))
+		for _, key := range keys {
+			current := entries[key]
+			if current == nil || current.CreationToken != "" {
+				return false
+			}
+			found := false
+			for index, wanted := range expected {
+				if !matched[index] && sameWorktreeEntry(current, wanted) {
+					matched[index] = true
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		for _, key := range keys {
+			delete(entries, key)
+		}
+		if copied != nil {
+			entries[copied.Path] = copied
+		}
+		replaced = true
+		return true
+	})
+	return replaced, err
+}
+
+// RemoveIfMatchAfter runs removal and deletes a registry entry while the
+// complete observed policy record remains unchanged under the registry lock.
+// The registry entry is retained when removal fails.
+func (r *Registry) RemoveIfMatchAfter(
+	path string,
+	expected *WorktreeEntry,
+	removal func() error,
+) (bool, error) {
+	removed := false
+	err := r.mutateChecked(func(entries map[string]*WorktreeEntry) (bool, error) {
+		keys := matchingRegistryKeys(entries, path)
+		if expected == nil || len(keys) != 1 ||
+			!sameWorktreeEntry(entries[keys[0]], expected) {
+			return false, nil
+		}
+		if err := removal(); err != nil {
+			return false, err
+		}
+		delete(entries, keys[0])
+		removed = true
+		return true, nil
+	})
+	return removed, err
+}
+
+// EntryMatches reports whether path still has the complete observed registry
+// entry after refreshing from disk under the registry lock.
+func (r *Registry) EntryMatches(path string, expected *WorktreeEntry) (bool, error) {
+	matched := false
+	err := r.mutateChecked(func(entries map[string]*WorktreeEntry) (bool, error) {
+		keys := matchingRegistryKeys(entries, path)
+		matched = expected != nil && len(keys) == 1 &&
+			sameWorktreeEntry(entries[keys[0]], expected)
+		return false, nil
+	})
+	return matched, err
+}
+
 // AcquireCreation holds path's creation ownership until the returned release
 // function is called. The operating system releases the lock if the creating
 // process exits, allowing a later operation to recover its provisional entry.
@@ -252,7 +446,7 @@ func (r *Registry) AcquireCreation(
 			err,
 		)
 	}
-	pathHash := sha256.Sum256([]byte(comparableRegistryPath(path)))
+	pathHash := sha256.Sum256([]byte(PathKey(path)))
 	lockPath := filepath.Join(
 		filepath.Dir(r.path),
 		fmt.Sprintf(".creation-%x.lock", pathHash),
@@ -266,6 +460,22 @@ func (r *Registry) AcquireCreation(
 		return nil, false, nil
 	}
 	return lock.Unlock, true, nil
+}
+
+// CreationActive reports whether another process currently owns path's
+// creation lock. A persisted token without a lock is abandoned state.
+func (r *Registry) CreationActive(path string) (bool, error) {
+	release, acquired, err := r.AcquireCreation(path)
+	if err != nil {
+		return false, err
+	}
+	if !acquired {
+		return true, nil
+	}
+	if err := release(); err != nil {
+		return false, fmt.Errorf("release worktree creation inspection: %w", err)
+	}
+	return false, nil
 }
 
 // CompleteCreation finalizes only the provisional owner named by token. Other
@@ -351,6 +561,7 @@ func (r *Registry) SetExpirationIfGeneration(
 	branch string,
 	expiresAt *time.Time,
 ) (bool, error) {
+	repository, _ = repositoryurl.CanonicalRepositoryIdentity(repository)
 	updated := false
 	err := r.mutate(func(entries map[string]*WorktreeEntry) bool {
 		keys := matchingRegistryKeys(entries, path)
@@ -517,9 +728,9 @@ func entryForPath(
 	if entry, ok := entries[path]; ok {
 		return entry, true
 	}
-	want := comparableRegistryPath(path)
+	want := PathKey(path)
 	for _, entry := range entries {
-		if comparableRegistryPath(entry.Path) == want {
+		if PathKey(entry.Path) == want {
 			return entry, true
 		}
 	}
@@ -530,18 +741,24 @@ func matchingRegistryKeys(
 	entries map[string]*WorktreeEntry,
 	path string,
 ) []string {
-	want := comparableRegistryPath(path)
+	want := PathKey(path)
 	keys := make([]string, 0, 1)
 	for key, entry := range entries {
 		if key == path || entry.Path == path ||
-			comparableRegistryPath(entry.Path) == want {
+			PathKey(entry.Path) == want {
 			keys = append(keys, key)
 		}
 	}
 	return keys
 }
 
-func comparableRegistryPath(path string) string {
+// PathKey returns the canonical identity used for registry path matching. It
+// resolves the nearest existing ancestor before restoring missing path
+// components, then applies the platform's path comparison rules.
+func PathKey(path string) string {
+	if path == "" {
+		return ""
+	}
 	if absolute, err := filepath.Abs(path); err == nil {
 		path = absolute
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -355,13 +355,18 @@ func (r *Registry) RemoveIfMatchAfter(
 }
 
 // EntryMatches reports whether path still has the complete observed registry
-// entry after refreshing from disk under the registry lock.
+// entry after refreshing from disk under the registry lock. A nil expected
+// entry matches only while the path remains unregistered.
 func (r *Registry) EntryMatches(path string, expected *WorktreeEntry) (bool, error) {
 	matched := false
 	err := r.mutateChecked(func(entries map[string]*WorktreeEntry) (bool, error) {
 		keys := matchingRegistryKeys(entries, path)
-		matched = expected != nil && len(keys) == 1 &&
-			sameWorktreeEntry(entries[keys[0]], expected)
+		if expected == nil {
+			matched = len(keys) == 0
+		} else {
+			matched = len(keys) == 1 &&
+				sameWorktreeEntry(entries[keys[0]], expected)
+		}
 		return false, nil
 	})
 	return matched, err

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -53,6 +53,124 @@ func TestWorktreeEntry_IsExpired(t *testing.T) {
 	}
 }
 
+func TestPathKeyResolvesNearestExistingAncestor(t *testing.T) {
+	assert.Empty(t, PathKey(""))
+	realParent := t.TempDir()
+	aliasParent := filepath.Join(t.TempDir(), "worktrees-link")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	realPath := filepath.Join(realParent, "missing", "topic")
+	aliasPath := filepath.Join(aliasParent, "missing", "topic")
+
+	assert.Equal(t, PathKey(realPath), PathKey(aliasPath))
+}
+
+func TestNewUsesKWT_HOME(t *testing.T) {
+	kwtHome := filepath.Join(t.TempDir(), "kwt-home")
+	platformConfigHome := filepath.Join(t.TempDir(), "platform-config")
+	t.Setenv("KWT_HOME", kwtHome)
+	t.Setenv("HOME", platformConfigHome)
+	t.Setenv("APPDATA", platformConfigHome)
+	t.Setenv("XDG_CONFIG_HOME", platformConfigHome)
+
+	reg, err := New()
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(kwtHome, "registry.json"), reg.path)
+	assert.DirExists(t, kwtHome)
+}
+
+func TestNewMigratesLegacyRegistryIntoKwtHome(t *testing.T) {
+	root := t.TempDir()
+	platformConfigHome := filepath.Join(root, "platform-config")
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("APPDATA", platformConfigHome)
+	t.Setenv("XDG_CONFIG_HOME", platformConfigHome)
+
+	configDir, err := os.UserConfigDir()
+	require.NoError(t, err)
+	legacyPath := filepath.Join(configDir, "kwt", "registry.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyPath), 0o755))
+	legacyEntry := &WorktreeEntry{
+		Repository: "github.com/example/widget",
+		Branch:     "feature",
+		Path:       filepath.Join(root, "worktrees", "feature"),
+		Generation: "legacy-generation",
+	}
+	require.NoError(t, saveEntries(legacyPath, map[string]*WorktreeEntry{
+		legacyEntry.Path: legacyEntry,
+	}))
+	legacyContents, err := os.ReadFile(legacyPath)
+	require.NoError(t, err)
+
+	kwtHome := filepath.Join(root, "kwt-home")
+	t.Setenv("KWT_HOME", kwtHome)
+	reg, err := New()
+
+	require.NoError(t, err)
+	require.Len(t, reg.List(), 1)
+	assert.Equal(t, legacyEntry, reg.List()[0])
+	targetContents, err := os.ReadFile(filepath.Join(kwtHome, "registry.json"))
+	require.NoError(t, err)
+	assert.JSONEq(t, string(legacyContents), string(targetContents))
+	afterLegacyContents, err := os.ReadFile(legacyPath)
+	require.NoError(t, err)
+	assert.Equal(t, legacyContents, afterLegacyContents)
+}
+
+func TestNewWithFreshKwtHomeDoesNotCreateLegacyRegistryArtifacts(t *testing.T) {
+	root := t.TempDir()
+	platformConfigHome := filepath.Join(root, "platform-config")
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("APPDATA", platformConfigHome)
+	t.Setenv("XDG_CONFIG_HOME", platformConfigHome)
+	t.Setenv("KWT_HOME", filepath.Join(root, "kwt-home"))
+
+	configDir, err := os.UserConfigDir()
+	require.NoError(t, err)
+	legacyDir := filepath.Join(configDir, "kwt")
+	_, err = New()
+
+	require.NoError(t, err)
+	assert.NoDirExists(t, legacyDir)
+}
+
+func TestNewDoesNotOverwriteExistingKwtHomeRegistry(t *testing.T) {
+	root := t.TempDir()
+	platformConfigHome := filepath.Join(root, "platform-config")
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("APPDATA", platformConfigHome)
+	t.Setenv("XDG_CONFIG_HOME", platformConfigHome)
+
+	configDir, err := os.UserConfigDir()
+	require.NoError(t, err)
+	legacyPath := filepath.Join(configDir, "kwt", "registry.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyPath), 0o755))
+	legacyEntry := &WorktreeEntry{Path: filepath.Join(root, "legacy")}
+	require.NoError(t, saveEntries(legacyPath, map[string]*WorktreeEntry{
+		legacyEntry.Path: legacyEntry,
+	}))
+
+	kwtHome := filepath.Join(root, "kwt-home")
+	require.NoError(t, os.MkdirAll(kwtHome, 0o755))
+	targetPath := filepath.Join(kwtHome, "registry.json")
+	targetEntry := &WorktreeEntry{Path: filepath.Join(root, "target")}
+	require.NoError(t, saveEntries(targetPath, map[string]*WorktreeEntry{
+		targetEntry.Path: targetEntry,
+	}))
+	t.Setenv("KWT_HOME", kwtHome)
+
+	reg, err := New()
+
+	require.NoError(t, err)
+	require.Len(t, reg.List(), 1)
+	assert.Equal(t, targetEntry, reg.List()[0])
+	legacyEntries, err := loadEntries(legacyPath)
+	require.NoError(t, err)
+	assert.Contains(t, legacyEntries, legacyEntry.Path)
+}
+
 func TestRegistry_ListExpired(t *testing.T) {
 	// Create a temporary registry
 	tmpDir, err := os.MkdirTemp("", "registry-test")
@@ -442,6 +560,170 @@ func TestRegistryCreationFinalizationPreservesReplacementOwner(t *testing.T) {
 	assert.True(t, entry.ExpiresAt.Equal(replacementExpiry))
 }
 
+func TestRegistryCompareAndSwapAliases(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	worktreePath := t.TempDir()
+	aliasPath := filepath.Dir(worktreePath) + string(os.PathSeparator) + "." +
+		string(os.PathSeparator) + filepath.Base(worktreePath)
+	thirdAliasPath := filepath.Dir(worktreePath) + string(os.PathSeparator) + "." +
+		string(os.PathSeparator) + "." + string(os.PathSeparator) + filepath.Base(worktreePath)
+	registeredAt := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	first := &WorktreeEntry{
+		Repository: "github.com/acme/widget", Branch: "feature/topic",
+		Path: worktreePath, Hash: "abc123", RegisteredAt: registeredAt,
+		Generation: generation,
+	}
+	second := *first
+	second.Path = aliasPath
+
+	tests := []struct {
+		name        string
+		current     []*WorktreeEntry
+		expected    []*WorktreeEntry
+		wantChanged bool
+	}{
+		{
+			name:        "collapse exact group",
+			current:     []*WorktreeEntry{first, &second},
+			expected:    []*WorktreeEntry{first, &second},
+			wantChanged: true,
+		},
+		{
+			name: "preserve metadata change",
+			current: func() []*WorktreeEntry {
+				changed := second
+				changed.Branch = "feature/changed"
+				return []*WorktreeEntry{first, &changed}
+			}(),
+			expected: []*WorktreeEntry{first, &second},
+		},
+		{
+			name: "preserve added alias",
+			current: func() []*WorktreeEntry {
+				third := second
+				third.Path = thirdAliasPath
+				return []*WorktreeEntry{first, &second, &third}
+			}(),
+			expected: []*WorktreeEntry{first, &second},
+		},
+		{
+			name: "preserve active creation",
+			current: func() []*WorktreeEntry {
+				active := second
+				active.CreationToken = "active-owner"
+				return []*WorktreeEntry{first, &active}
+			}(),
+			expected: func() []*WorktreeEntry {
+				active := second
+				active.CreationToken = "active-owner"
+				return []*WorktreeEntry{first, &active}
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registryPath := filepath.Join(t.TempDir(), "registry.json")
+			stored := make(map[string]*WorktreeEntry, len(tt.current))
+			for _, entry := range tt.current {
+				copy := *entry
+				stored[entry.Path] = &copy
+			}
+			require.NoError(t, saveEntries(registryPath, stored))
+			r := &Registry{entries: make(map[string]*WorktreeEntry), path: registryPath}
+			require.NoError(t, r.load())
+
+			changed, err := r.CompareAndSwapAliases(tt.expected, first)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, changed)
+			entries := r.List()
+			if tt.wantChanged {
+				require.Len(t, entries, 1)
+				assert.Equal(t, first.Path, entries[0].Path)
+				assert.Equal(t, first.Generation, entries[0].Generation)
+			} else {
+				assert.Len(t, entries, len(tt.current))
+			}
+		})
+	}
+}
+
+func TestRegistryCompareAndSwapAliasesRemovesExactGroup(t *testing.T) {
+	realParent := t.TempDir()
+	aliasParent := filepath.Join(t.TempDir(), "worktrees-link")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symbolic links are not supported on this filesystem: %v", err)
+	}
+	worktreePath := filepath.Join(realParent, "missing-worktree")
+	aliasPath := filepath.Join(aliasParent, "missing-worktree")
+	thirdAliasPath := realParent + string(os.PathSeparator) + "." +
+		string(os.PathSeparator) + "." + string(os.PathSeparator) + filepath.Base(worktreePath)
+	registeredAt := time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC)
+	first := &WorktreeEntry{
+		Repository: "github.com/acme/widget", Branch: "feature/topic",
+		Path: worktreePath, RegisteredAt: registeredAt,
+	}
+	second := *first
+	second.Path = aliasPath
+	tests := []struct {
+		name        string
+		current     []*WorktreeEntry
+		wantChanged bool
+	}{
+		{name: "remove exact group", current: []*WorktreeEntry{first, &second}, wantChanged: true},
+		{
+			name: "preserve metadata change",
+			current: func() []*WorktreeEntry {
+				changed := second
+				changed.Branch = "feature/changed"
+				return []*WorktreeEntry{first, &changed}
+			}(),
+		},
+		{
+			name: "preserve added alias",
+			current: func() []*WorktreeEntry {
+				third := second
+				third.Path = thirdAliasPath
+				return []*WorktreeEntry{first, &second, &third}
+			}(),
+		},
+		{
+			name: "preserve active creation",
+			current: func() []*WorktreeEntry {
+				active := second
+				active.CreationToken = "active-owner"
+				return []*WorktreeEntry{first, &active}
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registryPath := filepath.Join(t.TempDir(), "registry.json")
+			stored := make(map[string]*WorktreeEntry, len(tt.current))
+			for _, entry := range tt.current {
+				copy := *entry
+				stored[entry.Path] = &copy
+			}
+			require.NoError(t, saveEntries(registryPath, stored))
+			r := &Registry{entries: make(map[string]*WorktreeEntry), path: registryPath}
+			require.NoError(t, r.load())
+
+			changed, err := r.CompareAndSwapAliases(
+				[]*WorktreeEntry{first, &second},
+				nil,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, changed)
+			if tt.wantChanged {
+				assert.Empty(t, r.List())
+			} else {
+				assert.Len(t, r.List(), len(tt.current))
+			}
+		})
+	}
+}
+
 func TestRegistryCreationLockDistinguishesActiveAndAbandonedClaims(
 	t *testing.T,
 ) {
@@ -469,6 +751,26 @@ func TestRegistryCreationLockDistinguishesActiveAndAbandonedClaims(
 	require.NoError(t, err)
 	require.True(t, acquired)
 	require.NoError(t, releaseSecond())
+}
+
+func TestRegistryReportsWhetherCreationOwnerIsActive(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	worktreePath := filepath.Join(t.TempDir(), "creating-worktree")
+	release, acquired, err := r.AcquireCreation(worktreePath)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	active, err := r.CreationActive(worktreePath)
+	require.NoError(t, err)
+	assert.True(t, active)
+	require.NoError(t, release())
+
+	active, err = r.CreationActive(worktreePath)
+	require.NoError(t, err)
+	assert.False(t, active)
 }
 
 func TestRegistryCreationLockKeepsIdentityAfterDestinationAppears(
@@ -606,7 +908,7 @@ func TestRegistryCreationAbortPreservesReviewedState(t *testing.T) {
 	assert.False(t, entry.UnreviewedRemoteSource)
 }
 
-func TestRegistryExpirationUpdatePreservesAcknowledgement(t *testing.T) {
+func TestRegistryExpirationUpdatePreservesAcknowledgementAndCanonicalizesIdentity(t *testing.T) {
 	r := &Registry{
 		entries: make(map[string]*WorktreeEntry),
 		path:    filepath.Join(t.TempDir(), "registry.json"),
@@ -625,7 +927,7 @@ func TestRegistryExpirationUpdatePreservesAcknowledgement(t *testing.T) {
 	updated, err := r.SetExpirationIfGeneration(
 		path,
 		generation,
-		"https://github.com/example/repository.git",
+		"https://user:credential-must-not-appear@github.com/example/repository.git",
 		"feature/reviewed",
 		&expiresAt,
 	)
@@ -636,9 +938,12 @@ func TestRegistryExpirationUpdatePreservesAcknowledgement(t *testing.T) {
 	require.True(t, ok)
 	assert.False(t, entry.UnreviewedRemoteSource)
 	assert.Equal(t, generation, entry.Generation)
-	assert.Equal(t, "https://github.com/example/repository.git", entry.Repository)
+	assert.Equal(t, "github.com/example/repository", entry.Repository)
 	require.NotNil(t, entry.ExpiresAt)
 	assert.True(t, entry.ExpiresAt.Equal(expiresAt))
+	stored, err := os.ReadFile(r.path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(stored), "credential-must-not-appear")
 }
 
 func TestRegistryCreationClaimRejectsChangedObservedEntry(t *testing.T) {
@@ -676,6 +981,37 @@ func TestRegistryCreationClaimRejectsChangedObservedEntry(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "feature/replacement", entry.Branch)
 	assert.Equal(t, "fedcba9876543210fedcba9876543210", entry.Generation)
+}
+
+func TestRegistryRemoveIfMatchAfterDoesNotRunRemovalForChangedExpiration(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "worktree")
+	expired := time.Now().Add(-time.Hour)
+	observed := &WorktreeEntry{
+		Path: path, Repository: "github.com/acme/widget",
+		Generation: "0123456789abcdef0123456789abcdef", ExpiresAt: &expired,
+	}
+	require.NoError(t, r.Register(observed))
+	extended := *observed
+	future := time.Now().Add(time.Hour)
+	extended.ExpiresAt = &future
+	require.NoError(t, r.Register(&extended))
+	removalCalled := false
+
+	removed, err := r.RemoveIfMatchAfter(path, observed, func() error {
+		removalCalled = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.False(t, removed)
+	assert.False(t, removalCalled)
+	current, ok := r.Get(path)
+	require.True(t, ok)
+	assert.True(t, future.Equal(*current.ExpiresAt))
 }
 
 func TestRegistryLegacyCleanupPreservesProvisionalCreation(t *testing.T) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -81,6 +81,22 @@ func TestNewUsesKWT_HOME(t *testing.T) {
 	assert.DirExists(t, kwtHome)
 }
 
+func TestEntryMatchesNilOnlyWhenPathIsUnregistered(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	reg, err := New()
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "worktree")
+
+	matched, err := reg.EntryMatches(path, nil)
+	require.NoError(t, err)
+	assert.True(t, matched)
+
+	require.NoError(t, reg.Register(&WorktreeEntry{Path: path}))
+	matched, err = reg.EntryMatches(path, nil)
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
 func TestNewWithFreshKwtHomeDoesNotImportPlatformRegistry(t *testing.T) {
 	root := t.TempDir()
 	platformConfigHome := filepath.Join(root, "platform-config")

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1022,6 +1022,24 @@ func TestRegistryRemoveIfMatchAfterDoesNotRunRemovalForChangedExpiration(t *test
 	assert.True(t, future.Equal(*current.ExpiresAt))
 }
 
+func TestRegistryRemoveIfMatchAfterClaimsAbsentEntryDuringRemoval(t *testing.T) {
+	r := &Registry{
+		entries: make(map[string]*WorktreeEntry),
+		path:    filepath.Join(t.TempDir(), "registry.json"),
+	}
+	path := filepath.Join(t.TempDir(), "unregistered-worktree")
+	removalCalled := false
+
+	removed, err := r.RemoveIfMatchAfter(path, nil, func() error {
+		removalCalled = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, removed)
+	assert.True(t, removalCalled)
+}
+
 func TestRegistryLegacyCleanupPreservesProvisionalCreation(t *testing.T) {
 	r := &Registry{
 		entries: make(map[string]*WorktreeEntry),

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -81,7 +81,7 @@ func TestNewUsesKWT_HOME(t *testing.T) {
 	assert.DirExists(t, kwtHome)
 }
 
-func TestNewMigratesLegacyRegistryIntoKwtHome(t *testing.T) {
+func TestNewWithFreshKwtHomeDoesNotImportPlatformRegistry(t *testing.T) {
 	root := t.TempDir()
 	platformConfigHome := filepath.Join(root, "platform-config")
 	t.Setenv("HOME", filepath.Join(root, "home"))
@@ -101,22 +101,14 @@ func TestNewMigratesLegacyRegistryIntoKwtHome(t *testing.T) {
 	require.NoError(t, saveEntries(legacyPath, map[string]*WorktreeEntry{
 		legacyEntry.Path: legacyEntry,
 	}))
-	legacyContents, err := os.ReadFile(legacyPath)
-	require.NoError(t, err)
-
 	kwtHome := filepath.Join(root, "kwt-home")
 	t.Setenv("KWT_HOME", kwtHome)
 	reg, err := New()
 
 	require.NoError(t, err)
-	require.Len(t, reg.List(), 1)
-	assert.Equal(t, legacyEntry, reg.List()[0])
-	targetContents, err := os.ReadFile(filepath.Join(kwtHome, "registry.json"))
-	require.NoError(t, err)
-	assert.JSONEq(t, string(legacyContents), string(targetContents))
-	afterLegacyContents, err := os.ReadFile(legacyPath)
-	require.NoError(t, err)
-	assert.Equal(t, legacyContents, afterLegacyContents)
+	assert.Empty(t, reg.List())
+	assert.NoFileExists(t, filepath.Join(kwtHome, "registry.json"))
+	assert.FileExists(t, legacyPath)
 }
 
 func TestNewWithFreshKwtHomeDoesNotCreateLegacyRegistryArtifacts(t *testing.T) {


### PR DESCRIPTION
Repository moves and folder renames can leave project registrations and Git worktree metadata pointing at old locations. This PR adds safe inspection, repair, and explicit pruning commands.

## Usage

- `kwt doctor` reports moved or deleted projects, broken backlinks, stale Git records, and registry drift without changing anything.
- `kwt doctor --fix` applies only confirmed repairs, lists what it fixed, and rescans the final state. It never removes a live worktree.
- `kwt doctor --quiet` suppresses the human report when only the exit status matters.
- `kwt prune --expired [--dry-run]` removes worktrees whose configured expiration has passed.
- `kwt prune --merged [--dry-run]` removes only clean worktrees with an exact, confirmed merged GitHub pull request. Local branches are preserved.
- Doctor and prune support `--json`; skipped worktrees include a reason and suggested next step.

## Compatibility

- Bare `kwt prune` is replaced by `kwt doctor --fix` for stale metadata cleanup.
- `KWT_HOME` isolates config, registry, and pull-request state. Existing registry files must be copied deliberately; fresh homes never import the default registry.
- kwt supports Git 2.20 or newer; doctor and explicit prune policies require Git 2.31 or newer.