### PR TITLE
Expose and open registered directory workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ kwt open /path/to/worktree
 # Establish that exact workspace session for another tmux client
 kwt open /path/to/worktree --start-session
 
+# Register, inventory, and open a plain directory workspace
+kwt workspace add ~/notes
+kwt workspace list --json
+kwt open ~/notes --start-session
+
 # Inspect worktrees and git status
 kwt list
 kwt status

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@ stable command surface.
 | `kwt`, `kwt tui` | Open the cross-project and multi-machine dashboard.    |
 | `kwt add`        | Create a worktree and optionally launch its workspace. |
 | `kwt branches`   | List branches available for a new worktree.            |
-| `kwt open`       | Open or establish a worktree workspace session.        |
+| `kwt open`       | Open or establish a workspace session.                 |
 | `kwt list`       | List worktrees.                                        |
 | `kwt status`     | Show Git status, sync state, and activity.             |
 | `kwt projects`   | List registered project repositories.                  |
@@ -41,6 +41,8 @@ kwt sync status
 kwt exec fix/parser-race -- go test ./internal/parser
 kwt workspace add ~/notes
 kwt workspace list
+kwt workspace list --json
+kwt open ~/notes --start-session
 kwt config get layouts.default
 kwt config set --local layouts.default stack
 ```
@@ -73,8 +75,10 @@ acknowledgement that opts in to its layout and pane commands.
 ## `kwt open`
 
 With no argument, `kwt open` fuzzy-picks a worktree. A pattern narrows the
-cross-project list and opens the sole match directly. Kwt creates or repairs
-the canonical tmux workspace with its resolved layout before attaching.
+cross-project list and opens the sole match directly. An exact registered
+directory workspace path resolves before Git worktree discovery. Kwt creates
+or repairs the canonical tmux workspace with its resolved layout before
+attaching.
 
 An exact worktree-root path is resolved directly from Git before pattern
 matching, including registered primary checkouts and linked worktrees outside
@@ -88,13 +92,28 @@ An ordinary open from inside tmux switches the current client instead.
 Protected attachment always remains external because it targets a separate
 workspace-specific socket.
 
-`kwt open <exact-worktree-path> --start-session` performs the same layout and
+`kwt open <exact-workspace-path> --start-session` performs the same layout and
 session bootstrap without attaching a client. Use it before an external
-ordinary tmux client attaches to a session that may not exist yet. The exact
-path is resolved directly from Git rather than the global worktree base, which
-keeps this automation mode noninteractive and supports linked worktrees stored
+ordinary tmux client attaches to a session that may not exist yet. Registered
+directory paths resolve from the workspace registry; worktree paths resolve
+directly from Git rather than the global worktree base. This keeps automation
+noninteractive and supports both plain directories and linked worktrees stored
 outside that base.
 Protected pull-request imports remain restricted to `kwt pr attach`.
+
+## `kwt workspace`
+
+`workspace add [path]` registers a plain directory. The `workspace remove`
+command accepts its name and unregisters it without deleting the directory or
+killing a live tmux session. `workspace list` reports registered directories
+and session state.
+
+`workspace list --json` emits an array of objects with `name`, canonical
+absolute `path`, effective `session_name`, and boolean `session_live`. An empty
+registry emits `[]` with no table prose. When a workspace was renamed while its
+session remained live, `session_name` reports that matching live session so
+clients can attach to it; otherwise it reports the canonical name kwt will use
+when establishing the session.
 
 ## `kwt list`
 

--- a/docs/workflows/directory-workspaces.md
+++ b/docs/workflows/directory-workspaces.md
@@ -10,6 +10,7 @@ configured layouts, and show them in the dashboard next to worktrees.
 kwt workspace add ~/notes
 kwt workspace add ~/scratch/protos --name protos
 kwt workspace list
+kwt workspace list --json
 kwt workspace remove protos
 ```
 
@@ -47,6 +48,21 @@ default in the directory's `.kwt.toml`:
 [layouts]
 default = "stack"
 ```
+
+Open a registered workspace by its exact path to attach normally, or establish
+the same layout and session without attaching for another client:
+
+```sh
+kwt open ~/notes
+kwt open ~/notes --start-session
+```
+
+For inventory clients, `kwt workspace list --json` returns `name`, canonical
+absolute `path`, effective `session_name`, and `session_live` for each entry.
+It returns `[]` when nothing is registered. If a workspace is renamed while a
+matching session is still live, the effective session name remains the live
+name until that session exits; otherwise it is the canonical name kwt will use
+for the next launch.
 
 ## Scope
 

--- a/internal/cmd/directory_workspace.go
+++ b/internal/cmd/directory_workspace.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+type directoryWorkspaceRecord struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	SessionName string `json:"session_name"`
+	SessionLive bool   `json:"session_live"`
+}
+
+func directoryWorkspaceRecords(
+	workspaces []models.Workspace,
+	sessions []string,
+) []directoryWorkspaceRecord {
+	records := make([]directoryWorkspaceRecord, 0, len(workspaces))
+	for _, workspace := range workspaces {
+		sessionName := tmux.DirWorkspaceSessionName(
+			workspace.Name,
+			workspace.Path,
+		)
+		sessionLive := false
+		if live, ok := tmux.MatchDirWorkspaceSession(
+			sessions,
+			workspace.Path,
+		); ok {
+			sessionName = live
+			sessionLive = true
+		}
+		records = append(records, directoryWorkspaceRecord{
+			Name:        workspace.Name,
+			Path:        workspace.Path,
+			SessionName: sessionName,
+			SessionLive: sessionLive,
+		})
+	}
+	return records
+}
+
+func findRegisteredDirectoryWorkspace(
+	workspaces []models.Workspace,
+	path string,
+) (models.Workspace, bool) {
+	pathKey := utils.PathKey(path)
+	for _, workspace := range workspaces {
+		if utils.PathKey(workspace.Path) == pathKey {
+			return workspace, true
+		}
+	}
+	return models.Workspace{}, false
+}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -39,13 +39,12 @@ type openWorkspaceRunner interface {
 
 var openCmd = &cobra.Command{
 	Use:   "open [pattern]",
-	Short: "Open a worktree workspace from any repository",
+	Short: "Open a worktree or registered directory workspace",
 	Long: `Fuzzy-pick a worktree across all repositories in the configured base
 directory and attach to its tmux workspace, creating the workspace with the
 resolved layout if it does not yet exist. A pattern filters the worktree list.
-An exact worktree path resolves directly even when it is outside the configured
-base directory. Add --start-session to create or repair the workspace without
-attaching.`,
+An exact worktree path or registered directory workspace path resolves directly.
+Add --start-session to create or repair the workspace without attaching.`,
 	Example: `  # Pick a worktree and open its workspace
   kwt open
 
@@ -54,6 +53,9 @@ attaching.`,
 
   # Ensure an exact worktree workspace exists without attaching
   kwt open /path/to/worktree --start-session
+
+  # Open a registered directory workspace
+  kwt open /path/to/directory-workspace
 
   # Force a specific layout
   kwt open --layout focus
@@ -77,7 +79,7 @@ func init() {
 		&openStartSession,
 		"start-session",
 		false,
-		"ensure an exact worktree's workspace exists without attaching",
+		"ensure an exact workspace exists without attaching",
 	)
 	openCmd.MarkFlagsMutuallyExclusive("layout", "select-layout")
 	openCmd.MarkFlagsMutuallyExclusive("start-session", "select-layout")
@@ -85,47 +87,70 @@ func init() {
 
 func runOpen(cmd *cobra.Command, args []string) error {
 	return ExecuteWithContext(false, func(ctx *CommandContext) error {
-		if err := tmux.ValidateLayouts(ctx.Config.Layouts, ctx.Config.Agents); err != nil {
-			return err
-		}
-		if openStartSession && len(args) != 1 {
-			return fmt.Errorf("--start-session requires an exact worktree path")
-		}
+		return runOpenWithContext(cmd, args, ctx)
+	})(cmd, args)
+}
 
-		entry, requestedPath, err := resolveOpenWorktree(
-			ctx,
-			args,
-			openStartSession,
-		)
+func runOpenWithContext(
+	cmd *cobra.Command,
+	args []string,
+	ctx *CommandContext,
+) error {
+	if err := tmux.ValidateLayouts(ctx.Config.Layouts, ctx.Config.Agents); err != nil {
+		return err
+	}
+	if openStartSession && len(args) != 1 {
+		return fmt.Errorf("--start-session requires an exact workspace path")
+	}
+	finder := ctx.GetGlobalFinder()
+	selectLayout := func(layouts []models.Layout) (models.Layout, error) {
+		selected, err := finder.SelectLayout(layouts)
 		if err != nil {
-			return err
+			return models.Layout{}, err
 		}
-		if entry == nil {
-			return nil
-		}
-		if entry.RepositoryInfo == nil {
-			return fmt.Errorf(
-				"could not resolve worktree %s",
-				requestedPath,
+		return *selected, nil
+	}
+	if len(args) == 1 {
+		if workspace, ok := findRegisteredDirectoryWorkspace(
+			ctx.Config.Workspaces,
+			args[0],
+		); ok {
+			return openSelectedDirectoryWorkspace(
+				cmd.Context(),
+				ctx,
+				workspace,
+				selectLayout,
+				openStartSession,
+				config.StdinInteractive(),
 			)
 		}
-		finder := ctx.GetGlobalFinder()
+	}
 
-		return openSelectedWorktree(
-			cmd.Context(),
-			ctx,
-			entry,
-			func(ls []models.Layout) (models.Layout, error) {
-				sel, err := finder.SelectLayout(ls)
-				if err != nil {
-					return models.Layout{}, err
-				}
-				return *sel, nil
-			},
-			openStartSession,
-			config.StdinInteractive(),
+	entry, requestedPath, err := resolveOpenWorktree(
+		ctx,
+		args,
+		openStartSession,
+	)
+	if err != nil {
+		return err
+	}
+	if entry == nil {
+		return nil
+	}
+	if entry.RepositoryInfo == nil {
+		return fmt.Errorf(
+			"could not resolve worktree %s",
+			requestedPath,
 		)
-	})(cmd, args)
+	}
+	return openSelectedWorktree(
+		cmd.Context(),
+		ctx,
+		entry,
+		selectLayout,
+		openStartSession,
+		config.StdinInteractive(),
+	)
 }
 
 func resolveOpenWorktree(
@@ -283,6 +308,95 @@ func openSelectedWorktree(
 	return runner.EnsureAndAttach(
 		commandCtx, session, entry.Path, layout, os.Getenv("TMUX") != "",
 	)
+}
+
+func openSelectedDirectoryWorkspace(
+	commandCtx context.Context,
+	ctx *CommandContext,
+	workspace models.Workspace,
+	selectLayout func([]models.Layout) (models.Layout, error),
+	startSession bool,
+	stdinInteractive bool,
+) error {
+	if err := rejectProtectedWorkspaceOpen(
+		commandCtx,
+		workspace.Path,
+	); err != nil {
+		return err
+	}
+	if err := acknowledgeRemoteSourcePath(workspace.Path); err != nil {
+		return err
+	}
+	sessions, err := listWorkspaceSessions()
+	if err != nil {
+		return fmt.Errorf("failed to list tmux sessions: %w", err)
+	}
+	records := directoryWorkspaceRecords(
+		[]models.Workspace{workspace},
+		sessions,
+	)
+	if len(records) != 1 {
+		return fmt.Errorf("could not resolve directory workspace %s", workspace.Path)
+	}
+	layout, err := resolveDirectoryWorkspaceLayout(
+		ctx.Config,
+		workspace,
+		openLayout,
+		openSelectLayout,
+		selectLayout,
+		stdinInteractive && !startSession,
+	)
+	if err != nil {
+		return err
+	}
+	runner := newOpenWorkspaceRunner(credentials.ProtectedNames(ctx.Config))
+	if startSession {
+		return runner.Ensure(
+			commandCtx,
+			records[0].SessionName,
+			workspace.Path,
+			layout,
+		)
+	}
+	return runner.EnsureAndAttach(
+		commandCtx,
+		records[0].SessionName,
+		workspace.Path,
+		layout,
+		os.Getenv("TMUX") != "",
+	)
+}
+
+func resolveDirectoryWorkspaceLayout(
+	cfg *models.Config,
+	workspace models.Workspace,
+	layoutName string,
+	selectLayout bool,
+	chooseLayout func([]models.Layout) (models.Layout, error),
+	interactive bool,
+) (models.Layout, error) {
+	targetDefault := ""
+	if shouldLoadTargetDefault(layoutName, selectLayout) {
+		var err error
+		targetDefault, err = config.LoadRepoLayoutDefault(
+			workspace.Path,
+			interactive,
+		)
+		if err != nil {
+			return models.Layout{}, err
+		}
+	}
+	layout, err := tmux.ResolveLayout(
+		cfg.Layouts,
+		layoutName,
+		selectLayout,
+		targetDefault,
+		chooseLayout,
+	)
+	if err != nil {
+		return models.Layout{}, err
+	}
+	return tmux.ResolvePaneCommands(layout, cfg.Agents)
 }
 
 // shouldLoadTargetDefault reports whether kwt open must consult the target

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/registry"
@@ -19,21 +22,36 @@ import (
 )
 
 type recordingOpenWorkspaceRunner struct {
-	ensured  bool
-	attached bool
+	ensured          bool
+	attached         bool
+	sessionName      string
+	workingDirectory string
+	layout           models.Layout
+	insideTmux       bool
 }
 
 func (r *recordingOpenWorkspaceRunner) Ensure(
-	context.Context, string, string, models.Layout,
+	_ context.Context, sessionName, workingDirectory string, layout models.Layout,
 ) error {
 	r.ensured = true
+	r.sessionName = sessionName
+	r.workingDirectory = workingDirectory
+	r.layout = layout
 	return nil
 }
 
 func (r *recordingOpenWorkspaceRunner) EnsureAndAttach(
-	context.Context, string, string, models.Layout, bool,
+	_ context.Context,
+	sessionName string,
+	workingDirectory string,
+	layout models.Layout,
+	insideTmux bool,
 ) error {
 	r.attached = true
+	r.sessionName = sessionName
+	r.workingDirectory = workingDirectory
+	r.layout = layout
+	r.insideTmux = insideTmux
 	return nil
 }
 
@@ -95,6 +113,219 @@ func TestOpenStartSessionFlagGroups(t *testing.T) {
 	selectLayout.Changed = false
 	layout.Changed = true
 	require.NoError(t, openCmd.ValidateFlagGroups())
+}
+
+func TestOpenSelectedDirectoryWorkspaceEnsuresOrAttaches(t *testing.T) {
+	tests := []struct {
+		name         string
+		startSession bool
+	}{
+		{name: "attach", startSession: false},
+		{name: "start only", startSession: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetWorkspaceCommandDeps(t)
+			workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
+			listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+			runner := &recordingOpenWorkspaceRunner{}
+			originalRunner := newOpenWorkspaceRunner
+			originalLayout := openLayout
+			originalSelectLayout := openSelectLayout
+			newOpenWorkspaceRunner = func([]string) openWorkspaceRunner {
+				return runner
+			}
+			openLayout = tmux.BlankLayoutName
+			openSelectLayout = false
+			t.Cleanup(func() {
+				newOpenWorkspaceRunner = originalRunner
+				openLayout = originalLayout
+				openSelectLayout = originalSelectLayout
+			})
+
+			err := openSelectedDirectoryWorkspace(
+				context.Background(),
+				&CommandContext{Config: &models.Config{}},
+				workspace,
+				func([]models.Layout) (models.Layout, error) {
+					return models.Layout{}, nil
+				},
+				tt.startSession,
+				false,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, workspace.Path, runner.workingDirectory)
+			assert.Equal(
+				t,
+				tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+				runner.sessionName,
+			)
+			assert.Equal(t, tt.startSession, runner.ensured)
+			assert.Equal(t, !tt.startSession, runner.attached)
+		})
+	}
+}
+
+func TestOpenSelectedDirectoryWorkspaceUsesRenamedLiveSession(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	workspace := models.Workspace{Name: "renamed", Path: t.TempDir()}
+	liveName := tmux.DirWorkspaceSessionName("old-name", workspace.Path)
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{liveName}, nil
+	}
+	runner := &recordingOpenWorkspaceRunner{}
+	originalRunner := newOpenWorkspaceRunner
+	originalLayout := openLayout
+	newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
+	openLayout = tmux.BlankLayoutName
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = originalRunner
+		openLayout = originalLayout
+	})
+
+	err := openSelectedDirectoryWorkspace(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		workspace,
+		nil,
+		true,
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, liveName, runner.sessionName)
+}
+
+func TestOpenSelectedDirectoryWorkspaceUsesDirectoryLayoutDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("KWT_HOME", filepath.Join(home, ".config", "kwt"))
+	resetWorkspaceCommandDeps(t)
+	workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
+	localTOML := []byte("[layouts]\ndefault = \"focus\"\n")
+	localConfigPath := filepath.Join(workspace.Path, ".kwt.toml")
+	require.NoError(t, os.WriteFile(localConfigPath, localTOML, 0o644))
+	resolvedConfigPath, err := filepath.EvalSymlinks(localConfigPath)
+	require.NoError(t, err)
+	sum := sha256.Sum256(localTOML)
+	trustStore, err := config.LoadTrustStore(
+		filepath.Join(home, ".config", "kwt", "trusted_configs.json"),
+	)
+	require.NoError(t, err)
+	require.NoError(t, trustStore.Add(resolvedConfigPath, hex.EncodeToString(sum[:])))
+	listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+	runner := &recordingOpenWorkspaceRunner{}
+	originalRunner := newOpenWorkspaceRunner
+	originalLayout := openLayout
+	originalSelectLayout := openSelectLayout
+	newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
+	openLayout = ""
+	openSelectLayout = false
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = originalRunner
+		openLayout = originalLayout
+		openSelectLayout = originalSelectLayout
+	})
+
+	err = openSelectedDirectoryWorkspace(
+		context.Background(),
+		&CommandContext{Config: &models.Config{
+			Layouts: models.LayoutsConfig{Presets: []models.Layout{{
+				Name: "focus", Panes: []string{""},
+			}}},
+		}},
+		workspace,
+		nil,
+		true,
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "focus", runner.layout.Name)
+}
+
+func TestRunOpenWithContextChoosesRegisteredDirectory(t *testing.T) {
+	for _, startSession := range []bool{false, true} {
+		t.Run(map[bool]string{false: "attach", true: "start only"}[startSession], func(t *testing.T) {
+			resetWorkspaceCommandDeps(t)
+			workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
+			listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+			runner := &recordingOpenWorkspaceRunner{}
+			originalRunner := newOpenWorkspaceRunner
+			originalLayout := openLayout
+			originalSelectLayout := openSelectLayout
+			originalStartSession := openStartSession
+			newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
+			openLayout = tmux.BlankLayoutName
+			openSelectLayout = false
+			openStartSession = startSession
+			t.Cleanup(func() {
+				newOpenWorkspaceRunner = originalRunner
+				openLayout = originalLayout
+				openSelectLayout = originalSelectLayout
+				openStartSession = originalStartSession
+			})
+
+			cmd, _, _ := fleetTestCommand()
+			cmd.SetContext(context.Background())
+			err := runOpenWithContext(
+				cmd,
+				[]string{workspace.Path},
+				&CommandContext{Config: &models.Config{
+					Workspaces: []models.Workspace{workspace},
+				}},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, workspace.Path, runner.workingDirectory)
+			assert.Equal(t, startSession, runner.ensured)
+			assert.Equal(t, !startSession, runner.attached)
+		})
+	}
+}
+
+func TestOpenStartSessionRequiresExactWorkspacePath(t *testing.T) {
+	originalStartSession := openStartSession
+	openStartSession = true
+	t.Cleanup(func() { openStartSession = originalStartSession })
+	cmd, _, _ := fleetTestCommand()
+	cmd.SetContext(context.Background())
+
+	err := runOpenWithContext(
+		cmd,
+		nil,
+		&CommandContext{Config: &models.Config{}},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exact workspace path")
+}
+
+func TestRunOpenWithContextRejectsUnregisteredNonGitDirectory(t *testing.T) {
+	originalLayout := openLayout
+	originalStartSession := openStartSession
+	openLayout = tmux.BlankLayoutName
+	openStartSession = false
+	t.Cleanup(func() {
+		openLayout = originalLayout
+		openStartSession = originalStartSession
+	})
+	cmd, _, _ := fleetTestCommand()
+	cmd.SetContext(context.Background())
+	path := t.TempDir()
+
+	err := runOpenWithContext(
+		cmd,
+		[]string{path},
+		&CommandContext{Config: &models.Config{
+			Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
+		}},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not resolve worktree")
 }
 
 func TestResolveOpenWorktreeAcceptsExactPrimaryPathOutsideGlobalBase(

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -376,19 +376,14 @@ func (b *tuiBackend) workspaceRows(sessions []string) []dashboard.Row {
 		return nil
 	}
 	rows := make([]dashboard.Row, 0, len(b.cfg.Workspaces))
-	for _, workspace := range b.cfg.Workspaces {
-		sessionName := tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path)
-		sessionLive := false
-		// Match by path hash so a renamed workspace still finds (and later
-		// attaches to) its live session created under the old name.
-		if live, ok := tmux.MatchDirWorkspaceSession(sessions, workspace.Path); ok {
-			sessionName = live
-			sessionLive = true
-		}
+	for _, record := range directoryWorkspaceRecords(b.cfg.Workspaces, sessions) {
 		rows = append(rows, dashboard.Row{
-			Workspace:   &dashboard.WorkspaceInfo{Name: workspace.Name, Path: workspace.Path},
-			SessionName: sessionName,
-			SessionLive: sessionLive,
+			Workspace: &dashboard.WorkspaceInfo{
+				Name: record.Name,
+				Path: record.Path,
+			},
+			SessionName: record.SessionName,
+			SessionLive: record.SessionLive,
 		})
 	}
 	return rows

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1514,19 +1514,27 @@ func rowPaneRoot(row dashboard.Row) string {
 }
 
 func (b *tuiBackend) resolveLayout(row dashboard.Row, layoutName string, interactive bool) (models.Layout, error) {
+	if row.Workspace != nil {
+		return resolveDirectoryWorkspaceLayout(
+			b.cfg,
+			models.Workspace{
+				Name: row.Workspace.Name,
+				Path: row.Workspace.Path,
+			},
+			layoutName,
+			false,
+			nil,
+			interactive,
+		)
+	}
 	var layout models.Layout
 	var err error
 	if layoutName != "" {
 		layout, err = tmux.ResolveLayout(b.cfg.Layouts, layoutName, false, "", nil)
 	} else {
-		var layoutRoot string
-		if row.Workspace != nil {
-			layoutRoot = row.Workspace.Path
-		} else {
-			layoutRoot, err = b.repositoryRootForRow(row)
-			if err != nil {
-				return models.Layout{}, err
-			}
+		layoutRoot, rootErr := b.repositoryRootForRow(row)
+		if rootErr != nil {
+			return models.Layout{}, rootErr
 		}
 		var targetDefault string
 		targetDefault, err = config.LoadRepoLayoutDefault(layoutRoot, interactive)

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 var (
 	workspaceAddName string
+	workspaceJSON    bool
 
 	registerWorkspace     = config.RegisterWorkspace
 	unregisterWorkspace   = config.UnregisterWorkspace
@@ -56,6 +58,7 @@ var workspaceRemoveCmd = &cobra.Command{
 
 func init() {
 	workspaceAddCmd.Flags().StringVar(&workspaceAddName, "name", "", "workspace name (defaults to the directory base name)")
+	workspaceListCmd.Flags().BoolVar(&workspaceJSON, "json", false, "Output in JSON format")
 	workspaceCmd.AddCommand(workspaceAddCmd, workspaceListCmd, workspaceRemoveCmd)
 	rootCmd.AddCommand(workspaceCmd)
 }
@@ -85,6 +88,11 @@ func runWorkspaceList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 	if len(cfg.Workspaces) == 0 {
+		if workspaceJSON {
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(
+				[]directoryWorkspaceRecord{},
+			)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no workspaces registered")
 		return nil
 	}
@@ -92,13 +100,17 @@ func runWorkspaceList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to list tmux sessions: %w", err)
 	}
+	records := directoryWorkspaceRecords(cfg.Workspaces, sessions)
+	if workspaceJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(records)
+	}
 	t := table.New().SetOutput(cmd.OutOrStdout()).Headers("NAME", "PATH", "SESSION")
-	for _, workspace := range cfg.Workspaces {
+	for _, record := range records {
 		state := "stopped"
-		if _, ok := tmux.MatchDirWorkspaceSession(sessions, workspace.Path); ok {
+		if record.SessionLive {
 			state = "live"
 		}
-		t.Row(workspace.Name, workspace.Path, state)
+		t.Row(record.Name, record.Path, state)
 	}
 	return t.Println()
 }

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -96,6 +97,79 @@ func TestWorkspaceListShowsLiveState(t *testing.T) {
 	assert.Contains(t, out, "live")
 	assert.Contains(t, out, "scratch")
 	assert.Contains(t, out, "stopped")
+}
+
+func TestWorkspaceListJSONReportsCanonicalAndEffectiveSessions(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	workspaceJSON = true
+	t.Cleanup(func() { workspaceJSON = false })
+	workspaces := []models.Workspace{
+		{Name: "renamed", Path: "/Users/me/notes"},
+		{Name: "scratch", Path: "/Users/me/scratch"},
+	}
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{Workspaces: workspaces}, nil
+	}
+	oldLiveName := tmux.DirWorkspaceSessionName("old-name", workspaces[0].Path)
+	listWorkspaceSessions = func() ([]string, error) {
+		return []string{oldLiveName}, nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	require.NoError(t, runWorkspaceList(cmd, nil))
+
+	var got []directoryWorkspaceRecord
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, directoryWorkspaceRecord{
+		Name:        "renamed",
+		Path:        "/Users/me/notes",
+		SessionName: oldLiveName,
+		SessionLive: true,
+	}, got[0])
+	assert.Equal(t, directoryWorkspaceRecord{
+		Name: "scratch",
+		Path: "/Users/me/scratch",
+		SessionName: tmux.DirWorkspaceSessionName(
+			"scratch",
+			"/Users/me/scratch",
+		),
+		SessionLive: false,
+	}, got[1])
+}
+
+func TestWorkspaceListJSONEmptyRegistryEmitsArray(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	workspaceJSON = true
+	t.Cleanup(func() { workspaceJSON = false })
+	loadWorkspaceConfig = func() (*models.Config, error) {
+		return &models.Config{}, nil
+	}
+
+	cmd, stdout, _ := fleetTestCommand()
+	require.NoError(t, runWorkspaceList(cmd, nil))
+
+	assert.Equal(t, "[]\n", stdout.String())
+	assert.NotContains(t, stdout.String(), "no workspaces registered")
+}
+
+func TestFindRegisteredDirectoryWorkspaceUsesCanonicalPath(t *testing.T) {
+	workspaces := []models.Workspace{
+		{Name: "notes", Path: "/Users/me/workspaces/notes"},
+	}
+
+	got, ok := findRegisteredDirectoryWorkspace(
+		workspaces,
+		"/Users/me/workspaces/./notes/",
+	)
+	require.True(t, ok)
+	assert.Equal(t, workspaces[0], got)
+
+	_, ok = findRegisteredDirectoryWorkspace(
+		workspaces,
+		"/Users/me/workspaces/scratch",
+	)
+	assert.False(t, ok)
 }
 
 func TestWorkspaceRemoveReportsLiveSession(t *testing.T) {


### PR DESCRIPTION
Registered plain directories need the same machine-readable inventory and session bootstrap boundary as Git worktrees so Ghosthub and other clients do not have to parse tables or create bare tmux sessions. This adds structured workspace list output with effective live-session names, then extends exact-path open and start-session handling to registered directories while preserving kwt layout and trust behavior. The full Go test suite, build, vet, lint, and formatter checks pass.