### PR TITLE
test: prevent worktree tests from polluting the user registry

### DIFF
--- a/docs/superpowers/plans/2026-08-07-isolate-test-registry.md
+++ b/docs/superpowers/plans/2026-08-07-isolate-test-registry.md
@@ -1,0 +1,98 @@
+# Isolate Worktree Manager Test Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task with review checkpoints.
+
+**Goal:** Keep `TestManagerAdd` from persisting temporary worktree records in the user's kwt registry.
+
+**Architecture:** Change only `internal/worktree/worktree_test.go`. Give the test an isolated `KWT_HOME`, inject the package's existing `mockRemoteSourceState` into each manager, and assert that the isolated on-disk registry remains empty. No production behavior or registry API changes are needed.
+
+**Tech Stack:** Go, `testing`, `testify`, kwt's existing worktree and registry test doubles.
+
+## Global Constraints
+
+- Preserve production registry tracking for real unreviewed worktree creation.
+- Do not touch the user's default registry during tests.
+- Follow the repository's test-first rule and verify focused plus full checks.
+- Keep the change limited to the test harness and its regression assertion.
+
+---
+
+### Task 1: Isolate `TestManagerAdd` from the default registry
+
+**Files:**
+- Modify: `internal/worktree/worktree_test.go:345-415`
+
+**Interfaces:**
+- Consumes: `mockRemoteSourceState`, `Manager.openRemoteSourceState`, and `registry.New` already defined in the package.
+- Produces: A `TestManagerAdd` regression test that exercises all existing cases without persisting registry entries.
+
+- [ ] **Step 1: Write the failing regression assertion**
+
+At the beginning of `TestManagerAdd`, set `KWT_HOME` to `t.TempDir()`. After each successful add, open `registry.New()` and assert that its list is empty. Do not inject the fake state yet; the current manager setup should persist the existing/unreviewed cases and make this test fail.
+
+The assertion to add after the existing worktree-count check is:
+
+```go
+reg, err := registry.New()
+require.NoError(t, err)
+assert.Empty(t, reg.List())
+```
+
+- [ ] **Step 2: Run the focused test and verify the expected failure**
+
+Run:
+
+```bash
+KWT_HOME="$(mktemp -d)" go test ./internal/worktree -run '^TestManagerAdd$' -count=1
+```
+
+Expected: `TestManagerAdd/WithGeneratedPath` or `TestManagerAdd/WithCustomPath` fails because the current implementation persists an unreviewed-source entry.
+
+- [ ] **Step 3: Inject the fake remote-source state**
+
+After creating each manager in the subtest, install the existing in-memory state:
+
+```go
+state := &mockRemoteSourceState{}
+m.openRemoteSourceState = func() (remoteSourceState, error) {
+	return state, nil
+}
+```
+
+Keep the existing `mockGit` assertions and the isolated-registry assertion. This removes the disk-side effect while retaining the `Add` behavior under test.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+KWT_HOME="$(mktemp -d)" go test ./internal/worktree -run '^TestManagerAdd$' -count=1
+```
+
+Expected: all three subtests pass and the isolated registry remains empty.
+
+- [ ] **Step 5: Format and inspect the focused diff**
+
+Run:
+
+```bash
+gofmt -w internal/worktree/worktree_test.go
+git diff --check
+git diff -- internal/worktree/worktree_test.go
+```
+
+Expected: only the test setup and regression assertion change; no production files are modified.
+
+- [ ] **Step 6: Run repository verification**
+
+Run with `HOME` and temp paths redirected, but without a global `KWT_HOME` override so config tests that set `HOME` internally retain their intended behavior:
+
+```bash
+HOME="$scratch_home" XDG_CONFIG_HOME="$scratch_config" TMPDIR="$scratch_tmp" GH_CONFIG_DIR="$scratch_gh" GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
+make build
+go vet ./...
+make lint
+make fmt
+```
+
+Expected: all commands exit successfully and formatting produces no additional diff.

--- a/docs/superpowers/plans/2026-08-07-isolate-test-registry.md
+++ b/docs/superpowers/plans/2026-08-07-isolate-test-registry.md
@@ -20,9 +20,11 @@
 ### Task 1: Isolate `TestManagerAdd` from the default registry
 
 **Files:**
+
 - Modify: `internal/worktree/worktree_test.go:345-415`
 
 **Interfaces:**
+
 - Consumes: `mockRemoteSourceState`, `Manager.openRemoteSourceState`, and `registry.New` already defined in the package.
 - Produces: A `TestManagerAdd` regression test that exercises all existing cases without persisting registry entries.
 

--- a/docs/superpowers/specs/2026-08-07-isolate-test-registry-design.md
+++ b/docs/superpowers/specs/2026-08-07-isolate-test-registry-design.md
@@ -1,0 +1,36 @@
+# Isolate Worktree Manager Test Registry Design
+
+## Goal
+
+Prevent `internal/worktree` tests from writing registry entries to the user's
+default kwt registry when exercising existing/unreviewed worktree creation.
+
+## Root cause
+
+`Manager.Add` uses the remote-source registry for the default
+`createBranch=false` path. `TestManagerAdd` constructs a manager without
+replacing its `openRemoteSourceState` dependency, so the test opens the real
+registry. The test directories are removed by `t.TempDir`, but the registry
+records survive and later appear as stale entries.
+
+## Design
+
+Keep production behavior unchanged. The test will set `KWT_HOME` to a
+test-owned directory and assert that the test leaves that registry empty. Each
+subtest will inject the existing `mockRemoteSourceState`, matching the adjacent
+remote-source tests. This makes the test independent of filesystem-backed
+registry state while the explicit empty-registry assertion catches regressions
+that reintroduce persistence.
+
+## Error handling
+
+The test fails immediately if the isolated registry cannot be opened or if any
+entry is persisted. The fake state continues to exercise creation ownership,
+generation finalization, and worktree result behavior without involving disk
+state.
+
+## Verification
+
+Run the focused `TestManagerAdd` test in a scratch environment, then run the
+full Go test suite, build, vet, and the repository's lint/format checks. The
+focused test must pass without creating entries in the user's registry.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -391,8 +391,13 @@ func TestManagerAdd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KWT_HOME", t.TempDir())
 			mockG := &mockGit{}
 			m := New(mockG, tt.config)
+			state := &mockRemoteSourceState{}
+			m.openRemoteSourceState = func() (remoteSourceState, error) {
+				return state, nil
+			}
 
 			_, err := m.Add(tt.branch, tt.customPath, tt.createBranch)
 			if (err != nil) != tt.wantErr {
@@ -409,6 +414,9 @@ func TestManagerAdd(t *testing.T) {
 				if len(mockG.worktrees) != 1 {
 					t.Errorf("Expected 1 worktree, got %d", len(mockG.worktrees))
 				}
+				reg, err := registry.New()
+				require.NoError(t, err)
+				assert.Empty(t, reg.List())
 			}
 		})
 	}


### PR DESCRIPTION
TestManagerAdd exercised existing/unreviewed worktree creation through a real registry.New() call. Because its t.TempDir() paths are removed at test teardown, the persisted markers survived as stale records in a developer's registry and made doctor report test artifacts.

This keeps production registry tracking unchanged. The test now uses the existing in-memory remote-source state, isolates KWT_HOME, and asserts that the registry stays empty, so future changes that reintroduce disk writes fail in the test.