### PR TITLE
Move worktree inventory onto the kwt daemon

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -32,8 +32,15 @@ simultaneous direct and HTTP execution paths.
 current inventory result. They fail instead of falling back to cached or direct
 filesystem data. The TUI may paint immediately from the derived last-known-good
 cache at `<kwt-home>/cache/inventory-v1.json`, then requests one current
-snapshot. The cache is never mutation authority. Git status and fetch remain
-in the foreground client so their credential environment is unchanged.
+snapshot. Failure to initialize or publish the disposable cache is diagnostic;
+current inventory remains available without it. The cache is never mutation
+authority. Git status and fetch remain in the foreground client so their
+credential environment is unchanged.
+
+Each inventory request carries the invoking client's working directory, home
+directory, and sanitized environment map for path expansion. The daemon does
+not use its startup environment or working directory to interpret global path
+configuration, so a reused daemon preserves foreground CLI semantics.
 
 Repository-local configuration is resolved per request. Unknown content
 produces a digest-bound interaction requirement. Approval reopens and hashes

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -2,8 +2,8 @@
 
 Kwt runs at most one writable local service daemon for each canonical kwt
 home. The daemon is a host for kwt domain services; it is not the multi-machine
-sync hub. The foundation release does not route existing worktree, TUI, or SSH
-operations through it.
+sync hub. It owns worktree inventory reads; worktree mutations, status
+collection, tmux attachment, and SSH lifecycle move in later slices.
 
 The process binds an automatically selected IPv4 loopback port and publishes
 an owner-only runtime record under `<kwt-home>/runtime`. Clients verify the
@@ -22,8 +22,27 @@ newer daemon. Draining rejects new operations with a retryable typed response
 that carries the deadline. Active work and leases may finish until
 `daemon.replacement_grace`; the default is five minutes.
 
-The foundation API exposes authenticated status and graceful shutdown under
-`/api/v1`, proof-capable liveness at `/api/ping`, and credential-free OpenAPI at
-`/openapi.json`. Domain APIs and automatic daemon startup arrive with their
-individual migrations; an operation never has simultaneous direct and HTTP
-execution paths.
+The API exposes authenticated status, graceful shutdown, worktree inventory,
+and repository-config approval under `/api/v1`, proof-capable liveness at
+`/api/ping`, and credential-free OpenAPI at `/openapi.json`. Inventory clients
+require the `worktree.inventory.v1` capability. An operation never has
+simultaneous direct and HTTP execution paths.
+
+`kwt projects` and `kwt list` auto-start or reuse the daemon and require a
+current inventory result. They fail instead of falling back to cached or direct
+filesystem data. The TUI may paint immediately from the derived last-known-good
+cache at `<kwt-home>/cache/inventory-v1.json`, then requests one current
+snapshot. The cache is never mutation authority. Git status and fetch remain
+in the foreground client so their credential environment is unchanged.
+
+Repository-local configuration is resolved per request. Unknown content
+produces a digest-bound interaction requirement. Approval reopens and hashes
+the file before persisting trust; rejection and noninteractive ignore are
+request-local. Noninteractive commands preserve the historical global-only
+fallback and warning.
+
+For remote use, including Ghosthub, the remote shell invokes the remote `kwt`
+CLI and that CLI talks only to its same-machine loopback daemon. The daemon is
+never exposed as a remote service. A monitoring read may start or replace a
+daemon after a kwt upgrade; the later SSH lease migration must retain the
+documented replacement-grace behavior for active sessions.

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -37,6 +37,12 @@ current inventory remains available without it. The cache is never mutation
 authority. Git status and fetch remain in the foreground client so their
 credential environment is unchanged.
 
+A current snapshot carries the effective global configuration used for its
+discovery. Before enabling actions, the TUI installs that configuration,
+collects status with its worktree base directory, and rebuilds config-derived
+tmux and credential handling. Cached first paint never changes client
+configuration.
+
 Each inventory request carries the invoking client's working directory, home
 directory, and sanitized environment map for path expansion. The daemon does
 not use its startup environment or working directory to interpret global path

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -76,9 +76,12 @@ not URL paths. The owner-only inventory cache contains derived discovery data;
 it is disposable and never authorizes a mutation. Repository-local config is
 never implicitly trusted: interactive approval is bound to a content digest
 that the daemon revalidates, while rejection and noninteractive skipping apply
-only to that request. A remote client reaches inventory by invoking the remote
-machine's kwt CLI over its existing shell boundary; the loopback daemon itself
-is not remotely reachable.
+only to that request. Authenticated inventory requests also carry the client's
+path-expansion context, including its environment. This transient context is
+used only to interpret trusted global paths and is neither logged nor persisted.
+A remote client reaches inventory by invoking the remote machine's kwt CLI over
+its existing shell boundary; the loopback daemon itself is not remotely
+reachable.
 
 PID liveness alone does not authorize cleanup or replacement. Kwt also checks
 the recorded process creation identity. A dead PID or exact creation mismatch

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -71,6 +71,15 @@ the recorded endpoint before sending the bearer. The server accepts only its
 exact loopback Host, rejects browser Origin requests, bounds bodies and
 diagnostics, and never logs credentials or request bodies.
 
+Inventory repository paths are carried only in authenticated request bodies,
+not URL paths. The owner-only inventory cache contains derived discovery data;
+it is disposable and never authorizes a mutation. Repository-local config is
+never implicitly trusted: interactive approval is bound to a content digest
+that the daemon revalidates, while rejection and noninteractive skipping apply
+only to that request. A remote client reaches inventory by invoking the remote
+machine's kwt CLI over its existing shell boundary; the loopback daemon itself
+is not remotely reachable.
+
 PID liveness alone does not authorize cleanup or replacement. Kwt also checks
 the recorded process creation identity. A dead PID or exact creation mismatch
 makes a runtime record stale; an identity that cannot be read, a timed-out

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -62,9 +62,12 @@ kwt daemon stop
 kwt serve
 ```
 
-The daemon foundation does not yet route worktree, TUI, or SSH operations
-through the service. Each domain moves as a complete later migration without a
-simultaneous direct fallback.
+`kwt projects`, `kwt list`, and TUI inventory auto-start or reuse a compatible
+local daemon. CLI inventory requires a current refresh and fails if one cannot
+complete; it never prints cached data. The TUI may paint from the daemon's
+last-known-good cache while requesting one current snapshot. Worktree
+mutations, Git status collection, tmux attachment, and SSH remain on their
+existing paths until their complete service migrations.
 
 When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local
@@ -135,6 +138,11 @@ clients can attach to it; otherwise it reports the canonical name kwt will use
 when establishing the session.
 
 ## `kwt list`
+
+The command obtains inventory from the same-machine daemon, including when a
+remote shell invokes kwt. Its human output and machine-readable schema are
+unchanged; freshness metadata stays in the daemon API envelope and is not
+added to the top-level JSON array.
 
 `--json` emits an array of objects with `path`, `branch`, `commit_hash`, `is_main`,
 `created_at` (worktree directory mtime), `generation` (the durable identity for
@@ -332,6 +340,10 @@ repository lock as removal and report `locked_worktree` or `main_worktree`
 instead of claiming those paths would be removed.
 
 ## `kwt projects`
+
+The list action obtains a current inventory snapshot from the same-machine
+daemon. `projects add` remains a direct foreground mutation until the worktree
+mutation service migrates.
 
 `--json` emits an array of the registered project repositories (`{repository,
 name, path, last_touched}`), so external automation can discover main-repo

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/danielgtaylor/huma/v2 v2.39.1
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-github/v90 v90.0.0
 	github.com/ktr0731/go-fuzzyfinder v0.9.0
@@ -38,7 +39,6 @@ require (
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/gdamore/tcell/v2 v2.13.6 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ktr0731/go-ansisgr v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.kenn.io/kit v0.19.1
 	golang.org/x/mod v0.38.0
+	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 )
 
@@ -60,8 +62,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -175,6 +175,10 @@ func detailInt(details map[string]any, key string) int {
 
 func writeConfigNotes(stderr io.Writer, notes []publicworktree.Note, interactive, declined bool) {
 	for _, note := range notes {
+		if note.Code == "unsafe_config_skipped" {
+			_, _ = fmt.Fprintf(stderr, "kwt: skipping unsafe local config %s\n", note.Path)
+			continue
+		}
 		if note.Code != "untrusted_config_skipped" {
 			continue
 		}

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -175,6 +175,14 @@ func detailInt(details map[string]any, key string) int {
 
 func writeConfigNotes(stderr io.Writer, notes []publicworktree.Note, interactive, declined bool) {
 	for _, note := range notes {
+		if note.Code == "trust_store_unavailable" {
+			_, _ = fmt.Fprintf(
+				stderr,
+				"kwt: failed to load trust store %s (continuing empty)\n",
+				note.Path,
+			)
+			continue
+		}
 		if note.Code == "unsafe_config_skipped" {
 			_, _ = fmt.Fprintf(stderr, "kwt: skipping unsafe local config %s\n", note.Path)
 			continue

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"go.kenn.io/kwt/internal/config"
+	kwtdaemon "go.kenn.io/kwt/internal/daemon"
+	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
+)
+
+var queryCLIInventory = queryInventoryForCLI
+
+func queryInventoryForCLI(
+	ctx context.Context,
+	request publicworktree.Request,
+	interactive bool,
+	stderr io.Writer,
+) (publicworktree.Result, error) {
+	controller, err := newDaemonController()
+	if err != nil {
+		return publicworktree.Result{}, err
+	}
+	if interactive {
+		request.UntrustedConfig = publicworktree.RequireConfigInteraction
+	} else {
+		request.UntrustedConfig = publicworktree.IgnoreUntrustedConfig
+	}
+	declined := false
+	for {
+		result, queryErr := queryDaemonInventory(ctx, controller, request)
+		if queryErr == nil {
+			writeConfigNotes(stderr, result.Notes, interactive, declined)
+			return result, nil
+		}
+		if !interactive || !service.IsCode(queryErr, service.InteractionRequired) {
+			return publicworktree.Result{}, queryErr
+		}
+		requirement, requirementErr := trustRequirement(queryErr)
+		if requirementErr != nil {
+			return publicworktree.Result{}, requirementErr
+		}
+		approved, promptErr := config.PromptTrustRequirement(requirement)
+		if promptErr != nil {
+			return publicworktree.Result{}, promptErr
+		}
+		if !approved {
+			declined = true
+			request.UntrustedConfig = publicworktree.IgnoreUntrustedConfig
+			continue
+		}
+		observation, startErr := controller.Start(ctx)
+		if startErr != nil {
+			return publicworktree.Result{}, startErr
+		}
+		if err := requireInventoryCapability(observation); err != nil {
+			return publicworktree.Result{}, err
+		}
+		if err := observation.Client.ApproveConfig(ctx, publicworktree.ConfigApproval{
+			Path: requirement.Path, Digest: requirement.Digest,
+		}); err != nil {
+			return publicworktree.Result{}, err
+		}
+		request.UntrustedConfig = publicworktree.RequireConfigInteraction
+	}
+}
+
+func queryDaemonInventory(
+	ctx context.Context,
+	controller daemonController,
+	request publicworktree.Request,
+) (publicworktree.Result, error) {
+	for {
+		observation, err := controller.Start(ctx)
+		if err != nil {
+			return publicworktree.Result{}, err
+		}
+		if err := requireInventoryCapability(observation); err != nil {
+			return publicworktree.Result{}, err
+		}
+		result, err := observation.Client.Inventory(ctx, request)
+		if !service.IsCode(err, service.Busy) {
+			return result, err
+		}
+		if err := waitInventoryRetry(ctx, observation.Status.DrainDeadline); err != nil {
+			return publicworktree.Result{}, err
+		}
+	}
+}
+
+func requireInventoryCapability(observation kwtdaemon.Observation) error {
+	if observation.Client == nil || !slices.Contains(observation.Status.Capabilities, kwtdaemon.CapabilityInventory) {
+		return service.NewError(
+			service.Unsupported,
+			"the running kwt daemon does not provide worktree inventory",
+			false,
+			nil,
+			nil,
+		)
+	}
+	return nil
+}
+
+func waitInventoryRetry(ctx context.Context, deadline *time.Time) error {
+	delay := 50 * time.Millisecond
+	if deadline != nil {
+		remaining := time.Until(*deadline)
+		if remaining <= 0 {
+			return service.NewError(service.Busy, "the kwt daemon is still draining", true, nil, nil)
+		}
+		if remaining < delay {
+			delay = remaining
+		}
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func trustRequirement(err error) (config.TrustRequiredError, error) {
+	var typed *service.Error
+	if !errors.As(err, &typed) {
+		return config.TrustRequiredError{}, err
+	}
+	requirement := config.TrustRequiredError{
+		Path:      detailString(typed.Details, "path"),
+		Digest:    detailString(typed.Details, "digest"),
+		Preview:   detailString(typed.Details, "preview"),
+		Size:      detailInt(typed.Details, "size"),
+		Truncated: detailBool(typed.Details, "truncated"),
+	}
+	if detailString(typed.Details, "kind") != "repository_config_trust" ||
+		requirement.Path == "" || requirement.Digest == "" {
+		return config.TrustRequiredError{}, service.NewError(
+			service.TransportFailure,
+			"kwt daemon returned an incomplete trust requirement",
+			false,
+			nil,
+			err,
+		)
+	}
+	return requirement, nil
+}
+
+func detailString(details map[string]any, key string) string {
+	value, _ := details[key].(string)
+	return value
+}
+
+func detailBool(details map[string]any, key string) bool {
+	value, _ := details[key].(bool)
+	return value
+}
+
+func detailInt(details map[string]any, key string) int {
+	switch value := details[key].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func writeConfigNotes(stderr io.Writer, notes []publicworktree.Note, interactive, declined bool) {
+	for _, note := range notes {
+		if note.Code != "untrusted_config_skipped" {
+			continue
+		}
+		if interactive && declined {
+			_, _ = fmt.Fprintf(stderr, "kwt: local config %s not trusted, skipping\n", note.Path)
+			continue
+		}
+		_, _ = fmt.Fprintf(stderr, "kwt: skipping untrusted local config %s (non-interactive session)\n", note.Path)
+	}
+}

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -84,12 +84,28 @@ func queryDaemonInventory(
 			return publicworktree.Result{}, err
 		}
 		result, err := observation.Client.Inventory(ctx, request)
-		if !service.IsCode(err, service.Busy) {
+		deadline, draining := inventoryDrainDeadline(err)
+		if !draining {
 			return result, err
 		}
-		if err := waitInventoryRetry(ctx, observation.Status.DrainDeadline); err != nil {
+		if err := waitInventoryRetry(ctx, deadline); err != nil {
 			return publicworktree.Result{}, err
 		}
+	}
+}
+
+func inventoryDrainDeadline(err error) (*time.Time, bool) {
+	var typed *service.Error
+	if !errors.As(err, &typed) || typed.Code != service.Busy {
+		return nil, false
+	}
+	switch deadline := typed.Details["drain_deadline"].(type) {
+	case time.Time:
+		return &deadline, true
+	case *time.Time:
+		return deadline, deadline != nil
+	default:
+		return nil, false
 	}
 }
 

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -26,6 +26,14 @@ func TestWriteConfigNotesWarnsWhenUnsafeLocalConfigIsSkipped(t *testing.T) {
 	assert.Equal(t, "kwt: skipping unsafe local config /repo/.kwt.toml\n", stderr.String())
 }
 
+func TestWriteConfigNotesWarnsWhenTrustStoreIsUnavailable(t *testing.T) {
+	var stderr bytes.Buffer
+	writeConfigNotes(&stderr, []publicworktree.Note{{
+		Code: "trust_store_unavailable", Path: "/home/trusted_configs.json",
+	}}, false, false)
+	assert.Equal(t, "kwt: failed to load trust store /home/trusted_configs.json (continuing empty)\n", stderr.String())
+}
+
 func TestTrustRequirementDecodesHTTPDetailTypes(t *testing.T) {
 	err := service.NewError(service.InteractionRequired, "trust", false, map[string]any{
 		"kind": "repository_config_trust", "path": "/repo/.kwt.toml",

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -18,6 +18,14 @@ func TestWriteConfigNotesPreservesNoninteractiveWarning(t *testing.T) {
 	assert.Equal(t, "kwt: skipping untrusted local config /repo/.kwt.toml (non-interactive session)\n", stderr.String())
 }
 
+func TestWriteConfigNotesWarnsWhenUnsafeLocalConfigIsSkipped(t *testing.T) {
+	var stderr bytes.Buffer
+	writeConfigNotes(&stderr, []publicworktree.Note{{
+		Code: "unsafe_config_skipped", Path: "/repo/.kwt.toml",
+	}}, false, false)
+	assert.Equal(t, "kwt: skipping unsafe local config /repo/.kwt.toml\n", stderr.String())
+}
+
 func TestTrustRequirementDecodesHTTPDetailTypes(t *testing.T) {
 	err := service.NewError(service.InteractionRequired, "trust", false, map[string]any{
 		"kind": "repository_config_trust", "path": "/repo/.kwt.toml",

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
+)
+
+func TestWriteConfigNotesPreservesNoninteractiveWarning(t *testing.T) {
+	var stderr bytes.Buffer
+	writeConfigNotes(&stderr, []publicworktree.Note{{
+		Code: "untrusted_config_skipped", Path: "/repo/.kwt.toml",
+	}}, false, false)
+	assert.Equal(t, "kwt: skipping untrusted local config /repo/.kwt.toml (non-interactive session)\n", stderr.String())
+}
+
+func TestTrustRequirementDecodesHTTPDetailTypes(t *testing.T) {
+	err := service.NewError(service.InteractionRequired, "trust", false, map[string]any{
+		"kind": "repository_config_trust", "path": "/repo/.kwt.toml",
+		"digest": "abc", "size": float64(42), "preview": "[naming]", "truncated": true,
+	}, nil)
+	requirement, decodeErr := trustRequirement(err)
+	require.NoError(t, decodeErr)
+	assert.Equal(t, 42, requirement.Size)
+	assert.True(t, requirement.Truncated)
+}

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -3,12 +3,48 @@ package cmd
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/service"
 	publicworktree "go.kenn.io/kwt/worktree"
 )
+
+func TestInventoryDrainDeadlineRequiresDeadlineBearingBusyError(t *testing.T) {
+	deadline := time.Now().Add(time.Minute)
+	tests := []struct {
+		name string
+		err  error
+		want *time.Time
+	}{
+		{
+			name: "inventory refresh timeout",
+			err:  service.NewError(service.Busy, "inventory refresh timed out", true, nil, nil),
+		},
+		{
+			name: "daemon drain",
+			err: service.NewError(service.Busy, "daemon is draining", true, map[string]any{
+				"drain_deadline": deadline,
+			}, nil),
+			want: &deadline,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := inventoryDrainDeadline(tt.err)
+			if tt.want == nil {
+				assert.False(t, ok)
+				assert.Nil(t, got)
+				return
+			}
+			require.True(t, ok)
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
+		})
+	}
+}
 
 func TestWriteConfigNotesPreservesNoninteractiveWarning(t *testing.T) {
 	var stderr bytes.Buffer

--- a/internal/cmd/inventory_subprocess_test.go
+++ b/internal/cmd/inventory_subprocess_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 func runInventoryCommand(
@@ -91,6 +92,42 @@ func TestInventorySubprocessPreservesGhosthubJSONAndTrustBehavior(t *testing.T) 
 	stdout, stderr, err = runInventoryCommand(t, binary, home, repository, "projects", "--json")
 	require.NoError(t, err, "stderr=%s", stderr)
 	assert.Equal(t, "[]\n", string(stdout))
+}
+
+func TestInventorySubprocessExpandsGlobalPathsForEachClient(t *testing.T) {
+	binary, cleanupBinary := buildDaemonTestBinaries(t)
+	home := newDaemonTestHome(t, validDaemonConfig+`
+[[projects]]
+repository = "github.com/acme/selected"
+name = "selected"
+path = "$KWT_TEST_PROJECT"
+`)
+	registerDaemonCleanup(t, cleanupBinary, home)
+	firstRepository := filepath.Join(t.TempDir(), "first")
+	secondRepository := filepath.Join(t.TempDir(), "second")
+	for _, repository := range []string{firstRepository, secondRepository} {
+		require.NoError(t, exec.Command("git", "init", repository).Run())
+	}
+	firstRepository, err := filepath.EvalSymlinks(firstRepository)
+	require.NoError(t, err)
+	secondRepository, err = filepath.EvalSymlinks(secondRepository)
+	require.NoError(t, err)
+	directory := t.TempDir()
+
+	t.Setenv("KWT_TEST_PROJECT", firstRepository)
+	first, stderr, err := runInventoryCommand(t, binary, home, directory, "projects", "--json")
+	require.NoError(t, err, "stderr=%s", stderr)
+	t.Setenv("KWT_TEST_PROJECT", secondRepository)
+	second, stderr, err := runInventoryCommand(t, binary, home, directory, "projects", "--json")
+	require.NoError(t, err, "stderr=%s", stderr)
+
+	var firstProjects, secondProjects []models.Project
+	require.NoError(t, json.Unmarshal(first, &firstProjects))
+	require.NoError(t, json.Unmarshal(second, &secondProjects))
+	require.Len(t, firstProjects, 1)
+	require.Len(t, secondProjects, 1)
+	assert.Equal(t, firstRepository, firstProjects[0].Path)
+	assert.Equal(t, secondRepository, secondProjects[0].Path)
 }
 
 func TestInventorySubprocessDaemonFailuresNeverUseSSHExit255(t *testing.T) {

--- a/internal/cmd/inventory_subprocess_test.go
+++ b/internal/cmd/inventory_subprocess_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runInventoryCommand(
+	t *testing.T,
+	binary, home, directory string,
+	args ...string,
+) ([]byte, []byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, binary, args...)
+	command.Dir = directory
+	command.Env = append(os.Environ(), "KWT_HOME="+home)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	if ctx.Err() != nil {
+		return stdout.Bytes(), stderr.Bytes(), ctx.Err()
+	}
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+func buildDaemonFixture(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	path := filepath.Join(t.TempDir(), "daemonfixture"+suffix)
+	command := exec.Command("go", "build", "-o", path, "./internal/cmd/testdata/daemonfixture")
+	command.Dir = root
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return path
+}
+
+func startDaemonFixture(t *testing.T, fixture, home, mode string) {
+	t.Helper()
+	canonicalHome, err := filepath.EvalSymlinks(home)
+	require.NoError(t, err)
+	marker := filepath.Join(t.TempDir(), "ready")
+	command := exec.Command(fixture, "-home", canonicalHome, "-mode", mode, "-ready", marker)
+	require.NoError(t, command.Start())
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	})
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestInventorySubprocessPreservesGhosthubJSONAndTrustBehavior(t *testing.T) {
+	binary, cleanupBinary := buildDaemonTestBinaries(t)
+	home := newDaemonTestHome(t, validDaemonConfig)
+	registerDaemonCleanup(t, cleanupBinary, home)
+	repository := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, exec.Command("git", "init", repository).Run())
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repository, ".kwt.toml"),
+		[]byte("[naming]\ntemplate = 'untrusted/{{.Branch}}'\n"),
+		0o600,
+	))
+
+	stdout, stderr, err := runInventoryCommand(t, binary, home, repository, "list", "--json")
+	require.NoError(t, err, "stderr=%s", stderr)
+	assert.True(t, json.Valid(stdout))
+	assert.Equal(t, byte('['), bytes.TrimSpace(stdout)[0])
+	assert.Contains(t, string(stderr), "kwt: skipping untrusted local config ")
+	assert.Contains(t, string(stderr), " (non-interactive session)\n")
+
+	stdout, stderr, err = runInventoryCommand(t, binary, home, repository, "projects", "--json")
+	require.NoError(t, err, "stderr=%s", stderr)
+	assert.Equal(t, "[]\n", string(stdout))
+}
+
+func TestInventorySubprocessDaemonFailuresNeverUseSSHExit255(t *testing.T) {
+	binary, _ := buildDaemonTestBinaries(t)
+	fixture := buildDaemonFixture(t)
+	for _, mode := range []string{"unresponsive", "incompatible", "draining"} {
+		t.Run(mode, func(t *testing.T) {
+			home := newDaemonTestHome(t, validDaemonConfig)
+			repository := filepath.Join(t.TempDir(), "repo")
+			require.NoError(t, exec.Command("git", "init", repository).Run())
+			startDaemonFixture(t, fixture, home, mode)
+
+			_, stderr, err := runInventoryCommand(t, binary, home, repository, "list", "--json")
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr, "stderr=%s", stderr)
+			assert.Equal(t, 1, exitErr.ExitCode(), "stderr=%s", stderr)
+			assert.NotEqual(t, 255, exitErr.ExitCode())
+		})
+	}
+}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -1,21 +1,21 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"go.kenn.io/kwt/internal/pullrequest"
-	"go.kenn.io/kwt/internal/tmux"
-	"go.kenn.io/kwt/internal/utils"
-	"go.kenn.io/kwt/internal/worktree"
+	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/pkg/models"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 var (
-	listVerbose bool
-	listJSON    bool
-	listGlobal  bool
+	listVerbose        bool
+	listJSON           bool
+	listGlobal         bool
+	queryListInventory = queryCLIInventory
 )
 
 // listCmd represents the list command.
@@ -44,7 +44,8 @@ Use --json flag to output in JSON format for scripting.`,
 
   # Show all worktrees from base directory (from anywhere)
   kwt list -g`,
-	RunE: runList,
+	PersistentPreRunE: globalOnlyPreRun,
+	RunE:              runList,
 }
 
 func init() {
@@ -56,171 +57,50 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	// Try git context first, fall back to non-git if needed
-	ctx, err := NewGitCommandContext()
+	workingDirectory, err := os.Getwd()
 	if err != nil {
-		// If git initialization fails, create non-git context for global mode
-		ctx, err = NewCommandContext()
-		if err != nil {
-			return err
-		}
+		return err
 	}
-
-	return ctx.WithGlobalLocalSupport(
-		listGlobal,
-		func(ctx *CommandContext) error {
-			// Local mode - show worktrees from current repository
-			worktrees, err := ctx.WorktreeManager.List()
-			if err != nil {
-				return fmt.Errorf("failed to list worktrees: %w", err)
-			}
-
-			if listJSON {
-				enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-				if err := enrichProtectedSocketIdentity(
-					cmd.Context(),
-					worktrees,
-				); err != nil {
-					return err
-				}
-				return ctx.Printer.PrintWorktreesJSON(worktrees)
-			}
-
-			ctx.Printer.PrintWorktrees(worktrees, listVerbose)
-			return nil
+	workingDirectory, err = filepath.Abs(workingDirectory)
+	if err != nil {
+		return err
+	}
+	result, err := queryListInventory(
+		cmd.Context(),
+		publicworktree.Request{
+			View: publicworktree.ViewRepository, WorkingDirectory: workingDirectory,
+			ForceGlobal: listGlobal, RequireCurrent: true,
 		},
-		func(ctx *CommandContext) error {
-			// Global mode - show all worktrees from base directory
-			return showGlobalWorktrees(ctx)
-		},
+		config.StdinInteractive(),
+		cmd.ErrOrStderr(),
 	)
-}
-
-func showGlobalWorktrees(ctx *CommandContext) error {
-	worktreePointers, err := ctx.DiscoverGlobalWorktrees()
 	if err != nil {
-		return fmt.Errorf("failed to discover worktrees: %w", err)
+		return fmt.Errorf("failed to list worktrees: %w", err)
 	}
-
-	if len(worktreePointers) == 0 {
-		// JSON mode always emits a JSON array, empty included, so scripts can
-		// parse the output unconditionally; the prose message is non-JSON only.
-		if listJSON {
-			return ctx.Printer.PrintWorktreesJSON([]models.Worktree{})
-		}
+	ctx, err := NewCommandContext()
+	if err != nil {
+		return err
+	}
+	worktrees := make([]models.Worktree, len(result.Snapshot.Entries))
+	for index, entry := range result.Snapshot.Entries {
+		worktrees[index] = listedWorktree(entry)
+	}
+	if len(worktrees) == 0 && !listJSON && listGlobal {
 		ctx.Printer.PrintInfo("No worktrees found in " + ctx.Config.Worktree.BaseDir)
 		return nil
 	}
-
-	// Convert from []*models.Worktree to []models.Worktree for printer
-	var worktrees []models.Worktree
-	for _, w := range worktreePointers {
-		worktrees = append(worktrees, *w)
-	}
-
 	if listJSON {
-		if err := enrichProtectedSocketIdentity(
-			context.Background(),
-			worktrees,
-		); err != nil {
-			return err
-		}
 		return ctx.Printer.PrintWorktreesJSON(worktrees)
 	}
-
 	ctx.Printer.PrintWorktrees(worktrees, listVerbose)
 	return nil
 }
 
-func enrichProtectedSocketIdentity(
-	ctx context.Context,
-	worktrees []models.Worktree,
-) error {
-	records := make(map[string]pullrequest.Provenance)
-	if err := pullrequest.NewFileStore(prStorePath()).View(
-		ctx,
-		func(current map[string]pullrequest.Provenance) error {
-			for key, record := range current {
-				records[key] = record
-			}
-			return nil
-		},
-	); err != nil {
-		return fmt.Errorf("failed to read pull-request provenance: %w", err)
-	}
-	annotateProtectedSocketIdentity(worktrees, records)
-	return nil
-}
-
-func annotateProtectedSocketIdentity(
-	worktrees []models.Worktree,
-	records map[string]pullrequest.Provenance,
-) {
-	type workspaceIdentity struct {
-		path       string
-		branch     string
-		session    string
-		repository string
-		generation string
-	}
-	socketByIdentity := make(map[workspaceIdentity]string, len(records))
-	for _, record := range records {
-		workspace := record.Workspace
-		repository := workspace.Repository
-		if repository == "" {
-			repository = record.Project.Identity
-		}
-		if workspace.Path == "" ||
-			workspace.Branch == "" ||
-			workspace.SessionName == "" ||
-			repository == "" {
-			continue
-		}
-		key := workspaceIdentity{
-			path:       utils.CanonicalPath(workspace.Path),
-			branch:     workspace.Branch,
-			session:    workspace.SessionName,
-			repository: pullrequest.NormalizeRepositoryIdentity(repository),
-			generation: workspace.Generation,
-		}
-		socketByIdentity[key] =
-			tmux.ProtectedWorkspaceSocketName(
-				workspace.SessionName,
-				workspace.Path,
-			)
-	}
-	for i := range worktrees {
-		key := workspaceIdentity{
-			path:    utils.CanonicalPath(worktrees[i].Path),
-			branch:  worktrees[i].Branch,
-			session: worktrees[i].SessionName,
-			repository: pullrequest.NormalizeRepositoryIdentity(
-				worktrees[i].Repository,
-			),
-			generation: worktrees[i].Generation,
-		}
-		worktrees[i].TmuxSocketName = socketByIdentity[key]
-		if worktrees[i].TmuxSocketName == "" {
-			key.generation = ""
-			worktrees[i].TmuxSocketName = socketByIdentity[key]
-		}
-	}
-}
-
-// enrichWorktreeIdentity fills the repository slug and session name for each
-// local worktree so JSON surfaces carry the same identity fields as global
-// (-g) mode. Identity follows the single registered-identity precedence: a
-// registered project's canonical identity wins over a fork origin, so these
-// surfaces join with `kwt projects` and derive the same session names as
-// every other path. Best effort: when repository identity cannot be resolved
-// the fields stay empty.
-func enrichWorktreeIdentity(g worktree.RepoIdentityGit, projects []models.Project, worktrees []models.Worktree) {
-	info, err := worktree.RepositoryInfoWithProjects(g, projects)
-	if err != nil {
-		return
-	}
-	for i := range worktrees {
-		worktrees[i].Repository = info.FullPath
-		worktrees[i].SessionName = tmux.WorkspaceSessionName(info, worktrees[i].Branch, worktrees[i].Path)
+func listedWorktree(entry publicworktree.Entry) models.Worktree {
+	return models.Worktree{
+		Path: entry.Path, Branch: entry.Branch, CommitHash: entry.CommitHash,
+		IsMain: entry.IsMain, CreatedAt: entry.CreatedAt, Generation: entry.Generation,
+		Repository: entry.Repository.FullPath, SessionName: entry.SessionName,
+		TmuxSocketName: entry.TmuxSocketName,
 	}
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -70,6 +70,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		publicworktree.Request{
 			View: publicworktree.ViewRepository, WorkingDirectory: workingDirectory,
 			ForceGlobal: listGlobal, RequireCurrent: true,
+			IncludeProtectedSockets: listJSON,
 		},
 		config.StdinInteractive(),
 		cmd.ErrOrStderr(),

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -62,6 +62,7 @@ func TestRunListRequestsCurrentInventoryAndPreservesJSONShape(t *testing.T) {
 	assert.Equal(t, publicworktree.ViewRepository, gotRequest.View)
 	assert.True(t, gotRequest.RequireCurrent)
 	assert.False(t, gotRequest.ForceGlobal)
+	assert.True(t, gotRequest.IncludeProtectedSockets)
 	assert.JSONEq(t, `[{
       "path": "`+repository+`",
       "branch": "main",

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -1,415 +1,97 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/kwt/internal/git"
-	"go.kenn.io/kwt/internal/pullrequest"
-	"go.kenn.io/kwt/internal/tmux"
-	"go.kenn.io/kwt/internal/ui"
-	"go.kenn.io/kwt/internal/worktree"
-	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/internal/config"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
-func TestImportedWorktreeReceivesProtectedSocketIdentity(t *testing.T) {
-	worktrees := []models.Worktree{{
-		Path:        "/worktrees/pr-32",
-		Branch:      "pr-32",
-		Repository:  "github.com/acme/widget",
-		SessionName: "kwt-workspace-pr-32",
-	}}
-	annotateProtectedSocketIdentity(worktrees, map[string]pullrequest.Provenance{
-		"pr-32": {
-			Project: pullrequest.Project{
-				Identity: "github.com/acme/widget",
-			},
-			Workspace: pullrequest.Workspace{
-				Path:        "/worktrees/pr-32",
-				Branch:      "pr-32",
-				Repository:  "github.com/acme/widget",
-				SessionName: "kwt-workspace-pr-32",
-			},
-		},
-	})
-
-	want := tmux.ProtectedWorkspaceSocketName(
-		"kwt-workspace-pr-32",
-		"/worktrees/pr-32",
-	)
-	if worktrees[0].TmuxSocketName != want {
-		t.Fatalf("tmux socket = %q, want %q", worktrees[0].TmuxSocketName, want)
-	}
-}
-
-func TestStaleProvenanceDoesNotLabelReusedWorktreePath(t *testing.T) {
-	record := pullrequest.Provenance{
-		Project: pullrequest.Project{Identity: "github.com/acme/widget"},
-		Workspace: pullrequest.Workspace{
-			Path:        "/worktrees/reused",
-			Branch:      "pr-32",
-			Repository:  "github.com/acme/widget",
-			SessionName: "kwt-workspace-pr-32",
-		},
-	}
-	tests := []models.Worktree{
-		{
-			Path: "/worktrees/reused", Branch: "other",
-			Repository:  "github.com/acme/widget",
-			SessionName: "kwt-workspace-pr-32",
-		},
-		{
-			Path: "/worktrees/reused", Branch: "pr-32",
-			Repository:  "github.com/acme/other",
-			SessionName: "kwt-workspace-pr-32",
-		},
-		{
-			Path: "/worktrees/reused", Branch: "pr-32",
-			Repository:  "github.com/acme/widget",
-			SessionName: "kwt-workspace-other",
-		},
-	}
-
-	annotateProtectedSocketIdentity(tests, map[string]pullrequest.Provenance{
-		"stale": record,
-	})
-
-	for _, worktree := range tests {
-		assert.Empty(t, worktree.TmuxSocketName)
-	}
-}
-
-func TestStaleProvenanceGenerationDoesNotLabelReusedWorktreePath(t *testing.T) {
-	worktrees := []models.Worktree{{
-		Path: "/worktrees/reused", Branch: "pr-32",
-		Repository: "github.com/acme/widget", SessionName: "kwt-workspace-pr-32",
-		Generation: "0123456789abcdef0123456789abcdef",
-	}}
-	annotateProtectedSocketIdentity(worktrees, map[string]pullrequest.Provenance{
-		"pr-32": {
-			Project: pullrequest.Project{Identity: "github.com/acme/widget"},
-			Workspace: pullrequest.Workspace{
-				Path: "/worktrees/reused", Branch: "pr-32",
-				Repository: "github.com/acme/widget", SessionName: "kwt-workspace-pr-32",
-				Generation: "fedcba9876543210fedcba9876543210",
-			},
-		},
-	})
-
-	assert.Empty(t, worktrees[0].TmuxSocketName)
-}
-
-func TestProtectedSocketEnrichmentReportsUnreadableProvenance(t *testing.T) {
-	kwtHome := t.TempDir()
-	t.Setenv("KWT_HOME", kwtHome)
-	require.NoError(t, os.WriteFile(
-		filepath.Join(kwtHome, "pull-requests.json"),
-		[]byte("{"),
-		0o600,
-	))
-
-	err := enrichProtectedSocketIdentity(
-		context.Background(),
-		[]models.Worktree{{Path: "/worktrees/pr-32"}},
-	)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "pull-request provenance")
-}
-
-// captureStdout runs fn with os.Stdout redirected to a pipe and returns
-// everything it wrote. The ui.Printer writes to os.Stdout directly, so this is
-// how its output is observed in tests.
-func captureStdout(t *testing.T, fn func()) string {
+func captureListStdout(t *testing.T, run func() error) (string, error) {
 	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	fn()
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("closing pipe: %v", err)
-	}
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("reading pipe: %v", err)
-	}
-	return string(out)
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+	original := os.Stdout
+	os.Stdout = write
+	defer func() { os.Stdout = original }()
+	runErr := run()
+	require.NoError(t, write.Close())
+	output, err := io.ReadAll(read)
+	require.NoError(t, err)
+	return string(output), runErr
 }
 
-func newGlobalListContext(baseDir string) *CommandContext {
-	return &CommandContext{
-		Config:  &models.Config{Worktree: models.WorktreeConfig{BaseDir: baseDir}},
-		Printer: ui.New(&models.UIConfig{}),
+func TestRunListRequestsCurrentInventoryAndPreservesJSONShape(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	require.NoError(t, config.Init())
+	repository := t.TempDir()
+	t.Chdir(repository)
+
+	originalQuery := queryListInventory
+	t.Cleanup(func() { queryListInventory = originalQuery })
+	var gotRequest publicworktree.Request
+	queryListInventory = func(
+		_ context.Context,
+		request publicworktree.Request,
+		_ bool,
+		_ io.Writer,
+	) (publicworktree.Result, error) {
+		gotRequest = request
+		return publicworktree.Result{Snapshot: publicworktree.Snapshot{Entries: []publicworktree.Entry{{
+			Path: repository, Branch: "main",
+			Repository:  publicworktree.Repository{FullPath: "github.com/acme/repo"},
+			SessionName: "kwt-workspace-repo-main",
+		}}}}, nil
 	}
+	previousJSON, previousGlobal := listJSON, listGlobal
+	listJSON, listGlobal = true, false
+	t.Cleanup(func() { listJSON, listGlobal = previousJSON, previousGlobal })
+
+	stdout, err := captureListStdout(t, func() error { return runList(listCmd, nil) })
+	require.NoError(t, err)
+	assert.Equal(t, publicworktree.ViewRepository, gotRequest.View)
+	assert.True(t, gotRequest.RequireCurrent)
+	assert.False(t, gotRequest.ForceGlobal)
+	assert.JSONEq(t, `[{
+      "path": "`+repository+`",
+      "branch": "main",
+      "commit_hash": "",
+      "is_main": false,
+      "created_at": "0001-01-01T00:00:00Z",
+      "generation": "",
+      "repository": "github.com/acme/repo",
+      "session_name": "kwt-workspace-repo-main"
+    }]`, stdout)
 }
 
-// TestShowGlobalWorktreesEmptyJSONEmitsArray pins that an empty global result
-// in JSON mode emits a JSON array ("[]"), not the human-readable prose, so
-// scripts can parse the output unconditionally.
-func TestShowGlobalWorktreesEmptyJSONEmitsArray(t *testing.T) {
-	ctx := newGlobalListContext(t.TempDir())
-
-	listJSON = true
-	defer func() { listJSON = false }()
-
-	out := captureStdout(t, func() {
-		if err := showGlobalWorktrees(ctx); err != nil {
-			t.Fatalf("showGlobalWorktrees: %v", err)
-		}
-	})
-
-	if out != "[]\n" {
-		t.Errorf("empty -g --json output = %q, want %q", out, "[]\n")
+func TestRunListGlobalEmptyJSONRemainsBareArray(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("KWT_HOME", t.TempDir())
+	require.NoError(t, config.Init())
+	t.Chdir(t.TempDir())
+	originalQuery := queryListInventory
+	t.Cleanup(func() { queryListInventory = originalQuery })
+	queryListInventory = func(context.Context, publicworktree.Request, bool, io.Writer) (publicworktree.Result, error) {
+		return publicworktree.Result{Snapshot: publicworktree.Snapshot{Entries: []publicworktree.Entry{}}}, nil
 	}
-}
+	previousJSON, previousGlobal := listJSON, listGlobal
+	listJSON, listGlobal = true, true
+	t.Cleanup(func() { listJSON, listGlobal = previousJSON, previousGlobal })
 
-// TestShowGlobalWorktreesEmptyProsePrintsMessage pins that non-JSON mode still
-// prints the human-readable "No worktrees found" message.
-func TestShowGlobalWorktreesEmptyProsePrintsMessage(t *testing.T) {
-	baseDir := t.TempDir()
-	ctx := newGlobalListContext(baseDir)
-
-	listJSON = false
-
-	out := captureStdout(t, func() {
-		if err := showGlobalWorktrees(ctx); err != nil {
-			t.Fatalf("showGlobalWorktrees: %v", err)
-		}
-	})
-
-	if !strings.Contains(out, "No worktrees found in "+baseDir) {
-		t.Errorf("empty -g prose output = %q, want it to mention the base dir", out)
-	}
-	if strings.Contains(out, "[]") {
-		t.Errorf("prose mode must not emit a JSON array; got %q", out)
-	}
-}
-
-func TestEnrichManifestFields(t *testing.T) {
-	t.Run("happy path - populates Repository from git origin", func(t *testing.T) {
-		// Create a temporary directory for our test git repo
-		tempDir := t.TempDir()
-
-		// Initialize git repo
-		cmd := exec.Command("git", "init")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to init git repo: %v", err)
-		}
-
-		// Add origin remote
-		cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/example/demo.git")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to add origin remote: %v", err)
-		}
-
-		// Create git instance pointing to our temp repo
-		g := git.New(tempDir)
-
-		// Create CommandContext with the git instance
-		ctx := &CommandContext{
-			Git:    g,
-			Config: &models.Config{},
-		}
-
-		// Create a worktree with empty Repository field
-		worktrees := []models.Worktree{
-			{
-				Path:       tempDir,
-				Branch:     "main",
-				CommitHash: "",
-				IsMain:     true,
-				Repository: "", // Should be populated
-			},
-		}
-
-		// Call enrichWorktreeIdentity
-		enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-
-		// Verify Repository is populated
-		if worktrees[0].Repository == "" {
-			t.Error("Repository field should be populated after enrichWorktreeIdentity")
-		}
-
-		// Verify it contains the expected path structure (github.com/example/demo)
-		if worktrees[0].Repository != "github.com/example/demo" {
-			t.Errorf("expected Repository to be 'github.com/example/demo', got %q", worktrees[0].Repository)
-		}
-		info, err := worktree.RepositoryInfoFromGit(g)
-		if err != nil {
-			t.Fatalf("resolve repository info: %v", err)
-		}
-		wantSession := tmux.WorkspaceSessionName(info, worktrees[0].Branch, worktrees[0].Path)
-		if worktrees[0].SessionName != wantSession {
-			t.Errorf("expected SessionName %q, got %q", wantSession, worktrees[0].SessionName)
-		}
-	})
-
-	t.Run("registered identity wins over fork origin", func(t *testing.T) {
-		tempDir := t.TempDir()
-
-		cmd := exec.Command("git", "init")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to init git repo: %v", err)
-		}
-		cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/fork/demo.git")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to add origin remote: %v", err)
-		}
-
-		g := git.New(tempDir)
-		ctx := &CommandContext{
-			Git: g,
-			Config: &models.Config{
-				Projects: []models.Project{
-					{Repository: "github.com/upstream/demo", Path: tempDir},
-				},
-			},
-		}
-		worktrees := []models.Worktree{
-			{Path: tempDir, Branch: "main", IsMain: true},
-		}
-
-		enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-
-		if worktrees[0].Repository != "github.com/upstream/demo" {
-			t.Errorf("Repository = %q, want registered identity github.com/upstream/demo",
-				worktrees[0].Repository)
-		}
-	})
-
-	t.Run("fallback path - non-git directory leaves Repository empty", func(t *testing.T) {
-		// Create a temporary directory that is NOT a git repo
-		tempDir := t.TempDir()
-
-		// Create git instance pointing to non-git directory
-		g := git.New(tempDir)
-
-		// Create CommandContext with the git instance
-		ctx := &CommandContext{
-			Git:    g,
-			Config: &models.Config{},
-		}
-
-		// Create a worktree with empty Repository field
-		worktrees := []models.Worktree{
-			{
-				Path:       tempDir,
-				Branch:     "main",
-				CommitHash: "",
-				IsMain:     true,
-				Repository: "", // Should remain empty
-			},
-		}
-
-		// Call enrichWorktreeIdentity - should not error
-		enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-
-		// Verify Repository remains empty (best-effort, no error)
-		if worktrees[0].Repository != "" {
-			t.Errorf("expected Repository to remain empty for non-git directory, got %q", worktrees[0].Repository)
-		}
-	})
-
-	t.Run("fallback path - git repo without origin populates Repository from local path", func(t *testing.T) {
-		// Create a temporary directory for our test git repo
-		tempDir := t.TempDir()
-
-		// Initialize git repo WITHOUT adding origin
-		cmd := exec.Command("git", "init")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to init git repo: %v", err)
-		}
-
-		// Create git instance pointing to our temp repo (no origin)
-		g := git.New(tempDir)
-
-		// Create CommandContext with the git instance
-		ctx := &CommandContext{
-			Git:    g,
-			Config: &models.Config{},
-		}
-
-		// Create a worktree with empty Repository field
-		worktrees := []models.Worktree{
-			{
-				Path:       tempDir,
-				Branch:     "main",
-				CommitHash: "",
-				IsMain:     true,
-				Repository: "", // Will fall back to local path
-			},
-		}
-
-		// Call enrichWorktreeIdentity
-		enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-
-		// Verify Repository is populated with local fallback (directory name based)
-		// The fallback uses the directory name or local path, so it should not be empty
-		if worktrees[0].Repository == "" {
-			t.Error("Repository field should be populated with local fallback")
-		}
-	})
-
-	t.Run("idempotent - calling multiple times doesn't break anything", func(t *testing.T) {
-		tempDir := t.TempDir()
-
-		// Initialize git repo
-		cmd := exec.Command("git", "init")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to init git repo: %v", err)
-		}
-
-		// Add origin remote
-		cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/example/test.git")
-		cmd.Dir = tempDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("failed to add origin remote: %v", err)
-		}
-
-		g := git.New(tempDir)
-		ctx := &CommandContext{
-			Git:    g,
-			Config: &models.Config{},
-		}
-
-		worktrees := []models.Worktree{
-			{
-				Path:       tempDir,
-				Branch:     "main",
-				CommitHash: "",
-				IsMain:     true,
-				Repository: "",
-			},
-		}
-
-		// Call twice
-		enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-		firstResult := worktrees[0].Repository
-		enrichWorktreeIdentity(ctx.Git, ctx.Config.Projects, worktrees)
-		secondResult := worktrees[0].Repository
-
-		// Should be the same both times
-		if firstResult != secondResult {
-			t.Errorf("idempotent call produced different results: %q vs %q", firstResult, secondResult)
-		}
-	})
+	var output bytes.Buffer
+	listCmd.SetOut(&output)
+	stdout, err := captureListStdout(t, func() error { return runList(listCmd, nil) })
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", stdout)
 }

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"testing"
@@ -63,8 +64,10 @@ func TestRunListRequestsCurrentInventoryAndPreservesJSONShape(t *testing.T) {
 	assert.True(t, gotRequest.RequireCurrent)
 	assert.False(t, gotRequest.ForceGlobal)
 	assert.True(t, gotRequest.IncludeProtectedSockets)
+	encodedRepository, err := json.Marshal(repository)
+	require.NoError(t, err)
 	assert.JSONEq(t, `[{
-      "path": "`+repository+`",
+	  "path": `+string(encodedRepository)+`,
       "branch": "main",
       "commit_hash": "",
       "is_main": false,

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -16,13 +16,15 @@ import (
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 var (
-	projectsJSON       bool
-	projectsAddJSON    bool
-	loadProjectsConfig = config.Load
-	registerProject    = config.RegisterProject
+	projectsJSON           bool
+	projectsAddJSON        bool
+	loadProjectsConfig     = config.Load
+	registerProject        = config.RegisterProject
+	queryProjectsInventory = queryCLIInventory
 )
 
 var projectsCmd = &cobra.Command{
@@ -69,12 +71,16 @@ func init() {
 }
 
 func runProjects(cmd *cobra.Command, args []string) error {
-	cfg, err := loadProjectsConfig()
+	result, err := queryProjectsInventory(
+		cmd.Context(),
+		publicworktree.Request{View: publicworktree.ViewProjects, RequireCurrent: true},
+		false,
+		cmd.ErrOrStderr(),
+	)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	projects := canonicalizeProjectIdentities(cfg.Projects)
+	projects := result.Snapshot.Projects
 
 	if projectsJSON {
 		encoder := json.NewEncoder(cmd.OutOrStdout())
@@ -291,33 +297,6 @@ func projectCommandJSONRequested() bool {
 		}
 	}
 	return requested
-}
-
-// canonicalizeProjectIdentities returns accessible registered projects with
-// Repository values resolved through the canonical identity bar, so projects
-// output (JSON and table) emits the same identities kwt list --json reports.
-func canonicalizeProjectIdentities(projects []models.Project) []models.Project {
-	out := make([]models.Project, 0, len(projects))
-	for _, project := range projects {
-		if strings.TrimSpace(project.Path) == "" {
-			continue
-		}
-		repositoryGit := worktree.NewCachedIdentityGit(git.New(project.Path))
-		mainPath, err := repositoryGit.GetMainRepositoryPath()
-		if err != nil || !samePath(mainPath, project.Path) {
-			continue
-		}
-		info, err := worktree.RepositoryInfoWithProjects(
-			repositoryGit,
-			[]models.Project{project},
-		)
-		if err != nil {
-			continue
-		}
-		project.Repository = info.FullPath
-		out = append(out, project)
-	}
-	return out
 }
 
 // publishableProjectRepository resolves the repository identity projects

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +17,7 @@ import (
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 func withProjectsConfig(t *testing.T, projects []models.Project) {
@@ -23,6 +26,18 @@ func withProjectsConfig(t *testing.T, projects []models.Project) {
 	t.Cleanup(func() { loadProjectsConfig = origLoad })
 	loadProjectsConfig = func() (*models.Config, error) {
 		return &models.Config{Projects: projects}, nil
+	}
+	origQuery := queryProjectsInventory
+	t.Cleanup(func() { queryProjectsInventory = origQuery })
+	queryProjectsInventory = func(
+		context.Context,
+		publicworktree.Request,
+		bool,
+		io.Writer,
+	) (publicworktree.Result, error) {
+		return publicworktree.Result{Snapshot: publicworktree.Snapshot{
+			Projects: publicworktree.CanonicalProjects(projects),
+		}}, nil
 	}
 }
 
@@ -95,15 +110,15 @@ func TestRunProjectsRendersTable(t *testing.T) {
 }
 
 func TestRunProjectsReturnsConfigLoadError(t *testing.T) {
-	origLoad := loadProjectsConfig
-	t.Cleanup(func() { loadProjectsConfig = origLoad })
-	loadProjectsConfig = func() (*models.Config, error) {
-		return nil, errors.New("config unavailable")
+	origQuery := queryProjectsInventory
+	t.Cleanup(func() { queryProjectsInventory = origQuery })
+	queryProjectsInventory = func(context.Context, publicworktree.Request, bool, io.Writer) (publicworktree.Result, error) {
+		return publicworktree.Result{}, errors.New("config unavailable")
 	}
 
 	err := runProjects(projectsCmd, nil)
 
-	require.EqualError(t, err, "failed to load config: config unavailable")
+	require.EqualError(t, err, "config unavailable")
 }
 
 // TestRunProjectsJSONCanonicalizesLegacyAbsolutePathIdentity pins the fix for

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -36,7 +36,11 @@ func withProjectsConfig(t *testing.T, projects []models.Project) {
 		io.Writer,
 	) (publicworktree.Result, error) {
 		return publicworktree.Result{Snapshot: publicworktree.Snapshot{
-			Projects: publicworktree.CanonicalProjects(projects),
+			Projects: func() []models.Project {
+				canonical, err := publicworktree.CanonicalProjects(context.Background(), projects)
+				require.NoError(t, err)
+				return canonical
+			}(),
 		}}, nil
 	}
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -10,6 +10,7 @@ import (
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/status"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/internal/ui"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
@@ -221,7 +222,7 @@ func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *u
 		// Local worktrees all belong to the repository containing cwd. Enrich
 		// them before collection so registered identity precedence and the
 		// canonical local fallback match the global status surface.
-		enrichWorktreeIdentity(g, cfg.Projects, localWorktrees)
+		enrichStatusWorktreeIdentity(g, cfg.Projects, localWorktrees)
 		for i := range localWorktrees {
 			worktrees = append(worktrees, &localWorktrees[i])
 		}
@@ -233,6 +234,25 @@ func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *u
 		BaseDir:        cfg.Worktree.BaseDir,
 	})
 	return collector.CollectAll(ctx, worktrees)
+}
+
+func enrichStatusWorktreeIdentity(
+	g worktree.RepoIdentityGit,
+	projects []models.Project,
+	worktrees []models.Worktree,
+) {
+	info, err := worktree.RepositoryInfoWithProjects(g, projects)
+	if err != nil {
+		return
+	}
+	for index := range worktrees {
+		worktrees[index].Repository = info.FullPath
+		worktrees[index].SessionName = tmux.WorkspaceSessionName(
+			info,
+			worktrees[index].Branch,
+			worktrees[index].Path,
+		)
+	}
 }
 
 func applyFiltersAndSort(statuses []*models.WorktreeStatus) []*models.WorktreeStatus {

--- a/internal/cmd/testdata/daemonfixture/main.go
+++ b/internal/cmd/testdata/daemonfixture/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	kitdaemon "go.kenn.io/kit/daemon"
+	kwtdaemon "go.kenn.io/kwt/internal/daemon"
+)
+
+type statusProvider struct {
+	status kwtdaemon.Status
+}
+
+func (p statusProvider) Status(time.Time) kwtdaemon.Status { return p.status }
+
+func main() {
+	home := flag.String("home", "", "kwt home")
+	mode := flag.String("mode", "", "fixture mode")
+	ready := flag.String("ready", "", "readiness marker")
+	flag.Parse()
+	if *home == "" || *ready == "" {
+		log.Fatal("home and ready are required")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	endpoint, err := kitdaemon.ParseEndpoint(
+		listener.Addr().String(),
+		kitdaemon.ParseEndpointOptions{TCPPolicy: kitdaemon.RequireLoopback},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	build := kwtdaemon.Build{Version: "v1.0.0", Revision: "fixture"}
+	record, token, err := kwtdaemon.NewRuntimeRecord(*home, build, endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+	schemaMajor := kwtdaemon.APISchemaMajor
+	schemaVersion := kwtdaemon.APISchemaVersion
+	if *mode == "incompatible" {
+		schemaMajor = 2
+		schemaVersion = "2.0.0"
+		record.Metadata["schema_major"] = strconv.Itoa(schemaMajor)
+		record.Metadata["schema_version"] = schemaVersion
+	}
+	if _, err := kwtdaemon.RuntimeStore(*home).Write(record); err != nil {
+		log.Fatal(err)
+	}
+	if *mode == "unresponsive" {
+		_ = listener.Close()
+		if err := os.WriteFile(*ready, []byte("ready"), 0o600); err != nil {
+			log.Fatal(err)
+		}
+		select {}
+	}
+
+	proof, err := kitdaemon.NewProof([]byte(token))
+	if err != nil {
+		log.Fatal(err)
+	}
+	ping, err := proof.NewPingHandler(record)
+	if err != nil {
+		log.Fatal(err)
+	}
+	capabilities := strings.Split(record.Metadata["capabilities"], ",")
+	started := time.Now()
+	status := kwtdaemon.Status{
+		Service: kwtdaemon.ServiceName, State: kwtdaemon.StateReady,
+		Home: *home, Endpoint: listener.Addr().String(), PID: os.Getpid(),
+		Version: build.Version, Revision: build.Revision,
+		SchemaMajor: schemaMajor, SchemaVersion: schemaVersion,
+		Capabilities: capabilities, StartedAt: started,
+	}
+	if *mode == "draining" {
+		status.State = kwtdaemon.StateDraining
+		deadline := time.Now().Add(-10 * time.Second)
+		status.DrainDeadline = &deadline
+	}
+	provider := statusProvider{status: status}
+	handler := kwtdaemon.NewServer(kwtdaemon.ServerOptions{
+		Token: token, ExpectedHost: listener.Addr().String(), Status: provider,
+		Shutdown: func(context.Context, kwtdaemon.ShutdownRequest) (kwtdaemon.Status, error) {
+			return provider.status, nil
+		},
+		Ping: ping,
+	})
+	server := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second}
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+	if err := os.WriteFile(*ready, []byte("ready"), 0o600); err != nil {
+		log.Fatal(err)
+	}
+	select {}
+}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -45,6 +46,8 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 
 	backend := newTUIBackend(cfg)
+	backend.queryInventory = queryCLIInventory
+	backend.stderr = os.Stderr
 	model := dashboard.NewModel(backend, cfg.Worktree.BaseDir).
 		WithInitialAnchor(launchAnchorPath(backend.launchDir))
 	final, err := tea.NewProgram(model).Run()

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -67,7 +67,7 @@ func newTUIBackend(cfg *models.Config) *tuiBackend {
 func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBackend {
 	protectedNames := credentials.ProtectedNames(cfg)
 	tmuxCmd := tmux.NewTmuxCommandWithStripNames("", protectedNames)
-	return &tuiBackend{
+	backend := &tuiBackend{
 		cfg:            cfg,
 		tmux:           tmuxCmd,
 		protectedNames: protectedNames,
@@ -90,10 +90,13 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		registerWorkspace:       config.RegisterWorkspace,
 		unregisterWorkspace:     config.UnregisterWorkspace,
 		readFleetState:          readTUIFleetState,
-		loadTargetConfig:        config.LoadForTarget,
 		acknowledgeRemoteSource: acknowledgeRemoteSourcePath,
 		now:                     time.Now,
 	}
+	backend.loadTargetConfig = func(repoRoot string, interactive bool) (*models.Config, error) {
+		return config.LoadForTargetFrom(backend.cfg, repoRoot, interactive)
+	}
+	return backend
 }
 
 func (b *tuiBackend) ListFast(ctx context.Context) ([]dashboard.Row, []string, error) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 type tuiBackend struct {
@@ -52,6 +54,8 @@ type tuiBackend struct {
 	loadTargetConfig          func(string, bool) (*models.Config, error)
 	acknowledgeRemoteSource   func(string) error
 	now                       func() time.Time
+	queryInventory            func(context.Context, publicworktree.Request, bool, io.Writer) (publicworktree.Result, error)
+	stderr                    io.Writer
 }
 
 func newTUIBackend(cfg *models.Config) *tuiBackend {
@@ -71,7 +75,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		// canonical identity wins over a fork origin (the same precedence
 		// applyProjectIdentityFallback applies to per-project discovery).
 		discoverGlobalWorktrees: func(baseDir string) ([]*discovery.GlobalWorktreeEntry, error) {
-			return discovery.DiscoverGlobalWorktrees(baseDir, cfg.Projects)
+			return discoverLegacyTUIWorktrees(baseDir, cfg.Projects)
 		},
 		discoverProjectWorktrees: discoverLaunchRepoWorktrees,
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
@@ -102,6 +106,12 @@ func (b *tuiBackend) List(ctx context.Context) ([]dashboard.Row, []string, error
 func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboard.Row, []string, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.queryInventory != nil {
+		return b.listDaemon(ctx, includeStatuses)
+	}
+	// The nil branch is retained only as an injected unit-test seam for the
+	// existing dashboard mutation/status tests. runTUI always installs the
+	// daemon query before the model can call ListFast or List.
 
 	var (
 		entries           []*discovery.GlobalWorktreeEntry
@@ -124,7 +134,7 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	go func() {
 		defer startup.Done()
 		registeredEntries, registeredErr =
-			b.discoverRegisteredProjectWorktrees()
+			b.loadRegisteredProjectInventory()
 	}()
 	go func() {
 		defer startup.Done()
@@ -184,6 +194,70 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	}
 	rows = append(rows, b.workspaceRows(sessions)...)
 	return rows, nil, nil
+}
+
+func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]dashboard.Row, []string, error) {
+	result, err := b.queryInventory(
+		ctx,
+		publicworktree.Request{
+			View: publicworktree.ViewDashboard, LaunchDirectory: b.launchDir,
+			RequireCurrent: includeStatuses,
+		},
+		config.StdinInteractive(),
+		b.stderr,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	entries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.Entries))
+	for _, entry := range result.Snapshot.Entries {
+		entries = append(entries, dashboardInventoryEntry(entry))
+	}
+	sessions, err := b.listSessions()
+	if err != nil {
+		return nil, nil, err
+	}
+	b.cfg.Projects = append([]models.Project(nil), result.Snapshot.Projects...)
+	b.cfg.Workspaces = append([]models.Workspace(nil), result.Snapshot.Workspaces...)
+	b.registerLaunchProject(entries)
+	b.registerLaunchWorkspace(entries)
+
+	var statusByPath map[string]*models.WorktreeStatus
+	if includeStatuses {
+		statusByPath, err = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	liveSessions := make(map[string]bool, len(sessions))
+	for _, session := range sessions {
+		liveSessions[session] = true
+	}
+	rows := make([]dashboard.Row, 0, len(entries))
+	for _, entry := range entries {
+		status := statusByPath[entry.Path]
+		if status == nil {
+			status = unknownStatusForEntry(entry)
+		}
+		rows = append(rows, buildTUIRow(entry, status, liveSessions))
+	}
+	rows = append(rows, b.workspaceRows(sessions)...)
+	return rows, nil, nil
+}
+
+func dashboardInventoryEntry(entry publicworktree.Entry) *discovery.GlobalWorktreeEntry {
+	var info *url.RepositoryInfo
+	if entry.Repository.FullPath != "" {
+		info = &url.RepositoryInfo{
+			Host: entry.Repository.Host, Owner: entry.Repository.Owner,
+			Repository: entry.Repository.Name, FullPath: entry.Repository.FullPath,
+		}
+	}
+	return &discovery.GlobalWorktreeEntry{
+		RepositoryURL: entry.Repository.URL, RepositoryInfo: info,
+		Path: entry.Path, Branch: entry.Branch, CommitHash: entry.CommitHash,
+		IsMain: entry.IsMain, CreatedAt: entry.CreatedAt, Generation: entry.Generation,
+	}
 }
 
 // MergeFleet overlays hub state onto locally discovered rows. It publishes
@@ -313,7 +387,7 @@ func localFleetObservation(currentHost string, localRow dashboard.Row, now time.
 	return observation, true
 }
 
-func (b *tuiBackend) discoverRegisteredProjectWorktrees() (
+func (b *tuiBackend) loadRegisteredProjectInventory() (
 	[]*discovery.GlobalWorktreeEntry,
 	error,
 ) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 	publicworktree "go.kenn.io/kwt/worktree"
 )
 
@@ -217,17 +218,11 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	if err != nil {
 		return nil, nil, err
 	}
-	var statusByPath map[string]*models.WorktreeStatus
 	renderWorkspaces := result.Snapshot.Workspaces
-	if includeStatuses {
-		statusByPath, err = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
-		if err != nil {
+	if includeStatuses && result.Freshness == publicworktree.Fresh {
+		if err := b.applyInventoryConfig(result.Snapshot.Config); err != nil {
 			return nil, nil, err
 		}
-	}
-	if includeStatuses && result.Freshness == publicworktree.Fresh {
-		b.cfg.Projects = append([]models.Project(nil), result.Snapshot.Projects...)
-		b.cfg.Workspaces = append([]models.Workspace(nil), result.Snapshot.Workspaces...)
 		launchEntries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.LaunchEntries))
 		for _, entry := range result.Snapshot.LaunchEntries {
 			launchEntries = append(launchEntries, dashboardInventoryEntry(entry))
@@ -235,6 +230,13 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 		b.registerLaunchProject(launchEntries)
 		b.registerLaunchWorkspace(launchEntries)
 		renderWorkspaces = append([]models.Workspace(nil), b.cfg.Workspaces...)
+	}
+	var statusByPath map[string]*models.WorktreeStatus
+	if includeStatuses {
+		statusByPath, err = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	liveSessions := make(map[string]bool, len(sessions))
 	for _, session := range sessions {
@@ -250,6 +252,31 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	}
 	rows = append(rows, workspaceRows(renderWorkspaces, sessions)...)
 	return rows, nil, nil
+}
+
+func (b *tuiBackend) applyInventoryConfig(effective *models.Config) error {
+	if effective == nil {
+		return service.NewError(
+			service.TransportFailure,
+			"kwt daemon returned fresh inventory without effective configuration",
+			true,
+			nil,
+			nil,
+		)
+	}
+	if b.cfg == nil {
+		b.cfg = effective
+	} else {
+		*b.cfg = *effective
+	}
+	b.protectedNames = credentials.ProtectedNames(b.cfg)
+	b.tmux = tmux.NewTmuxCommandWithStripNames("", b.protectedNames)
+	b.listSessions = b.tmux.ListSessions
+	b.ensureAndAttach = tmux.NewWorkspaceRunner(
+		b.tmux,
+		b.protectedNames,
+	).EnsureAndAttach
+	return nil
 }
 
 func dashboardInventoryEntry(entry publicworktree.Entry) *discovery.GlobalWorktreeEntry {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -217,23 +217,22 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	if err != nil {
 		return nil, nil, err
 	}
-	b.cfg.Projects = append([]models.Project(nil), result.Snapshot.Projects...)
-	b.cfg.Workspaces = append([]models.Workspace(nil), result.Snapshot.Workspaces...)
-	if result.Freshness == publicworktree.Fresh {
-		launchEntries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.LaunchEntries))
-		for _, entry := range result.Snapshot.LaunchEntries {
-			launchEntries = append(launchEntries, dashboardInventoryEntry(entry))
-		}
-		b.registerLaunchProject(launchEntries)
-		b.registerLaunchWorkspace(launchEntries)
-	}
-
 	var statusByPath map[string]*models.WorktreeStatus
 	if includeStatuses {
 		statusByPath, err = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
 		if err != nil {
 			return nil, nil, err
 		}
+	}
+	if includeStatuses && result.Freshness == publicworktree.Fresh {
+		b.cfg.Projects = append([]models.Project(nil), result.Snapshot.Projects...)
+		b.cfg.Workspaces = append([]models.Workspace(nil), result.Snapshot.Workspaces...)
+		launchEntries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.LaunchEntries))
+		for _, entry := range result.Snapshot.LaunchEntries {
+			launchEntries = append(launchEntries, dashboardInventoryEntry(entry))
+		}
+		b.registerLaunchProject(launchEntries)
+		b.registerLaunchWorkspace(launchEntries)
 	}
 	liveSessions := make(map[string]bool, len(sessions))
 	for _, session := range sessions {
@@ -247,7 +246,7 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 		}
 		rows = append(rows, buildTUIRow(entry, status, liveSessions))
 	}
-	rows = append(rows, b.workspaceRows(sessions)...)
+	rows = append(rows, workspaceRows(result.Snapshot.Workspaces, sessions)...)
 	return rows, nil, nil
 }
 
@@ -455,8 +454,12 @@ func (b *tuiBackend) workspaceRows(sessions []string) []dashboard.Row {
 	if b.cfg == nil || len(b.cfg.Workspaces) == 0 {
 		return nil
 	}
-	rows := make([]dashboard.Row, 0, len(b.cfg.Workspaces))
-	for _, record := range directoryWorkspaceRecords(b.cfg.Workspaces, sessions) {
+	return workspaceRows(b.cfg.Workspaces, sessions)
+}
+
+func workspaceRows(workspaces []models.Workspace, sessions []string) []dashboard.Row {
+	rows := make([]dashboard.Row, 0, len(workspaces))
+	for _, record := range directoryWorkspaceRecords(workspaces, sessions) {
 		rows = append(rows, dashboard.Row{
 			Workspace: &dashboard.WorkspaceInfo{
 				Name: record.Name,

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -219,8 +219,14 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	}
 	b.cfg.Projects = append([]models.Project(nil), result.Snapshot.Projects...)
 	b.cfg.Workspaces = append([]models.Workspace(nil), result.Snapshot.Workspaces...)
-	b.registerLaunchProject(entries)
-	b.registerLaunchWorkspace(entries)
+	if result.Freshness == publicworktree.Fresh {
+		launchEntries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.LaunchEntries))
+		for _, entry := range result.Snapshot.LaunchEntries {
+			launchEntries = append(launchEntries, dashboardInventoryEntry(entry))
+		}
+		b.registerLaunchProject(launchEntries)
+		b.registerLaunchWorkspace(launchEntries)
+	}
 
 	var statusByPath map[string]*models.WorktreeStatus
 	if includeStatuses {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -218,6 +218,7 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 		return nil, nil, err
 	}
 	var statusByPath map[string]*models.WorktreeStatus
+	renderWorkspaces := result.Snapshot.Workspaces
 	if includeStatuses {
 		statusByPath, err = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
 		if err != nil {
@@ -233,6 +234,7 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 		}
 		b.registerLaunchProject(launchEntries)
 		b.registerLaunchWorkspace(launchEntries)
+		renderWorkspaces = append([]models.Workspace(nil), b.cfg.Workspaces...)
 	}
 	liveSessions := make(map[string]bool, len(sessions))
 	for _, session := range sessions {
@@ -246,7 +248,7 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 		}
 		rows = append(rows, buildTUIRow(entry, status, liveSessions))
 	}
-	rows = append(rows, workspaceRows(result.Snapshot.Workspaces, sessions)...)
+	rows = append(rows, workspaceRows(renderWorkspaces, sessions)...)
 	return rows, nil, nil
 }
 

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -20,7 +20,9 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "/launch")
 	backend.listSessions = func() ([]string, error) { return nil, nil }
-	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
+	var statusBaseDirectory string
+	backend.collectStatuses = func(_ context.Context, baseDirectory string, _ []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
+		statusBaseDirectory = baseDirectory
 		return map[string]*models.WorktreeStatus{}, nil
 	}
 	backend.registerProject = nil
@@ -43,9 +45,20 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 			workspace = models.Workspace{Name: "fresh", Path: "/fresh/workspace"}
 			freshness = publicworktree.Fresh
 		}
+		effective := &models.Config{
+			Worktree:   models.WorktreeConfig{BaseDir: "/cached-base"},
+			Projects:   []models.Project{project},
+			Workspaces: []models.Workspace{workspace},
+			Layouts:    models.LayoutsConfig{Default: "cached-layout"},
+		}
+		if request.RequireCurrent {
+			effective.Worktree.BaseDir = "/fresh-base"
+			effective.Layouts.Default = "fresh-layout"
+		}
 		return publicworktree.Result{
 			Freshness: freshness,
 			Snapshot: publicworktree.Snapshot{
+				Config:   effective,
 				Projects: []models.Project{project},
 				Entries: []publicworktree.Entry{{
 					Path: path, Branch: "main", Repository: publicworktree.Repository{FullPath: "github.com/acme/repo", Name: "repo"},
@@ -66,6 +79,9 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	assert.Equal(t, "/fresh", current[0].Entry.Path)
 	assert.Equal(t, "/fresh", cfg.Projects[0].Path)
 	assert.Equal(t, "/fresh/workspace", cfg.Workspaces[0].Path)
+	assert.Equal(t, "/fresh-base", cfg.Worktree.BaseDir)
+	assert.Equal(t, "fresh-layout", cfg.Layouts.Default)
+	assert.Equal(t, "/fresh-base", statusBaseDirectory)
 	require.Len(t, requests, 2)
 	assert.False(t, requests[0].RequireCurrent)
 	assert.True(t, requests[1].RequireCurrent)
@@ -110,6 +126,7 @@ func TestTUIBackendRegistersOnlyCurrentLaunchInventory(t *testing.T) {
 		return publicworktree.Result{
 			Freshness: freshness,
 			Snapshot: publicworktree.Snapshot{
+				Config:        &models.Config{},
 				Entries:       []publicworktree.Entry{unrelated, launch},
 				LaunchEntries: []publicworktree.Entry{launch},
 			},
@@ -146,7 +163,10 @@ func TestTUIBackendCurrentInventoryIncludesNewLaunchWorkspace(t *testing.T) {
 		bool,
 		io.Writer,
 	) (publicworktree.Result, error) {
-		return publicworktree.Result{Freshness: publicworktree.Fresh}, nil
+		return publicworktree.Result{
+			Freshness: publicworktree.Fresh,
+			Snapshot:  publicworktree.Snapshot{Config: &models.Config{}},
+		}, nil
 	}
 
 	rows, _, err := backend.List(context.Background())

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -3,14 +3,69 @@ package cmd
 import (
 	"context"
 	"io"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/pkg/models"
 	publicworktree "go.kenn.io/kwt/worktree"
 )
+
+func TestTUIBackendMutationUsesLatestDaemonConfiguration(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	require.NoError(t, config.Init())
+	staleBase := filepath.Join(t.TempDir(), "stale")
+	viper.Set("worktree.basedir", staleBase)
+	viper.Set("worktree.auto_mkdir", true)
+	viper.Set("naming.template", "{{.Branch}}")
+	viper.Set("naming.sanitize_chars", map[string]string{"/": "-"})
+
+	repository := newTUITestRepo(t)
+	runTUITestGit(t, repository, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	currentBase := filepath.Join(t.TempDir(), "current")
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
+		return map[string]*models.WorktreeStatus{}, nil
+	}
+	backend.queryInventory = func(
+		context.Context,
+		publicworktree.Request,
+		bool,
+		io.Writer,
+	) (publicworktree.Result, error) {
+		return publicworktree.Result{
+			Freshness: publicworktree.Fresh,
+			Snapshot: publicworktree.Snapshot{
+				Config: &models.Config{
+					Worktree: models.WorktreeConfig{BaseDir: currentBase, AutoMkdir: true},
+					Naming: models.NamingConfig{
+						Template: "{{.Branch}}", SanitizeChars: map[string]string{"/": "-"},
+					},
+				},
+				Entries: []publicworktree.Entry{{
+					Path: repository, Branch: "main", IsMain: true,
+					Repository: publicworktree.Repository{FullPath: "github.com/acme/widget", Name: "widget"},
+				}},
+			},
+		}, nil
+	}
+
+	rows, _, err := backend.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	planned, err := backend.PreviewWorktree(rows[0], "feature/refreshed")
+
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(planned.Entry.Path))
+	assert.Equal(t, filepath.Join(currentBase, "feature-refreshed"), planned.Entry.Path)
+}
 
 func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	cfg := &models.Config{

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -126,3 +126,34 @@ func TestTUIBackendRegistersOnlyCurrentLaunchInventory(t *testing.T) {
 	assert.Equal(t, "github.com/acme/launch", registered[0].Repository)
 	assert.Equal(t, "/launch", registered[0].Path)
 }
+
+func TestTUIBackendCurrentInventoryIncludesNewLaunchWorkspace(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
+	}, "/launch")
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
+		return map[string]*models.WorktreeStatus{}, nil
+	}
+	backend.registerProject = nil
+	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
+		workspace.Name = "launch"
+		return workspace, nil
+	}
+	backend.queryInventory = func(
+		context.Context,
+		publicworktree.Request,
+		bool,
+		io.Writer,
+	) (publicworktree.Result, error) {
+		return publicworktree.Result{Freshness: publicworktree.Fresh}, nil
+	}
+
+	rows, _, err := backend.List(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].Workspace)
+	assert.Equal(t, "launch", rows[0].Workspace.Name)
+	assert.Equal(t, "/launch", rows[0].Workspace.Path)
+}

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -49,3 +49,59 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	assert.False(t, requests[0].RequireCurrent)
 	assert.True(t, requests[1].RequireCurrent)
 }
+
+func TestTUIBackendRegistersOnlyCurrentLaunchInventory(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
+	}, "/launch")
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
+		return map[string]*models.WorktreeStatus{}, nil
+	}
+	backend.registerWorkspace = nil
+	var registered []models.Project
+	backend.registerProject = func(project models.Project) error {
+		registered = append(registered, project)
+		return nil
+	}
+	backend.queryInventory = func(
+		_ context.Context,
+		request publicworktree.Request,
+		_ bool,
+		_ io.Writer,
+	) (publicworktree.Result, error) {
+		unrelated := publicworktree.Entry{
+			Path: "/other", IsMain: true,
+			Repository: publicworktree.Repository{
+				URL: "https://github.com/acme/other.git", FullPath: "github.com/acme/other", Name: "other",
+			},
+		}
+		launch := publicworktree.Entry{
+			Path: "/launch", IsMain: true,
+			Repository: publicworktree.Repository{
+				URL: "https://github.com/acme/launch.git", FullPath: "github.com/acme/launch", Name: "launch",
+			},
+		}
+		freshness := publicworktree.Stale
+		if request.RequireCurrent {
+			freshness = publicworktree.Fresh
+		}
+		return publicworktree.Result{
+			Freshness: freshness,
+			Snapshot: publicworktree.Snapshot{
+				Entries:       []publicworktree.Entry{unrelated, launch},
+				LaunchEntries: []publicworktree.Entry{launch},
+			},
+		}, nil
+	}
+
+	_, _, err := backend.ListFast(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, registered, "stale inventory must not mutate launch registration")
+	_, _, err = backend.List(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, registered, 1)
+	assert.Equal(t, "github.com/acme/launch", registered[0].Repository)
+	assert.Equal(t, "/launch", registered[0].Path)
+}

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/pkg/models"
+	publicworktree "go.kenn.io/kwt/worktree"
+)
+
+func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
+	}, "/launch")
+	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
+		return map[string]*models.WorktreeStatus{}, nil
+	}
+	backend.registerProject = nil
+	backend.registerWorkspace = nil
+	var requests []publicworktree.Request
+	backend.queryInventory = func(
+		_ context.Context,
+		request publicworktree.Request,
+		_ bool,
+		_ io.Writer,
+	) (publicworktree.Result, error) {
+		requests = append(requests, request)
+		path := "/cached"
+		if request.RequireCurrent {
+			path = "/fresh"
+		}
+		return publicworktree.Result{Snapshot: publicworktree.Snapshot{Entries: []publicworktree.Entry{{
+			Path: path, Branch: "main", Repository: publicworktree.Repository{FullPath: "github.com/acme/repo", Name: "repo"},
+		}}}}, nil
+	}
+
+	fast, _, err := backend.ListFast(context.Background())
+	require.NoError(t, err)
+	current, _, err := backend.List(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "/cached", fast[0].Entry.Path)
+	assert.Equal(t, "/fresh", current[0].Entry.Path)
+	require.Len(t, requests, 2)
+	assert.False(t, requests[0].RequireCurrent)
+	assert.True(t, requests[1].RequireCurrent)
+}

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -13,9 +13,12 @@ import (
 )
 
 func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
-	backend := newTUIBackendWithLaunchDir(&models.Config{
-		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
-	}, "/launch")
+	cfg := &models.Config{
+		Worktree:   models.WorktreeConfig{BaseDir: t.TempDir()},
+		Projects:   []models.Project{{Repository: "github.com/acme/live", Name: "live", Path: "/live"}},
+		Workspaces: []models.Workspace{{Name: "live", Path: "/live/workspace"}},
+	}
+	backend := newTUIBackendWithLaunchDir(cfg, "/launch")
 	backend.listSessions = func() ([]string, error) { return nil, nil }
 	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
 		return map[string]*models.WorktreeStatus{}, nil
@@ -31,20 +34,38 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	) (publicworktree.Result, error) {
 		requests = append(requests, request)
 		path := "/cached"
+		project := models.Project{Repository: "github.com/acme/cached", Name: "cached", Path: "/cached"}
+		workspace := models.Workspace{Name: "cached", Path: "/cached/workspace"}
+		freshness := publicworktree.Stale
 		if request.RequireCurrent {
 			path = "/fresh"
+			project = models.Project{Repository: "github.com/acme/fresh", Name: "fresh", Path: "/fresh"}
+			workspace = models.Workspace{Name: "fresh", Path: "/fresh/workspace"}
+			freshness = publicworktree.Fresh
 		}
-		return publicworktree.Result{Snapshot: publicworktree.Snapshot{Entries: []publicworktree.Entry{{
-			Path: path, Branch: "main", Repository: publicworktree.Repository{FullPath: "github.com/acme/repo", Name: "repo"},
-		}}}}, nil
+		return publicworktree.Result{
+			Freshness: freshness,
+			Snapshot: publicworktree.Snapshot{
+				Projects: []models.Project{project},
+				Entries: []publicworktree.Entry{{
+					Path: path, Branch: "main", Repository: publicworktree.Repository{FullPath: "github.com/acme/repo", Name: "repo"},
+				}},
+				Workspaces: []models.Workspace{workspace},
+			},
+		}, nil
 	}
 
 	fast, _, err := backend.ListFast(context.Background())
 	require.NoError(t, err)
+	assert.Equal(t, "/live", cfg.Projects[0].Path)
+	assert.Equal(t, "/live/workspace", cfg.Workspaces[0].Path)
+	assert.Equal(t, "/cached/workspace", fast[1].Workspace.Path)
 	current, _, err := backend.List(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "/cached", fast[0].Entry.Path)
 	assert.Equal(t, "/fresh", current[0].Entry.Path)
+	assert.Equal(t, "/fresh", cfg.Projects[0].Path)
+	assert.Equal(t, "/fresh/workspace", cfg.Workspaces[0].Path)
 	require.Len(t, requests, 2)
 	assert.False(t, requests[0].RequireCurrent)
 	assert.True(t, requests[1].RequireCurrent)

--- a/internal/cmd/tui_inventory_test_seam.go
+++ b/internal/cmd/tui_inventory_test_seam.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+// discoverLegacyTUIWorktrees supports the direct-discovery unit-test seam in
+// tuiBackend. Production TUI construction always replaces that seam with the
+// daemon inventory bridge.
+func discoverLegacyTUIWorktrees(
+	baseDirectory string,
+	projects []models.Project,
+) ([]*discovery.GlobalWorktreeEntry, error) {
+	return discovery.DiscoverGlobalWorktrees(baseDirectory, projects)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -750,6 +750,15 @@ func LoadGlobalSnapshot() (*GlobalSnapshot, error) {
 // LoadGlobalSnapshotAt re-reads global configuration from an explicit kwt
 // home. Daemon requests use it to avoid process-global environment state.
 func LoadGlobalSnapshotAt(home string) (*GlobalSnapshot, error) {
+	return LoadGlobalSnapshotAtWithExpansion(home, utils.ExpandPath)
+}
+
+// LoadGlobalSnapshotAtWithExpansion re-reads global configuration while using
+// the invoking client's path semantics instead of process-global daemon state.
+func LoadGlobalSnapshotAtWithExpansion(
+	home string,
+	expandPath func(string) (string, error),
+) (*GlobalSnapshot, error) {
 	configPath := filepath.Join(home, configName+"."+configType)
 	globalViper, err := readGlobalViper(configPath)
 	if err != nil {
@@ -768,7 +777,7 @@ func LoadGlobalSnapshotAt(home string) (*GlobalSnapshot, error) {
 	effective.Projects = slices.Clone(persisted.Projects)
 	effective.Workspaces = slices.Clone(persisted.Workspaces)
 	effective.RepositorySettings = slices.Clone(persisted.RepositorySettings)
-	if err := expandConfigPaths(&effective); err != nil {
+	if err := expandConfigPathsWith(&effective, expandPath); err != nil {
 		return nil, err
 	}
 
@@ -885,21 +894,31 @@ func cloneStringMap(source map[string]any) map[string]any {
 
 // expandConfigPaths expands all path fields in the configuration.
 func expandConfigPaths(cfg *models.Config) error {
-	expandedPath, err := utils.ExpandPath(cfg.Worktree.BaseDir)
+	return expandConfigPathsWith(cfg, utils.ExpandPath)
+}
+
+func expandConfigPathsWith(
+	cfg *models.Config,
+	expandPath func(string) (string, error),
+) error {
+	if expandPath == nil {
+		expandPath = utils.ExpandPath
+	}
+	expandedPath, err := expandPath(cfg.Worktree.BaseDir)
 	if err != nil {
 		return fmt.Errorf("failed to expand worktree base dir: %w", err)
 	}
 	cfg.Worktree.BaseDir = expandedPath
 
 	if cfg.Fleet.TokenFile != "" {
-		expandedPath, err = utils.ExpandPath(cfg.Fleet.TokenFile)
+		expandedPath, err = expandPath(cfg.Fleet.TokenFile)
 		if err != nil {
 			return fmt.Errorf("failed to expand fleet token file: %w", err)
 		}
 		cfg.Fleet.TokenFile = expandedPath
 	}
 	if cfg.Fleet.Hub.StorePath != "" {
-		expandedPath, err = utils.ExpandPath(cfg.Fleet.Hub.StorePath)
+		expandedPath, err = expandPath(cfg.Fleet.Hub.StorePath)
 		if err != nil {
 			return fmt.Errorf("failed to expand fleet hub store path: %w", err)
 		}
@@ -911,7 +930,7 @@ func expandConfigPaths(cfg *models.Config) error {
 		// Skip path expansion for glob patterns — ExpandPath would prepend
 		// the CWD to relative globs like "**/owner/repo", breaking matching.
 		if !strings.ContainsAny(repo, "*?[") {
-			expandedPath, err = utils.ExpandPath(repo)
+			expandedPath, err = expandPath(repo)
 			if err != nil {
 				return fmt.Errorf("failed to expand repository setting path: %w", err)
 			}
@@ -925,7 +944,7 @@ func expandConfigPaths(cfg *models.Config) error {
 		// BaseDir is a destination path (not compared against git-derived paths),
 		// so symlink resolution is not needed here.
 		if baseDir := cfg.RepositorySettings[i].BaseDir; baseDir != "" {
-			expanded, err := utils.ExpandPath(baseDir)
+			expanded, err := expandPath(baseDir)
 			if err != nil {
 				return fmt.Errorf("failed to expand repository basedir: %w", err)
 			}
@@ -937,7 +956,7 @@ func expandConfigPaths(cfg *models.Config) error {
 		if path == "" {
 			continue
 		}
-		expandedPath, err = utils.ExpandPath(path)
+		expandedPath, err = expandPath(path)
 		if err != nil {
 			return fmt.Errorf("failed to expand project path: %w", err)
 		}
@@ -951,7 +970,7 @@ func expandConfigPaths(cfg *models.Config) error {
 		if path == "" {
 			continue
 		}
-		expandedPath, err = utils.ExpandPath(path)
+		expandedPath, err = expandPath(path)
 		if err != nil {
 			return fmt.Errorf("failed to expand workspace path: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -739,7 +739,13 @@ type GlobalSnapshot struct {
 // LoadGlobalSnapshot re-reads global configuration without merging a
 // repository-local .kwt.toml file.
 func LoadGlobalSnapshot() (*GlobalSnapshot, error) {
-	configPath := filepath.Join(getConfigDir(), configName+"."+configType)
+	return LoadGlobalSnapshotAt(getConfigDir())
+}
+
+// LoadGlobalSnapshotAt re-reads global configuration from an explicit kwt
+// home. Daemon requests use it to avoid process-global environment state.
+func LoadGlobalSnapshotAt(home string) (*GlobalSnapshot, error) {
+	configPath := filepath.Join(home, configName+"."+configType)
 	globalViper, err := readGlobalViper(configPath)
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 	worktreetemplate "go.kenn.io/kwt/internal/template"
 	repositoryurl "go.kenn.io/kwt/internal/url"
@@ -468,8 +469,35 @@ func LoadRepoLayoutDefault(repoRoot string, interactive bool) (string, error) {
 // repository's trust-gated local configuration. It never consults the
 // caller's working directory and does not prompt when interactive is false.
 func LoadForTarget(repoRoot string, interactive bool) (*models.Config, error) {
+	return loadForTarget(viper.AllSettings(), repoRoot, interactive)
+}
+
+// LoadForTargetFrom returns the provided effective configuration merged with
+// the selected repository's trust-gated local configuration. Long-lived
+// clients use it after refreshing global configuration outside the process-
+// global Viper instance.
+func LoadForTargetFrom(
+	base *models.Config,
+	repoRoot string,
+	interactive bool,
+) (*models.Config, error) {
+	if base == nil {
+		return nil, fmt.Errorf("base configuration is required")
+	}
+	settings := make(map[string]any)
+	if err := mapstructure.Decode(base, &settings); err != nil {
+		return nil, fmt.Errorf("encode base config: %w", err)
+	}
+	return loadForTarget(settings, repoRoot, interactive)
+}
+
+func loadForTarget(
+	settings map[string]any,
+	repoRoot string,
+	interactive bool,
+) (*models.Config, error) {
 	target := viper.New()
-	if err := target.MergeConfigMap(viper.AllSettings()); err != nil {
+	if err := target.MergeConfigMap(settings); err != nil {
 		return nil, fmt.Errorf("copy global config: %w", err)
 	}
 	repositoryLocalTemplate := false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -569,10 +569,15 @@ func normalizeTargetConfigPath(path string) (string, error) {
 		return "", fmt.Errorf("stat %s: %w", lexicalPath, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return "", fmt.Errorf("%s is a symlink", lexicalPath)
+		return "", fmt.Errorf("%w: %s is a symlink", errUnsafeRepositoryConfig, lexicalPath)
 	}
 	if !info.Mode().IsRegular() {
-		return "", fmt.Errorf("%s is not a regular file (mode %s)", lexicalPath, info.Mode())
+		return "", fmt.Errorf(
+			"%w: %s is not a regular file (mode %s)",
+			errUnsafeRepositoryConfig,
+			lexicalPath,
+			info.Mode(),
+		)
 	}
 	return lexicalPath, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1896,6 +1896,38 @@ func TestLoadForTargetMergesTrustedRepositorySettings(t *testing.T) {
 	assert.Equal(t, []string{"echo trusted"}, cfg.RepositorySettings[0].SetupCommands)
 }
 
+func TestLoadForTargetFromMergesLocalConfigOverProvidedSnapshot(t *testing.T) {
+	kwtHome := t.TempDir()
+	t.Setenv("KWT_HOME", kwtHome)
+	target := t.TempDir()
+	localPath := filepath.Join(target, ".kwt.toml")
+	targetWorktrees := filepath.Join(target, "target-worktrees")
+	local := []byte("[worktree]\nbasedir = '" + targetWorktrees + "'\n[fleet]\ntoken_env = 'ATTACKER_TOKEN'\n[[repository_settings]]\nrepository = '" + target + "'\nsetup_commands = ['echo trusted']\n")
+	require.NoError(t, os.WriteFile(localPath, local, 0o600))
+	absPath, err := normalizeConfigPath(localPath)
+	require.NoError(t, err)
+	store := &TrustStore{path: defaultTrustStorePath()}
+	require.NoError(t, store.Add(absPath, computeSHA256(local)))
+	provided := &models.Config{
+		Worktree: models.WorktreeConfig{BaseDir: filepath.Join(t.TempDir(), "refreshed-worktrees"), AutoMkdir: true},
+		Fleet:    models.FleetConfig{TokenEnv: "REFRESHED_FLEET_TOKEN"},
+		Naming: models.NamingConfig{
+			Template:      "{{.Branch}}",
+			SanitizeChars: map[string]string{"/": "-"},
+		},
+	}
+
+	cfg, err := LoadForTargetFrom(provided, target, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, targetWorktrees, cfg.Worktree.BaseDir)
+	assert.True(t, cfg.Worktree.AutoMkdir)
+	assert.Equal(t, "REFRESHED_FLEET_TOKEN", cfg.Fleet.TokenEnv)
+	assert.Equal(t, "{{.Branch}}", cfg.Naming.Template)
+	require.Len(t, cfg.RepositorySettings, 1)
+	assert.Equal(t, []string{"echo trusted"}, cfg.RepositorySettings[0].SetupCommands)
+}
+
 func TestLoadForTargetResolvesRelativePathsAgainstSelectedRepository(t *testing.T) {
 	kwtHome := t.TempDir()
 	t.Setenv("KWT_HOME", kwtHome)

--- a/internal/config/request.go
+++ b/internal/config/request.go
@@ -22,6 +22,8 @@ const (
 
 var ErrConfigChanged = errors.New("repository config changed")
 
+var errUnsafeRepositoryConfig = errors.New("unsafe repository config")
+
 type ResolveRequest struct {
 	Home             string
 	WorkingDirectory string
@@ -83,10 +85,18 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 		return nil, fmt.Errorf("stat repository config %s: %w", path, err)
 	}
 
-	path, err = normalizeTargetConfigPath(path)
+	normalizedPath, err := normalizeTargetConfigPath(path)
 	if err != nil {
+		if errors.Is(err, errUnsafeRepositoryConfig) {
+			config, loadErr := configFromViper(target, false, false)
+			return &ResolveResult{
+				Config: config,
+				Notes:  []ConfigNote{{Code: "unsafe_config_skipped", Path: path}},
+			}, loadErr
+		}
 		return nil, err
 	}
+	path = normalizedPath
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read repository config %s: %w", path, err)

--- a/internal/config/request.go
+++ b/internal/config/request.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+type UntrustedPolicy string
+
+const (
+	RequireInteraction UntrustedPolicy = "require_interaction"
+	IgnoreUntrusted    UntrustedPolicy = "ignore"
+)
+
+var ErrConfigChanged = errors.New("repository config changed")
+
+type ResolveRequest struct {
+	Home             string
+	WorkingDirectory string
+	UntrustedPolicy  UntrustedPolicy
+}
+
+type ConfigNote struct {
+	Code string `json:"code"`
+	Path string `json:"path"`
+}
+
+type ResolveResult struct {
+	Config *models.Config
+	Notes  []ConfigNote
+}
+
+type TrustRequiredError struct {
+	Path      string
+	Digest    string
+	Size      int
+	Preview   string
+	Truncated bool
+}
+
+func (e *TrustRequiredError) Error() string {
+	return fmt.Sprintf("repository config %s requires trust", e.Path)
+}
+
+type Approval struct {
+	Home   string
+	Path   string
+	Digest string
+}
+
+// ResolveWorkingDirectory returns an isolated configuration snapshot for one
+// request. It never mutates the process-global Viper instance.
+func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
+	home, err := canonicalRequestDir(request.Home, "kwt home")
+	if err != nil {
+		return nil, err
+	}
+	workingDirectory, err := canonicalRequestDir(request.WorkingDirectory, "working directory")
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := readGlobalViper(filepath.Join(home, configName+"."+configType))
+	if err != nil {
+		return nil, err
+	}
+	applyGlobalDefaults(target)
+
+	path := filepath.Join(workingDirectory, localConfigName+"."+configType)
+	if _, err := os.Lstat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			config, loadErr := configFromViper(target, false, false)
+			return &ResolveResult{Config: config}, loadErr
+		}
+		return nil, fmt.Errorf("stat repository config %s: %w", path, err)
+	}
+
+	path, err = normalizeTargetConfigPath(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read repository config %s: %w", path, err)
+	}
+	digest := computeSHA256(data)
+	store, err := LoadTrustStore(filepath.Join(home, trustStoreFilename))
+	if err != nil {
+		return nil, err
+	}
+	if !store.IsTrusted(path, digest) {
+		if request.UntrustedPolicy == IgnoreUntrusted {
+			config, loadErr := configFromViper(target, false, false)
+			return &ResolveResult{
+				Config: config,
+				Notes:  []ConfigNote{{Code: "untrusted_config_skipped", Path: path}},
+			}, loadErr
+		}
+		preview := data
+		truncated := len(preview) > promptPreviewLimit
+		if truncated {
+			preview = preview[:promptPreviewLimit]
+		}
+		return nil, &TrustRequiredError{
+			Path:      path,
+			Digest:    digest,
+			Size:      len(data),
+			Preview:   sanitizeForTerminal(string(preview)),
+			Truncated: truncated,
+		}
+	}
+
+	local := viper.New()
+	local.SetConfigType(configType)
+	if err := local.ReadConfig(bytes.NewReader(data)); err != nil {
+		return nil, fmt.Errorf("parse repository config %s: %w", path, err)
+	}
+	if err := resolveTargetLocalPaths(local, workingDirectory); err != nil {
+		return nil, fmt.Errorf("resolve repository config paths %s: %w", path, err)
+	}
+	localTemplate := local.IsSet("naming.template")
+	localSanitize := local.IsSet("naming.sanitize_chars")
+	mergeRequestLocal(target, local)
+	config, err := configFromViper(target, localTemplate, localSanitize)
+	return &ResolveResult{Config: config}, err
+}
+
+// ApproveWorkingDirectory persists trust only after reopening the file and
+// confirming that its content still matches the prompted digest.
+func ApproveWorkingDirectory(approval Approval) error {
+	home, err := canonicalRequestDir(approval.Home, "kwt home")
+	if err != nil {
+		return err
+	}
+	path, err := normalizeTargetConfigPath(approval.Path)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read repository config %s: %w", path, err)
+	}
+	actual := computeSHA256(data)
+	if len(actual) != len(approval.Digest) || subtle.ConstantTimeCompare([]byte(actual), []byte(approval.Digest)) != 1 {
+		return ErrConfigChanged
+	}
+	store, err := LoadTrustStore(filepath.Join(home, trustStoreFilename))
+	if err != nil {
+		return err
+	}
+	return store.Add(path, actual)
+}
+
+func canonicalRequestDir(path, label string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", label, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize %s: %w", label, err)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func mergeRequestLocal(target, local *viper.Viper) {
+	for _, key := range local.AllKeys() {
+		switch {
+		case key == "repository_settings":
+			mergeRepositorySettingsInto(target, local)
+		case key == "projects" || key == "workspaces" || strings.HasPrefix(key, "workspaces."),
+			key == "fleet" || strings.HasPrefix(key, "fleet."),
+			key == "daemon" || strings.HasPrefix(key, "daemon."):
+			continue
+		default:
+			target.Set(key, local.Get(key))
+		}
+	}
+}
+
+func configFromViper(target *viper.Viper, localTemplate, localSanitize bool) (*models.Config, error) {
+	var config models.Config
+	if err := target.Unmarshal(&config); err != nil {
+		return nil, fmt.Errorf("unmarshal request config: %w", err)
+	}
+	if err := validateDaemonConfig(config.Daemon); err != nil {
+		return nil, err
+	}
+	if err := expandConfigPaths(&config); err != nil {
+		return nil, err
+	}
+	config.Naming.TemplateRepositoryLocal = localTemplate
+	config.Naming.SanitizeCharsRepositoryLocal = localSanitize
+	return &config, nil
+}

--- a/internal/config/request.go
+++ b/internal/config/request.go
@@ -28,6 +28,7 @@ type ResolveRequest struct {
 	Home             string
 	WorkingDirectory string
 	UntrustedPolicy  UntrustedPolicy
+	ExpandPath       func(string) (string, error)
 }
 
 type ConfigNote struct {
@@ -79,7 +80,7 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 	path := filepath.Join(workingDirectory, localConfigName+"."+configType)
 	if _, err := os.Lstat(path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			config, loadErr := configFromViper(target, false, false)
+			config, loadErr := configFromViper(target, false, false, request.ExpandPath)
 			return &ResolveResult{Config: config}, loadErr
 		}
 		return nil, fmt.Errorf("stat repository config %s: %w", path, err)
@@ -88,7 +89,7 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 	normalizedPath, err := normalizeTargetConfigPath(path)
 	if err != nil {
 		if errors.Is(err, errUnsafeRepositoryConfig) {
-			config, loadErr := configFromViper(target, false, false)
+			config, loadErr := configFromViper(target, false, false, request.ExpandPath)
 			return &ResolveResult{
 				Config: config,
 				Notes:  []ConfigNote{{Code: "unsafe_config_skipped", Path: path}},
@@ -106,7 +107,7 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 	store, err := LoadTrustStore(trustStorePath)
 	if err != nil {
 		if request.UntrustedPolicy == IgnoreUntrusted {
-			config, loadErr := configFromViper(target, false, false)
+			config, loadErr := configFromViper(target, false, false, request.ExpandPath)
 			return &ResolveResult{
 				Config: config,
 				Notes: []ConfigNote{
@@ -119,7 +120,7 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 	}
 	if !store.IsTrusted(path, digest) {
 		if request.UntrustedPolicy == IgnoreUntrusted {
-			config, loadErr := configFromViper(target, false, false)
+			config, loadErr := configFromViper(target, false, false, request.ExpandPath)
 			return &ResolveResult{
 				Config: config,
 				Notes:  []ConfigNote{{Code: "untrusted_config_skipped", Path: path}},
@@ -150,7 +151,7 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 	localTemplate := local.IsSet("naming.template")
 	localSanitize := local.IsSet("naming.sanitize_chars")
 	mergeRequestLocal(target, local)
-	config, err := configFromViper(target, localTemplate, localSanitize)
+	config, err := configFromViper(target, localTemplate, localSanitize, request.ExpandPath)
 	return &ResolveResult{Config: config}, err
 }
 
@@ -210,7 +211,11 @@ func mergeRequestLocal(target, local *viper.Viper) {
 	}
 }
 
-func configFromViper(target *viper.Viper, localTemplate, localSanitize bool) (*models.Config, error) {
+func configFromViper(
+	target *viper.Viper,
+	localTemplate, localSanitize bool,
+	expandPath func(string) (string, error),
+) (*models.Config, error) {
 	var config models.Config
 	if err := target.Unmarshal(&config); err != nil {
 		return nil, fmt.Errorf("unmarshal request config: %w", err)
@@ -218,7 +223,7 @@ func configFromViper(target *viper.Viper, localTemplate, localSanitize bool) (*m
 	if err := validateDaemonConfig(config.Daemon); err != nil {
 		return nil, err
 	}
-	if err := expandConfigPaths(&config); err != nil {
+	if err := expandConfigPathsWith(&config, expandPath); err != nil {
 		return nil, err
 	}
 	config.Naming.TemplateRepositoryLocal = localTemplate

--- a/internal/config/request.go
+++ b/internal/config/request.go
@@ -102,8 +102,19 @@ func ResolveWorkingDirectory(request ResolveRequest) (*ResolveResult, error) {
 		return nil, fmt.Errorf("read repository config %s: %w", path, err)
 	}
 	digest := computeSHA256(data)
-	store, err := LoadTrustStore(filepath.Join(home, trustStoreFilename))
+	trustStorePath := filepath.Join(home, trustStoreFilename)
+	store, err := LoadTrustStore(trustStorePath)
 	if err != nil {
+		if request.UntrustedPolicy == IgnoreUntrusted {
+			config, loadErr := configFromViper(target, false, false)
+			return &ResolveResult{
+				Config: config,
+				Notes: []ConfigNote{
+					{Code: "trust_store_unavailable", Path: trustStorePath},
+					{Code: "untrusted_config_skipped", Path: path},
+				},
+			}, loadErr
+		}
 		return nil, err
 	}
 	if !store.IsTrusted(path, digest) {

--- a/internal/config/request_test.go
+++ b/internal/config/request_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -72,6 +73,55 @@ func TestResolveWorkingDirectoryIgnoresUntrustedForOneRequest(t *testing.T) {
 	})
 	var required *TrustRequiredError
 	assert.ErrorAs(t, err, &required)
+}
+
+func TestResolveWorkingDirectorySkipsUnsafeLocalConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "directory",
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.Mkdir(path, 0o700))
+			},
+		},
+		{
+			name: "symlink",
+			setup: func(t *testing.T, path string) {
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation requires privileges on Windows")
+				}
+				target := filepath.Join(t.TempDir(), "target.toml")
+				require.NoError(t, os.WriteFile(target, []byte("[naming]\ntemplate = 'unsafe'\n"), 0o600))
+				require.NoError(t, os.Symlink(target, path))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home, repo := t.TempDir(), t.TempDir()
+			require.NoError(t, os.WriteFile(
+				filepath.Join(home, "config.toml"),
+				[]byte("[naming]\ntemplate = 'global/{{.Branch}}'\n"),
+				0o600,
+			))
+			path := filepath.Join(repo, ".kwt.toml")
+			test.setup(t, path)
+			canonicalRepo, err := filepath.EvalSymlinks(repo)
+			require.NoError(t, err)
+
+			result, err := ResolveWorkingDirectory(ResolveRequest{
+				Home: home, WorkingDirectory: repo, UntrustedPolicy: RequireInteraction,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "global/{{.Branch}}", result.Config.Naming.Template)
+			assert.Equal(t, []ConfigNote{{
+				Code: "unsafe_config_skipped", Path: filepath.Join(canonicalRepo, ".kwt.toml"),
+			}}, result.Notes)
+		})
+	}
 }
 
 func TestApproveWorkingDirectoryRevalidatesDigest(t *testing.T) {

--- a/internal/config/request_test.go
+++ b/internal/config/request_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requestConfigFixture(t *testing.T) (home, repo, localPath string) {
+	t.Helper()
+	home = t.TempDir()
+	repo = t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte(""),
+		0o600,
+	))
+	localPath = filepath.Join(repo, ".kwt.toml")
+	require.NoError(t, os.WriteFile(
+		localPath,
+		[]byte("[naming]\ntemplate = \"trusted/{{.Branch}}\"\n"),
+		0o600,
+	))
+	localPath, err := filepath.EvalSymlinks(localPath)
+	require.NoError(t, err)
+	return home, repo, localPath
+}
+
+func TestResolveWorkingDirectoryRequiresTrust(t *testing.T) {
+	home, repo, localPath := requestConfigFixture(t)
+
+	_, err := ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  RequireInteraction,
+	})
+
+	var required *TrustRequiredError
+	require.ErrorAs(t, err, &required)
+	assert.Equal(t, localPath, required.Path)
+	assert.Len(t, required.Digest, 64)
+	assert.Equal(t, len("[naming]\ntemplate = \"trusted/{{.Branch}}\"\n"), required.Size)
+	assert.Contains(t, required.Preview, "trusted/{{.Branch}}")
+}
+
+func TestResolveWorkingDirectoryIgnoresUntrustedForOneRequest(t *testing.T) {
+	home, repo, localPath := requestConfigFixture(t)
+
+	result, err := ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  IgnoreUntrusted,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultNamingTemplate, result.Config.Naming.Template)
+	assert.Equal(t, []ConfigNote{{
+		Code: "untrusted_config_skipped",
+		Path: localPath,
+	}}, result.Notes)
+
+	_, err = ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  RequireInteraction,
+	})
+	var required *TrustRequiredError
+	assert.ErrorAs(t, err, &required)
+}
+
+func TestApproveWorkingDirectoryRevalidatesDigest(t *testing.T) {
+	home, repo, localPath := requestConfigFixture(t)
+	_, err := ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  RequireInteraction,
+	})
+	var required *TrustRequiredError
+	require.ErrorAs(t, err, &required)
+
+	require.NoError(t, os.WriteFile(
+		localPath,
+		[]byte("[naming]\ntemplate = \"changed/{{.Branch}}\"\n"),
+		0o600,
+	))
+	err = ApproveWorkingDirectory(Approval{
+		Home: home, Path: required.Path, Digest: required.Digest,
+	})
+	assert.ErrorIs(t, err, ErrConfigChanged)
+}
+
+func TestApproveWorkingDirectoryLoadsTrustedConfig(t *testing.T) {
+	home, repo, _ := requestConfigFixture(t)
+	_, err := ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  RequireInteraction,
+	})
+	var required *TrustRequiredError
+	require.ErrorAs(t, err, &required)
+	require.NoError(t, ApproveWorkingDirectory(Approval{
+		Home: home, Path: required.Path, Digest: required.Digest,
+	}))
+
+	result, err := ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  RequireInteraction,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "trusted/{{.Branch}}", result.Config.Naming.Template)
+}
+
+func TestTrustRequirementBoundsAndSanitizesPreview(t *testing.T) {
+	home, repo, localPath := requestConfigFixture(t)
+	content := "\x1b[31m" + strings.Repeat("x", promptPreviewLimit+100)
+	require.NoError(t, os.WriteFile(localPath, []byte(content), 0o600))
+
+	_, err := ResolveWorkingDirectory(ResolveRequest{
+		Home:             home,
+		WorkingDirectory: repo,
+		UntrustedPolicy:  RequireInteraction,
+	})
+
+	var required *TrustRequiredError
+	require.True(t, errors.As(err, &required))
+	assert.True(t, required.Truncated)
+	assert.NotContains(t, required.Preview, "\x1b")
+	assert.Contains(t, required.Preview, `\x1b`)
+}

--- a/internal/config/request_test.go
+++ b/internal/config/request_test.go
@@ -75,6 +75,22 @@ func TestResolveWorkingDirectoryIgnoresUntrustedForOneRequest(t *testing.T) {
 	assert.ErrorAs(t, err, &required)
 }
 
+func TestResolveWorkingDirectoryIgnoresUnavailableTrustStore(t *testing.T) {
+	home, repo, localPath := requestConfigFixture(t)
+	require.NoError(t, os.Mkdir(filepath.Join(home, trustStoreFilename), 0o700))
+
+	result, err := ResolveWorkingDirectory(ResolveRequest{
+		Home: home, WorkingDirectory: repo, UntrustedPolicy: IgnoreUntrusted,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultNamingTemplate, result.Config.Naming.Template)
+	require.Len(t, result.Notes, 2)
+	assert.Equal(t, "trust_store_unavailable", result.Notes[0].Code)
+	assert.Equal(t, "untrusted_config_skipped", result.Notes[1].Code)
+	assert.Equal(t, localPath, result.Notes[1].Path)
+}
+
 func TestResolveWorkingDirectorySkipsUnsafeLocalConfig(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/config/trust.go
+++ b/internal/config/trust.go
@@ -227,14 +227,28 @@ func (p *stdioPrompter) PromptTrust(absPath string, content []byte) (bool, error
 		truncated = true
 	}
 
+	return p.PromptTrustPreview(
+		absPath,
+		len(content),
+		sanitizeForTerminal(string(preview)),
+		truncated,
+	)
+}
+
+func (p *stdioPrompter) PromptTrustPreview(
+	absPath string,
+	size int,
+	preview string,
+	truncated bool,
+) (bool, error) {
 	var b strings.Builder
 	b.WriteString("\nkwt: untrusted local config detected:\n")
 	fmt.Fprintf(&b, "  path: %s\n", sanitizeForTerminal(absPath))
-	fmt.Fprintf(&b, "  size: %d bytes\n\n", len(content))
+	fmt.Fprintf(&b, "  size: %d bytes\n\n", size)
 	b.WriteString("--- file contents ---\n")
-	b.WriteString(strings.TrimRight(sanitizeForTerminal(string(preview)), "\n"))
+	b.WriteString(strings.TrimRight(preview, "\n"))
 	if truncated {
-		fmt.Fprintf(&b, "\n... (truncated, showing first %d of %d bytes)", promptPreviewLimit, len(content))
+		fmt.Fprintf(&b, "\n... (truncated, showing first %d of %d bytes)", promptPreviewLimit, size)
 	}
 	b.WriteString("\n--------------------\n\n")
 	b.WriteString("Trust this file and load it? [y/N]: ")
@@ -248,6 +262,17 @@ func (p *stdioPrompter) PromptTrust(absPath string, content []byte) (bool, error
 	}
 	response = strings.ToLower(strings.TrimSpace(response))
 	return response == "y" || response == "yes", nil
+}
+
+// PromptTrustRequirement renders a daemon-provided, already bounded and
+// sanitized trust requirement using the ordinary foreground prompt.
+func PromptTrustRequirement(requirement TrustRequiredError) (bool, error) {
+	return newStdioPrompter().PromptTrustPreview(
+		requirement.Path,
+		requirement.Size,
+		requirement.Preview,
+		requirement.Truncated,
+	)
 }
 
 // sanitizeForTerminal replaces terminal control characters with a visible

--- a/internal/config/trust.go
+++ b/internal/config/trust.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
 	"golang.org/x/term"
 )
 
@@ -89,12 +90,38 @@ func (s *TrustStore) IsTrusted(absPath, sha256 string) bool {
 	return false
 }
 
-// Add registers (absPath, sha256) as trusted and persists to disk with atomic rename.
+// Add registers (absPath, sha256) as trusted and persists to disk with a
+// lock-scoped reload and atomic rename.
 // Refuses to write if the trust store path is a symlink (anti-tampering).
 // If s.path is empty, the store is in-memory only and Add just updates entries.
 func (s *TrustStore) Add(absPath, sha256 string) error {
+	if s.path == "" {
+		s.add(absPath, sha256, time.Now().UTC())
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("create trust store dir: %w", err)
+	}
+	lock := flock.New(s.path+".lock", flock.SetPermissions(0o600))
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("lock trust store: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	current, err := LoadTrustStore(s.path)
+	if err != nil {
+		return err
+	}
+	current.add(absPath, sha256, time.Now().UTC())
+	if err := current.save(); err != nil {
+		return err
+	}
+	s.entries = current.entries
+	return nil
+}
+
+func (s *TrustStore) add(absPath, sha256 string, now time.Time) {
 	// Update or insert entry (dedupe by path; sha256 may differ).
-	now := time.Now().UTC()
 	replaced := false
 	for i := range s.entries {
 		if s.entries[i].Path == absPath {
@@ -111,11 +138,6 @@ func (s *TrustStore) Add(absPath, sha256 string) error {
 			TrustedAt: now,
 		})
 	}
-
-	if s.path == "" {
-		return nil
-	}
-	return s.save()
 }
 
 // save serializes entries and writes them atomically.

--- a/internal/config/trust_test.go
+++ b/internal/config/trust_test.go
@@ -207,6 +207,36 @@ func TestTrustStore_Add_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestTrustStore_Add_MergesStaleLoadedSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trusted_configs.json")
+	first, err := LoadTrustStore(path)
+	if err != nil {
+		t.Fatalf("load first store: %v", err)
+	}
+	second, err := LoadTrustStore(path)
+	if err != nil {
+		t.Fatalf("load second store: %v", err)
+	}
+
+	if err := first.Add("/abs/first", "sha-first"); err != nil {
+		t.Fatalf("add first trust: %v", err)
+	}
+	if err := second.Add("/abs/second", "sha-second"); err != nil {
+		t.Fatalf("add second trust: %v", err)
+	}
+
+	reloaded, err := LoadTrustStore(path)
+	if err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+	if !reloaded.IsTrusted("/abs/first", "sha-first") {
+		t.Error("first approval was lost by the stale writer")
+	}
+	if !reloaded.IsTrusted("/abs/second", "sha-second") {
+		t.Error("second approval was not persisted")
+	}
+}
+
 func TestTrustStore_Add_DedupeUpdatesHash(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "trusted_configs.json")
 	s, _ := LoadTrustStore(path)

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -49,7 +49,7 @@ func NewVerifiedClient(
 		token:    token,
 		http: ep.HTTPClient(kitdaemon.HTTPClientOptions{
 			Timeout:               30 * time.Second,
-			ResponseHeaderTimeout: 2 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
 		}),
 	}, nil
 }

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -25,10 +25,11 @@ type Client struct {
 var ErrResponseTooLarge = errors.New("kwt daemon response is too large")
 
 const (
-	controlRequestTimeout         = 2 * time.Second
-	inventoryRequestTimeout       = 30 * time.Second
-	controlResponseLimit    int64 = 1 << 20
-	inventoryResponseLimit        = 64 << 20
+	controlRequestTimeout           = 2 * time.Second
+	inventoryResponseHeadroom       = 5 * time.Second
+	inventoryRequestTimeout         = publicworktree.DefaultRefreshTimeout + inventoryResponseHeadroom
+	controlResponseLimit      int64 = 1 << 20
+	inventoryResponseLimit          = 64 << 20
 )
 
 func NewVerifiedClient(

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -12,6 +12,7 @@ import (
 
 	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 type Client struct {
@@ -47,10 +48,20 @@ func NewVerifiedClient(
 		endpoint: ep,
 		token:    token,
 		http: ep.HTTPClient(kitdaemon.HTTPClientOptions{
-			Timeout:               5 * time.Second,
+			Timeout:               30 * time.Second,
 			ResponseHeaderTimeout: 2 * time.Second,
 		}),
 	}, nil
+}
+
+func (c *Client) Inventory(ctx context.Context, request publicworktree.Request) (publicworktree.Result, error) {
+	var result publicworktree.Result
+	err := c.do(ctx, http.MethodPost, "/api/v1/inventory", request, &result)
+	return result, err
+}
+
+func (c *Client) ApproveConfig(ctx context.Context, approval publicworktree.ConfigApproval) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/config/trust", approval, nil)
 }
 
 func newClient(ep kitdaemon.Endpoint, token string, client *http.Client) *Client {
@@ -157,9 +168,12 @@ func decodeProblem(status int, body io.Reader) error {
 			nil,
 		)
 	}
-	var details map[string]any
+	details := problem.Details
 	if problem.DrainDeadline != nil {
-		details = map[string]any{"drain_deadline": *problem.DrainDeadline}
+		if details == nil {
+			details = make(map[string]any)
+		}
+		details["drain_deadline"] = *problem.DrainDeadline
 	}
 	message := problem.Detail
 	if message == "" {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -16,10 +16,20 @@ import (
 )
 
 type Client struct {
-	endpoint kitdaemon.Endpoint
-	token    string
-	http     *http.Client
+	endpoint      kitdaemon.Endpoint
+	token         string
+	controlHTTP   *http.Client
+	inventoryHTTP *http.Client
 }
+
+var ErrResponseTooLarge = errors.New("kwt daemon response is too large")
+
+const (
+	controlRequestTimeout         = 2 * time.Second
+	inventoryRequestTimeout       = 30 * time.Second
+	controlResponseLimit    int64 = 1 << 20
+	inventoryResponseLimit        = 64 << 20
+)
 
 func NewVerifiedClient(
 	ctx context.Context,
@@ -47,16 +57,28 @@ func NewVerifiedClient(
 	return &Client{
 		endpoint: ep,
 		token:    token,
-		http: ep.HTTPClient(kitdaemon.HTTPClientOptions{
-			Timeout:               30 * time.Second,
-			ResponseHeaderTimeout: 30 * time.Second,
+		controlHTTP: ep.HTTPClient(kitdaemon.HTTPClientOptions{
+			Timeout:               controlRequestTimeout,
+			ResponseHeaderTimeout: controlRequestTimeout,
+		}),
+		inventoryHTTP: ep.HTTPClient(kitdaemon.HTTPClientOptions{
+			Timeout:               inventoryRequestTimeout,
+			ResponseHeaderTimeout: inventoryRequestTimeout,
 		}),
 	}, nil
 }
 
 func (c *Client) Inventory(ctx context.Context, request publicworktree.Request) (publicworktree.Result, error) {
 	var result publicworktree.Result
-	err := c.do(ctx, http.MethodPost, "/api/v1/inventory", request, &result)
+	err := c.doWith(
+		ctx,
+		c.inventoryHTTP,
+		inventoryResponseLimit,
+		http.MethodPost,
+		"/api/v1/inventory",
+		request,
+		&result,
+	)
 	return result, err
 }
 
@@ -65,7 +87,9 @@ func (c *Client) ApproveConfig(ctx context.Context, approval publicworktree.Conf
 }
 
 func newClient(ep kitdaemon.Endpoint, token string, client *http.Client) *Client {
-	return &Client{endpoint: ep, token: token, http: client}
+	return &Client{
+		endpoint: ep, token: token, controlHTTP: client, inventoryHTTP: client,
+	}
 }
 
 func (c *Client) Status(ctx context.Context) (Status, error) {
@@ -96,6 +120,26 @@ func (c *Client) do(
 	input any,
 	output any,
 ) error {
+	return c.doWith(
+		ctx,
+		c.controlHTTP,
+		controlResponseLimit,
+		method,
+		path,
+		input,
+		output,
+	)
+}
+
+func (c *Client) doWith(
+	ctx context.Context,
+	client *http.Client,
+	responseLimit int64,
+	method string,
+	path string,
+	input any,
+	output any,
+) error {
 	var body io.Reader
 	if input != nil {
 		encoded, err := json.Marshal(input)
@@ -117,7 +161,7 @@ func (c *Client) do(
 	if input != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.http.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return service.NewError(
 			service.TransportFailure,
@@ -128,14 +172,27 @@ func (c *Client) do(
 		)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	limited := io.LimitReader(resp.Body, 1<<20)
+	encoded, err := readResponse(resp.Body, responseLimit, path)
+	if err != nil {
+		message := "read kwt daemon response"
+		if errors.Is(err, ErrResponseTooLarge) {
+			message = err.Error()
+		}
+		return service.NewError(
+			service.TransportFailure,
+			message,
+			true,
+			nil,
+			err,
+		)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return decodeProblem(resp.StatusCode, limited)
+		return decodeProblem(resp.StatusCode, bytes.NewReader(encoded))
 	}
 	if output == nil {
 		return nil
 	}
-	if err := json.NewDecoder(limited).Decode(output); err != nil {
+	if err := json.Unmarshal(encoded, output); err != nil {
 		return service.NewError(
 			service.TransportFailure,
 			"decode kwt daemon response",
@@ -145,6 +202,22 @@ func (c *Client) do(
 		)
 	}
 	return nil
+}
+
+func readResponse(body io.Reader, limit int64, path string) ([]byte, error) {
+	encoded, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(encoded)) > limit {
+		return nil, fmt.Errorf(
+			"%w: %s exceeds %d bytes",
+			ErrResponseTooLarge,
+			path,
+			limit,
+		)
+	}
+	return encoded, nil
 }
 
 func decodeProblem(status int, body io.Reader) error {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -69,8 +69,13 @@ func NewVerifiedClient(
 }
 
 func (c *Client) Inventory(ctx context.Context, request publicworktree.Request) (publicworktree.Result, error) {
+	expansion, err := publicworktree.CaptureExpansionContext()
+	if err != nil {
+		return publicworktree.Result{}, err
+	}
+	request.Expansion = expansion
 	var result publicworktree.Result
-	err := c.doWith(
+	err = c.doWith(
 		ctx,
 		c.inventoryHTTP,
 		inventoryResponseLimit,

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 func runtimeRecordForServer(
@@ -116,4 +117,29 @@ func TestVerifiedClientUsesBearerAfterSuccessfulProof(t *testing.T) {
 	status, err := client.Status(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, APISchemaMajor, status.SchemaMajor)
+}
+
+func TestVerifiedClientAllowsInventoryDiscoveryBeforeHeaders(t *testing.T) {
+	token := "test-secret"
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	rec := runtimeRecordForServer(t, server, token)
+	proof, err := kitdaemon.NewProof([]byte(token))
+	require.NoError(t, err)
+	ping, err := proof.NewPingHandler(rec)
+	require.NoError(t, err)
+	mux.Handle("/api/ping", ping)
+	mux.HandleFunc("/api/v1/inventory", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2100 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{"freshness": "fresh"})
+	})
+
+	client, err := NewVerifiedClient(context.Background(), rec, token)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = client.Inventory(ctx, publicworktree.Request{View: publicworktree.ViewDashboard})
+
+	require.NoError(t, err)
 }

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -142,4 +143,72 @@ func TestVerifiedClientAllowsInventoryDiscoveryBeforeHeaders(t *testing.T) {
 	_, err = client.Inventory(ctx, publicworktree.Request{View: publicworktree.ViewDashboard})
 
 	require.NoError(t, err)
+}
+
+func TestVerifiedClientBoundsControlPlaneResponseWait(t *testing.T) {
+	token := "test-secret"
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	rec := runtimeRecordForServer(t, server, token)
+	proof, err := kitdaemon.NewProof([]byte(token))
+	require.NoError(t, err)
+	ping, err := proof.NewPingHandler(rec)
+	require.NoError(t, err)
+	mux.Handle("/api/ping", ping)
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2500 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(Status{State: StateReady})
+	})
+
+	client, err := NewVerifiedClient(context.Background(), rec, token)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	_, err = client.Status(ctx)
+
+	require.Error(t, err)
+	var typed *service.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, service.TransportFailure, typed.Code)
+}
+
+func TestClientAllowsInventoryResponseLargerThanControlPlaneLimit(t *testing.T) {
+	largePath := strings.Repeat("x", 2<<20)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(publicworktree.Result{
+			Notes: []publicworktree.Note{{Code: "large", Path: largePath}},
+		}))
+	}))
+	defer server.Close()
+
+	client := clientForUnverifiedServer(t, server, "secret")
+	result, err := client.Inventory(context.Background(), publicworktree.Request{
+		View: publicworktree.ViewDashboard,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Notes, 1)
+	assert.Equal(t, largePath, result.Notes[0].Path)
+}
+
+func TestClientReportsEndpointSpecificResponseLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("response exceeds limit"))
+	}))
+	defer server.Close()
+	client := clientForUnverifiedServer(t, server, "secret")
+
+	err := client.doWith(
+		context.Background(),
+		client.inventoryHTTP,
+		8,
+		http.MethodGet,
+		"/api/v1/inventory",
+		nil,
+		nil,
+	)
+
+	require.ErrorIs(t, err, ErrResponseTooLarge)
+	assert.ErrorContains(t, err, "/api/v1/inventory exceeds 8 bytes")
 }

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -145,6 +145,10 @@ func TestVerifiedClientAllowsInventoryDiscoveryBeforeHeaders(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestInventoryTransportOutlivesServerRefresh(t *testing.T) {
+	assert.Greater(t, inventoryRequestTimeout, publicworktree.DefaultRefreshTimeout)
+}
+
 func TestVerifiedClientBoundsControlPlaneResponseWait(t *testing.T) {
 	token := "test-secret"
 	mux := http.NewServeMux()

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -174,9 +174,10 @@ func runHost(
 			serviceCache = cache
 		}
 		inventory = publicworktree.NewInventoryService(publicworktree.ServiceOptions{
-			Source: publicworktree.NewSource(publicworktree.SourceOptions{Home: opts.Home}),
-			Cache:  serviceCache,
-			Now:    opts.Now,
+			Source:  publicworktree.NewSource(publicworktree.SourceOptions{Home: opts.Home}),
+			Cache:   serviceCache,
+			Now:     opts.Now,
+			Context: ctx,
 		})
 	}
 	status := &hostStatus{

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -164,14 +164,18 @@ func runHost(
 	var cacheDiagnostic *publicworktree.Diagnostic
 	if inventory == nil {
 		cache, diagnostic, cacheErr := publicworktree.NewFileCache(opts.Home)
+		var serviceCache publicworktree.Cache
 		if cacheErr != nil {
-			_ = listener.Close()
-			return cacheErr
+			cacheDiagnostic = &publicworktree.Diagnostic{
+				At: opts.Now(), Message: boundedError(cacheErr),
+			}
+		} else {
+			cacheDiagnostic = diagnostic
+			serviceCache = cache
 		}
-		cacheDiagnostic = diagnostic
 		inventory = publicworktree.NewInventoryService(publicworktree.ServiceOptions{
 			Source: publicworktree.NewSource(publicworktree.SourceOptions{Home: opts.Home}),
-			Cache:  cache,
+			Cache:  serviceCache,
 			Now:    opts.Now,
 		})
 	}

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -15,6 +15,7 @@ import (
 	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kwt/pkg/models"
 	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 const (
@@ -33,6 +34,7 @@ type ServeOptions struct {
 	IdleCheckInterval time.Duration
 	Stdout            io.Writer
 	Stderr            io.Writer
+	Inventory         publicworktree.Inventory
 }
 
 type hostStatus struct {
@@ -158,6 +160,21 @@ func runHost(
 
 	startedAt := opts.Now()
 	gate := NewGate(startedAt)
+	inventory := opts.Inventory
+	var cacheDiagnostic *publicworktree.Diagnostic
+	if inventory == nil {
+		cache, diagnostic, cacheErr := publicworktree.NewFileCache(opts.Home)
+		if cacheErr != nil {
+			_ = listener.Close()
+			return cacheErr
+		}
+		cacheDiagnostic = diagnostic
+		inventory = publicworktree.NewInventoryService(publicworktree.ServiceOptions{
+			Source: publicworktree.NewSource(publicworktree.SourceOptions{Home: opts.Home}),
+			Cache:  cache,
+			Now:    opts.Now,
+		})
+	}
 	status := &hostStatus{
 		base: Status{
 			Service:       ServiceName,
@@ -172,10 +189,14 @@ func runHost(
 			Capabilities: []string{
 				CapabilityShutdown,
 				CapabilityStatus,
+				CapabilityInventory,
 			},
 			StartedAt: startedAt,
 		},
 		gate: gate,
+	}
+	if cacheDiagnostic != nil {
+		status.lastError = &Failure{At: cacheDiagnostic.At, Message: cacheDiagnostic.Message}
 	}
 	shutdownRequested := make(chan string, 1)
 	shutdown := func(_ context.Context, request ShutdownRequest) (Status, error) {
@@ -195,6 +216,8 @@ func runHost(
 		Ping:         ping,
 		Touch:        gate.Touch,
 		Now:          opts.Now,
+		Inventory:    inventory,
+		Gate:         gate,
 	})
 	httpServer := newHTTPServer(handler)
 	serverDone := make(chan error, 1)

--- a/internal/daemon/host_test.go
+++ b/internal/daemon/host_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 func TestHTTPServerBoundsUnauthenticatedRequests(t *testing.T) {
@@ -168,6 +170,51 @@ func TestServePublishesReadyRuntimeAndRemovesItOnShutdown(t *testing.T) {
 	require.NoError(t, <-done)
 	assert.Empty(t, runtimeFiles(t, home))
 	cancel()
+}
+
+func TestServeContinuesWithoutDisposableInventoryCache(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(home, "cache"), []byte("blocked"), 0o600))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeOptions{
+			Home:  home,
+			Build: Build{Version: "v1.0.0", Revision: "abc"},
+			Config: models.DaemonConfig{
+				IdleTimeout:      time.Hour,
+				AutoRestart:      "newer",
+				ReplacementGrace: time.Second,
+			},
+			Foreground: true,
+		})
+	}()
+	select {
+	case err := <-done:
+		require.FailNow(t, "daemon stopped for a disposable cache failure", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	observation := waitForRuntime(t, home)
+	result, err := observation.Client.Inventory(context.Background(), publicworktree.Request{
+		View: publicworktree.ViewProjects, UntrustedConfig: publicworktree.IgnoreUntrustedConfig,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, publicworktree.Fresh, result.Freshness)
+	result, err = observation.Client.Inventory(context.Background(), publicworktree.Request{
+		View: publicworktree.ViewDashboard, UntrustedConfig: publicworktree.IgnoreUntrustedConfig,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, publicworktree.Fresh, result.Freshness)
+	status, err := observation.Client.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status.LastError)
+	assert.Contains(t, status.LastError.Message, "inventory cache")
+
+	_, err = observation.Client.Shutdown(context.Background(), "stop")
+	require.NoError(t, err)
+	require.NoError(t, <-done)
 }
 
 func TestServeRefusesASecondWritableOwner(t *testing.T) {

--- a/internal/daemon/inventory_test.go
+++ b/internal/daemon/inventory_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"context"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +14,46 @@ import (
 	"go.kenn.io/kwt/service"
 	publicworktree "go.kenn.io/kwt/worktree"
 )
+
+func TestInventoryClientPreservesActionableSourceFailure(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[[projects]\n"),
+		0o600,
+	))
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	server := httptest.NewUnstartedServer(nil)
+	server.Config.Handler = NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: server.Listener.Addr().String(), Status: provider,
+		Shutdown: func(context.Context, ShutdownRequest) (Status, error) {
+			return provider.status, nil
+		},
+		Inventory: publicworktree.NewInventoryService(publicworktree.ServiceOptions{
+			Source: publicworktree.NewSource(publicworktree.SourceOptions{Home: home}),
+		}),
+		Gate: NewGate(time.Now()),
+	})
+	server.Start()
+	defer server.Close()
+	endpoint, err := kitdaemon.ParseEndpoint(
+		server.URL[len("http://"):],
+		kitdaemon.ParseEndpointOptions{TCPPolicy: kitdaemon.RequireLoopback},
+	)
+	require.NoError(t, err)
+	client := newClient(endpoint, "secret", server.Client())
+	expansion, err := publicworktree.CaptureExpansionContext()
+	require.NoError(t, err)
+
+	_, err = client.Inventory(context.Background(), publicworktree.Request{
+		View: publicworktree.ViewProjects, Expansion: expansion,
+		UntrustedConfig: publicworktree.IgnoreUntrustedConfig,
+	})
+
+	typed := service.AsError(err)
+	assert.NotEqual(t, "internal failure", typed.Message)
+	assert.Contains(t, typed.Message, "config")
+}
 
 type fakeInventory struct {
 	result   publicworktree.Result

--- a/internal/daemon/inventory_test.go
+++ b/internal/daemon/inventory_test.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
+	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
+)
+
+type fakeInventory struct {
+	result   publicworktree.Result
+	err      error
+	requests []publicworktree.Request
+}
+
+func (f *fakeInventory) Query(_ context.Context, request publicworktree.Request) (publicworktree.Result, error) {
+	f.requests = append(f.requests, request)
+	return f.result, f.err
+}
+
+func (*fakeInventory) ApproveConfig(context.Context, publicworktree.ConfigApproval) error { return nil }
+
+func TestInventoryClientRoundTripsResult(t *testing.T) {
+	inventory := &fakeInventory{result: publicworktree.Result{Freshness: publicworktree.Fresh}}
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	server := httptest.NewUnstartedServer(nil)
+	server.Config.Handler = NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: server.Listener.Addr().String(), Status: provider,
+		Shutdown:  func(context.Context, ShutdownRequest) (Status, error) { return provider.status, nil },
+		Inventory: inventory, Gate: NewGate(time.Now()),
+	})
+	server.Start()
+	defer server.Close()
+	endpoint, err := kitdaemon.ParseEndpoint(server.URL[len("http://"):], kitdaemon.ParseEndpointOptions{TCPPolicy: kitdaemon.RequireLoopback})
+	require.NoError(t, err)
+	client := newClient(endpoint, "secret", server.Client())
+
+	result, err := client.Inventory(context.Background(), publicworktree.Request{View: publicworktree.ViewProjects})
+	require.NoError(t, err)
+	assert.Equal(t, publicworktree.Fresh, result.Freshness)
+	require.Len(t, inventory.requests, 1)
+}
+
+func TestInventoryClientPreservesTrustDetails(t *testing.T) {
+	inventory := &fakeInventory{err: service.NewError(
+		service.InteractionRequired, "trust required", false,
+		map[string]any{"kind": "repository_config_trust", "path": "/repo/.kwt.toml", "digest": "abc"}, nil,
+	)}
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	server := httptest.NewUnstartedServer(nil)
+	server.Config.Handler = NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: server.Listener.Addr().String(), Status: provider,
+		Shutdown:  func(context.Context, ShutdownRequest) (Status, error) { return provider.status, nil },
+		Inventory: inventory, Gate: NewGate(time.Now()),
+	})
+	server.Start()
+	defer server.Close()
+	endpoint, err := kitdaemon.ParseEndpoint(server.URL[len("http://"):], kitdaemon.ParseEndpointOptions{TCPPolicy: kitdaemon.RequireLoopback})
+	require.NoError(t, err)
+	client := newClient(endpoint, "secret", server.Client())
+
+	_, err = client.Inventory(context.Background(), publicworktree.Request{View: publicworktree.ViewProjects})
+	typed := service.AsError(err)
+	assert.Equal(t, service.InteractionRequired, typed.Code)
+	assert.Equal(t, "/repo/.kwt.toml", typed.Details["path"])
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -87,6 +87,7 @@ func NewRuntimeRecord(
 		metadataCapabilities: strings.Join([]string{
 			CapabilityShutdown,
 			CapabilityStatus,
+			CapabilityInventory,
 		}, ","),
 		metadataToken: token,
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"go.kenn.io/kwt/service"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 type StatusProvider interface {
@@ -28,12 +29,22 @@ type ServerOptions struct {
 	Touch        func(time.Time)
 	Now          func() time.Time
 	MaxBodyBytes int64
+	Inventory    publicworktree.Inventory
+	Gate         *Gate
 }
 
 type emptyInput struct{}
 type statusOutput struct{ Body Status }
 type shutdownInput struct{ Body ShutdownRequest }
 type shutdownOutput struct{ Body ShutdownResponse }
+type inventoryInput struct{ Body publicworktree.Request }
+type inventoryOutput struct{ Body publicworktree.Result }
+type configApprovalInput struct{ Body publicworktree.ConfigApproval }
+type configApprovalOutput struct {
+	Body struct {
+		Status string `json:"status"`
+	}
+}
 
 func NewServer(opts ServerOptions) http.Handler {
 	if opts.Now == nil {
@@ -58,6 +69,41 @@ func NewServer(opts ServerOptions) http.Handler {
 			return &statusOutput{Body: opts.Status.Status(opts.Now())}, nil
 		},
 	)
+	if opts.Inventory != nil {
+		huma.Register(
+			api,
+			huma.Operation{Method: http.MethodPost, Path: "/api/v1/inventory", OperationID: "worktree-inventory"},
+			func(ctx context.Context, input *inventoryInput) (*inventoryOutput, error) {
+				release, err := reserveInventoryWork(opts)
+				if err != nil {
+					return nil, problemFromError(err)
+				}
+				defer release()
+				result, err := opts.Inventory.Query(ctx, input.Body)
+				if err != nil {
+					return nil, problemFromError(err)
+				}
+				return &inventoryOutput{Body: result}, nil
+			},
+		)
+		huma.Register(
+			api,
+			huma.Operation{Method: http.MethodPost, Path: "/api/v1/config/trust", OperationID: "repository-config-trust"},
+			func(ctx context.Context, input *configApprovalInput) (*configApprovalOutput, error) {
+				release, err := reserveInventoryWork(opts)
+				if err != nil {
+					return nil, problemFromError(err)
+				}
+				defer release()
+				if err := opts.Inventory.ApproveConfig(ctx, input.Body); err != nil {
+					return nil, problemFromError(err)
+				}
+				output := &configApprovalOutput{}
+				output.Body.Status = "approved"
+				return output, nil
+			},
+		)
+	}
 	huma.Register(
 		api,
 		huma.Operation{
@@ -77,6 +123,13 @@ func NewServer(opts ServerOptions) http.Handler {
 		mux.Handle("/api/ping", opts.Ping)
 	}
 	return secureLocalHandler(mux, opts)
+}
+
+func reserveInventoryWork(opts ServerOptions) (func(), error) {
+	if opts.Gate == nil {
+		return func() {}, nil
+	}
+	return opts.Gate.Reserve(ReservationWork, opts.Now())
 }
 
 func secureLocalHandler(next http.Handler, opts ServerOptions) http.Handler {
@@ -213,6 +266,7 @@ func problemFromError(err error) *Problem {
 		Detail:    typed.Message,
 		Code:      string(typed.Code),
 		Retryable: typed.Retryable,
+		Details:   allowedProblemDetails(typed.Details),
 	}
 	if deadline, ok := typed.Details["drain_deadline"].(time.Time); ok {
 		problem.DrainDeadline = &deadline
@@ -221,6 +275,26 @@ func problemFromError(err error) *Problem {
 		problem.DrainDeadline = deadline
 	}
 	return problem
+}
+
+func allowedProblemDetails(details map[string]any) map[string]any {
+	if len(details) == 0 {
+		return nil
+	}
+	allowed := map[string]bool{
+		"kind": true, "path": true, "digest": true, "size": true,
+		"preview": true, "truncated": true, "drain_deadline": true,
+	}
+	result := make(map[string]any)
+	for key, value := range details {
+		if allowed[key] {
+			result[key] = value
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func init() {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -46,12 +46,14 @@ type configApprovalOutput struct {
 	}
 }
 
+const defaultMaxBodyBytes = 1 << 20
+
 func NewServer(opts ServerOptions) http.Handler {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
 	if opts.MaxBodyBytes <= 0 {
-		opts.MaxBodyBytes = 64 << 10
+		opts.MaxBodyBytes = defaultMaxBodyBytes
 	}
 	mux := http.NewServeMux()
 	config := huma.DefaultConfig("kwt daemon API", APISchemaVersion)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	publicworktree "go.kenn.io/kwt/worktree"
 )
 
 type testStatusProvider struct{ status Status }
@@ -92,6 +93,40 @@ func TestServerRejectsBrowserOriginAndOversizedBodies(t *testing.T) {
 	var problem Problem
 	require.NoError(t, json.NewDecoder(response.Body).Decode(&problem))
 	assert.Equal(t, "invalid_request", problem.Code)
+}
+
+func TestServerDefaultBodyLimitAccommodatesClientExpansionContext(t *testing.T) {
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	handler := NewServer(ServerOptions{
+		Token:        "secret",
+		ExpectedHost: "127.0.0.1:43210",
+		Status:       provider,
+		Inventory:    &fakeInventory{},
+		Gate:         NewGate(time.Now()),
+	})
+	body, err := json.Marshal(publicworktree.Request{
+		View: publicworktree.ViewProjects,
+		Expansion: publicworktree.ExpansionContext{
+			WorkingDirectory: "/workspace",
+			HomeDirectory:    "/home/user",
+			Environment:      map[string]string{"LARGE_PATH_CONTEXT": strings.Repeat("x", 100<<10)},
+		},
+		UntrustedConfig: publicworktree.IgnoreUntrustedConfig,
+	})
+	require.NoError(t, err)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"http://127.0.0.1:43210/api/v1/inventory",
+		strings.NewReader(string(body)),
+	)
+	request.Host = "127.0.0.1:43210"
+	request.Header.Set("Authorization", "Bearer secret")
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
 }
 
 func TestServerPublishesOpenAPIWithoutAuthentication(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -3,11 +3,12 @@ package daemon
 import "time"
 
 const (
-	ServiceName        = "kwt"
-	APISchemaMajor     = 1
-	APISchemaVersion   = "1.0.0"
-	CapabilityStatus   = "daemon.status"
-	CapabilityShutdown = "daemon.shutdown"
+	ServiceName         = "kwt"
+	APISchemaMajor      = 1
+	APISchemaVersion    = "1.1.0"
+	CapabilityStatus    = "daemon.status"
+	CapabilityShutdown  = "daemon.shutdown"
+	CapabilityInventory = "worktree.inventory.v1"
 )
 
 type State string
@@ -52,11 +53,12 @@ type ShutdownResponse struct {
 }
 
 type Problem struct {
-	Type          string     `json:"type"`
-	Title         string     `json:"title"`
-	Status        int        `json:"status"`
-	Detail        string     `json:"detail"`
-	Code          string     `json:"code"`
-	Retryable     bool       `json:"retryable"`
-	DrainDeadline *time.Time `json:"drain_deadline,omitempty"`
+	Type          string         `json:"type"`
+	Title         string         `json:"title"`
+	Status        int            `json:"status"`
+	Detail        string         `json:"detail"`
+	Code          string         `json:"code"`
+	Retryable     bool           `json:"retryable"`
+	DrainDeadline *time.Time     `json:"drain_deadline,omitempty"`
+	Details       map[string]any `json:"details,omitempty"`
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -2,6 +2,7 @@
 package discovery
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -47,32 +48,47 @@ var (
 // identity wins over a fork origin; see worktree.RepositoryInfoWithProjects);
 // pass nil when no registry is available.
 func DiscoverGlobalWorktrees(baseDir string, projects []models.Project) ([]*GlobalWorktreeEntry, error) {
-	candidates, err := findGlobalWorktreeCandidates(baseDir, false)
+	return DiscoverGlobalWorktreesContext(context.Background(), baseDir, projects)
+}
+
+// DiscoverGlobalWorktreesContext finds all worktrees while allowing callers
+// to stop filesystem traversal, lock waits, and Git subprocesses.
+func DiscoverGlobalWorktreesContext(
+	ctx context.Context,
+	baseDir string,
+	projects []models.Project,
+) ([]*GlobalWorktreeEntry, error) {
+	candidates, err := findGlobalWorktreeCandidates(ctx, baseDir, false)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshots, err := snapshotCandidateWorktrees(candidates)
+	snapshots, err := snapshotCandidateWorktrees(ctx, candidates)
 	if err != nil {
 		return nil, err
 	}
 	return extractWorktreeCandidates(
+		ctx,
 		candidates,
 		projects,
-		func(path string, projects []models.Project) (*GlobalWorktreeEntry, error) {
+		func(
+			ctx context.Context,
+			path string,
+			projects []models.Project,
+		) (*GlobalWorktreeEntry, error) {
 			snapshot, ok := snapshots[utils.PathKey(path)]
 			if !ok {
 				return nil, fmt.Errorf("worktree disappeared during discovery")
 			}
-			return extractWorktreeInfoFromSnapshot(path, projects, snapshot)
+			return extractWorktreeInfoFromSnapshot(ctx, path, projects, snapshot)
 		},
-	), nil
+	)
 }
 
 // FindGlobalWorktreePaths returns filesystem worktree candidates without
 // snapshotting repositories or initializing durable generations.
 func FindGlobalWorktreePaths(baseDir string) ([]string, error) {
-	candidates, err := findGlobalWorktreeCandidates(baseDir, false)
+	candidates, err := findGlobalWorktreeCandidates(context.Background(), baseDir, false)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +102,7 @@ func FindGlobalWorktreePaths(baseDir string) ([]string, error) {
 // FindGlobalWorktreePathsStrict returns filesystem worktree candidates only
 // when the complete configured tree can be traversed and inspected.
 func FindGlobalWorktreePathsStrict(baseDir string) ([]string, error) {
-	candidates, err := findGlobalWorktreeCandidates(baseDir, true)
+	candidates, err := findGlobalWorktreeCandidates(context.Background(), baseDir, true)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +113,14 @@ func FindGlobalWorktreePathsStrict(baseDir string) ([]string, error) {
 	return paths, nil
 }
 
-func findGlobalWorktreeCandidates(baseDir string, strict bool) ([]worktreeCandidate, error) {
+func findGlobalWorktreeCandidates(
+	ctx context.Context,
+	baseDir string,
+	strict bool,
+) ([]worktreeCandidate, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if baseDir == "" {
 		return nil, fmt.Errorf("base directory not configured")
 	}
@@ -135,6 +158,9 @@ func findGlobalWorktreeCandidates(baseDir string, strict bool) ([]worktreeCandid
 	var candidates []worktreeCandidate
 
 	err = walkGlobalWorktreePaths(baseDir, func(path string, info os.FileInfo, err error) error {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return contextErr
+		}
 		if err != nil {
 			if strict {
 				return err
@@ -244,12 +270,16 @@ func DiscoverWorktree(path string, projects []models.Project) (*GlobalWorktreeEn
 }
 
 func extractWorktreeCandidates(
+	ctx context.Context,
 	candidates []worktreeCandidate,
 	projects []models.Project,
-	extract func(string, []models.Project) (*GlobalWorktreeEntry, error),
-) []*GlobalWorktreeEntry {
+	extract func(context.Context, string, []models.Project) (*GlobalWorktreeEntry, error),
+) ([]*GlobalWorktreeEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(candidates) == 0 {
-		return []*GlobalWorktreeEntry{}
+		return []*GlobalWorktreeEntry{}, nil
 	}
 
 	const maxWorkers = 16
@@ -262,7 +292,10 @@ func extractWorktreeCandidates(
 		go func() {
 			defer workers.Done()
 			for index := range jobs {
-				entry, err := extract(candidates[index].path, projects)
+				if ctx.Err() != nil {
+					return
+				}
+				entry, err := extract(ctx, candidates[index].path, projects)
 				if err != nil {
 					continue
 				}
@@ -271,11 +304,19 @@ func extractWorktreeCandidates(
 			}
 		}()
 	}
+sendCandidates:
 	for index := range candidates {
-		jobs <- index
+		select {
+		case <-ctx.Done():
+			break sendCandidates
+		case jobs <- index:
+		}
 	}
 	close(jobs)
 	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	entries := make([]*GlobalWorktreeEntry, 0, len(results))
 	for _, entry := range results {
@@ -283,19 +324,26 @@ func extractWorktreeCandidates(
 			entries = append(entries, entry)
 		}
 	}
-	return entries
+	return entries, nil
 }
 
 func snapshotCandidateWorktrees(
+	ctx context.Context,
 	candidates []worktreeCandidate,
 ) (map[string]models.Worktree, error) {
 	repositories := make(map[string]string)
 	for _, candidate := range candidates {
-		mainRoot, err := git.New(candidate.path).GetMainRepositoryPath()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		mainRoot, err := git.NewWithContext(ctx, candidate.path).GetMainRepositoryPath()
 		if err != nil {
 			continue
 		}
 		repositories[utils.PathKey(mainRoot)] = mainRoot
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	snapshots := make(map[string]models.Worktree)
@@ -314,7 +362,10 @@ func snapshotCandidateWorktrees(
 		go func() {
 			defer workers.Done()
 			for repositoryRoot := range jobs {
-				worktrees, err := git.New(repositoryRoot).ListWorktrees()
+				if ctx.Err() != nil {
+					return
+				}
+				worktrees, err := git.NewWithContext(ctx, repositoryRoot).ListWorktrees()
 				if err != nil {
 					snapshotsMu.Lock()
 					snapshotErrors = append(
@@ -336,11 +387,19 @@ func snapshotCandidateWorktrees(
 			}
 		}()
 	}
+sendRepositories:
 	for _, repositoryRoot := range repositories {
-		jobs <- repositoryRoot
+		select {
+		case <-ctx.Done():
+			break sendRepositories
+		case jobs <- repositoryRoot:
+		}
 	}
 	close(jobs)
 	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	return snapshots, errors.Join(snapshotErrors...)
 }
@@ -363,17 +422,18 @@ func extractWorktreeInfo(worktreePath string, projects []models.Project) (*Globa
 	if snapshot == nil {
 		return nil, fmt.Errorf("worktree disappeared during discovery")
 	}
-	return extractWorktreeInfoFromSnapshot(worktreePath, projects, *snapshot)
+	return extractWorktreeInfoFromSnapshot(context.Background(), worktreePath, projects, *snapshot)
 }
 
 func extractWorktreeInfoFromSnapshot(
+	ctx context.Context,
 	worktreePath string,
 	projects []models.Project,
 	snapshot models.Worktree,
 ) (*GlobalWorktreeEntry, error) {
 	// The cached wrapper keeps the entry's recorded remote URL and the
 	// resolver's own reads to one subprocess per call kind.
-	g := worktree.NewCachedIdentityGit(git.New(worktreePath))
+	g := worktree.NewCachedIdentityGit(git.NewWithContext(ctx, worktreePath))
 	repoURL := ""
 	if gotURL, err := g.GetRepositoryURL(); err == nil {
 		repoURL = gotURL

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -57,13 +57,14 @@ func DiscoverGlobalWorktreesContext(
 	ctx context.Context,
 	baseDir string,
 	projects []models.Project,
+	protectedNames ...string,
 ) ([]*GlobalWorktreeEntry, error) {
 	candidates, err := findGlobalWorktreeCandidates(ctx, baseDir, false)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshots, err := snapshotCandidateWorktrees(ctx, candidates)
+	snapshots, err := snapshotCandidateWorktrees(ctx, candidates, protectedNames)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,13 @@ func DiscoverGlobalWorktreesContext(
 			if !ok {
 				return nil, fmt.Errorf("worktree disappeared during discovery")
 			}
-			return extractWorktreeInfoFromSnapshot(ctx, path, projects, snapshot)
+			return extractWorktreeInfoFromSnapshot(
+				ctx,
+				path,
+				projects,
+				snapshot,
+				protectedNames...,
+			)
 		},
 	)
 }
@@ -330,13 +337,18 @@ sendCandidates:
 func snapshotCandidateWorktrees(
 	ctx context.Context,
 	candidates []worktreeCandidate,
+	protectedNames []string,
 ) (map[string]models.Worktree, error) {
 	repositories := make(map[string]string)
 	for _, candidate := range candidates {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		mainRoot, err := git.NewWithContext(ctx, candidate.path).GetMainRepositoryPath()
+		mainRoot, err := git.NewForInventory(
+			ctx,
+			candidate.path,
+			protectedNames,
+		).GetMainRepositoryPath()
 		if err != nil {
 			continue
 		}
@@ -365,7 +377,11 @@ func snapshotCandidateWorktrees(
 				if ctx.Err() != nil {
 					return
 				}
-				worktrees, err := git.NewWithContext(ctx, repositoryRoot).ListWorktrees()
+				worktrees, err := git.NewForInventory(
+					ctx,
+					repositoryRoot,
+					protectedNames,
+				).ListWorktrees()
 				if err != nil {
 					snapshotsMu.Lock()
 					snapshotErrors = append(
@@ -430,10 +446,13 @@ func extractWorktreeInfoFromSnapshot(
 	worktreePath string,
 	projects []models.Project,
 	snapshot models.Worktree,
+	protectedNames ...string,
 ) (*GlobalWorktreeEntry, error) {
 	// The cached wrapper keeps the entry's recorded remote URL and the
 	// resolver's own reads to one subprocess per call kind.
-	g := worktree.NewCachedIdentityGit(git.NewWithContext(ctx, worktreePath))
+	g := worktree.NewCachedIdentityGit(
+		git.NewForInventory(ctx, worktreePath, protectedNames),
+	)
 	repoURL := ""
 	if gotURL, err := g.GetRepositoryURL(); err == nil {
 		repoURL = gotURL

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/tmux"
@@ -20,6 +22,48 @@ import (
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+func TestDiscoverGlobalWorktreesContextCancelsBlockedRepositorySnapshot(t *testing.T) {
+	repo := NewTestRepository(t)
+	lock := flock.New(filepath.Join(repo.Path, ".git", "kwt-worktree.lock"))
+	require.NoError(t, lock.Lock())
+	t.Cleanup(func() { _ = lock.Unlock() })
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := DiscoverGlobalWorktreesContext(ctx, repo.Path, nil)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(2 * time.Second):
+		t.Fatal("global discovery did not stop after its context expired")
+	}
+}
+
+func TestDiscoverGlobalWorktreesContextStopsFilesystemTraversal(t *testing.T) {
+	baseDirectory := t.TempDir()
+	info, err := os.Stat(baseDirectory)
+	require.NoError(t, err)
+	originalWalk := walkGlobalWorktreePaths
+	t.Cleanup(func() { walkGlobalWorktreePaths = originalWalk })
+	ctx, cancel := context.WithCancel(context.Background())
+	walkGlobalWorktreePaths = func(
+		root string,
+		visit filepath.WalkFunc,
+	) error {
+		cancel()
+		return visit(root, info, nil)
+	}
+
+	_, err = DiscoverGlobalWorktreesContext(ctx, baseDirectory, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
 
 // TestRepository creates a test git repository (copy from git package for testing)
 type TestRepository struct {
@@ -715,18 +759,28 @@ func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T
 	}
 	started := make(chan string, len(candidates))
 	release := make(chan struct{})
-	done := make(chan []*GlobalWorktreeEntry, 1)
+	type extractionResult struct {
+		entries []*GlobalWorktreeEntry
+		err     error
+	}
+	done := make(chan extractionResult, 1)
 
 	go func() {
-		done <- extractWorktreeCandidates(
+		entries, err := extractWorktreeCandidates(
+			context.Background(),
 			candidates,
 			nil,
-			func(path string, _ []models.Project) (*GlobalWorktreeEntry, error) {
+			func(
+				_ context.Context,
+				path string,
+				_ []models.Project,
+			) (*GlobalWorktreeEntry, error) {
 				started <- path
 				<-release
 				return &GlobalWorktreeEntry{Path: path}, nil
 			},
 		)
+		done <- extractionResult{entries: entries, err: err}
 	}()
 
 	for range candidates {
@@ -738,7 +792,11 @@ func TestExtractWorktreeCandidatesRunsConcurrentlyAndPreservesOrder(t *testing.T
 	}
 	close(release)
 
-	entries := <-done
+	result := <-done
+	if result.err != nil {
+		t.Fatalf("Unexpected error: %v", result.err)
+	}
+	entries := result.entries
 	if len(entries) != 2 {
 		t.Fatalf("Expected 2 entries, got %d", len(entries))
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -15,6 +15,7 @@ import (
 // Git provides Git command operations.
 type Git struct {
 	workDir string
+	ctx     context.Context
 }
 
 // New creates a new Git instance.
@@ -22,6 +23,11 @@ func New(workDir string) *Git {
 	return &Git{
 		workDir: workDir,
 	}
+}
+
+// NewWithContext creates a Git instance whose operations stop when ctx is canceled.
+func NewWithContext(ctx context.Context, workDir string) *Git {
+	return &Git{workDir: workDir, ctx: ctx}
 }
 
 // NewFromCwd creates a new Git instance using the current working directory.
@@ -56,7 +62,7 @@ func (g *Git) RunWithContext(ctx context.Context, args ...string) (string, error
 
 // run executes a git command.
 func (g *Git) run(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd := g.command(args...)
 	if g.workDir != "" {
 		cmd.Dir = g.workDir
 	}
@@ -66,6 +72,9 @@ func (g *Git) run(args ...string) (string, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
+		if g.ctx != nil && g.ctx.Err() != nil {
+			return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), g.ctx.Err())
+		}
 		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), stderr.String())
 	}
 
@@ -78,7 +87,7 @@ func (g *Git) runWithoutCredentials(
 	protectedNames []string,
 	args ...string,
 ) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd := g.command(args...)
 	if g.workDir != "" {
 		cmd.Dir = g.workDir
 	}
@@ -88,9 +97,19 @@ func (g *Git) runWithoutCredentials(
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if g.ctx != nil && g.ctx.Err() != nil {
+			return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), g.ctx.Err())
+		}
 		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), stderr.String())
 	}
 	return stdout.String(), nil
+}
+
+func (g *Git) command(args ...string) *exec.Cmd {
+	if g.ctx != nil {
+		return exec.CommandContext(g.ctx, "git", args...)
+	}
+	return exec.Command("git", args...)
 }
 
 // runWithContext executes a git command with context support.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -14,8 +14,9 @@ import (
 
 // Git provides Git command operations.
 type Git struct {
-	workDir string
-	ctx     context.Context
+	workDir     string
+	ctx         context.Context
+	environment []string
 }
 
 // New creates a new Git instance.
@@ -28,6 +29,37 @@ func New(workDir string) *Git {
 // NewWithContext creates a Git instance whose operations stop when ctx is canceled.
 func NewWithContext(ctx context.Context, workDir string) *Git {
 	return &Git{workDir: workDir, ctx: ctx}
+}
+
+// NewForInventory creates a Git instance isolated from repository-routing
+// variables and credentials inherited by a long-lived daemon.
+func NewForInventory(
+	ctx context.Context,
+	workDir string,
+	protectedNames []string,
+) *Git {
+	return &Git{
+		workDir: workDir,
+		ctx:     ctx,
+		environment: inventoryEnvironment(
+			os.Environ(),
+			protectedNames,
+		),
+	}
+}
+
+func inventoryEnvironment(env, protectedNames []string) []string {
+	names := append(credentials.ProtectedNames(nil), protectedNames...)
+	filtered := credentials.StripEnvironment(env, names)
+	result := make([]string, 0, len(filtered)+1)
+	for _, entry := range filtered {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && strings.HasPrefix(strings.ToUpper(name), "GIT_") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, "GIT_TERMINAL_PROMPT=0")
 }
 
 // NewFromCwd creates a new Git instance using the current working directory.
@@ -91,7 +123,11 @@ func (g *Git) runWithoutCredentials(
 	if g.workDir != "" {
 		cmd.Dir = g.workDir
 	}
-	cmd.Env = credentials.StripEnvironment(os.Environ(), protectedNames)
+	environment := os.Environ()
+	if g.environment != nil {
+		environment = g.environment
+	}
+	cmd.Env = credentials.StripEnvironment(environment, protectedNames)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -106,15 +142,24 @@ func (g *Git) runWithoutCredentials(
 }
 
 func (g *Git) command(args ...string) *exec.Cmd {
+	var cmd *exec.Cmd
 	if g.ctx != nil {
-		return exec.CommandContext(g.ctx, "git", args...)
+		cmd = exec.CommandContext(g.ctx, "git", args...)
+	} else {
+		cmd = exec.Command("git", args...)
 	}
-	return exec.Command("git", args...)
+	if g.environment != nil {
+		cmd.Env = append([]string(nil), g.environment...)
+	}
+	return cmd
 }
 
 // runWithContext executes a git command with context support.
 func (g *Git) runWithContext(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
+	if g.environment != nil {
+		cmd.Env = append([]string(nil), g.environment...)
+	}
 	if g.workDir != "" {
 		cmd.Dir = g.workDir
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -29,6 +29,24 @@ func TestGitOperationsUseInstanceContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+func TestInventoryEnvironmentRemovesGitRoutingAndCredentials(t *testing.T) {
+	got := inventoryEnvironment([]string{
+		"PATH=/usr/bin",
+		"HOME=/home/test",
+		"GIT_DIR=/tmp/redirected.git",
+		"git_work_tree=/tmp/redirected-worktree",
+		"GIT_CONFIG_COUNT=1",
+		"KWT_GITHUB_TOKEN=builtin-secret",
+		"CUSTOM_FLEET_TOKEN=custom-secret",
+	}, []string{"CUSTOM_FLEET_TOKEN"})
+
+	assert.ElementsMatch(t, []string{
+		"PATH=/usr/bin",
+		"HOME=/home/test",
+		"GIT_TERMINAL_PROMPT=0",
+	}, got)
+}
+
 // TestRepository creates a test git repository
 type TestRepository struct {
 	Path string

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,15 @@ import (
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+func TestGitOperationsUseInstanceContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewWithContext(ctx, t.TempDir()).RunCommand("version")
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
 
 // TestRepository creates a test git repository
 type TestRepository struct {

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -1955,7 +1955,18 @@ func (g *Git) withWorktreeMutationLock(
 		filepath.Join(commonDir, worktreeMutationLockName),
 		flock.SetPermissions(0600),
 	)
-	if err := lock.Lock(); err != nil {
+	if g.ctx != nil {
+		locked, lockErr := lock.TryLockContext(g.ctx, 10*time.Millisecond)
+		if lockErr != nil {
+			return fmt.Errorf("lock worktree mutations: %w", lockErr)
+		}
+		if !locked {
+			if err := g.ctx.Err(); err != nil {
+				return fmt.Errorf("lock worktree mutations: %w", err)
+			}
+			return errors.New("lock worktree mutations: lock was not acquired")
+		}
+	} else if err := lock.Lock(); err != nil {
 		return fmt.Errorf("lock worktree mutations: %w", err)
 	}
 	defer func() { _ = lock.Unlock() }()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -98,6 +98,7 @@ type Model struct {
 	inputMode           inputMode
 	confirm             confirmState
 	fetching            bool
+	inventoryCurrent    bool
 	fleetPending        bool
 	fleetCancel         context.CancelFunc
 	loadSeq             int
@@ -259,6 +260,7 @@ func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 		warnings: msg.warnings,
 		err:      msg.err,
 	})
+	next.inventoryCurrent = false
 	next = next.cancelFleetMerge()
 	next.fleetPending = false
 	if msg.err != nil {
@@ -404,6 +406,7 @@ func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
 	rows = mergeCreatingRows(rows, m.rows, m.creating)
 	sortRows(rows)
 	m.rows = rows
+	m.inventoryCurrent = true
 	if !hadRows && m.anchorPath != "" {
 		m.projectPerspective = launchPerspective(rows, m.anchorPath)
 	}
@@ -549,6 +552,7 @@ func (m Model) startPendingRefresh() (Model, tea.Cmd) {
 func (m Model) startFetch() (Model, tea.Cmd) {
 	m.loadSeq++
 	m.fetching = true
+	m.inventoryCurrent = false
 	m.fleetPending = false
 	m = m.cancelFleetMerge()
 	return m, m.fetchFastRowsCmd()
@@ -652,6 +656,16 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 	if m.inputMode != inputNone {
 		return m.handleInputKey(msg)
+	}
+	if !m.inventoryCurrent && (key.Matches(msg, m.keys.Open) ||
+		key.Matches(msg, m.keys.New) ||
+		key.Matches(msg, m.keys.Existing) ||
+		key.Matches(msg, m.keys.Delete) ||
+		key.Matches(msg, m.keys.Sync) ||
+		key.Matches(msg, m.keys.Shell) ||
+		key.Matches(msg, m.keys.Kill)) {
+		m.message = "inventory is refreshing; wait for current results"
+		return m, nil
 	}
 
 	switch {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -254,12 +254,21 @@ func (m Model) filteredRows() []Row {
 
 func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 	pendingRefresh := m.pendingRefresh
+	initialAnchor := m.anchorPath
+	hadRows := len(m.rows) > 0
 	m.pendingRefresh = false
 	next, _ := m.applyRows(rowsMsg{
 		rows:     carryEnrichment(msg.rows, m.rows),
 		warnings: msg.warnings,
 		err:      msg.err,
 	})
+	if !hadRows && initialAnchor != "" {
+		_, exact := identityRowIndex(next.rows, initialAnchor)
+		_, contained := containingRowIndex(next.rows, initialAnchor)
+		if !exact && !contained {
+			next.anchorPath = initialAnchor
+		}
+	}
 	next.inventoryCurrent = false
 	next = next.cancelFleetMerge()
 	next.fleetPending = false

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -183,7 +184,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fastRowsMsg:
 		return m.applyFastRows(msg)
 	case rowsMsg:
-		return m.applyRows(msg)
+		return m.applyRows(msg, true)
 	case fleetRowsMsg:
 		return m.applyFleetRows(msg)
 	case actionDoneMsg:
@@ -261,7 +262,7 @@ func (m Model) applyFastRows(msg fastRowsMsg) (Model, tea.Cmd) {
 		rows:     carryEnrichment(msg.rows, m.rows),
 		warnings: msg.warnings,
 		err:      msg.err,
-	})
+	}, false)
 	if !hadRows && initialAnchor != "" {
 		_, exact := identityRowIndex(next.rows, initialAnchor)
 		_, contained := containingRowIndex(next.rows, initialAnchor)
@@ -399,12 +400,18 @@ func entryCommit(row Row) string {
 	return row.Entry.CommitHash
 }
 
-func (m Model) applyRows(msg rowsMsg) (Model, tea.Cmd) {
+func (m Model) applyRows(msg rowsMsg, refreshLayouts bool) (Model, tea.Cmd) {
 	m.fetching = false
 	if msg.err != nil {
 		m.err = msg.err
 		m.stickyError = false
 		return m.startPendingRefresh()
+	}
+	if refreshLayouts {
+		m.layouts = m.backend.LayoutNames()
+		if m.selectedLayout != "" && !slices.Contains(m.layouts, m.selectedLayout) {
+			m.selectedLayout = ""
+		}
 	}
 	m.warnings = msg.warnings
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -228,6 +228,21 @@ func TestWorkspaceRowActions(t *testing.T) {
 	assert.Equal(t, "notes", backend.unregistered[0].Workspace.Name)
 }
 
+func TestCachedRowsBlockMutationsUntilCurrentRowsArrive(t *testing.T) {
+	row := Row{Workspace: &WorkspaceInfo{Name: "notes", Path: "/stale/notes"}}
+	model := NewModel(&fakeBackend{}, "/worktrees")
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{row}})
+	blocked, _ := updateModel(t, model, press("d"))
+
+	assert.Equal(t, confirmNone, blocked.confirm.kind)
+	assert.Contains(t, blocked.message, "refresh")
+
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{row}})
+	current, _ := updateModel(t, model, press("d"))
+	assert.Equal(t, confirmUnregister, current.confirm.kind)
+}
+
 func TestModelRowsMessageSortsRendersAndUsesAltScreen(t *testing.T) {
 	model := NewModel(&fakeBackend{}, "/worktrees")
 	model, _ = updateModel(t, model, rowsMsg{rows: []Row{
@@ -988,16 +1003,15 @@ func TestModelKeepsCreatedWorktreeUntilRefreshFindsIt(t *testing.T) {
 		createPath: "/w/kwt/feature-created",
 	}
 	model := NewModel(backend, "/worktrees")
-	model, staleFullCmd := updateModel(t, model, fastRowsMsg{rows: backend.rows})
-	require.NotNil(t, staleFullCmd)
+	model, _ = updateModel(t, model, rowsMsg{rows: backend.rows})
 
 	model, _ = updateModel(t, model, press("n"))
 	model, _ = updateModel(t, model, paste("feature-created"))
 	model, createCmd := updateModel(t, model, press("enter"))
-	model, _ = updateModel(t, model, createCmd())
-	require.True(t, model.pendingRefresh)
+	model, refreshCmd := updateModel(t, model, createCmd())
+	require.NotNil(t, refreshCmd)
 
-	model, _ = updateModel(t, model, staleFullCmd())
+	model, _ = updateModel(t, model, refreshCmd())
 
 	require.Len(t, model.rows, 2)
 	assert.Equal(t, "/w/kwt/feature-created", rowPath(model.selectedRow()))

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -537,6 +537,20 @@ func TestModelCyclesLayoutSelection(t *testing.T) {
 	assert.Equal(t, footerLine, lineIndexContaining(strings.Split(stripANSI(viewContent(model)), "\n"), "q quit"))
 }
 
+func TestModelRefreshesLayoutsAfterCurrentInventoryLoad(t *testing.T) {
+	backend := &fakeBackend{layoutNames: []string{"quad"}}
+	model := NewModel(backend, "/worktrees")
+	model.selectedLayout = "quad"
+	backend.layoutNames = []string{"focus"}
+
+	model, _ = updateModel(t, model, rowsMsg{
+		rows: []Row{testRow("kwt", "main", "/w/kwt/main")},
+	})
+
+	assert.Equal(t, []string{"focus"}, model.layouts)
+	assert.Empty(t, model.selectedLayout)
+}
+
 func TestModelCursorFilterAndEscape(t *testing.T) {
 	model := NewModel(&fakeBackend{}, "/worktrees")
 	model, _ = updateModel(t, model, rowsMsg{rows: []Row{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -243,6 +243,20 @@ func TestCachedRowsBlockMutationsUntilCurrentRowsArrive(t *testing.T) {
 	assert.Equal(t, confirmUnregister, current.confirm.kind)
 }
 
+func TestCachedRowsPreserveUnresolvedInitialAnchor(t *testing.T) {
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model.anchorPath = "/launch"
+	cached := Row{Workspace: &WorkspaceInfo{Name: "cached", Path: "/cached"}}
+	current := Row{Workspace: &WorkspaceInfo{Name: "launch", Path: "/launch"}}
+
+	model, _ = updateModel(t, model, fastRowsMsg{rows: []Row{cached}})
+	assert.Equal(t, "/launch", model.anchorPath)
+
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{current}})
+	assert.Empty(t, model.anchorPath)
+	assert.Equal(t, "/launch", rowPath(model.selectedRow()))
+}
+
 func TestModelRowsMessageSortsRendersAndUsesAltScreen(t *testing.T) {
 	model := NewModel(&fakeBackend{}, "/worktrees")
 	model, _ = updateModel(t, model, rowsMsg{rows: []Row{

--- a/service/error.go
+++ b/service/error.go
@@ -74,3 +74,9 @@ func AsError(err error) *Error {
 	}
 	return NewError(Internal, "internal failure", false, nil, err)
 }
+
+// IsCode reports whether err contains a service error with the given code.
+func IsCode(err error, code Code) bool {
+	var typed *Error
+	return errors.As(err, &typed) && typed.Code == code
+}

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,4 +28,10 @@ func TestAsErrorNormalizesUnexpectedFailures(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, service.Internal, got.Code)
 	assert.False(t, got.Retryable)
+}
+
+func TestIsCodeMatchesWrappedTypedErrors(t *testing.T) {
+	err := fmt.Errorf("request failed: %w", service.NewError(service.Busy, "busy", true, nil, nil))
+	assert.True(t, service.IsCode(err, service.Busy))
+	assert.False(t, service.IsCode(err, service.Conflict))
 }

--- a/worktree/cache.go
+++ b/worktree/cache.go
@@ -1,0 +1,108 @@
+package worktree
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"go.kenn.io/kit/safefileio"
+)
+
+const cacheVersion = 1
+
+type Cache interface {
+	Current() (Result, bool)
+	Store(Result) error
+}
+
+type cacheFile struct {
+	Version    int       `json:"version"`
+	ObservedAt time.Time `json:"observed_at"`
+	Snapshot   Snapshot  `json:"snapshot"`
+}
+
+type FileCache struct {
+	mu      sync.RWMutex
+	path    string
+	current Result
+	loaded  bool
+}
+
+func NewFileCache(home string) (*FileCache, *Diagnostic, error) {
+	dir := filepath.Join(home, "cache")
+	if err := safefileio.EnsurePrivateDir(dir); err != nil {
+		return nil, nil, fmt.Errorf("secure inventory cache directory: %w", err)
+	}
+	cache := &FileCache{path: filepath.Join(dir, "inventory-v1.json")}
+	file, err := safefileio.OpenCurrentUserFile(cache.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cache, nil, nil
+		}
+		return cache, &Diagnostic{At: time.Now(), Message: boundedDiagnostic(err)}, nil
+	}
+	defer func() { _ = file.Close() }()
+	var stored cacheFile
+	if err := json.NewDecoder(file).Decode(&stored); err != nil {
+		return cache, &Diagnostic{At: time.Now(), Message: boundedDiagnostic(err)}, nil
+	}
+	if stored.Version != cacheVersion {
+		return cache, &Diagnostic{At: time.Now(), Message: "unsupported inventory cache version"}, nil
+	}
+	cache.current = Result{Snapshot: stored.Snapshot, ObservedAt: stored.ObservedAt, Freshness: Stale}
+	cache.loaded = true
+	return cache, nil, nil
+}
+
+func (c *FileCache) Current() (Result, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.loaded {
+		return Result{}, false
+	}
+	return cloneResult(c.current), true
+}
+
+func (c *FileCache) Store(result Result) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stored := cacheFile{Version: cacheVersion, ObservedAt: result.ObservedAt, Snapshot: cloneResult(result).Snapshot}
+	file, err := os.CreateTemp(filepath.Dir(c.path), ".inventory-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create inventory cache temporary file: %w", err)
+	}
+	temporary := file.Name()
+	defer func() { _ = os.Remove(temporary) }()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := json.NewEncoder(file).Encode(stored); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("encode inventory cache: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync inventory cache: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close inventory cache: %w", err)
+	}
+	if err := replaceCacheFile(temporary, c.path); err != nil {
+		return fmt.Errorf("publish inventory cache: %w", err)
+	}
+	c.current = cloneResult(result)
+	c.loaded = true
+	return nil
+}
+
+func boundedDiagnostic(err error) string {
+	message := err.Error()
+	if len(message) > 512 {
+		return message[:512]
+	}
+	return message
+}

--- a/worktree/cache.go
+++ b/worktree/cache.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"go.kenn.io/kit/safefileio"
 )
@@ -100,9 +103,20 @@ func (c *FileCache) Store(result Result) error {
 }
 
 func boundedDiagnostic(err error) string {
-	message := err.Error()
-	if len(message) > 512 {
-		return message[:512]
+	const maximumBytes = 512
+	var result strings.Builder
+	for _, character := range err.Error() {
+		if unicode.IsControl(character) {
+			character = ' '
+		}
+		if result.Len()+utf8.RuneLen(character) > maximumBytes {
+			break
+		}
+		result.WriteRune(character)
+	}
+	message := strings.TrimSpace(result.String())
+	if message == "" {
+		return "inventory operation failed"
 	}
 	return message
 }

--- a/worktree/cache_publish_unix.go
+++ b/worktree/cache_publish_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package worktree
+
+import "os"
+
+func replaceCacheFile(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/worktree/cache_publish_windows.go
+++ b/worktree/cache_publish_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package worktree
+
+import "golang.org/x/sys/windows"
+
+func replaceCacheFile(source, destination string) error {
+	return windows.Rename(source, destination)
+}

--- a/worktree/cache_test.go
+++ b/worktree/cache_test.go
@@ -1,0 +1,43 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileCacheRoundTripsSnapshot(t *testing.T) {
+	home := t.TempDir()
+	cache, diagnostic, err := NewFileCache(home)
+	require.NoError(t, err)
+	assert.Nil(t, diagnostic)
+	want := Result{ObservedAt: time.Unix(7, 0).UTC(), Snapshot: Snapshot{Entries: []Entry{{Path: "/repo", Branch: "main"}}}}
+	require.NoError(t, cache.Store(want))
+	want.Snapshot.Entries[0].Branch = "updated"
+	require.NoError(t, cache.Store(want))
+
+	reloaded, diagnostic, err := NewFileCache(home)
+	require.NoError(t, err)
+	assert.Nil(t, diagnostic)
+	got, ok := reloaded.Current()
+	require.True(t, ok)
+	assert.Equal(t, want.ObservedAt, got.ObservedAt)
+	assert.Equal(t, want.Snapshot, got.Snapshot)
+}
+
+func TestFileCacheWrongVersionIsDisposable(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "cache")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v1.json"), []byte(`{"version":99}`), 0o600))
+
+	cache, diagnostic, err := NewFileCache(home)
+	require.NoError(t, err)
+	assert.NotNil(t, diagnostic)
+	_, ok := cache.Current()
+	assert.False(t, ok)
+}

--- a/worktree/cache_test.go
+++ b/worktree/cache_test.go
@@ -15,7 +15,10 @@ func TestFileCacheRoundTripsSnapshot(t *testing.T) {
 	cache, diagnostic, err := NewFileCache(home)
 	require.NoError(t, err)
 	assert.Nil(t, diagnostic)
-	want := Result{ObservedAt: time.Unix(7, 0).UTC(), Snapshot: Snapshot{Entries: []Entry{{Path: "/repo", Branch: "main"}}}}
+	want := Result{ObservedAt: time.Unix(7, 0).UTC(), Snapshot: Snapshot{
+		Entries:       []Entry{{Path: "/repo", Branch: "main"}},
+		LaunchEntries: []Entry{{Path: "/repo", Branch: "main"}},
+	}}
 	require.NoError(t, cache.Store(want))
 	want.Snapshot.Entries[0].Branch = "updated"
 	require.NoError(t, cache.Store(want))

--- a/worktree/inventory.go
+++ b/worktree/inventory.go
@@ -103,9 +103,10 @@ type Diagnostic struct {
 }
 
 type Snapshot struct {
-	Projects   []models.Project   `json:"projects"`
-	Entries    []Entry            `json:"entries"`
-	Workspaces []models.Workspace `json:"workspaces"`
+	Projects      []models.Project   `json:"projects"`
+	Entries       []Entry            `json:"entries"`
+	LaunchEntries []Entry            `json:"launch_entries,omitempty"`
+	Workspaces    []models.Workspace `json:"workspaces"`
 }
 
 type Result struct {

--- a/worktree/inventory.go
+++ b/worktree/inventory.go
@@ -24,6 +24,10 @@ const (
 
 type Freshness string
 
+// DefaultRefreshTimeout bounds one service-owned inventory refresh. Transports
+// must allow additional time for request delivery and response encoding.
+const DefaultRefreshTimeout = 30 * time.Second
+
 const (
 	Fresh      Freshness = "fresh"
 	Refreshing Freshness = "refreshing"
@@ -199,6 +203,7 @@ type Diagnostic struct {
 }
 
 type Snapshot struct {
+	Config        *models.Config     `json:"config"`
 	Projects      []models.Project   `json:"projects"`
 	Entries       []Entry            `json:"entries"`
 	LaunchEntries []Entry            `json:"launch_entries,omitempty"`

--- a/worktree/inventory.go
+++ b/worktree/inventory.go
@@ -1,0 +1,132 @@
+// Package worktree provides embeddable worktree inventory contracts.
+package worktree
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"go.kenn.io/kwt/pkg/models"
+)
+
+type View string
+
+const (
+	ViewProjects   View = "projects"
+	ViewRepository View = "repository"
+	ViewGlobal     View = "global"
+	ViewDashboard  View = "dashboard"
+)
+
+type Freshness string
+
+const (
+	Fresh      Freshness = "fresh"
+	Refreshing Freshness = "refreshing"
+	Stale      Freshness = "stale"
+)
+
+type UntrustedConfigPolicy string
+
+const (
+	RequireConfigInteraction UntrustedConfigPolicy = "require_interaction"
+	IgnoreUntrustedConfig    UntrustedConfigPolicy = "ignore"
+)
+
+type Request struct {
+	View             View                  `json:"view"`
+	WorkingDirectory string                `json:"working_directory,omitempty"`
+	LaunchDirectory  string                `json:"launch_directory,omitempty"`
+	ForceGlobal      bool                  `json:"force_global,omitempty"`
+	RequireCurrent   bool                  `json:"require_current,omitempty"`
+	UntrustedConfig  UntrustedConfigPolicy `json:"untrusted_config"`
+}
+
+func (r Request) validate() error {
+	if r.UntrustedConfig != RequireConfigInteraction && r.UntrustedConfig != IgnoreUntrustedConfig {
+		return fmt.Errorf("unknown untrusted config policy %q", r.UntrustedConfig)
+	}
+	switch r.View {
+	case ViewProjects, ViewGlobal:
+		if r.WorkingDirectory != "" || r.LaunchDirectory != "" || r.ForceGlobal {
+			return fmt.Errorf("%s inventory does not accept location metadata", r.View)
+		}
+	case ViewRepository:
+		if !filepath.IsAbs(r.WorkingDirectory) {
+			return fmt.Errorf("repository working directory must be absolute")
+		}
+		if r.LaunchDirectory != "" {
+			return fmt.Errorf("repository inventory does not accept a launch directory")
+		}
+	case ViewDashboard:
+		if r.WorkingDirectory != "" || r.ForceGlobal {
+			return fmt.Errorf("dashboard inventory does not accept repository location metadata")
+		}
+		if r.LaunchDirectory != "" && !filepath.IsAbs(r.LaunchDirectory) {
+			return fmt.Errorf("dashboard launch directory must be absolute")
+		}
+	default:
+		return fmt.Errorf("unknown inventory view %q", r.View)
+	}
+	return nil
+}
+
+type Repository struct {
+	URL      string `json:"url,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Owner    string `json:"owner,omitempty"`
+	Name     string `json:"name,omitempty"`
+	FullPath string `json:"full_path,omitempty"`
+}
+
+type Entry struct {
+	Path           string     `json:"path"`
+	Branch         string     `json:"branch"`
+	CommitHash     string     `json:"commit_hash"`
+	IsMain         bool       `json:"is_main"`
+	CreatedAt      time.Time  `json:"created_at"`
+	Generation     string     `json:"generation"`
+	Repository     Repository `json:"repository"`
+	SessionName    string     `json:"session_name"`
+	TmuxSocketName string     `json:"tmux_socket_name,omitempty"`
+}
+
+type Note struct {
+	Code string `json:"code"`
+	Path string `json:"path"`
+}
+
+type Diagnostic struct {
+	At      time.Time `json:"at"`
+	Message string    `json:"message"`
+}
+
+type Snapshot struct {
+	Projects   []models.Project   `json:"projects"`
+	Entries    []Entry            `json:"entries"`
+	Workspaces []models.Workspace `json:"workspaces"`
+}
+
+type Result struct {
+	Snapshot     Snapshot    `json:"snapshot"`
+	Freshness    Freshness   `json:"freshness"`
+	ObservedAt   time.Time   `json:"observed_at"`
+	RefreshError *Diagnostic `json:"refresh_error,omitempty"`
+	Notes        []Note      `json:"notes,omitempty"`
+}
+
+type ConfigApproval struct {
+	Path   string `json:"path"`
+	Digest string `json:"digest"`
+}
+
+type Inventory interface {
+	Query(context.Context, Request) (Result, error)
+	ApproveConfig(context.Context, ConfigApproval) error
+}
+
+type Source interface {
+	Load(context.Context, Request) (Result, error)
+	ApproveConfig(context.Context, ConfigApproval) error
+}

--- a/worktree/inventory.go
+++ b/worktree/inventory.go
@@ -4,7 +4,10 @@ package worktree
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"go.kenn.io/kwt/pkg/models"
@@ -38,10 +41,102 @@ type Request struct {
 	View                    View                  `json:"view"`
 	WorkingDirectory        string                `json:"working_directory,omitempty"`
 	LaunchDirectory         string                `json:"launch_directory,omitempty"`
+	Expansion               ExpansionContext      `json:"expansion"`
 	ForceGlobal             bool                  `json:"force_global,omitempty"`
 	RequireCurrent          bool                  `json:"require_current,omitempty"`
 	IncludeProtectedSockets bool                  `json:"include_protected_sockets,omitempty"`
 	UntrustedConfig         UntrustedConfigPolicy `json:"untrusted_config"`
+}
+
+// ExpansionContext carries the invoking client's path-expansion inputs across
+// the daemon boundary. The authenticated daemon uses it only for this request.
+type ExpansionContext struct {
+	WorkingDirectory string            `json:"working_directory"`
+	HomeDirectory    string            `json:"home_directory"`
+	Environment      map[string]string `json:"environment,omitempty"`
+}
+
+func CaptureExpansionContext() (ExpansionContext, error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return ExpansionContext{}, fmt.Errorf("get path-expansion working directory: %w", err)
+	}
+	workingDirectory, err = filepath.Abs(workingDirectory)
+	if err != nil {
+		return ExpansionContext{}, fmt.Errorf("resolve path-expansion working directory: %w", err)
+	}
+	homeDirectory, err := os.UserHomeDir()
+	if err != nil {
+		return ExpansionContext{}, fmt.Errorf("get path-expansion home directory: %w", err)
+	}
+	environment := make(map[string]string)
+	for _, assignment := range os.Environ() {
+		name, value, ok := strings.Cut(assignment, "=")
+		if !ok || !validEnvironmentName(name) {
+			continue
+		}
+		environment[normalizedEnvironmentName(name)] = value
+	}
+	return ExpansionContext{
+		WorkingDirectory: workingDirectory,
+		HomeDirectory:    homeDirectory,
+		Environment:      environment,
+	}, nil
+}
+
+func (c ExpansionContext) validate() error {
+	if !filepath.IsAbs(c.WorkingDirectory) {
+		return fmt.Errorf("path-expansion working directory must be absolute")
+	}
+	if !filepath.IsAbs(c.HomeDirectory) {
+		return fmt.Errorf("path-expansion home directory must be absolute")
+	}
+	for name := range c.Environment {
+		if !validEnvironmentName(name) {
+			return fmt.Errorf("invalid path-expansion environment name %q", name)
+		}
+	}
+	return nil
+}
+
+func (c ExpansionContext) expandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	path = os.Expand(path, func(name string) string {
+		return c.Environment[normalizedEnvironmentName(name)]
+	})
+	if path == "~" {
+		path = c.HomeDirectory
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(c.HomeDirectory, path[2:])
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(c.WorkingDirectory, path)
+	}
+	return path, nil
+}
+
+func validEnvironmentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index, character := range name {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			character == '_' || (index > 0 && character >= '0' && character <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizedEnvironmentName(name string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(name)
+	}
+	return name
 }
 
 func (r Request) validate() error {
@@ -70,7 +165,7 @@ func (r Request) validate() error {
 	default:
 		return fmt.Errorf("unknown inventory view %q", r.View)
 	}
-	return nil
+	return r.Expansion.validate()
 }
 
 type Repository struct {

--- a/worktree/inventory.go
+++ b/worktree/inventory.go
@@ -35,12 +35,13 @@ const (
 )
 
 type Request struct {
-	View             View                  `json:"view"`
-	WorkingDirectory string                `json:"working_directory,omitempty"`
-	LaunchDirectory  string                `json:"launch_directory,omitempty"`
-	ForceGlobal      bool                  `json:"force_global,omitempty"`
-	RequireCurrent   bool                  `json:"require_current,omitempty"`
-	UntrustedConfig  UntrustedConfigPolicy `json:"untrusted_config"`
+	View                    View                  `json:"view"`
+	WorkingDirectory        string                `json:"working_directory,omitempty"`
+	LaunchDirectory         string                `json:"launch_directory,omitempty"`
+	ForceGlobal             bool                  `json:"force_global,omitempty"`
+	RequireCurrent          bool                  `json:"require_current,omitempty"`
+	IncludeProtectedSockets bool                  `json:"include_protected_sockets,omitempty"`
+	UntrustedConfig         UntrustedConfigPolicy `json:"untrusted_config"`
 }
 
 func (r Request) validate() error {

--- a/worktree/service.go
+++ b/worktree/service.go
@@ -3,9 +3,12 @@ package worktree
 import (
 	"context"
 	"encoding/json"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
+	"go.kenn.io/kwt/pkg/models"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -39,7 +42,7 @@ func NewInventoryService(options ServiceOptions) *Service {
 		options.Context = context.Background()
 	}
 	if options.RefreshTimeout <= 0 {
-		options.RefreshTimeout = 30 * time.Second
+		options.RefreshTimeout = DefaultRefreshTimeout
 	}
 	return &Service{
 		source: options.Source, cache: options.Cache, now: options.Now,
@@ -148,6 +151,7 @@ func (s *Service) ApproveConfig(ctx context.Context, approval ConfigApproval) er
 
 func cloneResult(result Result) Result {
 	copy := result
+	copy.Snapshot.Config = cloneConfig(result.Snapshot.Config)
 	copy.Snapshot.Projects = cloneSlice(result.Snapshot.Projects)
 	copy.Snapshot.Entries = cloneSlice(result.Snapshot.Entries)
 	copy.Snapshot.LaunchEntries = cloneSlice(result.Snapshot.LaunchEntries)
@@ -155,6 +159,31 @@ func cloneResult(result Result) Result {
 	copy.Notes = cloneSlice(result.Notes)
 	copy.RefreshError = cloneDiagnostic(result.RefreshError)
 	return copy
+}
+
+func cloneConfig(value *models.Config) *models.Config {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	copy.Agents = maps.Clone(value.Agents)
+	copy.Projects = slices.Clone(value.Projects)
+	copy.Workspaces = slices.Clone(value.Workspaces)
+	copy.RepositorySettings = slices.Clone(value.RepositorySettings)
+	for index := range copy.RepositorySettings {
+		copy.RepositorySettings[index].SetupCommands = slices.Clone(
+			value.RepositorySettings[index].SetupCommands,
+		)
+		copy.RepositorySettings[index].CopyFiles = slices.Clone(
+			value.RepositorySettings[index].CopyFiles,
+		)
+	}
+	copy.Layouts.Presets = slices.Clone(value.Layouts.Presets)
+	for index := range copy.Layouts.Presets {
+		copy.Layouts.Presets[index].Panes = slices.Clone(value.Layouts.Presets[index].Panes)
+	}
+	copy.Naming.SanitizeChars = maps.Clone(value.Naming.SanitizeChars)
+	return &copy
 }
 
 func cloneSlice[T any](values []T) []T {

--- a/worktree/service.go
+++ b/worktree/service.go
@@ -70,11 +70,11 @@ func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
 		result.RefreshError = nil
 		if request.View == ViewDashboard {
 			if storeErr := s.cache.Store(result); storeErr != nil {
-				return Result{}, storeErr
+				result.RefreshError = &Diagnostic{At: s.now(), Message: boundedDiagnostic(storeErr)}
 			}
 		}
 		s.mu.Lock()
-		s.last = nil
+		s.last = cloneDiagnostic(result.RefreshError)
 		s.mu.Unlock()
 		return cloneResult(result), nil
 	})
@@ -92,6 +92,7 @@ func cloneResult(result Result) Result {
 	copy := result
 	copy.Snapshot.Projects = cloneSlice(result.Snapshot.Projects)
 	copy.Snapshot.Entries = cloneSlice(result.Snapshot.Entries)
+	copy.Snapshot.LaunchEntries = cloneSlice(result.Snapshot.LaunchEntries)
 	copy.Snapshot.Workspaces = cloneSlice(result.Snapshot.Workspaces)
 	copy.Notes = cloneSlice(result.Notes)
 	copy.RefreshError = cloneDiagnostic(result.RefreshError)

--- a/worktree/service.go
+++ b/worktree/service.go
@@ -16,13 +16,15 @@ type ServiceOptions struct {
 }
 
 type Service struct {
-	source Source
-	cache  Cache
-	now    func() time.Time
-	group  singleflight.Group
-	mu     sync.RWMutex
-	active bool
-	last   *Diagnostic
+	source              Source
+	cache               Cache
+	now                 func() time.Time
+	group               singleflight.Group
+	publishMu           sync.Mutex
+	mu                  sync.RWMutex
+	active              int
+	dashboardGeneration uint64
+	last                *Diagnostic
 }
 
 func NewInventoryService(options ServiceOptions) *Service {
@@ -36,7 +38,7 @@ func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
 	if request.View == ViewDashboard && !request.RequireCurrent {
 		if cached, ok := s.cache.Current(); ok {
 			s.mu.RLock()
-			if s.active {
+			if s.active > 0 {
 				cached.Freshness = Refreshing
 			} else {
 				cached.Freshness = Stale
@@ -48,40 +50,74 @@ func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
 	}
 	encoded, _ := json.Marshal(request)
 	value, err, _ := s.group.Do(string(encoded), func() (any, error) {
+		var generation uint64
 		if request.View == ViewDashboard {
 			s.mu.Lock()
-			s.active = true
+			s.active++
+			s.dashboardGeneration++
+			generation = s.dashboardGeneration
 			s.mu.Unlock()
 			defer func() {
 				s.mu.Lock()
-				s.active = false
+				s.active--
 				s.mu.Unlock()
 			}()
 		}
 		result, loadErr := s.source.Load(ctx, request)
 		if loadErr != nil {
-			s.mu.Lock()
-			s.last = &Diagnostic{At: s.now(), Message: boundedDiagnostic(loadErr)}
-			s.mu.Unlock()
+			if request.View == ViewDashboard {
+				s.setDashboardDiagnostic(generation, &Diagnostic{
+					At: s.now(), Message: boundedDiagnostic(loadErr),
+				})
+			}
 			return Result{}, loadErr
 		}
 		result.Freshness = Fresh
 		result.ObservedAt = s.now()
 		result.RefreshError = nil
 		if request.View == ViewDashboard {
-			if storeErr := s.cache.Store(result); storeErr != nil {
-				result.RefreshError = &Diagnostic{At: s.now(), Message: boundedDiagnostic(storeErr)}
-			}
+			result.RefreshError = s.publishDashboard(generation, result)
 		}
-		s.mu.Lock()
-		s.last = cloneDiagnostic(result.RefreshError)
-		s.mu.Unlock()
 		return cloneResult(result), nil
 	})
 	if err != nil {
 		return Result{}, err
 	}
 	return cloneResult(value.(Result)), nil
+}
+
+func (s *Service) publishDashboard(generation uint64, result Result) *Diagnostic {
+	s.publishMu.Lock()
+	defer s.publishMu.Unlock()
+	if !s.isLatestDashboard(generation) {
+		return nil
+	}
+	var diagnostic *Diagnostic
+	if err := s.cache.Store(result); err != nil {
+		diagnostic = &Diagnostic{At: s.now(), Message: boundedDiagnostic(err)}
+	}
+	s.mu.Lock()
+	if generation == s.dashboardGeneration {
+		s.last = cloneDiagnostic(diagnostic)
+	}
+	s.mu.Unlock()
+	return diagnostic
+}
+
+func (s *Service) setDashboardDiagnostic(generation uint64, diagnostic *Diagnostic) {
+	s.publishMu.Lock()
+	defer s.publishMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if generation == s.dashboardGeneration {
+		s.last = cloneDiagnostic(diagnostic)
+	}
+}
+
+func (s *Service) isLatestDashboard(generation uint64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return generation == s.dashboardGeneration
 }
 
 func (s *Service) ApproveConfig(ctx context.Context, approval ConfigApproval) error {

--- a/worktree/service.go
+++ b/worktree/service.go
@@ -35,7 +35,7 @@ func NewInventoryService(options ServiceOptions) *Service {
 }
 
 func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
-	if request.View == ViewDashboard && !request.RequireCurrent {
+	if request.View == ViewDashboard && !request.RequireCurrent && s.cache != nil {
 		if cached, ok := s.cache.Current(); ok {
 			s.mu.RLock()
 			if s.active > 0 {
@@ -93,8 +93,10 @@ func (s *Service) publishDashboard(generation uint64, result Result) *Diagnostic
 		return nil
 	}
 	var diagnostic *Diagnostic
-	if err := s.cache.Store(result); err != nil {
-		diagnostic = &Diagnostic{At: s.now(), Message: boundedDiagnostic(err)}
+	if s.cache != nil {
+		if err := s.cache.Store(result); err != nil {
+			diagnostic = &Diagnostic{At: s.now(), Message: boundedDiagnostic(err)}
+		}
 	}
 	s.mu.Lock()
 	if generation == s.dashboardGeneration {

--- a/worktree/service.go
+++ b/worktree/service.go
@@ -1,0 +1,116 @@
+package worktree
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type ServiceOptions struct {
+	Source Source
+	Cache  Cache
+	Now    func() time.Time
+}
+
+type Service struct {
+	source Source
+	cache  Cache
+	now    func() time.Time
+	group  singleflight.Group
+	mu     sync.RWMutex
+	active bool
+	last   *Diagnostic
+}
+
+func NewInventoryService(options ServiceOptions) *Service {
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	return &Service{source: options.Source, cache: options.Cache, now: options.Now}
+}
+
+func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
+	if request.View == ViewDashboard && !request.RequireCurrent {
+		if cached, ok := s.cache.Current(); ok {
+			s.mu.RLock()
+			if s.active {
+				cached.Freshness = Refreshing
+			} else {
+				cached.Freshness = Stale
+			}
+			cached.RefreshError = cloneDiagnostic(s.last)
+			s.mu.RUnlock()
+			return cloneResult(cached), nil
+		}
+	}
+	encoded, _ := json.Marshal(request)
+	value, err, _ := s.group.Do(string(encoded), func() (any, error) {
+		if request.View == ViewDashboard {
+			s.mu.Lock()
+			s.active = true
+			s.mu.Unlock()
+			defer func() {
+				s.mu.Lock()
+				s.active = false
+				s.mu.Unlock()
+			}()
+		}
+		result, loadErr := s.source.Load(ctx, request)
+		if loadErr != nil {
+			s.mu.Lock()
+			s.last = &Diagnostic{At: s.now(), Message: boundedDiagnostic(loadErr)}
+			s.mu.Unlock()
+			return Result{}, loadErr
+		}
+		result.Freshness = Fresh
+		result.ObservedAt = s.now()
+		result.RefreshError = nil
+		if request.View == ViewDashboard {
+			if storeErr := s.cache.Store(result); storeErr != nil {
+				return Result{}, storeErr
+			}
+		}
+		s.mu.Lock()
+		s.last = nil
+		s.mu.Unlock()
+		return cloneResult(result), nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return cloneResult(value.(Result)), nil
+}
+
+func (s *Service) ApproveConfig(ctx context.Context, approval ConfigApproval) error {
+	return s.source.ApproveConfig(ctx, approval)
+}
+
+func cloneResult(result Result) Result {
+	copy := result
+	copy.Snapshot.Projects = cloneSlice(result.Snapshot.Projects)
+	copy.Snapshot.Entries = cloneSlice(result.Snapshot.Entries)
+	copy.Snapshot.Workspaces = cloneSlice(result.Snapshot.Workspaces)
+	copy.Notes = cloneSlice(result.Notes)
+	copy.RefreshError = cloneDiagnostic(result.RefreshError)
+	return copy
+}
+
+func cloneSlice[T any](values []T) []T {
+	if values == nil {
+		return nil
+	}
+	result := make([]T, len(values))
+	copy(result, values)
+	return result
+}
+
+func cloneDiagnostic(diagnostic *Diagnostic) *Diagnostic {
+	if diagnostic == nil {
+		return nil
+	}
+	copy := *diagnostic
+	return &copy
+}

--- a/worktree/service.go
+++ b/worktree/service.go
@@ -10,15 +10,19 @@ import (
 )
 
 type ServiceOptions struct {
-	Source Source
-	Cache  Cache
-	Now    func() time.Time
+	Source         Source
+	Cache          Cache
+	Now            func() time.Time
+	Context        context.Context
+	RefreshTimeout time.Duration
 }
 
 type Service struct {
 	source              Source
 	cache               Cache
 	now                 func() time.Time
+	context             context.Context
+	refreshTimeout      time.Duration
 	group               singleflight.Group
 	publishMu           sync.Mutex
 	mu                  sync.RWMutex
@@ -31,7 +35,16 @@ func NewInventoryService(options ServiceOptions) *Service {
 	if options.Now == nil {
 		options.Now = time.Now
 	}
-	return &Service{source: options.Source, cache: options.Cache, now: options.Now}
+	if options.Context == nil {
+		options.Context = context.Background()
+	}
+	if options.RefreshTimeout <= 0 {
+		options.RefreshTimeout = 30 * time.Second
+	}
+	return &Service{
+		source: options.Source, cache: options.Cache, now: options.Now,
+		context: options.Context, refreshTimeout: options.RefreshTimeout,
+	}
 }
 
 func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
@@ -49,7 +62,9 @@ func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
 		}
 	}
 	encoded, _ := json.Marshal(request)
-	value, err, _ := s.group.Do(string(encoded), func() (any, error) {
+	result := s.group.DoChan(string(encoded), func() (any, error) {
+		refreshContext, cancel := context.WithTimeout(s.context, s.refreshTimeout)
+		defer cancel()
 		var generation uint64
 		if request.View == ViewDashboard {
 			s.mu.Lock()
@@ -63,7 +78,7 @@ func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
 				s.mu.Unlock()
 			}()
 		}
-		result, loadErr := s.source.Load(ctx, request)
+		result, loadErr := s.source.Load(refreshContext, request)
 		if loadErr != nil {
 			if request.View == ViewDashboard {
 				s.setDashboardDiagnostic(generation, &Diagnostic{
@@ -80,10 +95,15 @@ func (s *Service) Query(ctx context.Context, request Request) (Result, error) {
 		}
 		return cloneResult(result), nil
 	})
-	if err != nil {
-		return Result{}, err
+	select {
+	case <-ctx.Done():
+		return Result{}, ctx.Err()
+	case outcome := <-result:
+		if outcome.Err != nil {
+			return Result{}, outcome.Err
+		}
+		return cloneResult(outcome.Val.(Result)), nil
 	}
-	return cloneResult(value.(Result)), nil
 }
 
 func (s *Service) publishDashboard(generation uint64, result Result) *Diagnostic {

--- a/worktree/service_test.go
+++ b/worktree/service_test.go
@@ -64,6 +64,14 @@ func (s *testSource) Load(ctx context.Context, _ Request) (Result, error) {
 
 func (*testSource) ApproveConfig(context.Context, ConfigApproval) error { return nil }
 
+type sourceFunc func(context.Context, Request) (Result, error)
+
+func (f sourceFunc) Load(ctx context.Context, request Request) (Result, error) {
+	return f(ctx, request)
+}
+
+func (sourceFunc) ApproveConfig(context.Context, ConfigApproval) error { return nil }
+
 func TestServiceCachedDashboardReportsRefreshState(t *testing.T) {
 	cache := &testCache{ok: true, result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/old"}}}}}
 	source := &testSource{started: make(chan struct{}), release: make(chan struct{})}
@@ -140,4 +148,92 @@ func TestServiceFreshDashboardSurvivesCacheWriteFailure(t *testing.T) {
 	assert.Equal(t, "/new", result.Snapshot.Entries[0].Path)
 	require.NotNil(t, result.RefreshError)
 	assert.Contains(t, result.RefreshError.Message, cacheErr.Error())
+}
+
+func TestServiceNewestDashboardRefreshOwnsSharedCache(t *testing.T) {
+	oldStarted, oldRelease := make(chan struct{}), make(chan struct{})
+	newStarted, newRelease := make(chan struct{}), make(chan struct{})
+	source := sourceFunc(func(ctx context.Context, request Request) (Result, error) {
+		started, release, path := oldStarted, oldRelease, "/old"
+		if request.LaunchDirectory == "/new" {
+			started, release, path = newStarted, newRelease, "/new"
+		}
+		close(started)
+		select {
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		case <-release:
+			return Result{Snapshot: Snapshot{Entries: []Entry{{Path: path}}}}, nil
+		}
+	})
+	cache := &testCache{}
+	service := NewInventoryService(ServiceOptions{Source: source, Cache: cache})
+	oldDone, newDone := make(chan error, 1), make(chan error, 1)
+	go func() {
+		_, err := service.Query(context.Background(), Request{
+			View: ViewDashboard, LaunchDirectory: "/old", RequireCurrent: true,
+		})
+		oldDone <- err
+	}()
+	<-oldStarted
+	go func() {
+		_, err := service.Query(context.Background(), Request{
+			View: ViewDashboard, LaunchDirectory: "/new", RequireCurrent: true,
+		})
+		newDone <- err
+	}()
+	<-newStarted
+
+	close(newRelease)
+	require.NoError(t, <-newDone)
+	close(oldRelease)
+	require.NoError(t, <-oldDone)
+	cached, ok := cache.Current()
+	require.True(t, ok)
+	require.Len(t, cached.Snapshot.Entries, 1)
+	assert.Equal(t, "/new", cached.Snapshot.Entries[0].Path)
+}
+
+func TestServiceReportsRefreshingUntilEveryDashboardRefreshFinishes(t *testing.T) {
+	oneStarted, oneRelease := make(chan struct{}), make(chan struct{})
+	twoStarted, twoRelease := make(chan struct{}), make(chan struct{})
+	source := sourceFunc(func(ctx context.Context, request Request) (Result, error) {
+		started, release := oneStarted, oneRelease
+		if request.LaunchDirectory == "/two" {
+			started, release = twoStarted, twoRelease
+		}
+		close(started)
+		select {
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		case <-release:
+			return Result{}, nil
+		}
+	})
+	cache := &testCache{ok: true, result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/cached"}}}}}
+	service := NewInventoryService(ServiceOptions{Source: source, Cache: cache})
+	oneDone, twoDone := make(chan error, 1), make(chan error, 1)
+	go func() {
+		_, err := service.Query(context.Background(), Request{
+			View: ViewDashboard, LaunchDirectory: "/one", RequireCurrent: true,
+		})
+		oneDone <- err
+	}()
+	<-oneStarted
+	go func() {
+		_, err := service.Query(context.Background(), Request{
+			View: ViewDashboard, LaunchDirectory: "/two", RequireCurrent: true,
+		})
+		twoDone <- err
+	}()
+	<-twoStarted
+
+	close(twoRelease)
+	require.NoError(t, <-twoDone)
+	cached, err := service.Query(context.Background(), Request{View: ViewDashboard})
+	require.NoError(t, err)
+	assert.Equal(t, Refreshing, cached.Freshness)
+
+	close(oneRelease)
+	require.NoError(t, <-oneDone)
 }

--- a/worktree/service_test.go
+++ b/worktree/service_test.go
@@ -1,0 +1,121 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCache struct {
+	mu     sync.Mutex
+	result Result
+	ok     bool
+}
+
+func (c *testCache) Current() (Result, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.result, c.ok
+}
+
+func (c *testCache) Store(result Result) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.result, c.ok = result, true
+	return nil
+}
+
+type testSource struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+	result  Result
+	err     error
+}
+
+func (s *testSource) Load(ctx context.Context, _ Request) (Result, error) {
+	s.calls.Add(1)
+	if s.started != nil {
+		select {
+		case <-s.started:
+		default:
+			close(s.started)
+		}
+	}
+	if s.release != nil {
+		select {
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		case <-s.release:
+		}
+	}
+	return s.result, s.err
+}
+
+func (*testSource) ApproveConfig(context.Context, ConfigApproval) error { return nil }
+
+func TestServiceCachedDashboardReportsRefreshState(t *testing.T) {
+	cache := &testCache{ok: true, result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/old"}}}}}
+	source := &testSource{started: make(chan struct{}), release: make(chan struct{})}
+	service := NewInventoryService(ServiceOptions{Source: source, Cache: cache})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+	}()
+	<-source.started
+	got, err := service.Query(context.Background(), Request{View: ViewDashboard})
+	require.NoError(t, err)
+	assert.Equal(t, Refreshing, got.Freshness)
+	assert.Equal(t, "/old", got.Snapshot.Entries[0].Path)
+	close(source.release)
+	<-done
+}
+
+func TestServiceCurrentRefreshIsSingleFlight(t *testing.T) {
+	source := &testSource{
+		started: make(chan struct{}), release: make(chan struct{}),
+		result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/new"}}}},
+	}
+	service := NewInventoryService(ServiceOptions{Source: source, Cache: &testCache{}})
+	var wait sync.WaitGroup
+	errorsOut := make(chan error, 8)
+	for range 8 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+			errorsOut <- err
+		}()
+	}
+	<-source.started
+	time.Sleep(20 * time.Millisecond)
+	close(source.release)
+	wait.Wait()
+	close(errorsOut)
+	for err := range errorsOut {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), source.calls.Load())
+}
+
+func TestServiceFailedRefreshKeepsLastKnownGood(t *testing.T) {
+	cache := &testCache{ok: true, result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/old"}}}}}
+	service := NewInventoryService(ServiceOptions{
+		Source: &testSource{err: errors.New("scan failed")}, Cache: cache,
+		Now: func() time.Time { return time.Unix(10, 0) },
+	})
+
+	_, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+	require.Error(t, err)
+	cached, ok := cache.Current()
+	require.True(t, ok)
+	assert.Equal(t, "/old", cached.Snapshot.Entries[0].Path)
+}

--- a/worktree/service_test.go
+++ b/worktree/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 type testCache struct {
@@ -72,6 +73,17 @@ func (f sourceFunc) Load(ctx context.Context, request Request) (Result, error) {
 
 func (sourceFunc) ApproveConfig(context.Context, ConfigApproval) error { return nil }
 
+type observedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *observedDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
 func TestServiceCachedDashboardReportsRefreshState(t *testing.T) {
 	cache := &testCache{ok: true, result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/old"}}}}}
 	source := &testSource{started: make(chan struct{}), release: make(chan struct{})}
@@ -131,14 +143,15 @@ func TestServiceCallerCancellationDoesNotCancelSharedRefresh(t *testing.T) {
 		firstDone <- err
 	}()
 	<-source.started
-	secondEntered := make(chan struct{})
+	secondContext := &observedDoneContext{
+		Context: context.Background(), observed: make(chan struct{}),
+	}
 	secondDone := make(chan error, 1)
 	go func() {
-		close(secondEntered)
-		_, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+		_, err := service.Query(secondContext, Request{View: ViewDashboard, RequireCurrent: true})
 		secondDone <- err
 	}()
-	<-secondEntered
+	<-secondContext.observed
 	cancelFirst()
 	require.ErrorIs(t, <-firstDone, context.Canceled)
 	close(source.release)
@@ -159,15 +172,16 @@ func TestServiceCanceledWaiterReturnsBeforeSharedRefreshFinishes(t *testing.T) {
 		firstDone <- err
 	}()
 	<-source.started
-	waiterContext, cancelWaiter := context.WithCancel(context.Background())
-	waiterEntered := make(chan struct{})
+	waiterBase, cancelWaiter := context.WithCancel(context.Background())
+	waiterContext := &observedDoneContext{
+		Context: waiterBase, observed: make(chan struct{}),
+	}
 	waiterDone := make(chan error, 1)
 	go func() {
-		close(waiterEntered)
 		_, err := service.Query(waiterContext, Request{View: ViewDashboard, RequireCurrent: true})
 		waiterDone <- err
 	}()
-	<-waiterEntered
+	<-waiterContext.observed
 	cancelWaiter()
 
 	var waiterErr error
@@ -216,6 +230,35 @@ func TestServiceFreshDashboardSurvivesCacheWriteFailure(t *testing.T) {
 	assert.Equal(t, "/new", result.Snapshot.Entries[0].Path)
 	require.NotNil(t, result.RefreshError)
 	assert.Contains(t, result.RefreshError.Message, cacheErr.Error())
+}
+
+func TestServiceResultsDoNotShareEffectiveConfig(t *testing.T) {
+	cache := &testCache{}
+	service := NewInventoryService(ServiceOptions{
+		Source: &testSource{result: Result{Snapshot: Snapshot{Config: &models.Config{
+			Worktree: models.WorktreeConfig{BaseDir: "/original"},
+			Agents:   map[string]string{"agent": "command"},
+			Layouts: models.LayoutsConfig{Presets: []models.Layout{{
+				Name: "layout", Panes: []string{"original"},
+			}}},
+		}}}},
+		Cache: cache,
+	})
+
+	result, err := service.Query(context.Background(), Request{
+		View: ViewDashboard, RequireCurrent: true,
+	})
+	require.NoError(t, err)
+	result.Snapshot.Config.Worktree.BaseDir = "/mutated"
+	result.Snapshot.Config.Agents["agent"] = "changed"
+	result.Snapshot.Config.Layouts.Presets[0].Panes[0] = "changed"
+
+	cached, ok := cache.Current()
+	require.True(t, ok)
+	require.NotNil(t, cached.Snapshot.Config)
+	assert.Equal(t, "/original", cached.Snapshot.Config.Worktree.BaseDir)
+	assert.Equal(t, "command", cached.Snapshot.Config.Agents["agent"])
+	assert.Equal(t, "original", cached.Snapshot.Config.Layouts.Presets[0].Panes[0])
 }
 
 func TestServiceNewestDashboardRefreshOwnsSharedCache(t *testing.T) {

--- a/worktree/service_test.go
+++ b/worktree/service_test.go
@@ -118,6 +118,74 @@ func TestServiceCurrentRefreshIsSingleFlight(t *testing.T) {
 	assert.Equal(t, int32(1), source.calls.Load())
 }
 
+func TestServiceCallerCancellationDoesNotCancelSharedRefresh(t *testing.T) {
+	source := &testSource{
+		started: make(chan struct{}), release: make(chan struct{}),
+		result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/fresh"}}}},
+	}
+	service := NewInventoryService(ServiceOptions{Source: source, Cache: &testCache{}})
+	firstContext, cancelFirst := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := service.Query(firstContext, Request{View: ViewDashboard, RequireCurrent: true})
+		firstDone <- err
+	}()
+	<-source.started
+	secondEntered := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondEntered)
+		_, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+		secondDone <- err
+	}()
+	<-secondEntered
+	cancelFirst()
+	require.ErrorIs(t, <-firstDone, context.Canceled)
+	close(source.release)
+
+	require.NoError(t, <-secondDone)
+	assert.Equal(t, int32(1), source.calls.Load())
+}
+
+func TestServiceCanceledWaiterReturnsBeforeSharedRefreshFinishes(t *testing.T) {
+	source := &testSource{
+		started: make(chan struct{}), release: make(chan struct{}),
+		result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/fresh"}}}},
+	}
+	service := NewInventoryService(ServiceOptions{Source: source, Cache: &testCache{}})
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+		firstDone <- err
+	}()
+	<-source.started
+	waiterContext, cancelWaiter := context.WithCancel(context.Background())
+	waiterEntered := make(chan struct{})
+	waiterDone := make(chan error, 1)
+	go func() {
+		close(waiterEntered)
+		_, err := service.Query(waiterContext, Request{View: ViewDashboard, RequireCurrent: true})
+		waiterDone <- err
+	}()
+	<-waiterEntered
+	cancelWaiter()
+
+	var waiterErr error
+	returnedBeforeRefresh := false
+	select {
+	case waiterErr = <-waiterDone:
+		returnedBeforeRefresh = true
+	case <-time.After(time.Second):
+	}
+	close(source.release)
+	require.NoError(t, <-firstDone)
+	if !returnedBeforeRefresh {
+		waiterErr = <-waiterDone
+	}
+	assert.True(t, returnedBeforeRefresh)
+	require.ErrorIs(t, waiterErr, context.Canceled)
+}
+
 func TestServiceFailedRefreshKeepsLastKnownGood(t *testing.T) {
 	cache := &testCache{ok: true, result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/old"}}}}}
 	service := NewInventoryService(ServiceOptions{

--- a/worktree/service_test.go
+++ b/worktree/service_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type testCache struct {
-	mu     sync.Mutex
-	result Result
-	ok     bool
+	mu       sync.Mutex
+	result   Result
+	ok       bool
+	storeErr error
 }
 
 func (c *testCache) Current() (Result, bool) {
@@ -27,6 +28,9 @@ func (c *testCache) Current() (Result, bool) {
 func (c *testCache) Store(result Result) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.storeErr != nil {
+		return c.storeErr
+	}
 	c.result, c.ok = result, true
 	return nil
 }
@@ -118,4 +122,22 @@ func TestServiceFailedRefreshKeepsLastKnownGood(t *testing.T) {
 	cached, ok := cache.Current()
 	require.True(t, ok)
 	assert.Equal(t, "/old", cached.Snapshot.Entries[0].Path)
+}
+
+func TestServiceFreshDashboardSurvivesCacheWriteFailure(t *testing.T) {
+	cacheErr := errors.New("cache is read-only")
+	service := NewInventoryService(ServiceOptions{
+		Source: &testSource{result: Result{Snapshot: Snapshot{Entries: []Entry{{Path: "/new"}}}}},
+		Cache:  &testCache{storeErr: cacheErr},
+		Now:    func() time.Time { return time.Unix(10, 0) },
+	})
+
+	result, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, Fresh, result.Freshness)
+	require.Len(t, result.Snapshot.Entries, 1)
+	assert.Equal(t, "/new", result.Snapshot.Entries[0].Path)
+	require.NotNil(t, result.RefreshError)
+	assert.Contains(t, result.RefreshError.Message, cacheErr.Error())
 }

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -40,7 +40,10 @@ func NewSource(options SourceOptions) Source {
 	return &currentSource{home: options.Home}
 }
 
-func (s *currentSource) Load(ctx context.Context, request Request) (Result, error) {
+func (s *currentSource) Load(ctx context.Context, request Request) (result Result, err error) {
+	defer func() {
+		err = classifyInventoryError(err)
+	}()
 	if err := request.validate(); err != nil {
 		return Result{}, service.NewError(service.InvalidRequest, err.Error(), false, nil, err)
 	}
@@ -52,23 +55,27 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 	if err != nil {
 		return Result{}, err
 	}
-	result := Result{Snapshot: Snapshot{
+	result = Result{Snapshot: Snapshot{
 		Workspaces: append([]models.Workspace(nil), snapshot.Config.Workspaces...),
 	}}
 
 	switch request.View {
 	case ViewProjects:
-		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
-		return result, nil
+		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects)
+		return result, err
 	case ViewGlobal:
-		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
-		result.Snapshot.Entries, err = s.loadGlobal(snapshot.Config)
+		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects)
+		if err == nil {
+			result.Snapshot.Entries, err = s.loadGlobal(ctx, snapshot.Config)
+		}
 	case ViewRepository:
 		result, err = s.loadRepository(ctx, request, snapshot.Config, expansion.expandPath)
 	case ViewDashboard:
-		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
-		result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
-			s.loadDashboard(ctx, request, snapshot.Config)
+		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects)
+		if err == nil {
+			result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
+				s.loadDashboard(ctx, request, snapshot.Config)
+		}
 	}
 	if err != nil {
 		return Result{}, err
@@ -79,6 +86,29 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 		}
 	}
 	return result, nil
+}
+
+func classifyInventoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var typed *service.Error
+	if errors.As(err, &typed) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return service.NewError(
+			service.Busy, "inventory refresh timed out", true, nil, err,
+		)
+	}
+	if errors.Is(err, context.Canceled) {
+		return service.NewError(
+			service.Busy, "inventory refresh canceled", true, nil, err,
+		)
+	}
+	return service.NewError(
+		service.Internal, boundedDiagnostic(err), false, nil, err,
+	)
 }
 
 func (s *currentSource) ApproveConfig(_ context.Context, approval ConfigApproval) error {
@@ -119,9 +149,13 @@ func (s *currentSource) loadRepository(
 		return Result{}, err
 	}
 	if request.ForceGlobal {
-		entries, loadErr := s.loadGlobal(resolved.Config)
+		entries, loadErr := s.loadGlobal(ctx, resolved.Config)
+		projects, projectsErr := CanonicalProjects(ctx, resolved.Config.Projects)
+		if loadErr == nil {
+			loadErr = projectsErr
+		}
 		return Result{Snapshot: Snapshot{
-			Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
+			Projects: projects, Entries: entries,
 			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
@@ -131,9 +165,13 @@ func (s *currentSource) loadRepository(
 		return Result{}, err
 	}
 	if !isRepository {
-		entries, loadErr := s.loadGlobal(resolved.Config)
+		entries, loadErr := s.loadGlobal(ctx, resolved.Config)
+		projects, projectsErr := CanonicalProjects(ctx, resolved.Config.Projects)
+		if loadErr == nil {
+			loadErr = projectsErr
+		}
 		return Result{Snapshot: Snapshot{
-			Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
+			Projects: projects, Entries: entries,
 			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
@@ -154,8 +192,12 @@ func (s *currentSource) loadRepository(
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}
+	projects, err := CanonicalProjects(ctx, resolved.Config.Projects)
+	if err != nil {
+		return Result{}, err
+	}
 	return Result{Snapshot: Snapshot{
-		Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
+		Projects: projects, Entries: entries,
 		Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 	}, Notes: publicNotes(resolved.Notes)}, nil
 }
@@ -178,8 +220,8 @@ func hasGitMarker(path string) (bool, error) {
 	}
 }
 
-func (s *currentSource) loadGlobal(cfg *models.Config) ([]Entry, error) {
-	entries, err := discovery.DiscoverGlobalWorktrees(cfg.Worktree.BaseDir, cfg.Projects)
+func (s *currentSource) loadGlobal(ctx context.Context, cfg *models.Config) ([]Entry, error) {
+	entries, err := discovery.DiscoverGlobalWorktreesContext(ctx, cfg.Worktree.BaseDir, cfg.Projects)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover worktrees: %w", err)
 	}
@@ -191,7 +233,7 @@ func (s *currentSource) loadDashboard(
 	request Request,
 	cfg *models.Config,
 ) ([]Entry, []Entry, error) {
-	entries, err := s.loadGlobal(cfg)
+	entries, err := s.loadGlobal(ctx, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,13 +372,19 @@ func modelEntry(worktree models.Worktree, repositoryURL string, info *repository
 
 // CanonicalProjects returns accessible registrations with their resolved
 // repository identities. It never mutates the supplied registry slice.
-func CanonicalProjects(projects []models.Project) []models.Project {
+func CanonicalProjects(
+	ctx context.Context,
+	projects []models.Project,
+) ([]models.Project, error) {
 	result := make([]models.Project, 0, len(projects))
 	for _, project := range projects {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if strings.TrimSpace(project.Path) == "" {
 			continue
 		}
-		g := internalworktree.NewCachedIdentityGit(git.New(project.Path))
+		g := internalworktree.NewCachedIdentityGit(git.NewWithContext(ctx, project.Path))
 		mainPath, err := g.GetMainRepositoryPath()
 		if err != nil || utils.PathKey(mainPath) != utils.PathKey(project.Path) {
 			continue
@@ -348,7 +396,10 @@ func CanonicalProjects(projects []models.Project) []models.Project {
 		project.Repository = info.FullPath
 		result = append(result, project)
 	}
-	return result
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func mergeEntries(existing, incoming []Entry) []Entry {

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -56,6 +56,7 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 		return Result{}, err
 	}
 	result = Result{Snapshot: Snapshot{
+		Config:     snapshot.Config,
 		Workspaces: append([]models.Workspace(nil), snapshot.Config.Workspaces...),
 	}}
 

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
@@ -19,6 +20,13 @@ import (
 	"go.kenn.io/kwt/pkg/models"
 	"go.kenn.io/kwt/service"
 )
+
+const maxDashboardRepositoryScans = 8
+
+type repositoryScanResult struct {
+	entries []Entry
+	err     error
+}
 
 type SourceOptions struct {
 	Home string
@@ -130,7 +138,7 @@ func (s *currentSource) loadRepository(
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
 
-	g := git.New(request.WorkingDirectory)
+	g := git.NewWithContext(ctx, request.WorkingDirectory)
 	worktrees, listErr := g.ListWorktrees()
 	if listErr != nil {
 		return Result{}, listErr
@@ -187,23 +195,32 @@ func (s *currentSource) loadDashboard(
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, project := range cfg.Projects {
-		if err := ctx.Err(); err != nil {
-			return nil, nil, err
-		}
-		projectEntries, loadErr := entriesForRepository(project.Path, cfg.Projects)
-		if loadErr != nil {
-			if git.IsIncompleteInventory(loadErr) {
-				return nil, nil, loadErr
+	paths := make([]string, len(cfg.Projects))
+	for index, project := range cfg.Projects {
+		paths[index] = project.Path
+	}
+	projectResults, err := scanRepositories(ctx, paths, func(
+		ctx context.Context,
+		path string,
+	) ([]Entry, error) {
+		return entriesForRepository(ctx, path, cfg.Projects)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, result := range projectResults {
+		if result.err != nil {
+			if git.IsIncompleteInventory(result.err) {
+				return nil, nil, result.err
 			}
 			continue
 		}
-		entries = mergeEntries(entries, projectEntries)
+		entries = mergeEntries(entries, result.entries)
 	}
 	var launchEntries []Entry
 	if request.LaunchDirectory != "" {
 		var loadErr error
-		launchEntries, loadErr = entriesForRepository(request.LaunchDirectory, cfg.Projects)
+		launchEntries, loadErr = entriesForRepository(ctx, request.LaunchDirectory, cfg.Projects)
 		if loadErr != nil && git.IsIncompleteInventory(loadErr) {
 			return nil, nil, loadErr
 		}
@@ -212,11 +229,50 @@ func (s *currentSource) loadDashboard(
 	return entries, launchEntries, nil
 }
 
-func entriesForRepository(path string, projects []models.Project) ([]Entry, error) {
+func scanRepositories(
+	ctx context.Context,
+	paths []string,
+	scan func(context.Context, string) ([]Entry, error),
+) ([]repositoryScanResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	results := make([]repositoryScanResult, len(paths))
+	jobs := make(chan int, len(paths))
+	for index := range paths {
+		jobs <- index
+	}
+	close(jobs)
+	workerCount := min(len(paths), maxDashboardRepositoryScans)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+				results[index].entries, results[index].err = scan(ctx, paths[index])
+			}
+		}()
+	}
+	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func entriesForRepository(
+	ctx context.Context,
+	path string,
+	projects []models.Project,
+) ([]Entry, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, nil
 	}
-	g := git.New(path)
+	g := git.NewWithContext(ctx, path)
 	worktrees, err := g.ListWorktrees()
 	if err != nil {
 		return nil, err

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -1,0 +1,321 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/pullrequest"
+	"go.kenn.io/kwt/internal/tmux"
+	repositoryurl "go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
+	internalworktree "go.kenn.io/kwt/internal/worktree"
+	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
+)
+
+type SourceOptions struct {
+	Home string
+}
+
+type currentSource struct {
+	home string
+}
+
+func NewSource(options SourceOptions) Source {
+	return &currentSource{home: options.Home}
+}
+
+func (s *currentSource) Load(ctx context.Context, request Request) (Result, error) {
+	if err := request.validate(); err != nil {
+		return Result{}, service.NewError(service.InvalidRequest, err.Error(), false, nil, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	snapshot, err := config.LoadGlobalSnapshotAt(s.home)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{Snapshot: Snapshot{
+		Projects:   CanonicalProjects(snapshot.Config.Projects),
+		Workspaces: append([]models.Workspace(nil), snapshot.Config.Workspaces...),
+	}}
+
+	switch request.View {
+	case ViewProjects:
+		return result, nil
+	case ViewGlobal:
+		result.Snapshot.Entries, err = s.loadGlobal(snapshot.Config)
+	case ViewRepository:
+		result, err = s.loadRepository(ctx, request, snapshot.Config)
+	case ViewDashboard:
+		result.Snapshot.Entries, err = s.loadDashboard(ctx, request, snapshot.Config)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	if err := s.annotateProtectedSockets(ctx, result.Snapshot.Entries); err != nil {
+		return Result{}, err
+	}
+	return result, nil
+}
+
+func (s *currentSource) ApproveConfig(_ context.Context, approval ConfigApproval) error {
+	return config.ApproveWorkingDirectory(config.Approval{
+		Home: s.home, Path: approval.Path, Digest: approval.Digest,
+	})
+}
+
+func (s *currentSource) loadRepository(
+	ctx context.Context,
+	request Request,
+	global *models.Config,
+) (Result, error) {
+	policy := config.RequireInteraction
+	if request.UntrustedConfig == IgnoreUntrustedConfig {
+		policy = config.IgnoreUntrusted
+	}
+	resolved, err := config.ResolveWorkingDirectory(config.ResolveRequest{
+		Home: s.home, WorkingDirectory: request.WorkingDirectory, UntrustedPolicy: policy,
+	})
+	if err != nil {
+		var trust *config.TrustRequiredError
+		if errors.As(err, &trust) {
+			return Result{}, service.NewError(
+				service.InteractionRequired,
+				"repository configuration trust is required",
+				false,
+				map[string]any{
+					"kind": "repository_config_trust", "path": trust.Path,
+					"digest": trust.Digest, "size": trust.Size,
+					"preview": trust.Preview, "truncated": trust.Truncated,
+				},
+				err,
+			)
+		}
+		return Result{}, err
+	}
+	if request.ForceGlobal {
+		entries, loadErr := s.loadGlobal(resolved.Config)
+		return Result{Snapshot: Snapshot{
+			Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
+			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
+		}, Notes: publicNotes(resolved.Notes)}, loadErr
+	}
+
+	g := git.New(request.WorkingDirectory)
+	worktrees, listErr := g.ListWorktrees()
+	if listErr != nil {
+		entries, loadErr := s.loadGlobal(resolved.Config)
+		return Result{Snapshot: Snapshot{
+			Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
+			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
+		}, Notes: publicNotes(resolved.Notes)}, loadErr
+	}
+	info, infoErr := internalworktree.RepositoryInfoWithProjects(g, resolved.Config.Projects)
+	if infoErr != nil {
+		return Result{}, infoErr
+	}
+	entries := make([]Entry, 0, len(worktrees))
+	for _, worktree := range worktrees {
+		entries = append(entries, modelEntry(worktree, "", info))
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	return Result{Snapshot: Snapshot{
+		Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
+		Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
+	}, Notes: publicNotes(resolved.Notes)}, nil
+}
+
+func (s *currentSource) loadGlobal(cfg *models.Config) ([]Entry, error) {
+	entries, err := discovery.DiscoverGlobalWorktrees(cfg.Worktree.BaseDir, cfg.Projects)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover worktrees: %w", err)
+	}
+	return publicEntries(entries), nil
+}
+
+func (s *currentSource) loadDashboard(
+	ctx context.Context,
+	request Request,
+	cfg *models.Config,
+) ([]Entry, error) {
+	entries, err := s.loadGlobal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	for _, project := range cfg.Projects {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		projectEntries, loadErr := entriesForRepository(project.Path, cfg.Projects)
+		if loadErr != nil {
+			if git.IsIncompleteInventory(loadErr) {
+				return nil, loadErr
+			}
+			continue
+		}
+		entries = mergeEntries(entries, projectEntries)
+	}
+	if request.LaunchDirectory != "" {
+		launchEntries, loadErr := entriesForRepository(request.LaunchDirectory, cfg.Projects)
+		if loadErr != nil && git.IsIncompleteInventory(loadErr) {
+			return nil, loadErr
+		}
+		entries = mergeEntries(entries, launchEntries)
+	}
+	return entries, nil
+}
+
+func entriesForRepository(path string, projects []models.Project) ([]Entry, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	g := git.New(path)
+	worktrees, err := g.ListWorktrees()
+	if err != nil {
+		return nil, err
+	}
+	info, err := internalworktree.RepositoryInfoWithProjects(g, projects)
+	if err != nil {
+		return nil, err
+	}
+	repositoryURL, _ := g.GetRepositoryURL()
+	entries := make([]Entry, 0, len(worktrees))
+	for _, worktree := range worktrees {
+		entries = append(entries, modelEntry(worktree, repositoryURL, info))
+	}
+	return entries, nil
+}
+
+func publicEntries(entries []*discovery.GlobalWorktreeEntry) []Entry {
+	result := make([]Entry, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		public := Entry{
+			Path: entry.Path, Branch: entry.Branch, CommitHash: entry.CommitHash,
+			IsMain: entry.IsMain, CreatedAt: entry.CreatedAt, Generation: entry.Generation,
+			Repository: Repository{URL: entry.RepositoryURL},
+		}
+		if entry.RepositoryInfo != nil {
+			public.Repository.Host = entry.RepositoryInfo.Host
+			public.Repository.Owner = entry.RepositoryInfo.Owner
+			public.Repository.Name = entry.RepositoryInfo.Repository
+			public.Repository.FullPath = entry.RepositoryInfo.FullPath
+			public.SessionName = tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path)
+		}
+		result = append(result, public)
+	}
+	return result
+}
+
+func modelEntry(worktree models.Worktree, repositoryURL string, info *repositoryurl.RepositoryInfo) Entry {
+	entry := Entry{
+		Path: worktree.Path, Branch: worktree.Branch, CommitHash: worktree.CommitHash,
+		IsMain: worktree.IsMain, CreatedAt: worktree.CreatedAt, Generation: worktree.Generation,
+		Repository: Repository{URL: repositoryURL},
+	}
+	if info != nil {
+		entry.Repository.Host = info.Host
+		entry.Repository.Owner = info.Owner
+		entry.Repository.Name = info.Repository
+		entry.Repository.FullPath = info.FullPath
+		entry.SessionName = tmux.WorkspaceSessionName(info, entry.Branch, entry.Path)
+	}
+	return entry
+}
+
+// CanonicalProjects returns accessible registrations with their resolved
+// repository identities. It never mutates the supplied registry slice.
+func CanonicalProjects(projects []models.Project) []models.Project {
+	result := make([]models.Project, 0, len(projects))
+	for _, project := range projects {
+		if strings.TrimSpace(project.Path) == "" {
+			continue
+		}
+		g := internalworktree.NewCachedIdentityGit(git.New(project.Path))
+		mainPath, err := g.GetMainRepositoryPath()
+		if err != nil || utils.PathKey(mainPath) != utils.PathKey(project.Path) {
+			continue
+		}
+		info, err := internalworktree.RepositoryInfoWithProjects(g, []models.Project{project})
+		if err != nil {
+			continue
+		}
+		project.Repository = info.FullPath
+		result = append(result, project)
+	}
+	return result
+}
+
+func mergeEntries(existing, incoming []Entry) []Entry {
+	result := append([]Entry(nil), existing...)
+	seen := make(map[string]struct{}, len(result))
+	for _, entry := range result {
+		seen[utils.PathKey(entry.Path)] = struct{}{}
+	}
+	for _, entry := range incoming {
+		key := utils.PathKey(entry.Path)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		result = append(result, entry)
+		seen[key] = struct{}{}
+	}
+	return result
+}
+
+func publicNotes(notes []config.ConfigNote) []Note {
+	result := make([]Note, len(notes))
+	for index, note := range notes {
+		result[index] = Note{Code: note.Code, Path: note.Path}
+	}
+	return result
+}
+
+func (s *currentSource) annotateProtectedSockets(ctx context.Context, entries []Entry) error {
+	records := make(map[string]pullrequest.Provenance)
+	err := pullrequest.NewFileStore(filepath.Join(s.home, "pull-requests.json")).View(
+		ctx,
+		func(current map[string]pullrequest.Provenance) error {
+			for key, record := range current {
+				records[key] = record
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to read pull-request provenance: %w", err)
+	}
+	for index := range entries {
+		for _, record := range records {
+			workspace := record.Workspace
+			repository := workspace.Repository
+			if repository == "" {
+				repository = record.Project.Identity
+			}
+			if utils.PathKey(workspace.Path) != utils.PathKey(entries[index].Path) ||
+				workspace.Branch != entries[index].Branch ||
+				workspace.SessionName != entries[index].SessionName ||
+				pullrequest.NormalizeRepositoryIdentity(repository) != pullrequest.NormalizeRepositoryIdentity(entries[index].Repository.FullPath) {
+				continue
+			}
+			if workspace.Generation != "" && workspace.Generation != entries[index].Generation {
+				continue
+			}
+			entries[index].TmuxSocketName = tmux.ProtectedWorkspaceSocketName(workspace.SessionName, workspace.Path)
+			break
+		}
+	}
+	return nil
+}

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -62,8 +62,10 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 	if err != nil {
 		return Result{}, err
 	}
-	if err := s.annotateProtectedSockets(ctx, result.Snapshot.Entries); err != nil {
-		return Result{}, err
+	if request.IncludeProtectedSockets {
+		if err := s.annotateProtectedSockets(ctx, result.Snapshot.Entries); err != nil {
+			return Result{}, err
+		}
 	}
 	return result, nil
 }

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -44,18 +44,20 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 		return Result{}, err
 	}
 	result := Result{Snapshot: Snapshot{
-		Projects:   CanonicalProjects(snapshot.Config.Projects),
 		Workspaces: append([]models.Workspace(nil), snapshot.Config.Workspaces...),
 	}}
 
 	switch request.View {
 	case ViewProjects:
+		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
 		return result, nil
 	case ViewGlobal:
+		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
 		result.Snapshot.Entries, err = s.loadGlobal(snapshot.Config)
 	case ViewRepository:
 		result, err = s.loadRepository(ctx, request, snapshot.Config)
 	case ViewDashboard:
+		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
 		result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
 			s.loadDashboard(ctx, request, snapshot.Config)
 	}

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/pullrequest"
@@ -59,20 +60,21 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 		Config:     snapshot.Config,
 		Workspaces: append([]models.Workspace(nil), snapshot.Config.Workspaces...),
 	}}
+	protectedNames := credentials.ProtectedNames(snapshot.Config)
 
 	switch request.View {
 	case ViewProjects:
-		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects)
+		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects, protectedNames...)
 		return result, err
 	case ViewGlobal:
-		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects)
+		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects, protectedNames...)
 		if err == nil {
 			result.Snapshot.Entries, err = s.loadGlobal(ctx, snapshot.Config)
 		}
 	case ViewRepository:
 		result, err = s.loadRepository(ctx, request, snapshot.Config, expansion.expandPath)
 	case ViewDashboard:
-		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects)
+		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects, protectedNames...)
 		if err == nil {
 			result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
 				s.loadDashboard(ctx, request, snapshot.Config)
@@ -151,7 +153,11 @@ func (s *currentSource) loadRepository(
 	}
 	if request.ForceGlobal {
 		entries, loadErr := s.loadGlobal(ctx, resolved.Config)
-		projects, projectsErr := CanonicalProjects(ctx, resolved.Config.Projects)
+		projects, projectsErr := CanonicalProjects(
+			ctx,
+			resolved.Config.Projects,
+			credentials.ProtectedNames(resolved.Config)...,
+		)
 		if loadErr == nil {
 			loadErr = projectsErr
 		}
@@ -171,7 +177,11 @@ func (s *currentSource) loadRepository(
 	}
 	if !isRepository {
 		entries, loadErr := s.loadGlobal(ctx, resolved.Config)
-		projects, projectsErr := CanonicalProjects(ctx, resolved.Config.Projects)
+		projects, projectsErr := CanonicalProjects(
+			ctx,
+			resolved.Config.Projects,
+			credentials.ProtectedNames(resolved.Config)...,
+		)
 		if loadErr == nil {
 			loadErr = projectsErr
 		}
@@ -181,7 +191,8 @@ func (s *currentSource) loadRepository(
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
 
-	g := git.NewWithContext(ctx, workingDirectory)
+	protectedNames := credentials.ProtectedNames(resolved.Config)
+	g := git.NewForInventory(ctx, workingDirectory, protectedNames)
 	worktrees, listErr := g.ListWorktrees()
 	if listErr != nil {
 		return Result{}, listErr
@@ -197,7 +208,7 @@ func (s *currentSource) loadRepository(
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}
-	projects, err := CanonicalProjects(ctx, resolved.Config.Projects)
+	projects, err := CanonicalProjects(ctx, resolved.Config.Projects, protectedNames...)
 	if err != nil {
 		return Result{}, err
 	}
@@ -226,7 +237,12 @@ func hasGitMarker(path string) (bool, error) {
 }
 
 func (s *currentSource) loadGlobal(ctx context.Context, cfg *models.Config) ([]Entry, error) {
-	entries, err := discovery.DiscoverGlobalWorktreesContext(ctx, cfg.Worktree.BaseDir, cfg.Projects)
+	entries, err := discovery.DiscoverGlobalWorktreesContext(
+		ctx,
+		cfg.Worktree.BaseDir,
+		cfg.Projects,
+		credentials.ProtectedNames(cfg)...,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover worktrees: %w", err)
 	}
@@ -238,6 +254,7 @@ func (s *currentSource) loadDashboard(
 	request Request,
 	cfg *models.Config,
 ) ([]Entry, []Entry, error) {
+	protectedNames := credentials.ProtectedNames(cfg)
 	entries, err := s.loadGlobal(ctx, cfg)
 	if err != nil {
 		return nil, nil, err
@@ -250,7 +267,7 @@ func (s *currentSource) loadDashboard(
 		ctx context.Context,
 		path string,
 	) ([]Entry, error) {
-		return entriesForRepository(ctx, path, cfg.Projects)
+		return entriesForRepository(ctx, path, cfg.Projects, protectedNames)
 	})
 	if err != nil {
 		return nil, nil, err
@@ -267,11 +284,24 @@ func (s *currentSource) loadDashboard(
 	var launchEntries []Entry
 	if request.LaunchDirectory != "" {
 		var loadErr error
-		launchEntries, loadErr = entriesForRepository(ctx, request.LaunchDirectory, cfg.Projects)
-		if loadErr != nil && git.IsIncompleteInventory(loadErr) {
-			return nil, nil, loadErr
+		launchEntries, loadErr = entriesForRepository(
+			ctx,
+			request.LaunchDirectory,
+			cfg.Projects,
+			protectedNames,
+		)
+		if loadErr != nil {
+			if errors.Is(loadErr, context.Canceled) || errors.Is(loadErr, context.DeadlineExceeded) {
+				return nil, nil, loadErr
+			}
+			if git.IsIncompleteInventory(loadErr) {
+				return nil, nil, loadErr
+			}
 		}
 		entries = mergeEntries(entries, launchEntries)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
 	}
 	return entries, launchEntries, nil
 }
@@ -315,11 +345,12 @@ func entriesForRepository(
 	ctx context.Context,
 	path string,
 	projects []models.Project,
+	protectedNames []string,
 ) ([]Entry, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, nil
 	}
-	g := git.NewWithContext(ctx, path)
+	g := git.NewForInventory(ctx, path, protectedNames)
 	worktrees, err := g.ListWorktrees()
 	if err != nil {
 		return nil, err
@@ -380,6 +411,7 @@ func modelEntry(worktree models.Worktree, repositoryURL string, info *repository
 func CanonicalProjects(
 	ctx context.Context,
 	projects []models.Project,
+	protectedNames ...string,
 ) ([]models.Project, error) {
 	result := make([]models.Project, 0, len(projects))
 	for _, project := range projects {
@@ -389,7 +421,9 @@ func CanonicalProjects(
 		if strings.TrimSpace(project.Path) == "" {
 			continue
 		}
-		g := internalworktree.NewCachedIdentityGit(git.NewWithContext(ctx, project.Path))
+		g := internalworktree.NewCachedIdentityGit(
+			git.NewForInventory(ctx, project.Path, protectedNames),
+		)
 		mainPath, err := g.GetMainRepositoryPath()
 		if err != nil || utils.PathKey(mainPath) != utils.PathKey(project.Path) {
 			continue

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -55,7 +56,8 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 	case ViewRepository:
 		result, err = s.loadRepository(ctx, request, snapshot.Config)
 	case ViewDashboard:
-		result.Snapshot.Entries, err = s.loadDashboard(ctx, request, snapshot.Config)
+		result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
+			s.loadDashboard(ctx, request, snapshot.Config)
 	}
 	if err != nil {
 		return Result{}, err
@@ -109,14 +111,22 @@ func (s *currentSource) loadRepository(
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
 
-	g := git.New(request.WorkingDirectory)
-	worktrees, listErr := g.ListWorktrees()
-	if listErr != nil {
+	isRepository, err := hasGitMarker(request.WorkingDirectory)
+	if err != nil {
+		return Result{}, err
+	}
+	if !isRepository {
 		entries, loadErr := s.loadGlobal(resolved.Config)
 		return Result{Snapshot: Snapshot{
 			Projects: CanonicalProjects(resolved.Config.Projects), Entries: entries,
 			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
+	}
+
+	g := git.New(request.WorkingDirectory)
+	worktrees, listErr := g.ListWorktrees()
+	if listErr != nil {
+		return Result{}, listErr
 	}
 	info, infoErr := internalworktree.RepositoryInfoWithProjects(g, resolved.Config.Projects)
 	if infoErr != nil {
@@ -135,6 +145,24 @@ func (s *currentSource) loadRepository(
 	}, Notes: publicNotes(resolved.Notes)}, nil
 }
 
+func hasGitMarker(path string) (bool, error) {
+	current := filepath.Clean(path)
+	for {
+		_, err := os.Lstat(filepath.Join(current, ".git"))
+		switch {
+		case err == nil:
+			return true, nil
+		case !errors.Is(err, os.ErrNotExist):
+			return false, fmt.Errorf("inspect repository marker: %w", err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false, nil
+		}
+		current = parent
+	}
+}
+
 func (s *currentSource) loadGlobal(cfg *models.Config) ([]Entry, error) {
 	entries, err := discovery.DiscoverGlobalWorktrees(cfg.Worktree.BaseDir, cfg.Projects)
 	if err != nil {
@@ -147,32 +175,34 @@ func (s *currentSource) loadDashboard(
 	ctx context.Context,
 	request Request,
 	cfg *models.Config,
-) ([]Entry, error) {
+) ([]Entry, []Entry, error) {
 	entries, err := s.loadGlobal(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, project := range cfg.Projects {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		projectEntries, loadErr := entriesForRepository(project.Path, cfg.Projects)
 		if loadErr != nil {
 			if git.IsIncompleteInventory(loadErr) {
-				return nil, loadErr
+				return nil, nil, loadErr
 			}
 			continue
 		}
 		entries = mergeEntries(entries, projectEntries)
 	}
+	var launchEntries []Entry
 	if request.LaunchDirectory != "" {
-		launchEntries, loadErr := entriesForRepository(request.LaunchDirectory, cfg.Projects)
+		var loadErr error
+		launchEntries, loadErr = entriesForRepository(request.LaunchDirectory, cfg.Projects)
 		if loadErr != nil && git.IsIncompleteInventory(loadErr) {
-			return nil, loadErr
+			return nil, nil, loadErr
 		}
 		entries = mergeEntries(entries, launchEntries)
 	}
-	return entries, nil
+	return entries, launchEntries, nil
 }
 
 func entriesForRepository(path string, projects []models.Project) ([]Entry, error) {

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -161,7 +161,11 @@ func (s *currentSource) loadRepository(
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
 
-	isRepository, err := hasGitMarker(request.WorkingDirectory)
+	workingDirectory, err := filepath.EvalSymlinks(request.WorkingDirectory)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve repository path: %w", err)
+	}
+	isRepository, err := hasGitMarker(workingDirectory)
 	if err != nil {
 		return Result{}, err
 	}
@@ -177,7 +181,7 @@ func (s *currentSource) loadRepository(
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
 
-	g := git.NewWithContext(ctx, request.WorkingDirectory)
+	g := git.NewWithContext(ctx, workingDirectory)
 	worktrees, listErr := g.ListWorktrees()
 	if listErr != nil {
 		return Result{}, listErr

--- a/worktree/source.go
+++ b/worktree/source.go
@@ -39,7 +39,8 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}
-	snapshot, err := config.LoadGlobalSnapshotAt(s.home)
+	expansion := request.Expansion
+	snapshot, err := config.LoadGlobalSnapshotAtWithExpansion(s.home, expansion.expandPath)
 	if err != nil {
 		return Result{}, err
 	}
@@ -55,7 +56,7 @@ func (s *currentSource) Load(ctx context.Context, request Request) (Result, erro
 		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
 		result.Snapshot.Entries, err = s.loadGlobal(snapshot.Config)
 	case ViewRepository:
-		result, err = s.loadRepository(ctx, request, snapshot.Config)
+		result, err = s.loadRepository(ctx, request, snapshot.Config, expansion.expandPath)
 	case ViewDashboard:
 		result.Snapshot.Projects = CanonicalProjects(snapshot.Config.Projects)
 		result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
@@ -82,6 +83,7 @@ func (s *currentSource) loadRepository(
 	ctx context.Context,
 	request Request,
 	global *models.Config,
+	expandPath func(string) (string, error),
 ) (Result, error) {
 	policy := config.RequireInteraction
 	if request.UntrustedConfig == IgnoreUntrustedConfig {
@@ -89,6 +91,7 @@ func (s *currentSource) loadRepository(
 	}
 	resolved, err := config.ResolveWorkingDirectory(config.ResolveRequest{
 		Home: s.home, WorkingDirectory: request.WorkingDirectory, UntrustedPolicy: policy,
+		ExpandPath: expandPath,
 	})
 	if err != nil {
 		var trust *config.TrustRequiredError

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +13,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 )
+
+func TestCanonicalProjectsStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := CanonicalProjects(ctx, []models.Project{{Path: t.TempDir()}})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSourceClassifiesInventoryFailuresWithActionableMessage(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[[projects]\n"),
+		0o600,
+	))
+
+	_, err := NewSource(SourceOptions{Home: home}).Load(context.Background(), Request{
+		View: ViewProjects, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
+	})
+
+	var typed *service.Error
+	require.ErrorAs(t, err, &typed)
+	assert.NotEqual(t, "internal failure", typed.Message)
+	assert.Contains(t, typed.Message, "config")
+	assert.LessOrEqual(t, len(typed.Message), 512)
+}
+
+func TestBoundedDiagnosticRemovesControlCharacters(t *testing.T) {
+	got := boundedDiagnostic(errors.New("unsafe\nmessage\twith\rcontrols"))
+
+	assert.Equal(t, "unsafe message with controls", got)
+}
 
 func TestScanRepositoriesBoundsConcurrencyAndPreservesOrder(t *testing.T) {
 	paths := make([]string, maxDashboardRepositoryScans+4)

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -1,0 +1,39 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceProjectsFiltersInaccessibleRegistrations(t *testing.T) {
+	home := t.TempDir()
+	repository := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.Mkdir(repository, 0o755))
+	command := exec.Command("git", "init", repository)
+	require.NoError(t, command.Run())
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
+		"[[projects]]\nrepository = 'github.com/acme/repo'\nname = 'repo'\npath = '"+repository+"'\n\n"+
+			"[[projects]]\nrepository = 'github.com/acme/missing'\nname = 'missing'\npath = '"+filepath.Join(t.TempDir(), "missing")+"'\n",
+	), 0o600))
+
+	result, err := NewSource(SourceOptions{Home: home}).Load(context.Background(), Request{
+		View: ViewProjects, UntrustedConfig: IgnoreUntrustedConfig,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Snapshot.Projects, 1)
+	assert.Equal(t, "github.com/acme/repo", result.Snapshot.Projects[0].Repository)
+}
+
+func TestSourceRejectsRelativeRepositoryDirectory(t *testing.T) {
+	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
+		View: ViewRepository, WorkingDirectory: "relative", UntrustedConfig: IgnoreUntrustedConfig,
+	})
+	assert.ErrorContains(t, err, "must be absolute")
+}

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
@@ -228,6 +229,35 @@ func TestSourceRecognizesRepositoryThroughSymlinkedSubdirectory(t *testing.T) {
 	assert.Equal(t, canonicalRepository, result.Snapshot.Entries[0].Path)
 }
 
+func TestSourceRepositoryInventoryIgnoresInheritedGitRouting(t *testing.T) {
+	createRepository := func(path string) {
+		t.Helper()
+		for _, args := range [][]string{
+			{"init", "-b", "main", path},
+			{"-C", path, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial"},
+		} {
+			command := exec.Command("git", args...)
+			require.NoError(t, command.Run())
+		}
+	}
+	target := filepath.Join(t.TempDir(), "target")
+	redirected := filepath.Join(t.TempDir(), "redirected")
+	createRepository(target)
+	createRepository(redirected)
+	t.Setenv("GIT_DIR", filepath.Join(redirected, ".git"))
+
+	result, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
+		View: ViewRepository, WorkingDirectory: target,
+		UntrustedConfig: IgnoreUntrustedConfig, Expansion: testExpansion(t),
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Snapshot.Entries)
+	canonicalTarget, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+	assert.Equal(t, canonicalTarget, result.Snapshot.Entries[0].Path)
+}
+
 func TestSourceReadsProvenanceOnlyWhenRequested(t *testing.T) {
 	home := t.TempDir()
 	baseDirectory := t.TempDir()
@@ -274,4 +304,29 @@ func TestSourceSeparatesLaunchInventoryFromDashboardEntries(t *testing.T) {
 		assert.Equal(t, canonicalLaunchDirectory, entry.Path)
 		assert.Equal(t, "github.com/acme/launch", entry.Repository.FullPath)
 	}
+}
+
+func TestDashboardLaunchInventoryPropagatesRefreshDeadline(t *testing.T) {
+	launchDirectory := filepath.Join(t.TempDir(), "launch")
+	for _, args := range [][]string{
+		{"init", "-b", "main", launchDirectory},
+		{"-C", launchDirectory, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial"},
+	} {
+		command := exec.Command("git", args...)
+		require.NoError(t, command.Run())
+	}
+	lock := flock.New(
+		filepath.Join(launchDirectory, ".git", "kwt-worktree.lock"),
+		flock.SetPermissions(0o600),
+	)
+	require.NoError(t, lock.Lock())
+	t.Cleanup(func() { _ = lock.Unlock() })
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := (&currentSource{}).loadDashboard(ctx, Request{
+		LaunchDirectory: launchDirectory,
+	}, &models.Config{Worktree: models.WorktreeConfig{BaseDir: t.TempDir()}})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -200,6 +200,34 @@ func TestSourcePropagatesRepositoryInventoryErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSourceRecognizesRepositoryThroughSymlinkedSubdirectory(t *testing.T) {
+	repository := filepath.Join(t.TempDir(), "repository")
+	for _, args := range [][]string{
+		{"init", "-b", "main", repository},
+		{"-C", repository, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial"},
+	} {
+		command := exec.Command("git", args...)
+		require.NoError(t, command.Run())
+	}
+	subdirectory := filepath.Join(repository, "nested", "directory")
+	require.NoError(t, os.MkdirAll(subdirectory, 0o755))
+	linkedDirectory := filepath.Join(t.TempDir(), "linked-directory")
+	if err := os.Symlink(subdirectory, linkedDirectory); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	result, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
+		View: ViewRepository, WorkingDirectory: linkedDirectory,
+		UntrustedConfig: IgnoreUntrustedConfig, Expansion: testExpansion(t),
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Snapshot.Entries)
+	canonicalRepository, err := filepath.EvalSymlinks(repository)
+	require.NoError(t, err)
+	assert.Equal(t, canonicalRepository, result.Snapshot.Entries[0].Path)
+}
+
 func TestSourceReadsProvenanceOnlyWhenRequested(t *testing.T) {
 	home := t.TempDir()
 	baseDirectory := t.TempDir()

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -5,12 +5,86 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+func TestScanRepositoriesBoundsConcurrencyAndPreservesOrder(t *testing.T) {
+	paths := make([]string, maxDashboardRepositoryScans+4)
+	for index := range paths {
+		paths[index] = string(rune('a' + index))
+	}
+	release := make(chan struct{})
+	var active atomic.Int32
+	var maximum atomic.Int32
+	type scanOutcome struct {
+		results []repositoryScanResult
+		err     error
+	}
+	done := make(chan scanOutcome, 1)
+	go func() {
+		results, err := scanRepositories(context.Background(), paths, func(
+			_ context.Context,
+			path string,
+		) ([]Entry, error) {
+			current := active.Add(1)
+			defer active.Add(-1)
+			for {
+				observed := maximum.Load()
+				if current <= observed || maximum.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			<-release
+			return []Entry{{Path: path}}, nil
+		})
+		done <- scanOutcome{results: results, err: err}
+	}()
+	require.Eventually(t, func() bool {
+		return active.Load() == maxDashboardRepositoryScans
+	}, time.Second, time.Millisecond)
+	assert.LessOrEqual(t, maximum.Load(), int32(maxDashboardRepositoryScans))
+	close(release)
+	outcome := <-done
+	require.NoError(t, outcome.err)
+	results := outcome.results
+	require.Len(t, results, len(paths))
+	for index, result := range results {
+		require.NoError(t, result.err)
+		require.Len(t, result.entries, 1)
+		assert.Equal(t, paths[index], result.entries[0].Path)
+	}
+}
+
+func TestScanRepositoriesPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := scanRepositories(ctx, []string{"repository"}, func(
+			ctx context.Context,
+			_ string,
+		) ([]Entry, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+		done <- err
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("repository scan did not stop after cancellation")
+	}
+}
 
 func testExpansion(t *testing.T) ExpansionContext {
 	t.Helper()

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -149,6 +149,25 @@ func TestSourceProjectsFiltersInaccessibleRegistrations(t *testing.T) {
 	assert.Equal(t, "github.com/acme/repo", result.Snapshot.Projects[0].Repository)
 }
 
+func TestSourceSnapshotIncludesEffectiveGlobalConfig(t *testing.T) {
+	home := t.TempDir()
+	baseDirectory := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[worktree]\nbasedir = '"+baseDirectory+"'\n[layouts]\ndefault = 'quad'\n"),
+		0o600,
+	))
+
+	result, err := NewSource(SourceOptions{Home: home}).Load(context.Background(), Request{
+		View: ViewProjects, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Snapshot.Config)
+	assert.Equal(t, baseDirectory, result.Snapshot.Config.Worktree.BaseDir)
+	assert.Equal(t, "quad", result.Snapshot.Config.Layouts.Default)
+}
+
 func TestSourceRejectsRelativeRepositoryDirectory(t *testing.T) {
 	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
 		View: ViewRepository, WorkingDirectory: "relative", Expansion: testExpansion(t),

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -12,6 +12,13 @@ import (
 	"go.kenn.io/kwt/pkg/models"
 )
 
+func testExpansion(t *testing.T) ExpansionContext {
+	t.Helper()
+	expansion, err := CaptureExpansionContext()
+	require.NoError(t, err)
+	return expansion
+}
+
 func TestSourceProjectsFiltersInaccessibleRegistrations(t *testing.T) {
 	home := t.TempDir()
 	repository := filepath.Join(t.TempDir(), "repo")
@@ -24,7 +31,7 @@ func TestSourceProjectsFiltersInaccessibleRegistrations(t *testing.T) {
 	), 0o600))
 
 	result, err := NewSource(SourceOptions{Home: home}).Load(context.Background(), Request{
-		View: ViewProjects, UntrustedConfig: IgnoreUntrustedConfig,
+		View: ViewProjects, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
 	})
 
 	require.NoError(t, err)
@@ -34,9 +41,18 @@ func TestSourceProjectsFiltersInaccessibleRegistrations(t *testing.T) {
 
 func TestSourceRejectsRelativeRepositoryDirectory(t *testing.T) {
 	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
-		View: ViewRepository, WorkingDirectory: "relative", UntrustedConfig: IgnoreUntrustedConfig,
+		View: ViewRepository, WorkingDirectory: "relative", Expansion: testExpansion(t),
+		UntrustedConfig: IgnoreUntrustedConfig,
 	})
 	assert.ErrorContains(t, err, "must be absolute")
+}
+
+func TestSourceRejectsMissingPathExpansionContext(t *testing.T) {
+	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
+		View: ViewProjects, UntrustedConfig: IgnoreUntrustedConfig,
+	})
+
+	assert.ErrorContains(t, err, "path-expansion working directory must be absolute")
 }
 
 func TestSourcePropagatesRepositoryInventoryErrors(t *testing.T) {
@@ -49,6 +65,7 @@ func TestSourcePropagatesRepositoryInventoryErrors(t *testing.T) {
 
 	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
 		View: ViewRepository, WorkingDirectory: workingDirectory, UntrustedConfig: IgnoreUntrustedConfig,
+		Expansion: testExpansion(t),
 	})
 
 	require.Error(t, err)
@@ -64,12 +81,12 @@ func TestSourceReadsProvenanceOnlyWhenRequested(t *testing.T) {
 	source := NewSource(SourceOptions{Home: home})
 
 	_, err := source.Load(context.Background(), Request{
-		View: ViewDashboard, UntrustedConfig: IgnoreUntrustedConfig,
+		View: ViewDashboard, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
 	})
 	require.NoError(t, err)
 
 	_, err = source.Load(context.Background(), Request{
-		View: ViewDashboard, UntrustedConfig: IgnoreUntrustedConfig,
+		View: ViewDashboard, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
 		IncludeProtectedSockets: true,
 	})
 	require.ErrorContains(t, err, "failed to read pull-request provenance")

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -54,6 +54,27 @@ func TestSourcePropagatesRepositoryInventoryErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSourceReadsProvenanceOnlyWhenRequested(t *testing.T) {
+	home := t.TempDir()
+	baseDirectory := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
+		"[worktree]\nbasedir = '"+baseDirectory+"'\n",
+	), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "pull-requests.json"), []byte("{"), 0o600))
+	source := NewSource(SourceOptions{Home: home})
+
+	_, err := source.Load(context.Background(), Request{
+		View: ViewDashboard, UntrustedConfig: IgnoreUntrustedConfig,
+	})
+	require.NoError(t, err)
+
+	_, err = source.Load(context.Background(), Request{
+		View: ViewDashboard, UntrustedConfig: IgnoreUntrustedConfig,
+		IncludeProtectedSockets: true,
+	})
+	require.ErrorContains(t, err, "failed to read pull-request provenance")
+}
+
 func TestSourceSeparatesLaunchInventoryFromDashboardEntries(t *testing.T) {
 	launchDirectory := t.TempDir()
 	for _, args := range [][]string{

--- a/worktree/source_test.go
+++ b/worktree/source_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 func TestSourceProjectsFiltersInaccessibleRegistrations(t *testing.T) {
@@ -36,4 +37,46 @@ func TestSourceRejectsRelativeRepositoryDirectory(t *testing.T) {
 		View: ViewRepository, WorkingDirectory: "relative", UntrustedConfig: IgnoreUntrustedConfig,
 	})
 	assert.ErrorContains(t, err, "must be absolute")
+}
+
+func TestSourcePropagatesRepositoryInventoryErrors(t *testing.T) {
+	workingDirectory := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workingDirectory, ".git"),
+		[]byte("gitdir: /missing/repository\n"),
+		0o600,
+	))
+
+	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
+		View: ViewRepository, WorkingDirectory: workingDirectory, UntrustedConfig: IgnoreUntrustedConfig,
+	})
+
+	require.Error(t, err)
+}
+
+func TestSourceSeparatesLaunchInventoryFromDashboardEntries(t *testing.T) {
+	launchDirectory := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-b", "main", launchDirectory},
+		{"-C", launchDirectory, "remote", "add", "origin", "https://github.com/acme/launch.git"},
+		{"-C", launchDirectory, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial"},
+	} {
+		command := exec.Command("git", args...)
+		require.NoError(t, command.Run())
+	}
+	source := &currentSource{}
+
+	entries, launchEntries, err := source.loadDashboard(context.Background(), Request{
+		LaunchDirectory: launchDirectory,
+	}, &models.Config{Worktree: models.WorktreeConfig{BaseDir: t.TempDir()}})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	require.NotEmpty(t, launchEntries)
+	canonicalLaunchDirectory, err := filepath.EvalSymlinks(launchDirectory)
+	require.NoError(t, err)
+	for _, entry := range launchEntries {
+		assert.Equal(t, canonicalLaunchDirectory, entry.Path)
+		assert.Equal(t, "github.com/acme/launch", entry.Repository.FullPath)
+	}
 }


### PR DESCRIPTION
Ghosthub depends on kwt's machine-readable CLI, so this moves inventory ownership into the local daemon without changing the CLI boundary it consumes. `projects` and `list` now require a current daemon snapshot and retain their bare-array JSON, warnings, and exit behavior; the TUI paints from the disposable last-known-good cache before requesting one current snapshot.

The new public `worktree` package owns discovery, freshness, and cache policy, while the authenticated loopback API carries typed repository-config trust requirements. Remote callers still invoke the remote kwt CLI, which talks only to that machine's loopback daemon. Subprocess coverage pins cold startup, noninteractive trust behavior, and exit 1 for unresponsive, incompatible, and draining daemon owners so 255 remains reserved for SSH transport.

Validated with the race-enabled inventory/config/daemon/command/TUI suites, the full test and build gates, strict docs, and Windows cross-compilation.
