### PR TITLE
Expose noninteractive project unregistration

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ refreshes that project entry, so future dashboard launches can see its
 worktrees even when they are outside `worktree.basedir`.
 Noninteractive clients can register an existing checkout explicitly with
 `kwt projects add /absolute/repository/path --json`.
+They can unregister it without deleting repository or worktree data with
+`kwt projects remove /absolute/repository/path --json`.
 
 ### Repository Setup
 
@@ -276,7 +278,7 @@ spaces.
 | `kwt open`       | Open or establish a workspace session       |
 | `kwt list`       | List worktrees                              |
 | `kwt status`     | Show git status, sync state, and activity   |
-| `kwt projects`   | List or register project repositories       |
+| `kwt projects`   | List, register, or unregister projects      |
 | `kwt pr`         | Discover and import pull requests as JSON   |
 | `kwt get`        | Print a matching worktree path              |
 | `kwt cd`         | Open a shell in a matching worktree         |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -342,8 +342,8 @@ instead of claiming those paths would be removed.
 ## `kwt projects`
 
 The list action obtains a current inventory snapshot from the same-machine
-daemon. `projects add` remains a direct foreground mutation until the worktree
-mutation service migrates.
+daemon. `projects add` and `projects remove` remain direct foreground mutations
+until project mutations migrate to the daemon.
 
 `--json` emits an array of the registered project repositories (`{repository,
 name, path, last_touched}`), so external automation can discover main-repo
@@ -362,6 +362,12 @@ the dashboard. A linked-worktree path resolves to its main repository before
 registration, and repeating the command updates the existing entry rather than
 adding a duplicate.
 
+`kwt projects remove <path>` unregisters exactly one project by its configured
+path. The path may name a checkout that no longer exists. Unregistration only
+removes discovery metadata: it never deletes the repository, its worktrees, or
+tmux sessions. A concurrent change to the matched registration is preserved
+and reported as retryable instead of being overwritten.
+
 With `--json`, success returns:
 
 ```json
@@ -377,7 +383,9 @@ With `--json`, success returns:
 ```
 
 Failures return a stable error envelope on stdout. `invalid_repository` exits
-2; `registration_failed` exits 1. Both are non-retryable:
+2; `registration_failed` exits 1. Project removal additionally reports
+`project_not_found` with exit 2, `unregistration_failed` with exit 1, or the
+retryable `registration_changed` with exit 1:
 
 ```json
 {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,6 +93,8 @@ registers or refreshes that repository so future dashboard launches can find its
 worktrees from anywhere.
 Automation and graphical clients can perform the same explicit registration
 without opening the dashboard by running `kwt projects add <path> --json`.
+They can unregister that metadata with `kwt projects remove <path> --json`;
+the command never deletes repository, worktree, or tmux-session data.
 
 Project entries are discovery metadata, not worktree-creation policy:
 

--- a/internal/cmd/inventory_subprocess_test.go
+++ b/internal/cmd/inventory_subprocess_test.go
@@ -130,6 +130,47 @@ path = "$KWT_TEST_PROJECT"
 	assert.Equal(t, secondRepository, secondProjects[0].Path)
 }
 
+func TestProjectsRemoveIsVisibleToDaemonInventory(t *testing.T) {
+	binary, cleanupBinary := buildDaemonTestBinaries(t)
+	repository := filepath.Join(t.TempDir(), "widget")
+	require.NoError(t, exec.Command("git", "init", repository).Run())
+	repository, err := filepath.EvalSymlinks(repository)
+	require.NoError(t, err)
+	home := newDaemonTestHome(t, validDaemonConfig+`
+[[projects]]
+repository = "github.com/acme/widget"
+name = "widget"
+path = "`+filepath.ToSlash(repository)+`"
+`)
+	registerDaemonCleanup(t, cleanupBinary, home)
+	directory := t.TempDir()
+
+	before, stderr, err := runInventoryCommand(
+		t, binary, home, directory, "projects", "--json",
+	)
+	require.NoError(t, err, "stderr=%s", stderr)
+	var projects []models.Project
+	require.NoError(t, json.Unmarshal(before, &projects))
+	require.Len(t, projects, 1)
+
+	removed, stderr, err := runInventoryCommand(
+		t, binary, home, directory,
+		"projects", "remove", repository, "--json",
+	)
+	require.NoError(t, err, "stderr=%s", stderr)
+	var response struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(removed, &response))
+	assert.Equal(t, "unregistered", response.Status)
+
+	after, stderr, err := runInventoryCommand(
+		t, binary, home, directory, "projects", "--json",
+	)
+	require.NoError(t, err, "stderr=%s", stderr)
+	assert.Equal(t, "[]\n", string(after))
+}
+
 func TestInventorySubprocessDaemonFailuresNeverUseSSHExit255(t *testing.T) {
 	binary, _ := buildDaemonTestBinaries(t)
 	fixture := buildDaemonFixture(t)

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -245,6 +245,7 @@ func runProjectsRemove(cmd *cobra.Command, args []string) error {
 			true,
 		)
 	}
+	project.Repository = publishableProjectRepository(project)
 
 	if projectsRemoveJSON {
 		encoder := json.NewEncoder(cmd.OutOrStdout())

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -22,8 +22,10 @@ import (
 var (
 	projectsJSON           bool
 	projectsAddJSON        bool
+	projectsRemoveJSON     bool
 	loadProjectsConfig     = config.Load
 	registerProject        = config.RegisterProject
+	unregisterProject      = config.UnregisterProject
 	queryProjectsInventory = queryCLIInventory
 )
 
@@ -41,9 +43,13 @@ that external automation can consume without parsing the config file.`,
 	// initialization failures through Cobra.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := requireConfigInitialization(); err != nil {
+			code := "registration_failed"
+			if cmd == projectsRemoveCmd {
+				code = "unregistration_failed"
+			}
 			return writeProjectCommandError(
 				cmd,
-				"registration_failed",
+				code,
 				fmt.Sprintf("failed to initialize configuration: %v", err),
 				1,
 			)
@@ -60,11 +66,19 @@ var projectsAddCmd = &cobra.Command{
 	RunE:  runProjectsAdd,
 }
 
+var projectsRemoveCmd = &cobra.Command{
+	Use:   "remove <path>",
+	Short: "Unregister a project without deleting its repository",
+	Args:  projectsExactArgs(1),
+	RunE:  runProjectsRemove,
+}
+
 func init() {
 	rootCmd.AddCommand(projectsCmd)
 	projectsCmd.Flags().BoolVar(&projectsJSON, "json", false, "Output in JSON format")
 	projectsAddCmd.Flags().BoolVar(&projectsAddJSON, "json", false, "Output a machine-readable result")
-	projectsCmd.AddCommand(projectsAddCmd)
+	projectsRemoveCmd.Flags().BoolVar(&projectsRemoveJSON, "json", false, "Output a machine-readable result")
+	projectsCmd.AddCommand(projectsAddCmd, projectsRemoveCmd)
 	projectsCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return writeProjectCommandError(cmd, "invalid_repository", err.Error(), 2)
 	})
@@ -100,7 +114,7 @@ func runProjects(cmd *cobra.Command, args []string) error {
 	return t.Println()
 }
 
-type projectAddResult struct {
+type projectMutationResult struct {
 	Status  string         `json:"status"`
 	Project models.Project `json:"project"`
 }
@@ -190,7 +204,7 @@ func runProjectsAdd(cmd *cobra.Command, args []string) error {
 	if projectsAddJSON {
 		encoder := json.NewEncoder(cmd.OutOrStdout())
 		encoder.SetIndent("", "  ")
-		return encoder.Encode(projectAddResult{
+		return encoder.Encode(projectMutationResult{
 			Status:  "registered",
 			Project: project,
 		})
@@ -198,6 +212,51 @@ func runProjectsAdd(cmd *cobra.Command, args []string) error {
 	_, err = fmt.Fprintf(
 		cmd.OutOrStdout(),
 		"registered project %s at %s\n",
+		project.Name,
+		project.Path,
+	)
+	return err
+}
+
+func runProjectsRemove(cmd *cobra.Command, args []string) error {
+	project, changed, err := unregisterProject(args[0])
+	if err != nil {
+		return writeProjectCommandError(
+			cmd,
+			"unregistration_failed",
+			fmt.Sprintf("failed to unregister project: %v", err),
+			1,
+		)
+	}
+	if !changed && project.Path == "" {
+		return writeProjectCommandError(
+			cmd,
+			"project_not_found",
+			fmt.Sprintf("no project is registered at %s", args[0]),
+			2,
+		)
+	}
+	if !changed {
+		return writeProjectCommandErrorWithRetry(
+			cmd,
+			"registration_changed",
+			"the project registration changed before it could be removed",
+			1,
+			true,
+		)
+	}
+
+	if projectsRemoveJSON {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(projectMutationResult{
+			Status:  "unregistered",
+			Project: project,
+		})
+	}
+	_, err = fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"unregistered project %s at %s\n",
 		project.Name,
 		project.Path,
 	)
@@ -256,10 +315,22 @@ func writeProjectCommandError(
 	message string,
 	exitCode int,
 ) error {
+	return writeProjectCommandErrorWithRetry(
+		cmd, code, message, exitCode, false,
+	)
+}
+
+func writeProjectCommandErrorWithRetry(
+	cmd *cobra.Command,
+	code string,
+	message string,
+	exitCode int,
+	retryable bool,
+) error {
 	body := projectCommandErrorBody{
 		Code:      code,
 		Message:   message,
-		Retryable: false,
+		Retryable: retryable,
 	}
 	cmd.Root().SilenceUsage = true
 	cmd.Root().SilenceErrors = true
@@ -273,7 +344,7 @@ func writeProjectCommandError(
 }
 
 func projectCommandJSONRequested() bool {
-	if projectsJSON || projectsAddJSON {
+	if projectsJSON || projectsAddJSON || projectsRemoveJSON {
 		return true
 	}
 	// pflag stops at the first parse error, so a later --json never reaches

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -457,6 +457,61 @@ func TestRunProjectsAddJSONWritesStableInvalidRepositoryError(t *testing.T) {
 	assert.Contains(t, stderr.String(), "invalid_repository")
 }
 
+func TestRunProjectsRemoveJSONUnregistersByPath(t *testing.T) {
+	originalUnregister := unregisterProject
+	t.Cleanup(func() { unregisterProject = originalUnregister })
+	removed := models.Project{
+		Repository: "github.com/acme/widget",
+		Name:       "widget",
+		Path:       "/code/widget",
+	}
+	var requestedPath string
+	unregisterProject = func(path string) (models.Project, bool, error) {
+		requestedPath = path
+		return removed, true, nil
+	}
+	projectsRemoveJSON = true
+	t.Cleanup(func() { projectsRemoveJSON = false })
+	stdout := &bytes.Buffer{}
+	projectsRemoveCmd.SetOut(stdout)
+
+	require.NoError(t, runProjectsRemove(
+		projectsRemoveCmd,
+		[]string{"/code/widget"},
+	))
+
+	var response projectMutationResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
+	assert.Equal(t, "/code/widget", requestedPath)
+	assert.Equal(t, "unregistered", response.Status)
+	assert.Equal(t, removed, response.Project)
+}
+
+func TestRunProjectsRemoveJSONReportsMissingProject(t *testing.T) {
+	originalUnregister := unregisterProject
+	t.Cleanup(func() { unregisterProject = originalUnregister })
+	unregisterProject = func(string) (models.Project, bool, error) {
+		return models.Project{}, false, nil
+	}
+	projectsRemoveJSON = true
+	t.Cleanup(func() { projectsRemoveJSON = false })
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	projectsRemoveCmd.SetOut(stdout)
+	projectsRemoveCmd.SetErr(stderr)
+
+	err := runProjectsRemove(projectsRemoveCmd, []string{"/missing/widget"})
+
+	var exitErr interface{ ExitCode() int }
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 2, exitErr.ExitCode())
+	var response projectCommandErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
+	assert.Equal(t, "project_not_found", response.Error.Code)
+	assert.False(t, response.Error.Retryable)
+	assert.Contains(t, stderr.String(), "project_not_found")
+}
+
 func TestProjectsAddArgumentValidationUsesStructuredErrors(t *testing.T) {
 	projectsAddJSON = true
 	t.Cleanup(func() { projectsAddJSON = false })

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -487,6 +487,33 @@ func TestRunProjectsRemoveJSONUnregistersByPath(t *testing.T) {
 	assert.Equal(t, removed, response.Project)
 }
 
+func TestRunProjectsRemoveJSONNeverEmitsRegistryCredentials(t *testing.T) {
+	const token = "ghp_secret123"
+	originalUnregister := unregisterProject
+	t.Cleanup(func() { unregisterProject = originalUnregister })
+	unregisterProject = func(string) (models.Project, bool, error) {
+		return models.Project{
+			Repository: "https://wesm:" + token + "@github.com/acme/widget.git",
+			Name:       "widget",
+			Path:       "/code/widget",
+		}, true, nil
+	}
+	projectsRemoveJSON = true
+	t.Cleanup(func() { projectsRemoveJSON = false })
+	stdout := &bytes.Buffer{}
+	projectsRemoveCmd.SetOut(stdout)
+
+	require.NoError(t, runProjectsRemove(
+		projectsRemoveCmd,
+		[]string{"/code/widget"},
+	))
+
+	var response projectMutationResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
+	assert.Equal(t, "github.com/acme/widget", response.Project.Repository)
+	assert.NotContains(t, stdout.String(), token)
+}
+
 func TestRunProjectsRemoveJSONReportsMissingProject(t *testing.T) {
 	originalUnregister := unregisterProject
 	t.Cleanup(func() { unregisterProject = originalUnregister })

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -904,6 +904,43 @@ func CompareAndSwapProject(
 	return changed, nil
 }
 
+// UnregisterProject removes the one global project registration matching path.
+// It never removes repository or worktree data. A false result with a non-empty
+// project means the registration changed after it was read and was preserved.
+func UnregisterProject(path string) (models.Project, bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return models.Project{}, false, fmt.Errorf("project path required")
+	}
+	normalized, err := normalizeProjectPath(path)
+	if err != nil {
+		return models.Project{}, false, err
+	}
+	snapshot, err := LoadGlobalSnapshot()
+	if err != nil {
+		return models.Project{}, false, err
+	}
+	var match *ProjectRegistration
+	for index := range snapshot.Projects {
+		registration := &snapshot.Projects[index]
+		if !sameProjectPath(registration.Effective.Path, normalized) {
+			continue
+		}
+		if match != nil {
+			return models.Project{}, false, fmt.Errorf(
+				"multiple project registrations match %s",
+				normalized,
+			)
+		}
+		match = registration
+	}
+	if match == nil {
+		return models.Project{}, false, nil
+	}
+	changed, err := CompareAndSwapProject(*match, nil)
+	return match.Persisted, changed, err
+}
+
 func rawProjectEntries(source *viper.Viper) ([]map[string]any, error) {
 	var projects []map[string]any
 	if err := source.UnmarshalKey("projects", &projects); err != nil {

--- a/internal/config/project_snapshot_test.go
+++ b/internal/config/project_snapshot_test.go
@@ -260,6 +260,36 @@ future_policy = "observed"
 	assert.Equal(t, concurrent, string(stored))
 }
 
+func TestUnregisterProjectRemovesOnlyTheMatchingRegistration(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("KWT_HOME", configHome)
+	configPath := filepath.Join(configHome, "config.toml")
+	removed := models.Project{
+		Repository:  "github.com/acme/widget",
+		Name:        "widget",
+		Path:        filepath.Join(t.TempDir(), "missing-widget"),
+		LastTouched: "before",
+	}
+	kept := models.Project{
+		Repository:  "github.com/acme/other",
+		Name:        "other",
+		Path:        filepath.Join(t.TempDir(), "other"),
+		LastTouched: "kept",
+	}
+	writePersistedProjects(t, configPath, []models.Project{removed, kept})
+
+	got, changed, err := UnregisterProject(removed.Path)
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, removed, got)
+	stored, err := readGlobalViper(configPath)
+	require.NoError(t, err)
+	var projects []models.Project
+	require.NoError(t, stored.UnmarshalKey("projects", &projects))
+	assert.Equal(t, []models.Project{kept}, projects)
+}
+
 func writePersistedProjects(t *testing.T, path string, projects []models.Project) {
 	t.Helper()
 	current := viper.New()


### PR DESCRIPTION
Registered projects can outlive their checkout directories, but automation currently has no supported way to clear that metadata without editing kwt's configuration directly. Ghosthub needs a stable machine-readable boundary so stale projects can be removed without putting repository contents at risk.

- Adds `kwt projects remove <path> --json` with structured success and error envelopes.
- Removes only the matching registry entry; repositories, worktrees, and tmux sessions are never deleted.
- Uses exact snapshot comparison so concurrent registry changes return a retryable error instead of being overwritten.
- Keeps this mutation on the foreground CLI boundary during the daemon migration, allowing the daemon work to absorb the contract deliberately.
- `make test` and `make build` pass, including daemon-backed read-after-unregister coverage.