### PR TITLE
Order SHA-stamped daemon builds for replacement

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
       - -X go.kenn.io/kwt/internal/cmd.version={{ .Version }}
       - -X go.kenn.io/kwt/internal/cmd.commit={{ .Commit }}
       - -X go.kenn.io/kwt/internal/cmd.date={{ .CommitDate }}
+      - -X go.kenn.io/kwt/internal/cmd.revisionTime={{ .CommitDate }}
     goos:
       - darwin
       - linux

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -20,8 +20,10 @@ Compatible clients share the newest running daemon. Build order uses an exact
 full source revision first, then differing semantic versions, then the source
 commit time. Source times are canonical RFC3339 UTC values authenticated in
 both the private runtime record and status response. Hashes are never compared
-lexically. Different revisions with equal source times, missing contemporary
-metadata, or invalid values have unknown order.
+lexically. Matching semantic module versions count as the same build only when
+both installations explicitly lack VCS revision and time identity, as with
+`go install ...@version`. Different revisions with equal source times, missing
+contemporary metadata, or invalid values have unknown order.
 
 With `daemon.auto_restart = "newer"`, a provably newer client asks an older
 daemon to drain before replacement. Automatic start reuses a ready daemon when

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -23,7 +23,9 @@ both the private runtime record and status response. Hashes are never compared
 lexically. Matching semantic module versions count as the same build only when
 both installations explicitly lack VCS revision and time identity, as with
 `go install ...@version`. Different revisions with equal source times, missing
-contemporary metadata, or invalid values have unknown order.
+contemporary metadata, or invalid values have unknown order. A build from a
+dirty worktree marks its revision dirty and omits revision time, so it cannot
+claim the clean checkout's identity or source order.
 
 With `daemon.auto_restart = "newer"`, a provably newer client asks an older
 daemon to drain before replacement. Automatic start reuses a ready daemon when

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -16,11 +16,29 @@ serve` runs the same host in the foreground, disables idle exit, and refuses to
 replace an existing owner. Background logs are written to
 `<kwt-home>/daemon.log`, rotate at 10 MiB, and retain three owner-only backups.
 
-Compatible clients share the newest running daemon. A newer client asks an
-older daemon to drain before replacement; an older client never downgrades a
-newer daemon. Draining rejects new operations with a retryable typed response
-that carries the deadline. Active work and leases may finish until
-`daemon.replacement_grace`; the default is five minutes.
+Compatible clients share the newest running daemon. Build order uses an exact
+full source revision first, then differing semantic versions, then the source
+commit time. Source times are canonical RFC3339 UTC values authenticated in
+both the private runtime record and status response. Hashes are never compared
+lexically. Different revisions with equal source times, missing contemporary
+metadata, or invalid values have unknown order.
+
+With `daemon.auto_restart = "newer"`, a provably newer client asks an older
+daemon to drain before replacement. Automatic start reuses a ready daemon when
+order is unknown; it never guesses. Explicit restart accepts the same or a
+newer invoking build, returns `daemon_downgrade_refused` for an older build,
+and returns `daemon_build_order_unknown` when order cannot be proved. A
+draining daemon applies the same refusal before another binary waits and
+launches. `kwt daemon stop` followed by `kwt daemon start` is the deliberate
+operator override for unknown order and may install either build. Ghosthub may
+use that override only for an explicit helper-update action, never routine
+polling.
+
+Draining rejects new operations with a retryable typed response that carries
+the deadline. The command requesting shutdown prints the returned drain state
+immediately, then continues reporting observed drain state while it waits.
+Active work and leases may finish until `daemon.replacement_grace`; the default
+is five minutes.
 
 The API exposes authenticated status, graceful shutdown, worktree inventory,
 and repository-config approval under `/api/v1`, proof-capable liveness at

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -28,6 +28,18 @@ The release workflow tests the tagged commit, builds the supported target
 matrix with GoReleaser, and publishes archives, checksums, and generated notes
 to GitHub.
 
+Daemon build identity includes the full source revision and its source commit
+time. The source time must be canonical RFC3339 UTC and must not be a package,
+archive, or local build timestamp. Ordinary Go builds fall back to the embedded
+`vcs.time`. Build systems that stamp a pinned revision explicitly, including
+Ghosthub's managed helper build, must also pass its resolved source time:
+
+```sh
+-X go.kenn.io/kwt/internal/cmd.revisionTime=$revision_time
+```
+
+GoReleaser stamps the same field from the tagged commit date.
+
 ## Verify the result
 
 On the [GitHub Releases](https://github.com/kenn-io/kwt/releases) page, confirm

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -62,6 +62,15 @@ kwt daemon stop
 kwt serve
 ```
 
+`kwt daemon start` replaces a compatible running daemon only when the invoking
+build is provably newer and `daemon.auto_restart` is `"newer"`. `kwt daemon
+restart` refuses a provable downgrade and also refuses different builds whose
+order is unknown, including distinct revisions with the same source commit
+time. Use `kwt daemon stop` followed by `kwt daemon start` as the explicit
+override when you intend to install an otherwise unordered build. Replacement
+and restart print drain progress to stderr before waiting; JSON stdout and
+ordinary command exit behavior remain unchanged.
+
 `kwt projects`, `kwt list`, `kwt remove`, and TUI inventory/removal auto-start
 or reuse a compatible local daemon. CLI inventory requires a current refresh
 and fails if one cannot complete; it never prints cached data. The TUI may

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -34,8 +34,12 @@ var newDaemonController = func() (daemonController, error) {
 		return nil, err
 	}
 	return kwtdaemon.NewController(kwtdaemon.ControllerOptions{
-		Home:        home,
-		Build:       kwtdaemon.Build{Version: build.Version, Revision: build.Revision},
+		Home: home,
+		Build: kwtdaemon.Build{
+			Version:      build.Version,
+			Revision:     build.Revision,
+			RevisionTime: build.RevisionTime,
+		},
 		Config:      snapshot.Config.Daemon,
 		Executable:  executable,
 		Environment: os.Environ(),

--- a/internal/cmd/daemon_subprocess_test.go
+++ b/internal/cmd/daemon_subprocess_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,8 +50,8 @@ func buildDaemonTestBinaries(t *testing.T) (string, string) {
 		require.NoError(t, err, string(output))
 		return path
 	}
-	return build("kwt-old", "v1.0.0", "old"),
-		build("kwt-new", "v1.1.0", "new")
+	return build("kwt-old", "v1.0.0", strings.Repeat("a", 40)),
+		build("kwt-new", "v1.1.0", strings.Repeat("b", 40))
 }
 
 func newDaemonTestHome(t *testing.T, body string) string {

--- a/internal/cmd/daemon_subprocess_test.go
+++ b/internal/cmd/daemon_subprocess_test.go
@@ -26,6 +26,22 @@ replacement_grace = "200ms"
 
 func buildDaemonTestBinaries(t *testing.T) (string, string) {
 	t.Helper()
+	return buildDaemonTestBinary(t, daemonTestBuild{
+			Name: "kwt-old", Version: "v1.0.0", Revision: strings.Repeat("a", 40),
+		}), buildDaemonTestBinary(t, daemonTestBuild{
+			Name: "kwt-new", Version: "v1.1.0", Revision: strings.Repeat("b", 40),
+		})
+}
+
+type daemonTestBuild struct {
+	Name         string
+	Version      string
+	Revision     string
+	RevisionTime string
+}
+
+func buildDaemonTestBinary(t *testing.T, build daemonTestBuild) string {
+	t.Helper()
 	root, err := filepath.Abs(filepath.Join("..", ".."))
 	require.NoError(t, err)
 	suffix := ""
@@ -33,25 +49,22 @@ func buildDaemonTestBinaries(t *testing.T) (string, string) {
 		suffix = ".exe"
 	}
 	dir := t.TempDir()
-	build := func(name, version, revision string) string {
-		path := filepath.Join(dir, name+suffix)
-		command := exec.Command(
-			"go",
-			"build",
-			"-ldflags",
-			"-X go.kenn.io/kwt/internal/cmd.version="+version+
-				" -X go.kenn.io/kwt/internal/cmd.commit="+revision,
-			"-o",
-			path,
-			"./cmd/kwt",
-		)
-		command.Dir = root
-		output, err := command.CombinedOutput()
-		require.NoError(t, err, string(output))
-		return path
-	}
-	return build("kwt-old", "v1.0.0", strings.Repeat("a", 40)),
-		build("kwt-new", "v1.1.0", strings.Repeat("b", 40))
+	path := filepath.Join(dir, build.Name+suffix)
+	command := exec.Command(
+		"go",
+		"build",
+		"-ldflags",
+		"-X go.kenn.io/kwt/internal/cmd.version="+build.Version+
+			" -X go.kenn.io/kwt/internal/cmd.commit="+build.Revision+
+			" -X go.kenn.io/kwt/internal/cmd.revisionTime="+build.RevisionTime,
+		"-o",
+		path,
+		"./cmd/kwt",
+	)
+	command.Dir = root
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return path
 }
 
 func newDaemonTestHome(t *testing.T, body string) string {
@@ -186,6 +199,62 @@ func TestDaemonSubprocessNewestCompatibleBinaryWins(t *testing.T) {
 	requireCommandSuccess(t, oldBinary, home, "daemon", "start")
 	stillNew := daemonStatus(t, oldBinary, home)
 	assert.Equal(t, upgraded.PID, stillNew.PID)
+}
+
+func TestDaemonSubprocessSHARevisionOrderingAndEqualTimeOverride(t *testing.T) {
+	older := buildDaemonTestBinary(t, daemonTestBuild{
+		Name: "kwt-sha-older", Version: "sha-older", Revision: strings.Repeat("a", 40),
+		RevisionTime: "2026-08-09T12:00:00Z",
+	})
+	newer := buildDaemonTestBinary(t, daemonTestBuild{
+		Name: "kwt-sha-newer", Version: "sha-newer", Revision: strings.Repeat("b", 40),
+		RevisionTime: "2026-08-09T12:00:01Z",
+	})
+	equalLeft := buildDaemonTestBinary(t, daemonTestBuild{
+		Name: "kwt-sha-equal-left", Version: "sha-left", Revision: strings.Repeat("c", 40),
+		RevisionTime: "2026-08-09T12:00:02Z",
+	})
+	equalRight := buildDaemonTestBinary(t, daemonTestBuild{
+		Name: "kwt-sha-equal-right", Version: "sha-right", Revision: strings.Repeat("d", 40),
+		RevisionTime: "2026-08-09T12:00:02Z",
+	})
+
+	orderedHome := newDaemonTestHome(t, validDaemonConfig)
+	registerDaemonCleanup(t, newer, orderedHome)
+	requireCommandSuccess(t, older, orderedHome, "daemon", "start")
+	oldStatus := daemonStatus(t, older, orderedHome)
+	_, progress, err := runDaemonCommand(t, newer, orderedHome, "daemon", "start")
+	require.NoError(t, err, "stderr=%s", progress)
+	assert.Contains(t, string(progress), "daemon draining")
+	newStatus := daemonStatus(t, newer, orderedHome)
+	assert.Equal(t, strings.Repeat("b", 40), newStatus.Revision)
+	assert.Equal(t, "2026-08-09T12:00:01Z", newStatus.RevisionTime)
+	assert.NotEqual(t, oldStatus.PID, newStatus.PID)
+
+	requireCommandSuccess(t, older, orderedHome, "daemon", "start")
+	reused := daemonStatus(t, older, orderedHome)
+	assert.Equal(t, newStatus.PID, reused.PID)
+	_, stderr, err := runDaemonCommand(t, older, orderedHome, "daemon", "restart")
+	require.Error(t, err)
+	assert.Contains(t, string(stderr), "older kwt cannot replace")
+	assert.Equal(t, newStatus.PID, daemonStatus(t, newer, orderedHome).PID)
+
+	equalHome := newDaemonTestHome(t, validDaemonConfig)
+	registerDaemonCleanup(t, equalRight, equalHome)
+	requireCommandSuccess(t, equalLeft, equalHome, "daemon", "start")
+	leftStatus := daemonStatus(t, equalLeft, equalHome)
+	requireCommandSuccess(t, equalRight, equalHome, "daemon", "start")
+	assert.Equal(t, leftStatus.PID, daemonStatus(t, equalRight, equalHome).PID)
+	_, stderr, err = runDaemonCommand(t, equalRight, equalHome, "daemon", "restart")
+	require.Error(t, err)
+	assert.Contains(t, string(stderr), "cannot prove whether it is newer")
+	assert.Equal(t, leftStatus.PID, daemonStatus(t, equalLeft, equalHome).PID)
+
+	requireCommandSuccess(t, equalRight, equalHome, "daemon", "stop")
+	requireCommandSuccess(t, equalRight, equalHome, "daemon", "start")
+	rightStatus := daemonStatus(t, equalRight, equalHome)
+	assert.Equal(t, strings.Repeat("d", 40), rightStatus.Revision)
+	assert.NotEqual(t, leftStatus.PID, rightStatus.PID)
 }
 
 func TestDaemonSubprocessOlderBinaryCannotRestartNewerDaemon(t *testing.T) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	version      = "dev"
+	commit       = "none"
+	date         = "unknown"
+	revisionTime = ""
 )
 
 var (
@@ -32,7 +33,8 @@ var (
 	stdoutIsTerminal = func() bool {
 		return term.IsTerminal(int(os.Stdout.Fd()))
 	}
-	runRootTUI = runTUI
+	runRootTUI    = runTUI
+	readBuildInfo = debug.ReadBuildInfo
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -163,15 +165,17 @@ func globalOnlyPreRun(*cobra.Command, []string) error {
 }
 
 type buildInfo struct {
-	Version  string
-	Revision string
-	Date     string
-	Display  string
+	Version      string
+	Revision     string
+	RevisionTime string
+	Date         string
+	Display      string
 }
 
 func currentBuildInfo() buildInfo {
-	buildVersion, buildRevision, buildDate := version, commit, date
-	info, ok := debug.ReadBuildInfo()
+	buildVersion, buildRevision := version, commit
+	buildRevisionTime, buildDate := revisionTime, date
+	info, ok := readBuildInfo()
 	if ok {
 		if buildVersion == "dev" &&
 			info.Main.Version != "" && info.Main.Version != "(devel)" {
@@ -184,6 +188,9 @@ func currentBuildInfo() buildInfo {
 					buildRevision = setting.Value
 				}
 			case "vcs.time":
+				if buildRevisionTime == "" && setting.Value != "" {
+					buildRevisionTime = setting.Value
+				}
 				if buildDate == "unknown" && setting.Value != "" {
 					buildDate = setting.Value
 				}
@@ -195,9 +202,10 @@ func currentBuildInfo() buildInfo {
 		displayRevision = displayRevision[:7]
 	}
 	return buildInfo{
-		Version:  buildVersion,
-		Revision: buildRevision,
-		Date:     buildDate,
+		Version:      buildVersion,
+		Revision:     buildRevision,
+		RevisionTime: buildRevisionTime,
+		Date:         buildDate,
 		Display: fmt.Sprintf(
 			"%s (commit: %s, built: %s)",
 			buildVersion,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -177,6 +177,7 @@ func currentBuildInfo() buildInfo {
 	buildRevisionTime, buildDate := revisionTime, date
 	info, ok := readBuildInfo()
 	if ok {
+		var vcsRevision, vcsTime string
 		if buildVersion == "dev" &&
 			info.Main.Version != "" && info.Main.Version != "(devel)" {
 			buildVersion = info.Main.Version
@@ -184,17 +185,20 @@ func currentBuildInfo() buildInfo {
 		for _, setting := range info.Settings {
 			switch setting.Key {
 			case "vcs.revision":
-				if buildRevision == "none" && setting.Value != "" {
-					buildRevision = setting.Value
-				}
+				vcsRevision = setting.Value
 			case "vcs.time":
-				if buildRevisionTime == "" && setting.Value != "" {
-					buildRevisionTime = setting.Value
-				}
+				vcsTime = setting.Value
 				if buildDate == "unknown" && setting.Value != "" {
 					buildDate = setting.Value
 				}
 			}
+		}
+		if buildRevision == "none" && vcsRevision != "" {
+			buildRevision = vcsRevision
+		}
+		if buildRevisionTime == "" && vcsTime != "" &&
+			vcsRevision != "" && buildRevision == vcsRevision {
+			buildRevisionTime = vcsTime
 		}
 	}
 	displayRevision := buildRevision

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -178,6 +178,7 @@ func currentBuildInfo() buildInfo {
 	info, ok := readBuildInfo()
 	if ok {
 		var vcsRevision, vcsTime string
+		var vcsModified bool
 		if buildVersion == "dev" &&
 			info.Main.Version != "" && info.Main.Version != "(devel)" {
 			buildVersion = info.Main.Version
@@ -191,6 +192,8 @@ func currentBuildInfo() buildInfo {
 				if buildDate == "unknown" && setting.Value != "" {
 					buildDate = setting.Value
 				}
+			case "vcs.modified":
+				vcsModified = setting.Value == "true"
 			}
 		}
 		if buildRevision == "none" && vcsRevision != "" {
@@ -199,6 +202,14 @@ func currentBuildInfo() buildInfo {
 		if buildRevisionTime == "" && vcsTime != "" &&
 			vcsRevision != "" && buildRevision == vcsRevision {
 			buildRevisionTime = vcsTime
+		}
+		if vcsModified {
+			if buildRevision == "" || buildRevision == "none" {
+				buildRevision = "dirty"
+			} else {
+				buildRevision += "-dirty"
+			}
+			buildRevisionTime = ""
 		}
 	}
 	displayRevision := buildRevision

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -21,8 +21,12 @@ var loadServeOptions = func() (kwtdaemon.ServeOptions, error) {
 	}
 	build := currentBuildInfo()
 	return kwtdaemon.ServeOptions{
-		Home:   home,
-		Build:  kwtdaemon.Build{Version: build.Version, Revision: build.Revision},
+		Home: home,
+		Build: kwtdaemon.Build{
+			Version:      build.Version,
+			Revision:     build.Revision,
+			RevisionTime: build.RevisionTime,
+		},
 		Config: snapshot.Config.Daemon,
 	}, nil
 }

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -81,3 +81,28 @@ func TestCurrentBuildInfoRejectsVCSTimeForMismatchedExplicitRevision(t *testing.
 	assert.Empty(t, info.RevisionTime)
 	assert.Equal(t, "2026-08-09T12:00:00Z", info.Date)
 }
+
+func TestCurrentBuildInfoRejectsOrderingIdentityForModifiedSource(t *testing.T) {
+	oldVersion, oldCommit, oldDate, oldRevisionTime := version, commit, date, revisionTime
+	oldReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		version, commit, date, revisionTime = oldVersion, oldCommit, oldDate, oldRevisionTime
+		readBuildInfo = oldReadBuildInfo
+	})
+	version = "sha-build"
+	commit = "0123456789abcdef0123456789abcdef01234567"
+	date = "unknown"
+	revisionTime = "2026-08-09T12:00:00Z"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: commit},
+			{Key: "vcs.time", Value: revisionTime},
+			{Key: "vcs.modified", Value: "true"},
+		}}, true
+	}
+
+	info := currentBuildInfo()
+	assert.Equal(t, commit+"-dirty", info.Revision)
+	assert.Empty(t, info.RevisionTime)
+	assert.Equal(t, "2026-08-09T12:00:00Z", info.Date)
+}

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -60,3 +60,24 @@ func TestCurrentBuildInfoUsesVCSTimeForUnstampedRevisionTime(t *testing.T) {
 	assert.Equal(t, "2026-08-09T12:00:00Z", info.RevisionTime)
 	assert.Equal(t, "2026-08-09T12:00:00Z", info.Date)
 }
+
+func TestCurrentBuildInfoRejectsVCSTimeForMismatchedExplicitRevision(t *testing.T) {
+	oldVersion, oldCommit, oldDate, oldRevisionTime := version, commit, date, revisionTime
+	oldReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		version, commit, date, revisionTime = oldVersion, oldCommit, oldDate, oldRevisionTime
+		readBuildInfo = oldReadBuildInfo
+	})
+	version, commit, date, revisionTime = "sha-build", "explicit-revision", "unknown", ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "ambient-revision"},
+			{Key: "vcs.time", Value: "2026-08-09T12:00:00Z"},
+		}}, true
+	}
+
+	info := currentBuildInfo()
+	assert.Equal(t, "explicit-revision", info.Revision)
+	assert.Empty(t, info.RevisionTime)
+	assert.Equal(t, "2026-08-09T12:00:00Z", info.Date)
+}

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,4 +11,52 @@ func TestCurrentBuildInfoUsesTheSameVersionSourceAsVersionOutput(t *testing.T) {
 	info := currentBuildInfo()
 	assert.NotEmpty(t, info.Version)
 	assert.Equal(t, getVersionString(), info.Display)
+}
+
+func TestCurrentBuildInfoSeparatesSourceRevisionTimeFromBuildDate(t *testing.T) {
+	oldVersion, oldCommit, oldDate, oldRevisionTime := version, commit, date, revisionTime
+	oldReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		version, commit, date, revisionTime = oldVersion, oldCommit, oldDate, oldRevisionTime
+		readBuildInfo = oldReadBuildInfo
+	})
+	version = "sha-build"
+	commit = "explicit-revision"
+	date = "2026-08-09T13:00:00Z"
+	revisionTime = "2026-08-09T12:00:00Z"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "embedded-revision"},
+			{Key: "vcs.time", Value: "2026-08-09T11:00:00Z"},
+		}}, true
+	}
+
+	info := currentBuildInfo()
+	assert.Equal(t, "explicit-revision", info.Revision)
+	assert.Equal(t, "2026-08-09T12:00:00Z", info.RevisionTime)
+	assert.Equal(t, "2026-08-09T13:00:00Z", info.Date)
+}
+
+func TestCurrentBuildInfoUsesVCSTimeForUnstampedRevisionTime(t *testing.T) {
+	oldVersion, oldCommit, oldDate, oldRevisionTime := version, commit, date, revisionTime
+	oldReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		version, commit, date, revisionTime = oldVersion, oldCommit, oldDate, oldRevisionTime
+		readBuildInfo = oldReadBuildInfo
+	})
+	version, commit, date, revisionTime = "dev", "none", "unknown", ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v1.2.3"},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "embedded-revision"},
+				{Key: "vcs.time", Value: "2026-08-09T12:00:00Z"},
+			},
+		}, true
+	}
+
+	info := currentBuildInfo()
+	assert.Equal(t, "embedded-revision", info.Revision)
+	assert.Equal(t, "2026-08-09T12:00:00Z", info.RevisionTime)
+	assert.Equal(t, "2026-08-09T12:00:00Z", info.Date)
 }

--- a/internal/daemon/build.go
+++ b/internal/daemon/build.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"encoding/hex"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+// BuildOrder describes the invoking build relative to a running daemon.
+type BuildOrder uint8
+
+const (
+	BuildUnknown BuildOrder = iota
+	BuildSame
+	BuildNewer
+	BuildOlder
+)
+
+// CompareBuilds conservatively orders an invoking build against a running
+// daemon. Hashes prove equality only; source time or semantic version supplies
+// order.
+func CompareBuilds(
+	invoking Build,
+	running Build,
+	runningAdvertisedTime bool,
+) BuildOrder {
+	if fullRevision(invoking.Revision) && invoking.Revision == running.Revision {
+		return BuildSame
+	}
+	if left, leftOK := comparableVersion(invoking.Version); leftOK {
+		if right, rightOK := comparableVersion(running.Version); rightOK && left != right {
+			if semver.Compare(left, right) > 0 {
+				return BuildNewer
+			}
+			return BuildOlder
+		}
+	}
+	leftTime, leftOK := parseRevisionTime(invoking.RevisionTime)
+	rightTime, rightOK := parseRevisionTime(running.RevisionTime)
+	if leftOK && rightOK && !leftTime.Equal(rightTime) {
+		if leftTime.After(rightTime) {
+			return BuildNewer
+		}
+		return BuildOlder
+	}
+	if leftOK && !runningAdvertisedTime {
+		return BuildNewer
+	}
+	if invoking.RevisionTime == "" && rightOK {
+		return BuildOlder
+	}
+	return BuildUnknown
+}
+
+func fullRevision(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func parseRevisionTime(value string) (time.Time, bool) {
+	if value == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil || parsed.Location() != time.UTC || parsed.Format(time.RFC3339) != value {
+		return time.Time{}, false
+	}
+	return parsed, true
+}

--- a/internal/daemon/build.go
+++ b/internal/daemon/build.go
@@ -28,12 +28,17 @@ func CompareBuilds(
 	if fullRevision(invoking.Revision) && invoking.Revision == running.Revision {
 		return BuildSame
 	}
+	sameModuleVersion := false
 	if left, leftOK := comparableVersion(invoking.Version); leftOK {
-		if right, rightOK := comparableVersion(running.Version); rightOK && left != right {
-			if semver.Compare(left, right) > 0 {
+		if right, rightOK := comparableVersion(running.Version); rightOK {
+			comparison := semver.Compare(left, right)
+			if comparison > 0 {
 				return BuildNewer
 			}
-			return BuildOlder
+			if comparison < 0 {
+				return BuildOlder
+			}
+			sameModuleVersion = left == right
 		}
 	}
 	leftTime, leftOK := parseRevisionTime(invoking.RevisionTime)
@@ -50,7 +55,16 @@ func CompareBuilds(
 	if invoking.RevisionTime == "" && rightOK {
 		return BuildOlder
 	}
+	if sameModuleVersion && revisionUnavailable(invoking.Revision) &&
+		revisionUnavailable(running.Revision) && invoking.RevisionTime == "" &&
+		running.RevisionTime == "" {
+		return BuildSame
+	}
 	return BuildUnknown
+}
+
+func revisionUnavailable(value string) bool {
+	return value == "" || value == "none"
 }
 
 func fullRevision(value string) bool {

--- a/internal/daemon/build_test.go
+++ b/internal/daemon/build_test.go
@@ -49,6 +49,41 @@ func TestCompareBuilds(t *testing.T) {
 			want:                  BuildOlder,
 		},
 		{
+			name: "semantic build metadata falls through to revision time",
+			invoking: Build{
+				Version: "v1.2.3+one", Revision: "new",
+				RevisionTime: "2026-08-09T12:00:01Z",
+			},
+			running: Build{
+				Version: "v1.2.3+two", Revision: "old",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildNewer,
+		},
+		{
+			name: "same module version without VCS identity is same",
+			invoking: Build{
+				Version: "v1.2.3", Revision: "none",
+			},
+			running: Build{
+				Version: "v1.2.3", Revision: "none",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildSame,
+		},
+		{
+			name: "same module version with conflicting revisions is unknown",
+			invoking: Build{
+				Version: "v1.2.3", Revision: "left",
+			},
+			running: Build{
+				Version: "v1.2.3", Revision: "right",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildUnknown,
+		},
+		{
 			name: "newer revision time",
 			invoking: Build{
 				Version: "new", Revision: "new",

--- a/internal/daemon/build_test.go
+++ b/internal/daemon/build_test.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareBuilds(t *testing.T) {
+	tests := []struct {
+		name                  string
+		invoking              Build
+		running               Build
+		runningAdvertisedTime bool
+		want                  BuildOrder
+	}{
+		{
+			name: "same full revision",
+			invoking: Build{
+				Version: "sha-a", Revision: strings.Repeat("a", 40),
+			},
+			running: Build{
+				Version: "different-display", Revision: strings.Repeat("a", 40),
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildSame,
+		},
+		{
+			name: "newer semantic version",
+			invoking: Build{
+				Version: "v1.3.0", Revision: "new",
+			},
+			running: Build{
+				Version: "v1.2.0", Revision: "old",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildNewer,
+		},
+		{
+			name: "older semantic version",
+			invoking: Build{
+				Version: "v1.2.0", Revision: "old",
+			},
+			running: Build{
+				Version: "v1.3.0", Revision: "new",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildOlder,
+		},
+		{
+			name: "newer revision time",
+			invoking: Build{
+				Version: "new", Revision: "new",
+				RevisionTime: "2026-08-09T12:00:01Z",
+			},
+			running: Build{
+				Version: "old", Revision: "old",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildNewer,
+		},
+		{
+			name: "older revision time",
+			invoking: Build{
+				Version: "old", Revision: "old",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			running: Build{
+				Version: "new", Revision: "new",
+				RevisionTime: "2026-08-09T12:00:01Z",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildOlder,
+		},
+		{
+			name: "equal time different revisions is unknown",
+			invoking: Build{
+				Version: "new", Revision: "new",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			running: Build{
+				Version: "old", Revision: "old",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildUnknown,
+		},
+		{
+			name: "new metadata beats legacy omission",
+			invoking: Build{
+				Version: "new", Revision: "new",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			running: Build{
+				Version: "old", Revision: "old",
+			},
+			runningAdvertisedTime: false,
+			want:                  BuildNewer,
+		},
+		{
+			name: "metadata-less client is older",
+			invoking: Build{
+				Version: "old", Revision: "old",
+			},
+			running: Build{
+				Version: "new", Revision: "new",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildOlder,
+		},
+		{
+			name: "explicit unknown time does not trigger transition order",
+			invoking: Build{
+				Version: "left", Revision: "left",
+			},
+			running: Build{
+				Version: "right", Revision: "right",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildUnknown,
+		},
+		{
+			name: "invalid invoking time is unknown",
+			invoking: Build{
+				Version: "left", Revision: "left", RevisionTime: "not-a-time",
+			},
+			running: Build{
+				Version: "right", Revision: "right",
+				RevisionTime: "2026-08-09T12:00:00Z",
+			},
+			runningAdvertisedTime: true,
+			want:                  BuildUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, CompareBuilds(
+				test.invoking,
+				test.running,
+				test.runningAdvertisedTime,
+			))
+		})
+	}
+}

--- a/internal/daemon/controller.go
+++ b/internal/daemon/controller.go
@@ -129,15 +129,21 @@ func (c *Controller) Restart(ctx context.Context) (Observation, error) {
 	case RuntimeAbsent:
 		return c.startLocked(ctx)
 	case RuntimeReady, RuntimeStarting, RuntimeFailed:
-		if olderVersion(c.options.Build.Version, observation.Status.Version) {
+		switch c.buildOrder(observation) {
+		case BuildOlder:
 			return Observation{}, daemonDowngradeError()
+		case BuildUnknown:
+			return Observation{}, daemonBuildOrderUnknownError()
 		}
 		if err := c.options.RequestShutdown(ctx, observation, "restart"); err != nil {
 			return Observation{}, err
 		}
 	case RuntimeDraining:
-		if olderVersion(c.options.Build.Version, observation.Status.Version) {
+		switch c.buildOrder(observation) {
+		case BuildOlder:
 			return Observation{}, daemonDowngradeError()
+		case BuildUnknown:
+			return Observation{}, daemonBuildOrderUnknownError()
 		}
 		c.reportDrain(observation)
 	case RuntimeIncompatible:
@@ -161,8 +167,9 @@ func (c *Controller) startLocked(ctx context.Context) (Observation, error) {
 		return c.launchAndWait(ctx)
 	case RuntimeReady:
 		if decideReplacement(
-			c.options.Build.Version,
-			observation.Status.Version,
+			c.options.Build,
+			buildFromObservation(observation),
+			revisionTimeAdvertised(observation),
 			c.options.Config.AutoRestart,
 		) == reuseDaemon {
 			return observation, nil
@@ -179,8 +186,11 @@ func (c *Controller) startLocked(ctx context.Context) (Observation, error) {
 	case RuntimeFailed:
 		return Observation{}, c.failedError(observation)
 	case RuntimeDraining:
-		if olderVersion(c.options.Build.Version, observation.Status.Version) {
+		switch c.buildOrder(observation) {
+		case BuildOlder:
 			return Observation{}, daemonDowngradeError()
+		case BuildUnknown:
+			return Observation{}, daemonBuildOrderUnknownError()
 		}
 		c.reportDrain(observation)
 		if err := c.waitForAbsent(ctx); err != nil {
@@ -330,8 +340,18 @@ func (c *Controller) failedError(observation Observation) error {
 
 func daemonDowngradeError() error {
 	return service.NewError(
-		service.Unsupported,
+		service.DaemonDowngradeRefused,
 		"an older kwt cannot replace a newer daemon",
+		false,
+		nil,
+		nil,
+	)
+}
+
+func daemonBuildOrderUnknownError() error {
+	return service.NewError(
+		service.DaemonBuildOrderUnknown,
+		"kwt cannot prove whether it is newer than the running daemon",
 		false,
 		nil,
 		nil,
@@ -388,25 +408,40 @@ func comparableVersion(value string) (string, bool) {
 	return value, true
 }
 
-func decideReplacement(client, running, policy string) replacementDecision {
+func decideReplacement(
+	client Build,
+	running Build,
+	runningAdvertisedTime bool,
+	policy string,
+) replacementDecision {
 	if policy != "newer" {
 		return reuseDaemon
 	}
-	clientVersion, clientOK := comparableVersion(client)
-	runningVersion, runningOK := comparableVersion(running)
-	if !clientOK || !runningOK {
-		return reuseDaemon
-	}
-	if semver.Compare(clientVersion, runningVersion) > 0 {
+	if CompareBuilds(client, running, runningAdvertisedTime) == BuildNewer {
 		return replaceDaemon
 	}
 	return reuseDaemon
 }
 
-func olderVersion(client, running string) bool {
-	clientVersion, clientOK := comparableVersion(client)
-	runningVersion, runningOK := comparableVersion(running)
-	return clientOK && runningOK && semver.Compare(clientVersion, runningVersion) < 0
+func buildFromObservation(observation Observation) Build {
+	return Build{
+		Version:      observation.Status.Version,
+		Revision:     observation.Status.Revision,
+		RevisionTime: observation.Status.RevisionTime,
+	}
+}
+
+func revisionTimeAdvertised(observation Observation) bool {
+	_, present := observation.Record.Metadata[metadataRevisionTime]
+	return present
+}
+
+func (c *Controller) buildOrder(observation Observation) BuildOrder {
+	return CompareBuilds(
+		c.options.Build,
+		buildFromObservation(observation),
+		revisionTimeAdvertised(observation),
+	)
 }
 
 func environmentWithCanonicalHome(environment []string, home string) []string {

--- a/internal/daemon/controller.go
+++ b/internal/daemon/controller.go
@@ -32,7 +32,7 @@ type ControllerOptions struct {
 	AllowEphemeral   bool
 	Inspect          func(context.Context) (Observation, error)
 	Launch           func(context.Context) error
-	RequestShutdown  func(context.Context, Observation, string) error
+	RequestShutdown  func(context.Context, Observation, string) (Status, error)
 	PollInterval     time.Duration
 	StartTimeout     time.Duration
 	CleanupAllowance time.Duration
@@ -101,9 +101,11 @@ func (c *Controller) Stop(ctx context.Context) error {
 	case RuntimeAbsent:
 		return nil
 	case RuntimeReady, RuntimeStarting, RuntimeFailed:
-		if err := c.options.RequestShutdown(ctx, observation, "stop"); err != nil {
+		status, err := c.options.RequestShutdown(ctx, observation, "stop")
+		if err != nil {
 			return err
 		}
+		c.reportShutdown(status)
 	case RuntimeDraining:
 		c.reportDrain(observation)
 	case RuntimeIncompatible:
@@ -135,9 +137,11 @@ func (c *Controller) Restart(ctx context.Context) (Observation, error) {
 		case BuildUnknown:
 			return Observation{}, daemonBuildOrderUnknownError()
 		}
-		if err := c.options.RequestShutdown(ctx, observation, "restart"); err != nil {
+		status, err := c.options.RequestShutdown(ctx, observation, "restart")
+		if err != nil {
 			return Observation{}, err
 		}
+		c.reportShutdown(status)
 	case RuntimeDraining:
 		switch c.buildOrder(observation) {
 		case BuildOlder:
@@ -174,9 +178,11 @@ func (c *Controller) startLocked(ctx context.Context) (Observation, error) {
 		) == reuseDaemon {
 			return observation, nil
 		}
-		if err := c.options.RequestShutdown(ctx, observation, "replacement"); err != nil {
+		status, err := c.options.RequestShutdown(ctx, observation, "replacement")
+		if err != nil {
 			return Observation{}, err
 		}
+		c.reportShutdown(status)
 		if err := c.waitForAbsent(ctx); err != nil {
 			return Observation{}, err
 		}
@@ -304,6 +310,12 @@ func (c *Controller) reportDrain(observation Observation) {
 	)
 }
 
+func (c *Controller) reportShutdown(status Status) {
+	if status.State == StateDraining || status.DrainDeadline != nil {
+		c.reportDrain(Observation{State: RuntimeDraining, Status: status})
+	}
+}
+
 func (c *Controller) incompatibleError(observation Observation) error {
 	return service.NewError(
 		service.Unsupported,
@@ -381,9 +393,9 @@ func requestShutdown(
 	ctx context.Context,
 	observation Observation,
 	reason string,
-) error {
+) (Status, error) {
 	if observation.Client == nil {
-		return service.NewError(
+		return Status{}, service.NewError(
 			service.Conflict,
 			"the running kwt daemon was not proof-verified",
 			false,
@@ -391,8 +403,8 @@ func requestShutdown(
 			nil,
 		)
 	}
-	_, err := observation.Client.Shutdown(ctx, reason)
-	return err
+	response, err := observation.Client.Shutdown(ctx, reason)
+	return response.Status, err
 }
 
 func comparableVersion(value string) (string, bool) {

--- a/internal/daemon/controller_test.go
+++ b/internal/daemon/controller_test.go
@@ -3,33 +3,64 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 )
 
 func TestReplacementDecision(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		client  string
-		running string
-		policy  string
-		want    replacementDecision
+		name           string
+		client         Build
+		running        Build
+		advertisedTime bool
+		policy         string
+		want           replacementDecision
 	}{
-		{"newer client replaces", "v1.2.0", "v1.1.0", "newer", replaceDaemon},
-		{"older client reuses", "v1.1.0", "v1.2.0", "newer", reuseDaemon},
-		{"same client reuses", "v1.2.0", "v1.2.0", "newer", reuseDaemon},
-		{"policy never reuses", "v1.2.0", "v1.1.0", "never", reuseDaemon},
-		{"development versions do not order", "dev", "v1.1.0", "newer", reuseDaemon},
+		{
+			name:   "newer semantic client replaces",
+			client: Build{Version: "v1.2.0"}, running: Build{Version: "v1.1.0"},
+			policy: "newer", want: replaceDaemon,
+		},
+		{
+			name:   "older semantic client reuses",
+			client: Build{Version: "v1.1.0"}, running: Build{Version: "v1.2.0"},
+			policy: "newer", want: reuseDaemon,
+		},
+		{
+			name:           "newer SHA timestamp replaces",
+			client:         Build{Version: "sha-new", Revision: "new", RevisionTime: "2026-08-09T12:00:01Z"},
+			running:        Build{Version: "sha-old", Revision: "old", RevisionTime: "2026-08-09T12:00:00Z"},
+			advertisedTime: true, policy: "newer", want: replaceDaemon,
+		},
+		{
+			name:           "unknown order reuses",
+			client:         Build{Version: "sha-new", Revision: "new", RevisionTime: "2026-08-09T12:00:00Z"},
+			running:        Build{Version: "sha-old", Revision: "old", RevisionTime: "2026-08-09T12:00:00Z"},
+			advertisedTime: true, policy: "newer", want: reuseDaemon,
+		},
+		{
+			name:   "policy never reuses",
+			client: Build{Version: "v1.2.0"}, running: Build{Version: "v1.1.0"},
+			policy: "never", want: reuseDaemon,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(
 				t,
 				test.want,
-				decideReplacement(test.client, test.running, test.policy),
+				decideReplacement(
+					test.client,
+					test.running,
+					test.advertisedTime,
+					test.policy,
+				),
 			)
 		})
 	}
@@ -54,14 +85,25 @@ func scriptedInspector(
 func testControllerOptions(t *testing.T) ControllerOptions {
 	t.Helper()
 	return ControllerOptions{
-		Home:  t.TempDir(),
-		Build: Build{Version: "v1.2.0"},
+		Home: t.TempDir(),
+		Build: Build{
+			Version:  "v1.2.0",
+			Revision: strings.Repeat("a", 40),
+		},
 		Config: models.DaemonConfig{
 			AutoRestart:      "newer",
 			ReplacementGrace: 50 * time.Millisecond,
 		},
 		PollInterval: time.Millisecond,
 		StartTimeout: time.Second,
+	}
+}
+
+func matchingBuildStatus(options ControllerOptions) Status {
+	return Status{
+		Version:      options.Build.Version,
+		Revision:     options.Build.Revision,
+		RevisionTime: options.Build.RevisionTime,
 	}
 }
 
@@ -167,12 +209,46 @@ func TestControllerReplacesOlderDaemonAfterDrain(t *testing.T) {
 	assert.Equal(t, 1, launches)
 }
 
+func TestControllerReplacesOlderSHAStampedDaemon(t *testing.T) {
+	options := testControllerOptions(t)
+	options.Build = Build{
+		Version: "sha-new", Revision: "new", RevisionTime: "2026-08-09T12:00:01Z",
+	}
+	old := Observation{
+		State: RuntimeReady,
+		Status: Status{
+			Version: "sha-old", Revision: "old", RevisionTime: "2026-08-09T12:00:00Z",
+		},
+		Record: runtimeRecordWithRevisionTime("2026-08-09T12:00:00Z"),
+	}
+	ready := Observation{State: RuntimeReady, Status: matchingBuildStatus(options)}
+	options.Inspect = scriptedInspector(
+		t,
+		old,
+		Observation{State: RuntimeAbsent},
+		ready,
+	)
+	shutdown := false
+	options.RequestShutdown = func(context.Context, Observation, string) error {
+		shutdown = true
+		return nil
+	}
+	options.Launch = func(context.Context) error { return nil }
+
+	got, err := NewController(options).Start(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ready, got)
+	assert.True(t, shutdown)
+}
+
 func TestControllerReportsDrainProgressBeforeStarting(t *testing.T) {
 	options := testControllerOptions(t)
 	deadline := time.Now().Add(time.Second)
 	options.Inspect = scriptedInspector(
 		t,
 		Observation{State: RuntimeDraining, Status: Status{
+			Version:       options.Build.Version,
+			Revision:      options.Build.Revision,
 			State:         StateDraining,
 			ActiveLeases:  3,
 			DrainDeadline: &deadline,
@@ -275,10 +351,10 @@ func TestControllerStopUsesRunningDaemonDrainDeadline(t *testing.T) {
 
 func TestControllerRestartStopsThenStartsInvokingBinary(t *testing.T) {
 	options := testControllerOptions(t)
-	ready := Observation{State: RuntimeReady, Status: Status{Version: "v1.2.0"}}
+	ready := Observation{State: RuntimeReady, Status: matchingBuildStatus(options)}
 	options.Inspect = scriptedInspector(
 		t,
-		Observation{State: RuntimeReady, Status: Status{Version: "v1.2.0"}},
+		Observation{State: RuntimeReady, Status: matchingBuildStatus(options)},
 		Observation{State: RuntimeAbsent},
 		Observation{State: RuntimeAbsent},
 		ready,
@@ -301,10 +377,10 @@ func TestControllerRestartStopsThenStartsInvokingBinary(t *testing.T) {
 
 func TestControllerRestartRecoversFailedDaemon(t *testing.T) {
 	options := testControllerOptions(t)
-	ready := Observation{State: RuntimeReady, Status: Status{Version: "v1.2.0"}}
+	ready := Observation{State: RuntimeReady, Status: matchingBuildStatus(options)}
 	options.Inspect = scriptedInspector(
 		t,
-		Observation{State: RuntimeFailed, Status: Status{Version: "v1.2.0"}},
+		Observation{State: RuntimeFailed, Status: matchingBuildStatus(options)},
 		Observation{State: RuntimeAbsent},
 		Observation{State: RuntimeAbsent},
 		ready,
@@ -326,6 +402,71 @@ func TestControllerRestartRecoversFailedDaemon(t *testing.T) {
 	assert.True(t, shutdown)
 }
 
+func TestControllerRestartRejectsUnknownBuildOrder(t *testing.T) {
+	options := testControllerOptions(t)
+	options.Build = Build{
+		Version: "sha-new", Revision: "new", RevisionTime: "2026-08-09T12:00:00Z",
+	}
+	options.Inspect = scriptedInspector(t, Observation{
+		State: RuntimeReady,
+		Status: Status{
+			Version: "sha-old", Revision: "old", RevisionTime: "2026-08-09T12:00:00Z",
+		},
+		Record: runtimeRecordWithRevisionTime("2026-08-09T12:00:00Z"),
+	})
+	shutdown := false
+	options.RequestShutdown = func(context.Context, Observation, string) error {
+		shutdown = true
+		return nil
+	}
+
+	_, err := NewController(options).Restart(context.Background())
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.DaemonBuildOrderUnknown))
+	assert.False(t, shutdown)
+}
+
+func TestControllerUnknownBuildCannotReplaceDrainingDaemon(t *testing.T) {
+	for name, act := range map[string]func(*Controller) error{
+		"start": func(controller *Controller) error {
+			_, err := controller.Start(context.Background())
+			return err
+		},
+		"restart": func(controller *Controller) error {
+			_, err := controller.Restart(context.Background())
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			options := testControllerOptions(t)
+			options.Build = Build{
+				Version: "sha-new", Revision: "new", RevisionTime: "2026-08-09T12:00:00Z",
+			}
+			options.Inspect = scriptedInspector(t, Observation{
+				State: RuntimeDraining,
+				Status: Status{
+					Version: "sha-old", Revision: "old", RevisionTime: "2026-08-09T12:00:00Z",
+				},
+				Record: runtimeRecordWithRevisionTime("2026-08-09T12:00:00Z"),
+			})
+			launched := false
+			options.Launch = func(context.Context) error {
+				launched = true
+				return nil
+			}
+
+			err := act(NewController(options))
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.DaemonBuildOrderUnknown))
+			assert.False(t, launched)
+		})
+	}
+}
+
+func runtimeRecordWithRevisionTime(value string) kitdaemon.RuntimeRecord {
+	return kitdaemon.RuntimeRecord{Metadata: map[string]string{metadataRevisionTime: value}}
+}
+
 func TestControllerRestartRefusesToDowngradeNewerDaemon(t *testing.T) {
 	options := testControllerOptions(t)
 	options.Inspect = scriptedInspector(t, Observation{
@@ -344,6 +485,7 @@ func TestControllerRestartRefusesToDowngradeNewerDaemon(t *testing.T) {
 
 	_, err := NewController(options).Restart(context.Background())
 	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.DaemonDowngradeRefused))
 	assert.False(t, shutdown)
 }
 

--- a/internal/daemon/controller_test.go
+++ b/internal/daemon/controller_test.go
@@ -194,9 +194,9 @@ func TestControllerReplacesOlderDaemonAfterDrain(t *testing.T) {
 		_ context.Context,
 		_ Observation,
 		reason string,
-	) error {
+	) (Status, error) {
 		shutdownReason = reason
-		return nil
+		return Status{}, nil
 	}
 	launches := 0
 	options.Launch = func(context.Context) error {
@@ -229,9 +229,14 @@ func TestControllerReplacesOlderSHAStampedDaemon(t *testing.T) {
 		ready,
 	)
 	shutdown := false
-	options.RequestShutdown = func(context.Context, Observation, string) error {
+	deadline := time.Now().Add(time.Second)
+	var progress bytes.Buffer
+	options.Progress = &progress
+	options.RequestShutdown = func(context.Context, Observation, string) (Status, error) {
 		shutdown = true
-		return nil
+		return Status{
+			State: StateDraining, ActiveLeases: 2, DrainDeadline: &deadline,
+		}, nil
 	}
 	options.Launch = func(context.Context) error { return nil }
 
@@ -239,6 +244,7 @@ func TestControllerReplacesOlderSHAStampedDaemon(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ready, got)
 	assert.True(t, shutdown)
+	assert.Contains(t, progress.String(), "draining, waiting on 2 leases")
 }
 
 func TestControllerReportsDrainProgressBeforeStarting(t *testing.T) {
@@ -308,9 +314,9 @@ func TestControllerStopRequestsShutdownForNonReadyOwner(t *testing.T) {
 				_ context.Context,
 				_ Observation,
 				_ string,
-			) error {
+			) (Status, error) {
 				shutdown = true
-				return nil
+				return Status{}, nil
 			}
 
 			require.NoError(t, NewController(options).Stop(context.Background()))
@@ -342,8 +348,8 @@ func TestControllerStopUsesRunningDaemonDrainDeadline(t *testing.T) {
 		_ context.Context,
 		_ Observation,
 		_ string,
-	) error {
-		return nil
+	) (Status, error) {
+		return Status{}, nil
 	}
 
 	require.NoError(t, NewController(options).Stop(context.Background()))
@@ -364,9 +370,9 @@ func TestControllerRestartStopsThenStartsInvokingBinary(t *testing.T) {
 		_ context.Context,
 		_ Observation,
 		reason string,
-	) error {
+	) (Status, error) {
 		reasons = append(reasons, reason)
-		return nil
+		return Status{}, nil
 	}
 	options.Launch = func(context.Context) error { return nil }
 	got, err := NewController(options).Restart(context.Background())
@@ -390,9 +396,9 @@ func TestControllerRestartRecoversFailedDaemon(t *testing.T) {
 		_ context.Context,
 		_ Observation,
 		_ string,
-	) error {
+	) (Status, error) {
 		shutdown = true
-		return nil
+		return Status{}, nil
 	}
 	options.Launch = func(context.Context) error { return nil }
 
@@ -415,9 +421,9 @@ func TestControllerRestartRejectsUnknownBuildOrder(t *testing.T) {
 		Record: runtimeRecordWithRevisionTime("2026-08-09T12:00:00Z"),
 	})
 	shutdown := false
-	options.RequestShutdown = func(context.Context, Observation, string) error {
+	options.RequestShutdown = func(context.Context, Observation, string) (Status, error) {
 		shutdown = true
-		return nil
+		return Status{}, nil
 	}
 
 	_, err := NewController(options).Restart(context.Background())
@@ -478,9 +484,9 @@ func TestControllerRestartRefusesToDowngradeNewerDaemon(t *testing.T) {
 		_ context.Context,
 		_ Observation,
 		_ string,
-	) error {
+	) (Status, error) {
 		shutdown = true
-		return nil
+		return Status{}, nil
 	}
 
 	_, err := NewController(options).Restart(context.Background())

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -196,6 +196,7 @@ func runHost(
 			PID:           record.PID,
 			Version:       opts.Build.Version,
 			Revision:      opts.Build.Revision,
+			RevisionTime:  opts.Build.RevisionTime,
 			SchemaMajor:   APISchemaMajor,
 			SchemaVersion: APISchemaVersion,
 			Capabilities: []string{

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -14,12 +14,14 @@ import (
 
 	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kwt/service"
+	"golang.org/x/mod/semver"
 )
 
 const (
 	RuntimePrefix         = "kwt"
 	metadataHome          = "home"
 	metadataRevision      = "revision"
+	metadataRevisionTime  = "revision_time"
 	metadataSchemaMajor   = "schema_major"
 	metadataSchemaVersion = "schema_version"
 	metadataCapabilities  = "capabilities"
@@ -54,12 +56,14 @@ type Observation struct {
 }
 
 type runtimeMetadata struct {
-	home          string
-	revision      string
-	schemaMajor   int
-	schemaVersion string
-	capabilities  []string
-	token         string
+	home                   string
+	revision               string
+	revisionTime           string
+	revisionTimeAdvertised bool
+	schemaMajor            int
+	schemaVersion          string
+	capabilities           []string
+	token                  string
 }
 
 func RuntimeStore(home string) kitdaemon.RuntimeStore {
@@ -83,6 +87,7 @@ func NewRuntimeRecord(
 	rec.Metadata = map[string]string{
 		metadataHome:          home,
 		metadataRevision:      build.Revision,
+		metadataRevisionTime:  build.RevisionTime,
 		metadataSchemaMajor:   strconv.Itoa(APISchemaMajor),
 		metadataSchemaVersion: APISchemaVersion,
 		metadataCapabilities: strings.Join([]string{
@@ -218,6 +223,7 @@ func parseRuntimeMetadata(
 		schemaVersion: rec.Metadata[metadataSchemaVersion],
 		token:         rec.Metadata[metadataToken],
 	}
+	metadata.revisionTime, metadata.revisionTimeAdvertised = rec.Metadata[metadataRevisionTime]
 	if metadata.home == "" || metadata.home != home {
 		return runtimeMetadata{}, errors.New("runtime home does not match")
 	}
@@ -231,6 +237,19 @@ func parseRuntimeMetadata(
 	metadata.schemaMajor = major
 	if metadata.schemaVersion == "" {
 		return runtimeMetadata{}, errors.New("runtime schema version is missing")
+	}
+	schemaVersion, schemaVersionValid := comparableVersion(metadata.schemaVersion)
+	if !schemaVersionValid {
+		return runtimeMetadata{}, errors.New("runtime schema version is invalid")
+	}
+	if semver.Compare(schemaVersion, "v1.3.0") >= 0 &&
+		!metadata.revisionTimeAdvertised {
+		return runtimeMetadata{}, errors.New("runtime revision time is missing")
+	}
+	if metadata.revisionTime != "" {
+		if _, valid := parseRevisionTime(metadata.revisionTime); !valid {
+			return runtimeMetadata{}, errors.New("runtime revision time is invalid")
+		}
 	}
 	metadata.capabilities, err = parseCapabilities(rec.Metadata[metadataCapabilities])
 	if err != nil {
@@ -264,7 +283,8 @@ func validateRuntimeStatus(
 		status.PID != rec.PID || status.Endpoint != rec.Endpoint().Address {
 		return errors.New("daemon status does not match its runtime record")
 	}
-	if status.Version != rec.Version || status.Revision != metadata.revision {
+	if status.Version != rec.Version || status.Revision != metadata.revision ||
+		status.RevisionTime != metadata.revisionTime {
 		return errors.New("daemon build identity does not match its runtime record")
 	}
 	if status.SchemaMajor <= 0 || status.SchemaMajor != metadata.schemaMajor ||

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -27,8 +27,9 @@ const (
 )
 
 type Build struct {
-	Version  string
-	Revision string
+	Version      string
+	Revision     string
+	RevisionTime string
 }
 
 type RuntimeState uint8

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"maps"
 	"math"
 	"net"
 	"net/http"
@@ -24,6 +25,7 @@ func validMetadata(home, token string) map[string]string {
 	return map[string]string{
 		metadataHome:          home,
 		metadataRevision:      "abc",
+		metadataRevisionTime:  "2026-08-09T12:00:00Z",
 		metadataSchemaMajor:   strconv.Itoa(APISchemaMajor),
 		metadataSchemaVersion: APISchemaVersion,
 		metadataCapabilities: strings.Join([]string{
@@ -32,6 +34,83 @@ func validMetadata(home, token string) map[string]string {
 		}, ","),
 		metadataToken: token,
 	}
+}
+
+func TestNewRuntimeRecordAlwaysAdvertisesRevisionTime(t *testing.T) {
+	home := t.TempDir()
+	record, _, err := NewRuntimeRecord(home, Build{
+		Version:      "v1.2.3",
+		Revision:     "abc",
+		RevisionTime: "2026-08-09T12:00:00Z",
+	}, kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:1"})
+	require.NoError(t, err)
+
+	value, present := record.Metadata[metadataRevisionTime]
+	assert.True(t, present)
+	assert.Equal(t, "2026-08-09T12:00:00Z", value)
+
+	record, _, err = NewRuntimeRecord(home, Build{Version: "development"}, kitdaemon.Endpoint{
+		Network: kitdaemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+	})
+	require.NoError(t, err)
+	value, present = record.Metadata[metadataRevisionTime]
+	assert.True(t, present)
+	assert.Empty(t, value)
+}
+
+func TestParseRuntimeMetadataRevisionTimeCompatibility(t *testing.T) {
+	home := t.TempDir()
+	record := kitdaemon.NewRuntimeRecord(
+		ServiceName,
+		"v1.2.3",
+		kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:1"},
+	)
+	record.Metadata = validMetadata(home, "secret")
+
+	t.Run("new schema accepts canonical time", func(t *testing.T) {
+		metadata, err := parseRuntimeMetadata(record, home)
+		require.NoError(t, err)
+		assert.True(t, metadata.revisionTimeAdvertised)
+		assert.Equal(t, "2026-08-09T12:00:00Z", metadata.revisionTime)
+	})
+
+	t.Run("new schema accepts explicit unknown time", func(t *testing.T) {
+		unknown := record
+		unknown.Metadata = maps.Clone(record.Metadata)
+		unknown.Metadata[metadataRevisionTime] = ""
+		metadata, err := parseRuntimeMetadata(unknown, home)
+		require.NoError(t, err)
+		assert.True(t, metadata.revisionTimeAdvertised)
+		assert.Empty(t, metadata.revisionTime)
+	})
+
+	t.Run("new schema rejects missing time", func(t *testing.T) {
+		missing := record
+		missing.Metadata = maps.Clone(record.Metadata)
+		delete(missing.Metadata, metadataRevisionTime)
+		_, err := parseRuntimeMetadata(missing, home)
+		require.ErrorContains(t, err, "revision time")
+	})
+
+	t.Run("new schema rejects malformed time", func(t *testing.T) {
+		malformed := record
+		malformed.Metadata = maps.Clone(record.Metadata)
+		malformed.Metadata[metadataRevisionTime] = "2026-08-09 12:00:00"
+		_, err := parseRuntimeMetadata(malformed, home)
+		require.ErrorContains(t, err, "revision time")
+	})
+
+	t.Run("legacy schema accepts omitted time", func(t *testing.T) {
+		legacy := record
+		legacy.Metadata = maps.Clone(record.Metadata)
+		legacy.Metadata[metadataSchemaVersion] = "1.2.0"
+		delete(legacy.Metadata, metadataRevisionTime)
+		metadata, err := parseRuntimeMetadata(legacy, home)
+		require.NoError(t, err)
+		assert.False(t, metadata.revisionTimeAdvertised)
+		assert.Empty(t, metadata.revisionTime)
+	})
 }
 
 func TestInspectRemovesADeadPIDRuntimeRecord(t *testing.T) {
@@ -96,6 +175,26 @@ func TestInspectPreservesMatchingButUnresponsiveOwner(t *testing.T) {
 	assert.FileExists(t, path)
 }
 
+func TestInspectPreservesOwnerWithInvalidRevisionTime(t *testing.T) {
+	home := t.TempDir()
+	store := RuntimeStore(home)
+	record := kitdaemon.NewRuntimeRecord(
+		ServiceName,
+		"v1.2.3",
+		kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:1"},
+	)
+	record.Metadata = validMetadata(home, "secret")
+	record.Metadata[metadataRevisionTime] = "invalid"
+	path, err := store.Write(record)
+	require.NoError(t, err)
+
+	observation, err := Inspect(context.Background(), store, home)
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeUnresponsive, observation.State)
+	require.ErrorContains(t, observation.Err, "revision time")
+	assert.FileExists(t, path)
+}
+
 func TestInspectReturnsAProofVerifiedRuntime(t *testing.T) {
 	home := t.TempDir()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -113,6 +212,7 @@ func TestInspectReturnsAProofVerifiedRuntime(t *testing.T) {
 		PID:           rec.PID,
 		Version:       rec.Version,
 		Revision:      "abc",
+		RevisionTime:  "2026-08-09T12:00:00Z",
 		Home:          home,
 		Endpoint:      ep.Address,
 		SchemaMajor:   APISchemaMajor,
@@ -160,6 +260,7 @@ func TestInspectPreservesUnknownProcessIdentityAsUnresponsive(t *testing.T) {
 		PID:           rec.PID,
 		Version:       rec.Version,
 		Revision:      "abc",
+		RevisionTime:  "2026-08-09T12:00:00Z",
 		Home:          home,
 		Endpoint:      ep.Address,
 		SchemaMajor:   APISchemaMajor,
@@ -209,14 +310,16 @@ func TestValidateRuntimeStatusRejectsBuildIdentityMismatch(t *testing.T) {
 		PID:           rec.PID,
 		Version:       rec.Version,
 		Revision:      metadata.revision,
+		RevisionTime:  metadata.revisionTime,
 		SchemaMajor:   APISchemaMajor,
 		SchemaVersion: APISchemaVersion,
 		Capabilities:  []string{CapabilityShutdown, CapabilityStatus},
 	}
 
 	for name, mutate := range map[string]func(*Status){
-		"version":  func(value *Status) { value.Version = "v9.9.9" },
-		"revision": func(value *Status) { value.Revision = "different" },
+		"version":       func(value *Status) { value.Version = "v9.9.9" },
+		"revision":      func(value *Status) { value.Revision = "different" },
+		"revision_time": func(value *Status) { value.RevisionTime = "2026-08-09T12:00:01Z" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			mismatched := status

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	ServiceName         = "kwt"
 	APISchemaMajor      = 1
-	APISchemaVersion    = "1.2.0"
+	APISchemaVersion    = "1.3.0"
 	CapabilityStatus    = "daemon.status"
 	CapabilityShutdown  = "daemon.shutdown"
 	CapabilityInventory = "worktree.inventory.v1"
@@ -34,6 +34,7 @@ type Status struct {
 	PID           int        `json:"pid"`
 	Version       string     `json:"version"`
 	Revision      string     `json:"revision"`
+	RevisionTime  string     `json:"revision_time"`
 	SchemaMajor   int        `json:"schema_major"`
 	SchemaVersion string     `json:"schema_version"`
 	Capabilities  []string   `json:"capabilities"`

--- a/service/error.go
+++ b/service/error.go
@@ -7,16 +7,18 @@ import "errors"
 type Code string
 
 const (
-	InvalidRequest      Code = "invalid_request"
-	Conflict            Code = "conflict"
-	Busy                Code = "busy"
-	NotFound            Code = "not_found"
-	InteractionRequired Code = "interaction_required"
-	PermissionDenied    Code = "permission_denied"
-	ConnectionChanged   Code = "connection_changed"
-	Unsupported         Code = "unsupported"
-	TransportFailure    Code = "transport_failure"
-	Internal            Code = "internal"
+	InvalidRequest          Code = "invalid_request"
+	Conflict                Code = "conflict"
+	Busy                    Code = "busy"
+	NotFound                Code = "not_found"
+	InteractionRequired     Code = "interaction_required"
+	PermissionDenied        Code = "permission_denied"
+	ConnectionChanged       Code = "connection_changed"
+	Unsupported             Code = "unsupported"
+	TransportFailure        Code = "transport_failure"
+	DaemonDowngradeRefused  Code = "daemon_downgrade_refused"
+	DaemonBuildOrderUnknown Code = "daemon_build_order_unknown"
+	Internal                Code = "internal"
 )
 
 // Error carries a stable category and retry policy across in-process and HTTP


### PR DESCRIPTION
Ghosthub ships revision-pinned kwt helpers whose versions are commit SHAs, so semver-only daemon replacement can reuse an older helper indefinitely or let an ambiguous build replace the active owner. This makes source commit time part of the proof-verified daemon identity and applies one conservative order across automatic start, restart, and draining takeover: exact revision, differing semver, then authenticated RFC3339 source time. Hashes are never ordered lexically, and equal-time revisions remain unknown.

Automatic start reuses a ready daemon when order is unknown; explicit restart returns typed downgrade or unknown-order failures. Operators retain a deliberate `kwt daemon stop` then `start` escape hatch, and replacement prints drain status immediately while it waits. Tagged releases now stamp source time, with the same linker contract available to Ghosthub's managed helper build.

Validated with SHA-stamped subprocess upgrade/downgrade/equal-time fixtures, `go test -race ./internal/daemon ./internal/cmd`, `make test`, `make lint`, `make build`, and `make docs-check`. Kata: gj1m.