### PR TITLE
Stabilize daemon failure contracts for Ghosthub

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -50,6 +50,37 @@ and repository-config approval under `/api/v1`, proof-capable liveness at
 require the `worktree.inventory.v1` capability. An operation never has
 simultaneous direct and HTTP execution paths.
 
+Service failures cross the in-process, HTTP, and machine-readable CLI
+boundaries as one descriptor with `code`, human-facing `message`, `retryable`,
+and optional typed `details`. Adapters preserve the descriptor; they do not
+infer a failure from prose or HTTP status. HTTP uses the same message as its
+RFC problem `detail`. Unknown HTTP codes become `daemon_transport_failed`
+instead of being guessed. Detail keys are allowlisted per code: draining may
+carry an RFC3339 `drain_deadline`, and repository trust interaction carries
+its typed digest-bound prompt fields.
+
+The daemon and inventory paths currently emit these stable codes:
+
+| Code | Meaning |
+| --- | --- |
+| `invalid_request` | The request is structurally invalid. |
+| `daemon_start_failed` | The daemon could not launch or become ready. |
+| `daemon_unresponsive` | A verified owner exists but cannot safely be reused or replaced. |
+| `daemon_incompatible` | The owner lacks the required API major or capability. |
+| `daemon_downgrade_refused` | An older client attempted replacement. |
+| `daemon_build_order_unknown` | Replacement order cannot be proved. |
+| `daemon_draining` | The owner is draining; retry according to its deadline. |
+| `daemon_transport_failed` | The verified daemon exchange failed or was not understood. |
+| `inventory_timeout` | A current inventory refresh exceeded its bound. |
+| `inventory_failed` | Inventory discovery failed for another known source cause. |
+| `interaction_required` | Repository configuration needs digest-bound approval. |
+| `internal` | An unexpected failure was withheld from the public response. |
+
+`operation_id_conflict`, `operation_capacity_exhausted`,
+`operation_journal_unavailable`, and `operation_outcome_unknown` are reserved
+for the API-major-2 durable-operation protocol. No current endpoint emits
+them.
+
 `kwt projects` and `kwt list` auto-start or reuse the daemon and require a
 current inventory result. They fail instead of falling back to cached or direct
 filesystem data. The TUI may paint immediately from the derived last-known-good

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -64,20 +64,21 @@ deadline.
 
 The daemon and inventory paths currently emit these stable codes:
 
-| Code                         | Meaning                                                          |
-| ---------------------------- | ---------------------------------------------------------------- |
-| `invalid_request`            | The request is structurally invalid.                             |
-| `daemon_start_failed`        | The daemon could not launch or become ready.                     |
-| `daemon_unresponsive`        | A verified owner exists but cannot safely be reused or replaced. |
-| `daemon_incompatible`        | The owner lacks the required API major or capability.            |
-| `daemon_downgrade_refused`   | An older client attempted replacement.                           |
-| `daemon_build_order_unknown` | Replacement order cannot be proved.                              |
-| `daemon_draining`            | The owner is draining; retry according to its deadline.          |
-| `daemon_transport_failed`    | The verified daemon exchange failed or was not understood.       |
-| `inventory_timeout`          | A current inventory refresh exceeded its bound.                  |
-| `inventory_failed`           | Inventory discovery failed for another known source cause.       |
-| `interaction_required`       | Repository configuration needs digest-bound approval.            |
-| `internal`                   | An unexpected failure was withheld from the public response.     |
+| Code                         | Meaning                                                           |
+| ---------------------------- | ----------------------------------------------------------------- |
+| `invalid_request`            | The request is structurally invalid.                              |
+| `daemon_start_failed`        | The daemon could not launch or become ready.                      |
+| `daemon_unresponsive`        | A verified owner exists but cannot safely be reused or replaced.  |
+| `daemon_incompatible`        | The owner lacks the required API major or capability.             |
+| `daemon_downgrade_refused`   | An older client attempted replacement.                            |
+| `daemon_build_order_unknown` | Replacement order cannot be proved.                               |
+| `daemon_draining`            | The owner is draining; retry according to its deadline.           |
+| `daemon_transport_failed`    | The verified daemon exchange failed or was not understood.        |
+| `inventory_timeout`          | A current inventory refresh exceeded its bound.                   |
+| `inventory_failed`           | Inventory discovery failed for another known source cause.        |
+| `removal_failed`             | A known worktree removal failure retained safe actionable detail. |
+| `interaction_required`       | Repository configuration needs digest-bound approval.             |
+| `internal`                   | An unexpected failure was withheld from the public response.      |
 
 `operation_id_conflict`, `operation_capacity_exhausted`,
 `operation_journal_unavailable`, and `operation_outcome_unknown` are reserved

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -57,7 +57,10 @@ infer a failure from prose or HTTP status. HTTP uses the same message as its
 RFC problem `detail`. Unknown HTTP codes become `daemon_transport_failed`
 instead of being guessed. Detail keys are allowlisted per code: draining may
 carry an RFC3339 `drain_deadline`, and repository trust interaction carries
-its typed digest-bound prompt fields.
+its typed digest-bound prompt fields. Within API major 1, draining responses
+also mirror the deadline in the legacy top-level `drain_deadline` field, and
+clients recognize a legacy `busy` response only when it carries a valid drain
+deadline.
 
 The daemon and inventory paths currently emit these stable codes:
 

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -61,20 +61,20 @@ its typed digest-bound prompt fields.
 
 The daemon and inventory paths currently emit these stable codes:
 
-| Code | Meaning |
-| --- | --- |
-| `invalid_request` | The request is structurally invalid. |
-| `daemon_start_failed` | The daemon could not launch or become ready. |
-| `daemon_unresponsive` | A verified owner exists but cannot safely be reused or replaced. |
-| `daemon_incompatible` | The owner lacks the required API major or capability. |
-| `daemon_downgrade_refused` | An older client attempted replacement. |
-| `daemon_build_order_unknown` | Replacement order cannot be proved. |
-| `daemon_draining` | The owner is draining; retry according to its deadline. |
-| `daemon_transport_failed` | The verified daemon exchange failed or was not understood. |
-| `inventory_timeout` | A current inventory refresh exceeded its bound. |
-| `inventory_failed` | Inventory discovery failed for another known source cause. |
-| `interaction_required` | Repository configuration needs digest-bound approval. |
-| `internal` | An unexpected failure was withheld from the public response. |
+| Code                         | Meaning                                                          |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `invalid_request`            | The request is structurally invalid.                             |
+| `daemon_start_failed`        | The daemon could not launch or become ready.                     |
+| `daemon_unresponsive`        | A verified owner exists but cannot safely be reused or replaced. |
+| `daemon_incompatible`        | The owner lacks the required API major or capability.            |
+| `daemon_downgrade_refused`   | An older client attempted replacement.                           |
+| `daemon_build_order_unknown` | Replacement order cannot be proved.                              |
+| `daemon_draining`            | The owner is draining; retry according to its deadline.          |
+| `daemon_transport_failed`    | The verified daemon exchange failed or was not understood.       |
+| `inventory_timeout`          | A current inventory refresh exceeded its bound.                  |
+| `inventory_failed`           | Inventory discovery failed for another known source cause.       |
+| `interaction_required`       | Repository configuration needs digest-bound approval.            |
+| `internal`                   | An unexpected failure was withheld from the public response.     |
 
 `operation_id_conflict`, `operation_capacity_exhausted`,
 `operation_journal_unavailable`, and `operation_outcome_unknown` are reserved

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -83,6 +83,14 @@ A remote client reaches inventory by invoking the remote machine's kwt CLI over
 its existing shell boundary; the loopback daemon itself is not remotely
 reachable.
 
+Public service descriptors never contain an unexpected error's private cause.
+HTTP detail keys are selected by stable code and type-checked before
+serialization; arbitrary cause metadata is not forwarded. The owner-private
+daemon log records the route, stable code, and a diagnostic capped at 1024
+bytes. The bearer, values from credential-named environment variables,
+authorization headers, and URL user information are redacted before that
+diagnostic is written. Request bodies are never logged.
+
 PID liveness alone does not authorize cleanup or replacement. Kwt also checks
 the recorded process creation identity. A dead PID or exact creation mismatch
 makes a runtime record stale; an identity that cannot be read, a timed-out

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,7 +89,7 @@ shape to stdout:
     "code": "daemon_draining",
     "message": "the kwt daemon is draining",
     "retryable": true,
-    "details": {"drain_deadline": "2026-08-10T01:02:03Z"}
+    "details": { "drain_deadline": "2026-08-10T01:02:03Z" }
   }
 }
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,6 +79,30 @@ snapshot. Other worktree mutations, Git status collection, tmux attachment,
 and SSH remain on their existing paths until their complete service
 migrations.
 
+Successful `kwt list --json` and `kwt projects --json` output remains a bare
+top-level array. A daemon or inventory failure instead writes this shared
+shape to stdout:
+
+```json
+{
+  "error": {
+    "code": "daemon_draining",
+    "message": "the kwt daemon is draining",
+    "retryable": true,
+    "details": {"drain_deadline": "2026-08-10T01:02:03Z"}
+  }
+}
+```
+
+`code`, `retryable`, and documented detail types are the machine contract;
+`message` is explanatory prose and may change. A corresponding single human
+line remains on stderr. `list` daemon/inventory failures exit `1`.
+`projects` preserves its existing command contract: argument and not-found
+failures exit `2`, operational failures exit `1`, and existing mutation codes
+such as `registration_changed` retain the same envelope. Kwt does not
+normalize unrelated commands' exit behavior. Exit `255` remains unused so an
+SSH caller can distinguish a remote-shell transport failure.
+
 Daemon ownership must not buffer human-facing operation progress. Removal
 continues to print each selected worktree's result as soon as that target
 finishes. Before longer mutations such as add, pull-request import, doctor,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -216,6 +216,9 @@ generation, main-worktree status, and lock state while holding the repository's
 cross-process mutation lock. It also performs generation-safe registry cleanup.
 The CLI and TUI retain selection, output, fleet publication, and tmux-session
 cleanup; stale inventory alone never authorizes deletion.
+Known Git removal failures use the stable `removal_failed` code and preserve
+their credential-sanitized message and partial-result fields across the daemon
+boundary. Unexpected failures use `internal` and withhold their cause.
 If a removal response is lost, the client requests a fresh bounded repository
 inventory. A missing original generation is reported as an irreversible partial
 result so fleet publication, TUI refresh, and session cleanup still run. If the

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -135,7 +135,8 @@ func queryDaemonInventory(
 
 func inventoryDrainDeadline(err error) (*time.Time, bool) {
 	var typed *service.Error
-	if !errors.As(err, &typed) || typed.Code != service.DaemonDraining {
+	if !errors.As(err, &typed) ||
+		(typed.Code != service.DaemonDraining && typed.Code != service.Busy) {
 		return nil, false
 	}
 	switch deadline := typed.Details["drain_deadline"].(type) {

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -37,7 +37,7 @@ func removeWorktreeThroughDaemon(
 		if observation.Client == nil ||
 			!slices.Contains(observation.Status.Capabilities, kwtdaemon.CapabilityRemoval) {
 			return kwt.RemovalResult{}, service.NewError(
-				service.Unsupported,
+				service.DaemonIncompatible,
 				"the running kwt daemon does not provide worktree removal",
 				false,
 				nil,
@@ -135,7 +135,7 @@ func queryDaemonInventory(
 
 func inventoryDrainDeadline(err error) (*time.Time, bool) {
 	var typed *service.Error
-	if !errors.As(err, &typed) || typed.Code != service.Busy {
+	if !errors.As(err, &typed) || typed.Code != service.DaemonDraining {
 		return nil, false
 	}
 	switch deadline := typed.Details["drain_deadline"].(type) {
@@ -143,6 +143,9 @@ func inventoryDrainDeadline(err error) (*time.Time, bool) {
 		return &deadline, true
 	case *time.Time:
 		return deadline, deadline != nil
+	case string:
+		parsed, err := time.Parse(time.RFC3339Nano, deadline)
+		return &parsed, err == nil
 	default:
 		return nil, false
 	}
@@ -151,7 +154,7 @@ func inventoryDrainDeadline(err error) (*time.Time, bool) {
 func requireInventoryCapability(observation kwtdaemon.Observation) error {
 	if observation.Client == nil || !slices.Contains(observation.Status.Capabilities, kwtdaemon.CapabilityInventory) {
 		return service.NewError(
-			service.Unsupported,
+			service.DaemonIncompatible,
 			"the running kwt daemon does not provide worktree inventory",
 			false,
 			nil,
@@ -166,7 +169,13 @@ func waitInventoryRetry(ctx context.Context, deadline *time.Time) error {
 	if deadline != nil {
 		remaining := time.Until(*deadline)
 		if remaining <= 0 {
-			return service.NewError(service.Busy, "the kwt daemon is still draining", true, nil, nil)
+			return service.NewError(
+				service.DaemonDraining,
+				"the kwt daemon is still draining",
+				true,
+				map[string]any{"drain_deadline": deadline.Format(time.RFC3339Nano)},
+				nil,
+			)
 		}
 		if remaining < delay {
 			delay = remaining
@@ -197,7 +206,7 @@ func trustRequirement(err error) (config.TrustRequiredError, error) {
 	if detailString(typed.Details, "kind") != "repository_config_trust" ||
 		requirement.Path == "" || requirement.Digest == "" {
 		return config.TrustRequiredError{}, service.NewError(
-			service.TransportFailure,
+			service.DaemonTransportFailed,
 			"kwt daemon returned an incomplete trust requirement",
 			false,
 			nil,

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -29,6 +29,17 @@ func TestInventoryDrainDeadlineRequiresDaemonDrainingCode(t *testing.T) {
 			}, nil),
 			want: &deadline,
 		},
+		{
+			name: "legacy daemon drain",
+			err: service.NewError(service.Busy, "daemon is draining", true, map[string]any{
+				"drain_deadline": deadline,
+			}, nil),
+			want: &deadline,
+		},
+		{
+			name: "legacy busy without deadline",
+			err:  service.NewError(service.Busy, "inventory is busy", true, nil, nil),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -11,8 +11,8 @@ import (
 	"go.kenn.io/kwt/service"
 )
 
-func TestInventoryDrainDeadlineRequiresDeadlineBearingBusyError(t *testing.T) {
-	deadline := time.Now().Add(time.Minute)
+func TestInventoryDrainDeadlineRequiresDaemonDrainingCode(t *testing.T) {
+	deadline := time.Now().UTC().Add(time.Minute)
 	tests := []struct {
 		name string
 		err  error
@@ -20,12 +20,12 @@ func TestInventoryDrainDeadlineRequiresDeadlineBearingBusyError(t *testing.T) {
 	}{
 		{
 			name: "inventory refresh timeout",
-			err:  service.NewError(service.Busy, "inventory refresh timed out", true, nil, nil),
+			err:  service.NewError(service.InventoryTimeout, "inventory refresh timed out", true, nil, nil),
 		},
 		{
 			name: "daemon drain",
-			err: service.NewError(service.Busy, "daemon is draining", true, map[string]any{
-				"drain_deadline": deadline,
+			err: service.NewError(service.DaemonDraining, "daemon is draining", true, map[string]any{
+				"drain_deadline": deadline.Format(time.RFC3339Nano),
 			}, nil),
 			want: &deadline,
 		},

--- a/internal/cmd/inventory_subprocess_test.go
+++ b/internal/cmd/inventory_subprocess_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 )
 
 func runInventoryCommand(
@@ -174,18 +175,31 @@ path = "`+filepath.ToSlash(repository)+`"
 func TestInventorySubprocessDaemonFailuresNeverUseSSHExit255(t *testing.T) {
 	binary, _ := buildDaemonTestBinaries(t)
 	fixture := buildDaemonFixture(t)
-	for _, mode := range []string{"unresponsive", "incompatible", "draining"} {
-		t.Run(mode, func(t *testing.T) {
+	for _, test := range []struct {
+		mode string
+		code service.Code
+	}{
+		{mode: "unresponsive", code: service.DaemonUnresponsive},
+		{mode: "incompatible", code: service.DaemonIncompatible},
+		{mode: "draining", code: service.DaemonDraining},
+		{mode: "inventory_failed", code: service.InventoryFailed},
+	} {
+		t.Run(test.mode, func(t *testing.T) {
 			home := newDaemonTestHome(t, validDaemonConfig)
 			repository := filepath.Join(t.TempDir(), "repo")
 			require.NoError(t, exec.Command("git", "init", repository).Run())
-			startDaemonFixture(t, fixture, home, mode)
+			startDaemonFixture(t, fixture, home, test.mode)
 
-			_, stderr, err := runInventoryCommand(t, binary, home, repository, "list", "--json")
+			stdout, stderr, err := runInventoryCommand(t, binary, home, repository, "list", "--json")
 			var exitErr *exec.ExitError
 			require.ErrorAs(t, err, &exitErr, "stderr=%s", stderr)
 			assert.Equal(t, 1, exitErr.ExitCode(), "stderr=%s", stderr)
 			assert.NotEqual(t, 255, exitErr.ExitCode())
+			var envelope jsonErrorEnvelope
+			require.NoError(t, json.Unmarshal(stdout, &envelope), "stdout=%s stderr=%s", stdout, stderr)
+			assert.Equal(t, test.code, envelope.Error.Code)
+			assert.NotEmpty(t, envelope.Error.Message)
+			assert.NotContains(t, string(stderr), `{"error":`)
 		})
 	}
 }

--- a/internal/cmd/json_error.go
+++ b/internal/cmd/json_error.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kwt/service"
+)
+
+type jsonErrorEnvelope struct {
+	Error service.Descriptor `json:"error"`
+}
+
+type commandFailure struct {
+	descriptor service.Descriptor
+	exitCode   int
+}
+
+func (e *commandFailure) Error() string { return e.descriptor.Message }
+func (e *commandFailure) ExitCode() int { return e.exitCode }
+func (e *commandFailure) Unwrap() error {
+	return service.NewDescriptorError(e.descriptor, nil)
+}
+
+func writeCommandFailure(
+	cmd *cobra.Command,
+	descriptor service.Descriptor,
+	exitCode int,
+	jsonRequested bool,
+	prefix string,
+) error {
+	cmd.Root().SilenceUsage = true
+	cmd.Root().SilenceErrors = true
+	if jsonRequested {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		_ = encoder.Encode(jsonErrorEnvelope{Error: descriptor})
+	}
+	_, _ = fmt.Fprintf(
+		cmd.ErrOrStderr(),
+		"kwt %s: %s: %s\n",
+		prefix,
+		descriptor.Code,
+		descriptor.Message,
+	)
+	return &commandFailure{descriptor: descriptor, exitCode: exitCode}
+}

--- a/internal/cmd/json_error_test.go
+++ b/internal/cmd/json_error_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/service"
+)
+
+func TestWriteCommandFailureUsesSharedJSONEnvelope(t *testing.T) {
+	root := &cobra.Command{Use: "kwt"}
+	cmd := &cobra.Command{Use: "list"}
+	root.AddCommand(cmd)
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	descriptor := service.Descriptor{
+		Code: service.DaemonDraining, Message: "the kwt daemon is draining", Retryable: true,
+		Details: map[string]any{"drain_deadline": "2026-08-10T01:02:03Z"},
+	}
+
+	err := writeCommandFailure(cmd, descriptor, 1, true, "list")
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 1, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, descriptor.Code, envelope.Error.Code)
+	assert.Equal(t, descriptor.Message, envelope.Error.Message)
+	assert.Equal(t, descriptor.Retryable, envelope.Error.Retryable)
+	assert.Equal(t, descriptor.Details, envelope.Error.Details)
+	assert.Equal(t, "kwt list: daemon_draining: the kwt daemon is draining\n", stderr.String())
+	assert.True(t, root.SilenceUsage)
+	assert.True(t, root.SilenceErrors)
+}
+
+func TestWriteCommandFailureOmitsEmptyDetails(t *testing.T) {
+	cmd := &cobra.Command{Use: "kwt"}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	_ = writeCommandFailure(cmd, service.Descriptor{
+		Code: service.InvalidRequest, Message: "invalid request",
+	}, 2, true, "projects")
+
+	assert.NotContains(t, stdout.String(), "details")
+}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -9,6 +9,7 @@ import (
 	kwt "go.kenn.io/kwt"
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 )
 
 var (
@@ -59,11 +60,11 @@ func init() {
 func runList(cmd *cobra.Command, args []string) error {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
-		return err
+		return writeListFailure(cmd, err, err)
 	}
 	workingDirectory, err = filepath.Abs(workingDirectory)
 	if err != nil {
-		return err
+		return writeListFailure(cmd, err, err)
 	}
 	result, err := queryListInventory(
 		cmd.Context(),
@@ -76,11 +77,11 @@ func runList(cmd *cobra.Command, args []string) error {
 		cmd.ErrOrStderr(),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to list worktrees: %w", err)
+		return writeListFailure(cmd, err, fmt.Errorf("failed to list worktrees: %w", err))
 	}
 	ctx, err := NewCommandContext()
 	if err != nil {
-		return err
+		return writeListFailure(cmd, err, err)
 	}
 	worktrees := make([]models.Worktree, len(result.Snapshot.Entries))
 	for index, entry := range result.Snapshot.Entries {
@@ -95,6 +96,19 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 	ctx.Printer.PrintWorktrees(worktrees, listVerbose)
 	return nil
+}
+
+func writeListFailure(cmd *cobra.Command, err, humanError error) error {
+	if !listJSON {
+		return humanError
+	}
+	return writeCommandFailure(
+		cmd,
+		service.AsError(err).Descriptor,
+		1,
+		true,
+		"list",
+	)
 }
 
 func listedWorktree(entry kwt.Entry) models.Worktree {

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	kwt "go.kenn.io/kwt"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/service"
 )
 
 func captureListStdout(t *testing.T, run func() error) (string, error) {
@@ -98,4 +99,41 @@ func TestRunListGlobalEmptyJSONRemainsBareArray(t *testing.T) {
 	stdout, err := captureListStdout(t, func() error { return runList(listCmd, nil) })
 	require.NoError(t, err)
 	assert.Equal(t, "[]\n", stdout)
+}
+
+func TestRunListJSONWritesStableDaemonFailure(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("KWT_HOME", t.TempDir())
+	require.NoError(t, config.Init())
+	t.Chdir(t.TempDir())
+	originalQuery := queryListInventory
+	t.Cleanup(func() { queryListInventory = originalQuery })
+	queryListInventory = func(context.Context, kwt.Request, bool, io.Writer) (kwt.Result, error) {
+		return kwt.Result{}, service.NewError(
+			service.DaemonDraining,
+			"the kwt daemon is draining",
+			true,
+			map[string]any{"drain_deadline": "2026-08-10T01:02:03Z"},
+			nil,
+		)
+	}
+	previousJSON := listJSON
+	listJSON = true
+	t.Cleanup(func() { listJSON = previousJSON })
+	var stdout, stderr bytes.Buffer
+	listCmd.SetOut(&stdout)
+	listCmd.SetErr(&stderr)
+
+	err := runList(listCmd, nil)
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 1, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.DaemonDraining, envelope.Error.Code)
+	assert.True(t, envelope.Error.Retryable)
+	assert.NotEqual(t, byte('['), bytes.TrimSpace(stdout.Bytes())[0])
+	assert.Contains(t, stderr.String(), "daemon_draining")
 }

--- a/internal/cmd/projects.go
+++ b/internal/cmd/projects.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 )
 
 var (
@@ -92,6 +93,15 @@ func runProjects(cmd *cobra.Command, args []string) error {
 		cmd.ErrOrStderr(),
 	)
 	if err != nil {
+		if projectsJSON {
+			return writeCommandFailure(
+				cmd,
+				service.AsError(err).Descriptor,
+				1,
+				true,
+				"projects",
+			)
+		}
 		return err
 	}
 	projects := result.Snapshot.Projects
@@ -118,24 +128,6 @@ type projectMutationResult struct {
 	Status  string         `json:"status"`
 	Project models.Project `json:"project"`
 }
-
-type projectCommandErrorBody struct {
-	Code      string `json:"code"`
-	Message   string `json:"message"`
-	Retryable bool   `json:"retryable"`
-}
-
-type projectCommandErrorEnvelope struct {
-	Error projectCommandErrorBody `json:"error"`
-}
-
-type projectCommandError struct {
-	body     projectCommandErrorBody
-	exitCode int
-}
-
-func (e *projectCommandError) Error() string { return e.body.Message }
-func (e *projectCommandError) ExitCode() int { return e.exitCode }
 
 func projectsNoArgs(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
@@ -328,20 +320,15 @@ func writeProjectCommandErrorWithRetry(
 	exitCode int,
 	retryable bool,
 ) error {
-	body := projectCommandErrorBody{
-		Code:      code,
-		Message:   message,
-		Retryable: retryable,
-	}
-	cmd.Root().SilenceUsage = true
-	cmd.Root().SilenceErrors = true
-	if projectCommandJSONRequested() {
-		encoder := json.NewEncoder(cmd.OutOrStdout())
-		encoder.SetIndent("", "  ")
-		_ = encoder.Encode(projectCommandErrorEnvelope{Error: body})
-	}
-	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "kwt projects: %s: %s\n", code, message)
-	return &projectCommandError{body: body, exitCode: exitCode}
+	return writeCommandFailure(
+		cmd,
+		service.Descriptor{
+			Code: service.Code(code), Message: message, Retryable: retryable,
+		},
+		exitCode,
+		projectCommandJSONRequested(),
+		"projects",
+	)
 }
 
 func projectCommandJSONRequested() bool {

--- a/internal/cmd/projects_test.go
+++ b/internal/cmd/projects_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/worktree"
 	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
 )
 
 func withProjectsConfig(t *testing.T, projects []models.Project) {
@@ -123,6 +124,33 @@ func TestRunProjectsReturnsConfigLoadError(t *testing.T) {
 	err := runProjects(projectsCmd, nil)
 
 	require.EqualError(t, err, "config unavailable")
+}
+
+func TestRunProjectsJSONWritesStableInventoryFailure(t *testing.T) {
+	originalQuery := queryProjectsInventory
+	t.Cleanup(func() { queryProjectsInventory = originalQuery })
+	queryProjectsInventory = func(context.Context, kwt.Request, bool, io.Writer) (kwt.Result, error) {
+		return kwt.Result{}, service.NewError(
+			service.InventoryTimeout, "inventory refresh timed out", true, nil, context.DeadlineExceeded,
+		)
+	}
+	previousJSON := projectsJSON
+	projectsJSON = true
+	t.Cleanup(func() { projectsJSON = previousJSON })
+	var stdout, stderr bytes.Buffer
+	projectsCmd.SetOut(&stdout)
+	projectsCmd.SetErr(&stderr)
+
+	err := runProjects(projectsCmd, nil)
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 1, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.InventoryTimeout, envelope.Error.Code)
+	assert.True(t, envelope.Error.Retryable)
+	assert.Contains(t, stderr.String(), "inventory_timeout")
 }
 
 // TestRunProjectsJSONCanonicalizesLegacyAbsolutePathIdentity pins the fix for
@@ -532,9 +560,9 @@ func TestRunProjectsRemoveJSONReportsMissingProject(t *testing.T) {
 	var exitErr interface{ ExitCode() int }
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 2, exitErr.ExitCode())
-	var response projectCommandErrorEnvelope
+	var response jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
-	assert.Equal(t, "project_not_found", response.Error.Code)
+	assert.Equal(t, service.Code("project_not_found"), response.Error.Code)
 	assert.False(t, response.Error.Retryable)
 	assert.Contains(t, stderr.String(), "project_not_found")
 }
@@ -546,12 +574,12 @@ func TestProjectsAddArgumentValidationUsesStructuredErrors(t *testing.T) {
 
 	err := projectsExactArgs(1)(cmd, nil)
 
-	var exitErr *projectCommandError
+	var exitErr *commandFailure
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 2, exitErr.ExitCode())
-	var envelope projectCommandErrorEnvelope
+	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
-	assert.Equal(t, "invalid_repository", envelope.Error.Code)
+	assert.Equal(t, service.Code("invalid_repository"), envelope.Error.Code)
 	assert.Contains(t, stderr.String(), "invalid_repository")
 }
 
@@ -581,9 +609,9 @@ func TestProjectsAddUnknownFlagBeforeJSONUsesStructuredError(t *testing.T) {
 	var exitErr *exec.ExitError
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 2, exitErr.ExitCode())
-	var envelope projectCommandErrorEnvelope
+	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
-	assert.Equal(t, "invalid_repository", envelope.Error.Code)
+	assert.Equal(t, service.Code("invalid_repository"), envelope.Error.Code)
 	assert.Contains(t, stderr.String(), "invalid_repository")
 }
 
@@ -612,9 +640,9 @@ func TestProjectsConfigInitializationFailureUsesJSONContract(t *testing.T) {
 	var exitErr *exec.ExitError
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 1, exitErr.ExitCode())
-	var envelope projectCommandErrorEnvelope
+	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
-	assert.Equal(t, "registration_failed", envelope.Error.Code)
+	assert.Equal(t, service.Code("registration_failed"), envelope.Error.Code)
 	assert.Contains(t, stderr.String(), "registration_failed")
 }
 

--- a/internal/cmd/testdata/daemonfixture/main.go
+++ b/internal/cmd/testdata/daemonfixture/main.go
@@ -12,11 +12,25 @@ import (
 	"time"
 
 	kitdaemon "go.kenn.io/kit/daemon"
+	kwt "go.kenn.io/kwt"
 	kwtdaemon "go.kenn.io/kwt/internal/daemon"
+	"go.kenn.io/kwt/service"
 )
 
 type statusProvider struct {
 	status kwtdaemon.Status
+}
+
+type failingInventory struct{}
+
+func (failingInventory) Query(context.Context, kwt.Request) (kwt.Result, error) {
+	return kwt.Result{}, service.NewError(
+		service.InventoryFailed, "inventory source failed", false, nil, nil,
+	)
+}
+
+func (failingInventory) ApproveConfig(context.Context, kwt.ConfigApproval) error {
+	return nil
 }
 
 func (p statusProvider) Status(time.Time) kwtdaemon.Status { return p.status }
@@ -41,7 +55,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	build := kwtdaemon.Build{Version: "v1.0.0", Revision: "fixture"}
+	build := kwtdaemon.Build{Version: "v1.0.0", Revision: strings.Repeat("a", 40)}
 	record, token, err := kwtdaemon.NewRuntimeRecord(*home, build, endpoint)
 	if err != nil {
 		log.Fatal(err)
@@ -88,13 +102,17 @@ func main() {
 		status.DrainDeadline = &deadline
 	}
 	provider := statusProvider{status: status}
-	handler := kwtdaemon.NewServer(kwtdaemon.ServerOptions{
+	serverOptions := kwtdaemon.ServerOptions{
 		Token: token, ExpectedHost: listener.Addr().String(), Status: provider,
 		Shutdown: func(context.Context, kwtdaemon.ShutdownRequest) (kwtdaemon.Status, error) {
 			return provider.status, nil
 		},
 		Ping: ping,
-	})
+	}
+	if *mode == "inventory_failed" {
+		serverOptions.Inventory = failingInventory{}
+	}
+	handler := kwtdaemon.NewServer(serverOptions)
 	server := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second}
 	go func() {
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -420,6 +420,7 @@ func problemCode(code service.Code) (service.Code, bool) {
 		service.DaemonTransportFailed,
 		service.InventoryTimeout,
 		service.InventoryFailed,
+		service.RemovalFailed,
 		service.Internal:
 		return code, true
 	default:

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"time"
 
@@ -382,9 +383,17 @@ func decodeProblem(status int, body io.Reader) error {
 	if message == "" {
 		message = http.StatusText(status)
 	}
+	details := problem.Details
+	if _, validDeadline := drainDeadlineDetail(details); problem.DrainDeadline != nil && !validDeadline {
+		details = maps.Clone(details)
+		if details == nil {
+			details = make(map[string]any)
+		}
+		details["drain_deadline"] = *problem.DrainDeadline
+	}
 	return service.NewDescriptorError(service.Descriptor{
 		Code: code, Message: message, Retryable: problem.Retryable,
-		Details: problem.Details,
+		Details: details,
 	}, nil)
 }
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -383,6 +383,9 @@ func decodeProblem(status int, body io.Reader) error {
 	if message == "" {
 		message = http.StatusText(status)
 	}
+	if code == service.Internal {
+		message = "internal failure"
+	}
 	details := problem.Details
 	if _, validDeadline := drainDeadlineDetail(details); problem.DrainDeadline != nil && !validDeadline {
 		details = maps.Clone(details)

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -154,7 +154,7 @@ func (c *Client) RemoveWorktree(
 		result = removalResultFromError(err)
 		if result.WorktreeRemoved {
 			err = &worktreeRemovedError{err: err}
-		} else if service.IsCode(err, service.TransportFailure) {
+		} else if service.IsCode(err, service.DaemonTransportFailed) {
 			removed, reconcileErr := c.reconcileRemoval(request)
 			if reconcileErr != nil {
 				err = &refreshRequiredError{err: errors.Join(
@@ -298,7 +298,7 @@ func (c *Client) doWith(
 	resp, err := client.Do(req)
 	if err != nil {
 		return service.NewError(
-			service.TransportFailure,
+			service.DaemonTransportFailed,
 			"kwt daemon request failed",
 			true,
 			nil,
@@ -313,7 +313,7 @@ func (c *Client) doWith(
 			message = err.Error()
 		}
 		return service.NewError(
-			service.TransportFailure,
+			service.DaemonTransportFailed,
 			message,
 			true,
 			nil,
@@ -328,7 +328,7 @@ func (c *Client) doWith(
 	}
 	if err := json.Unmarshal(encoded, output); err != nil {
 		return service.NewError(
-			service.TransportFailure,
+			service.DaemonTransportFailed,
 			"decode kwt daemon response",
 			true,
 			nil,
@@ -358,74 +358,59 @@ func decodeProblem(status int, body io.Reader) error {
 	var problem Problem
 	if err := json.NewDecoder(body).Decode(&problem); err != nil {
 		return service.NewError(
-			service.TransportFailure,
+			service.DaemonTransportFailed,
 			fmt.Sprintf("kwt daemon returned HTTP %d", status),
 			true,
 			nil,
 			err,
 		)
 	}
-	code, ok := problemCode(status, problem.Code)
+	code, ok := problemCode(problem.Code)
 	if !ok {
 		return service.NewError(
-			service.TransportFailure,
+			service.DaemonTransportFailed,
 			fmt.Sprintf("kwt daemon returned HTTP %d", status),
 			true,
 			nil,
 			nil,
 		)
 	}
-	details := problem.Details
-	if problem.DrainDeadline != nil {
-		if details == nil {
-			details = make(map[string]any)
-		}
-		details["drain_deadline"] = *problem.DrainDeadline
+	message := problem.Message
+	if message == "" {
+		message = problem.Detail
 	}
-	message := problem.Detail
 	if message == "" {
 		message = http.StatusText(status)
 	}
-	return service.NewError(code, message, problem.Retryable, details, nil)
+	return service.NewDescriptorError(service.Descriptor{
+		Code: code, Message: message, Retryable: problem.Retryable,
+		Details: problem.Details,
+	}, nil)
 }
 
-func problemCode(status int, code string) (service.Code, bool) {
+func problemCode(code service.Code) (service.Code, bool) {
 	switch code {
-	case "daemon_draining":
-		return service.Busy, true
-	case string(service.InvalidRequest):
-		return service.InvalidRequest, true
-	case string(service.PermissionDenied):
-		return service.PermissionDenied, true
-	case string(service.NotFound):
-		return service.NotFound, true
-	case string(service.Conflict):
-		return service.Conflict, true
-	case string(service.Busy):
-		return service.Busy, true
-	case string(service.InteractionRequired):
-		return service.InteractionRequired, true
-	case string(service.ConnectionChanged):
-		return service.ConnectionChanged, true
-	case string(service.Unsupported):
-		return service.Unsupported, true
-	case string(service.TransportFailure):
-		return service.TransportFailure, true
-	case string(service.Internal):
-		return service.Internal, true
-	}
-	switch status {
-	case http.StatusBadRequest:
-		return service.InvalidRequest, true
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return service.PermissionDenied, true
-	case http.StatusNotFound:
-		return service.NotFound, true
-	case http.StatusConflict:
-		return service.Conflict, true
-	case http.StatusServiceUnavailable:
-		return service.Busy, true
+	case service.InvalidRequest,
+		service.PermissionDenied,
+		service.NotFound,
+		service.Conflict,
+		service.Busy,
+		service.InteractionRequired,
+		service.ConnectionChanged,
+		service.Unsupported,
+		service.TransportFailure,
+		service.DaemonStartFailed,
+		service.DaemonUnresponsive,
+		service.DaemonIncompatible,
+		service.DaemonDowngradeRefused,
+		service.DaemonBuildOrderUnknown,
+		service.DaemonDraining,
+		service.DaemonTransportFailed,
+		service.InventoryTimeout,
+		service.InventoryFailed,
+		service.Internal:
+		return code, true
 	default:
-		return service.TransportFailure, false
+		return "", false
 	}
 }

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -88,6 +88,26 @@ func TestClientDecodesDrainingProblem(t *testing.T) {
 	assert.Equal(t, deadline.Format(time.RFC3339), typed.Details["drain_deadline"])
 }
 
+func TestClientDecodesLegacyDeadlineBearingBusyAsDrain(t *testing.T) {
+	deadline := time.Now().Add(time.Minute).UTC().Truncate(time.Second)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"type": "https://kwt.dev/problems/busy", "title": "Service Unavailable",
+			"status": http.StatusServiceUnavailable, "detail": "daemon is draining",
+			"code": service.Busy, "retryable": true, "drain_deadline": deadline,
+		}))
+	}))
+	defer server.Close()
+
+	client := clientForUnverifiedServer(t, server, "secret")
+	_, err := client.Status(context.Background())
+	typed := service.AsError(err)
+	assert.Equal(t, service.Busy, typed.Code)
+	assert.Equal(t, deadline, typed.Details["drain_deadline"])
+}
+
 func TestClientRejectsUnknownProblemCodeWithoutStatusInference(t *testing.T) {
 	err := decodeProblem(http.StatusServiceUnavailable, strings.NewReader(
 		`{"type":"about:blank","title":"Unavailable","status":503,"detail":"future failure","code":"future_code","message":"future failure","retryable":true}`,

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -118,6 +118,20 @@ func TestClientRejectsUnknownProblemCodeWithoutStatusInference(t *testing.T) {
 	assert.NotEqual(t, service.Busy, typed.Code)
 }
 
+func TestClientNormalizesLegacyInternalProblemMessage(t *testing.T) {
+	const secret = "legacy-daemon-password"
+	err := decodeProblem(http.StatusInternalServerError, strings.NewReader(
+		`{"type":"about:blank","title":"Internal Server Error","status":500,"detail":"fetch ssh://user:`+
+			secret+`@example.invalid/repository","code":"internal","retryable":false}`,
+	))
+
+	var typed *service.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, service.Internal, typed.Code)
+	assert.Equal(t, "internal failure", typed.Message)
+	assert.NotContains(t, typed.Message, secret)
+}
+
 func TestVerifiedClientUsesBearerAfterSuccessfulProof(t *testing.T) {
 	token := "test-secret"
 	mux := http.NewServeMux()

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -69,11 +69,12 @@ func TestClientDecodesDrainingProblem(t *testing.T) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		require.NoError(t, json.NewEncoder(w).Encode(Problem{
-			Status:        http.StatusServiceUnavailable,
-			Code:          "daemon_draining",
-			Detail:        "daemon is draining",
-			Retryable:     true,
-			DrainDeadline: &deadline,
+			Status: http.StatusServiceUnavailable,
+			Detail: "daemon is draining",
+			Descriptor: service.Descriptor{
+				Code: service.DaemonDraining, Message: "daemon is draining", Retryable: true,
+				Details: map[string]any{"drain_deadline": deadline.Format(time.RFC3339)},
+			},
 		}))
 	}))
 	defer server.Close()
@@ -82,9 +83,19 @@ func TestClientDecodesDrainingProblem(t *testing.T) {
 	_, err := client.Status(context.Background())
 	var typed *service.Error
 	require.ErrorAs(t, err, &typed)
-	assert.Equal(t, service.Busy, typed.Code)
+	assert.Equal(t, service.DaemonDraining, typed.Code)
 	assert.True(t, typed.Retryable)
-	assert.Equal(t, deadline, typed.Details["drain_deadline"])
+	assert.Equal(t, deadline.Format(time.RFC3339), typed.Details["drain_deadline"])
+}
+
+func TestClientRejectsUnknownProblemCodeWithoutStatusInference(t *testing.T) {
+	err := decodeProblem(http.StatusServiceUnavailable, strings.NewReader(
+		`{"type":"about:blank","title":"Unavailable","status":503,"detail":"future failure","code":"future_code","message":"future failure","retryable":true}`,
+	))
+
+	typed := service.AsError(err)
+	assert.Equal(t, service.DaemonTransportFailed, typed.Code)
+	assert.NotEqual(t, service.Busy, typed.Code)
 }
 
 func TestVerifiedClientUsesBearerAfterSuccessfulProof(t *testing.T) {
@@ -174,7 +185,7 @@ func TestVerifiedClientBoundsControlPlaneResponseWait(t *testing.T) {
 	require.Error(t, err)
 	var typed *service.Error
 	require.ErrorAs(t, err, &typed)
-	assert.Equal(t, service.TransportFailure, typed.Code)
+	assert.Equal(t, service.DaemonTransportFailed, typed.Code)
 }
 
 func TestClientAllowsInventoryResponseLargerThanControlPlaneLimit(t *testing.T) {

--- a/internal/daemon/controller.go
+++ b/internal/daemon/controller.go
@@ -216,7 +216,13 @@ func (c *Controller) launchAndWait(ctx context.Context) (Observation, error) {
 	startupCtx, cancel := context.WithTimeout(ctx, c.options.StartTimeout)
 	defer cancel()
 	if err := c.options.Launch(startupCtx); err != nil {
-		return Observation{}, err
+		return Observation{}, service.NewError(
+			service.DaemonStartFailed,
+			"kwt daemon failed to start",
+			true,
+			nil,
+			err,
+		)
 	}
 	return c.waitUntilReady(startupCtx)
 }
@@ -241,7 +247,7 @@ func (c *Controller) waitUntilReady(ctx context.Context) (Observation, error) {
 		}
 		if err := c.waitPoll(ctx); err != nil {
 			return Observation{}, service.NewError(
-				service.Busy,
+				service.DaemonStartFailed,
 				"kwt daemon did not become ready",
 				true,
 				nil,
@@ -275,10 +281,10 @@ func (c *Controller) waitForAbsent(ctx context.Context) error {
 		if err := c.waitPoll(waitCtx); err != nil {
 			cancel()
 			return service.NewError(
-				service.Busy,
+				service.DaemonDraining,
 				"kwt daemon did not stop before the replacement deadline",
 				true,
-				nil,
+				map[string]any{"drain_deadline": waitDeadline},
 				err,
 			)
 		}
@@ -318,7 +324,7 @@ func (c *Controller) reportShutdown(status Status) {
 
 func (c *Controller) incompatibleError(observation Observation) error {
 	return service.NewError(
-		service.Unsupported,
+		service.DaemonIncompatible,
 		"the running kwt daemon uses an incompatible API",
 		false,
 		nil,
@@ -328,7 +334,7 @@ func (c *Controller) incompatibleError(observation Observation) error {
 
 func (c *Controller) unresponsiveError(observation Observation) error {
 	return service.NewError(
-		service.Conflict,
+		service.DaemonUnresponsive,
 		"the running kwt daemon owner is unresponsive",
 		true,
 		nil,
@@ -342,7 +348,7 @@ func (c *Controller) failedError(observation Observation) error {
 		cause = errors.New(observation.Status.LastError.Message)
 	}
 	return service.NewError(
-		service.Conflict,
+		service.DaemonStartFailed,
 		"the running kwt daemon is in a failed state",
 		true,
 		nil,

--- a/internal/daemon/controller_test.go
+++ b/internal/daemon/controller_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -138,7 +139,43 @@ func TestControllerLaunchFailsWhenDaemonReportsFailed(t *testing.T) {
 
 	_, err := NewController(options).Start(context.Background())
 	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.DaemonStartFailed))
 	assert.Contains(t, err.Error(), "failed state")
+}
+
+func TestControllerClassifiesLaunchFailure(t *testing.T) {
+	options := testControllerOptions(t)
+	options.Inspect = scriptedInspector(t, Observation{State: RuntimeAbsent})
+	options.Launch = func(context.Context) error { return context.DeadlineExceeded }
+
+	_, err := NewController(options).Start(context.Background())
+
+	assert.True(t, service.IsCode(err, service.DaemonStartFailed))
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestControllerClassifiesObservedRuntimeFailures(t *testing.T) {
+	controller := NewController(testControllerOptions(t))
+	for _, test := range []struct {
+		name string
+		err  error
+		code service.Code
+	}{
+		{
+			name: "incompatible",
+			err:  controller.incompatibleError(Observation{Err: errors.New("schema mismatch")}),
+			code: service.DaemonIncompatible,
+		},
+		{
+			name: "unresponsive",
+			err:  controller.unresponsiveError(Observation{Err: errors.New("identity unknown")}),
+			code: service.DaemonUnresponsive,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.True(t, service.IsCode(test.err, test.code))
+		})
+	}
 }
 
 func TestControllerWaitsForExistingStartingDaemon(t *testing.T) {

--- a/internal/daemon/gate.go
+++ b/internal/daemon/gate.go
@@ -71,7 +71,7 @@ func (g *Gate) Reserve(kind ReservationKind, now time.Time) (func(), error) {
 	defer g.mu.Unlock()
 	if g.draining {
 		return nil, service.NewError(
-			service.Busy,
+			service.DaemonDraining,
 			"daemon is draining",
 			true,
 			map[string]any{"drain_deadline": g.drainDeadline},

--- a/internal/daemon/gate_test.go
+++ b/internal/daemon/gate_test.go
@@ -19,7 +19,7 @@ func TestGateRejectsNewWorkDuringDrainWithDeadline(t *testing.T) {
 	_, err := gate.Reserve(ReservationWork, now)
 	var typed *service.Error
 	require.ErrorAs(t, err, &typed)
-	assert.Equal(t, service.Busy, typed.Code)
+	assert.Equal(t, service.DaemonDraining, typed.Code)
 	assert.True(t, typed.Retryable)
 	assert.Equal(t, deadline, typed.Details["drain_deadline"])
 }

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -234,8 +234,17 @@ func runHost(
 		Inventory:    inventory,
 		Remover:      remover,
 		Gate:         gate,
-		ReportError: func(route string, failure *service.Error) {
-			logServiceFailure(logger, route, failure, diagnosticSecrets)
+		ReportError: func(
+			route string,
+			failure *service.Error,
+			expansion kwt.ExpansionContext,
+		) {
+			secrets := append([]string(nil), diagnosticSecrets...)
+			secrets = append(
+				secrets,
+				invocationDiagnosticSecrets(opts.Home, expansion)...,
+			)
+			logServiceFailure(logger, route, failure, secrets)
 		},
 	})
 	httpServer := newHTTPServer(handler)

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -222,6 +222,7 @@ func runHost(
 		}
 		return status.Status(opts.Now()), nil
 	}
+	diagnosticSecrets := processDiagnosticSecrets(token)
 	handler := NewServer(ServerOptions{
 		Token:        token,
 		ExpectedHost: ep.Address,
@@ -233,6 +234,9 @@ func runHost(
 		Inventory:    inventory,
 		Remover:      remover,
 		Gate:         gate,
+		ReportError: func(route string, failure *service.Error) {
+			logServiceFailure(logger, route, failure, diagnosticSecrets)
+		},
 	})
 	httpServer := newHTTPServer(handler)
 	serverDone := make(chan error, 1)

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -222,7 +222,10 @@ func runHost(
 		}
 		return status.Status(opts.Now()), nil
 	}
-	diagnosticSecrets := processDiagnosticSecrets(token)
+	diagnosticSecrets := processDiagnosticSecrets(
+		token,
+		configuredFleetTokenEnvironment(opts.Home),
+	)
 	handler := NewServer(ServerOptions{
 		Token:        token,
 		ExpectedHost: ep.Address,

--- a/internal/daemon/host_test.go
+++ b/internal/daemon/host_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -215,6 +216,55 @@ func TestServeContinuesWithoutDisposableInventoryCache(t *testing.T) {
 	_, err = observation.Client.Shutdown(context.Background(), "stop")
 	require.NoError(t, err)
 	require.NoError(t, <-done)
+}
+
+func TestServeRedactsInvocationSecretsChangedAfterStartup(t *testing.T) {
+	const (
+		passwordName  = "KWT_TEST_PASSWORD"
+		passwordValue = "request-password-after-start"
+		fleetName     = "GHOSTHUB_AUTH"
+		fleetValue    = "request-fleet-auth-after-start"
+	)
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[fleet]\ntoken_env = \""+fleetName+"\"\n"),
+		0o600,
+	))
+	t.Setenv(passwordName, "")
+	t.Setenv(fleetName, "")
+	cause := errors.New("credentials " + passwordValue + " and " + fleetValue)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeOptions{
+			Home:  home,
+			Build: Build{Version: "v1.0.0", Revision: "abc"},
+			Config: models.DaemonConfig{
+				IdleTimeout: time.Hour, AutoRestart: "newer",
+				ReplacementGrace: time.Second,
+			},
+			Inventory: &fakeInventory{err: cause},
+		})
+	}()
+
+	observation := waitForRuntime(t, home)
+	require.NoError(t, os.Setenv(passwordName, passwordValue))
+	require.NoError(t, os.Setenv(fleetName, fleetValue))
+	_, err := observation.Client.Inventory(context.Background(), kwt.Request{
+		View: kwt.ViewProjects, UntrustedConfig: kwt.IgnoreUntrustedConfig,
+	})
+	require.Error(t, err)
+	_, err = observation.Client.Shutdown(context.Background(), "stop")
+	require.NoError(t, err)
+	require.NoError(t, <-done)
+
+	logBody, err := os.ReadFile(filepath.Join(home, backgroundLogName))
+	require.NoError(t, err)
+	assert.NotContains(t, string(logBody), passwordValue)
+	assert.NotContains(t, string(logBody), fleetValue)
+	assert.Contains(t, string(logBody), "[redacted]")
 }
 
 func TestServeRefusesASecondWritableOwner(t *testing.T) {

--- a/internal/daemon/host_test.go
+++ b/internal/daemon/host_test.go
@@ -267,6 +267,50 @@ func TestServeRedactsInvocationSecretsChangedAfterStartup(t *testing.T) {
 	assert.Contains(t, string(logBody), "[redacted]")
 }
 
+func TestServeRedactsConfiguredFleetTokenWithoutRequestExpansion(t *testing.T) {
+	const (
+		fleetName  = "GHOSTHUB_AUTH"
+		fleetValue = "startup-fleet-auth-value"
+	)
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[fleet]\ntoken_env = \"  "+fleetName+"  \"\n"),
+		0o600,
+	))
+	t.Setenv(fleetName, fleetValue)
+	cause := errors.New("removal credential " + fleetValue)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeOptions{
+			Home:  home,
+			Build: Build{Version: "v1.0.0", Revision: "abc"},
+			Config: models.DaemonConfig{
+				IdleTimeout: time.Hour, AutoRestart: "newer",
+				ReplacementGrace: time.Second,
+			},
+			Remover: &fakeRemover{err: cause},
+		})
+	}()
+
+	observation := waitForRuntime(t, home)
+	_, err := observation.Client.RemoveWorktree(
+		context.Background(),
+		kwt.RemovalRequest{Path: "/worktrees/topic"},
+	)
+	require.Error(t, err)
+	_, err = observation.Client.Shutdown(context.Background(), "stop")
+	require.NoError(t, err)
+	require.NoError(t, <-done)
+
+	logBody, err := os.ReadFile(filepath.Join(home, backgroundLogName))
+	require.NoError(t, err)
+	assert.NotContains(t, string(logBody), fleetValue)
+	assert.Contains(t, string(logBody), "[redacted]")
+}
+
 func TestServeRefusesASecondWritableOwner(t *testing.T) {
 	home := t.TempDir()
 	store := RuntimeStore(home)

--- a/internal/daemon/inventory_test.go
+++ b/internal/daemon/inventory_test.go
@@ -51,6 +51,7 @@ func TestInventoryClientPreservesActionableSourceFailure(t *testing.T) {
 	})
 
 	typed := service.AsError(err)
+	assert.Equal(t, service.InventoryFailed, typed.Code)
 	assert.NotEqual(t, "internal failure", typed.Message)
 	assert.Contains(t, typed.Message, "config")
 }

--- a/internal/daemon/inventory_test.go
+++ b/internal/daemon/inventory_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -88,6 +89,43 @@ func TestInventoryClientRoundTripsResult(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, kwt.Fresh, result.Freshness)
 	require.Len(t, inventory.requests, 1)
+}
+
+func TestInventoryServerReportsPrivateCauseWithoutReturningIt(t *testing.T) {
+	cause := errors.New("private inventory diagnostic")
+	inventory := &fakeInventory{err: service.NewError(
+		service.Internal, "internal failure", false, nil, cause,
+	)}
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	var reportedRoute string
+	var reported *service.Error
+	server := httptest.NewUnstartedServer(nil)
+	server.Config.Handler = NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: server.Listener.Addr().String(), Status: provider,
+		Shutdown:  func(context.Context, ShutdownRequest) (Status, error) { return provider.status, nil },
+		Inventory: inventory, Gate: NewGate(time.Now()),
+		ReportError: func(route string, failure *service.Error) {
+			reportedRoute, reported = route, failure
+		},
+	})
+	server.Start()
+	defer server.Close()
+	endpoint, err := kitdaemon.ParseEndpoint(
+		server.URL[len("http://"):],
+		kitdaemon.ParseEndpointOptions{TCPPolicy: kitdaemon.RequireLoopback},
+	)
+	require.NoError(t, err)
+	client := newClient(endpoint, "secret", server.Client())
+
+	_, err = client.Inventory(context.Background(), kwt.Request{View: kwt.ViewProjects})
+
+	typed := service.AsError(err)
+	assert.Equal(t, service.Internal, typed.Code)
+	assert.Equal(t, "internal failure", typed.Message)
+	assert.NotContains(t, typed.Error(), cause.Error())
+	assert.Equal(t, "/api/v1/inventory", reportedRoute)
+	require.NotNil(t, reported)
+	assert.ErrorIs(t, reported, cause)
 }
 
 func TestInventoryClientPreservesTrustDetails(t *testing.T) {

--- a/internal/daemon/inventory_test.go
+++ b/internal/daemon/inventory_test.go
@@ -92,10 +92,9 @@ func TestInventoryClientRoundTripsResult(t *testing.T) {
 }
 
 func TestInventoryServerReportsPrivateCauseWithoutReturningIt(t *testing.T) {
-	cause := errors.New("private inventory diagnostic")
-	inventory := &fakeInventory{err: service.NewError(
-		service.Internal, "internal failure", false, nil, cause,
-	)}
+	const secret = "inventory-password"
+	cause := errors.New("fetch https://user:" + secret + "@example.invalid/repository")
+	inventory := &fakeInventory{err: cause}
 	provider := &testStatusProvider{status: Status{State: StateReady}}
 	var reportedRoute string
 	var reported *service.Error
@@ -123,6 +122,7 @@ func TestInventoryServerReportsPrivateCauseWithoutReturningIt(t *testing.T) {
 	assert.Equal(t, service.Internal, typed.Code)
 	assert.Equal(t, "internal failure", typed.Message)
 	assert.NotContains(t, typed.Error(), cause.Error())
+	assert.NotContains(t, typed.Error(), secret)
 	assert.Equal(t, "/api/v1/inventory", reportedRoute)
 	require.NotNil(t, reported)
 	assert.ErrorIs(t, reported, cause)

--- a/internal/daemon/inventory_test.go
+++ b/internal/daemon/inventory_test.go
@@ -103,7 +103,7 @@ func TestInventoryServerReportsPrivateCauseWithoutReturningIt(t *testing.T) {
 		Token: "secret", ExpectedHost: server.Listener.Addr().String(), Status: provider,
 		Shutdown:  func(context.Context, ShutdownRequest) (Status, error) { return provider.status, nil },
 		Inventory: inventory, Gate: NewGate(time.Now()),
-		ReportError: func(route string, failure *service.Error) {
+		ReportError: func(route string, failure *service.Error, _ kwt.ExpansionContext) {
 			reportedRoute, reported = route, failure
 		},
 	})

--- a/internal/daemon/log.go
+++ b/internal/daemon/log.go
@@ -81,10 +81,15 @@ func privateDiagnostic(err error, sensitiveValues []string) string {
 	return message
 }
 
-func processDiagnosticSecrets(bearer string) []string {
+func processDiagnosticSecrets(bearer string, fleetTokenEnvironment string) []string {
 	values := make([]string, 0, 4)
 	if bearer != "" {
 		values = append(values, bearer)
+	}
+	if name := strings.TrimSpace(fleetTokenEnvironment); name != "" {
+		if value, ok := os.LookupEnv(name); ok && value != "" {
+			values = append(values, value)
+		}
 	}
 	for _, entry := range os.Environ() {
 		name, value, ok := strings.Cut(entry, "=")
@@ -103,20 +108,28 @@ func invocationDiagnosticSecrets(home string, expansion kwt.ExpansionContext) []
 			values = append(values, value)
 		}
 	}
-	snapshot, err := config.LoadGlobalSnapshotAtWithExpansion(
-		home,
-		func(path string) (string, error) { return path, nil },
-	)
-	if err != nil || snapshot.Config.Fleet.TokenEnv == "" {
+	fleetTokenEnvironment := configuredFleetTokenEnvironment(home)
+	if fleetTokenEnvironment == "" {
 		return values
 	}
 	if value := environmentValue(
 		expansion.Environment,
-		snapshot.Config.Fleet.TokenEnv,
+		fleetTokenEnvironment,
 	); value != "" {
 		values = append(values, value)
 	}
 	return values
+}
+
+func configuredFleetTokenEnvironment(home string) string {
+	snapshot, err := config.LoadGlobalSnapshotAtWithExpansion(
+		home,
+		func(path string) (string, error) { return path, nil },
+	)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(snapshot.Config.Fleet.TokenEnv)
 }
 
 func environmentValue(environment map[string]string, name string) string {

--- a/internal/daemon/log.go
+++ b/internal/daemon/log.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 
@@ -67,18 +68,41 @@ func privateDiagnostic(err error, sensitiveValues []string) string {
 		return ""
 	}
 	message := err.Error()
-	for _, value := range sensitiveValues {
-		if value != "" {
-			message = strings.ReplaceAll(message, value, "[redacted]")
-		}
-	}
 	message = sensitiveAssignmentPattern.ReplaceAllString(message, "$1=[redacted]")
 	message = authorizationHeaderPattern.ReplaceAllString(message, "$1[redacted]")
 	message = credentialURLPattern.ReplaceAllString(message, "$1[redacted]@")
+	message = redactSensitiveValues(message, sensitiveValues)
 	if len(message) > maximumDiagnosticBytes {
 		message = message[:maximumDiagnosticBytes]
 	}
 	return message
+}
+
+func redactSensitiveValues(message string, sensitiveValues []string) string {
+	unique := make(map[string]struct{}, len(sensitiveValues))
+	for _, value := range sensitiveValues {
+		if value != "" {
+			unique[value] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(unique))
+	for value := range unique {
+		values = append(values, value)
+	}
+	sort.Slice(values, func(left, right int) bool {
+		if len(values[left]) == len(values[right]) {
+			return values[left] < values[right]
+		}
+		return len(values[left]) > len(values[right])
+	})
+	replacements := make([]string, 0, len(values)*2)
+	for _, value := range values {
+		replacements = append(replacements, value, "[redacted]")
+	}
+	if len(replacements) == 0 {
+		return message
+	}
+	return strings.NewReplacer(replacements...).Replace(message)
 }
 
 func processDiagnosticSecrets(bearer string, fleetTokenEnvironment string) []string {

--- a/internal/daemon/log.go
+++ b/internal/daemon/log.go
@@ -3,17 +3,32 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 
 	"go.kenn.io/kit/safefileio"
+	"go.kenn.io/kwt/service"
 )
 
 const (
-	backgroundLogName = "daemon.log"
-	backgroundLogSize = int64(10 << 20)
-	backgroundBackups = 3
+	backgroundLogName      = "daemon.log"
+	backgroundLogSize      = int64(10 << 20)
+	backgroundBackups      = 3
+	maximumDiagnosticBytes = 1024
+)
+
+var (
+	sensitiveAssignmentPattern = regexp.MustCompile(
+		`(?i)\b([a-z_][a-z0-9_]*(?:token|secret|password|passwd|credential|api_key)[a-z0-9_]*)=("[^"]*"|'[^']*'|[^\s]+)`,
+	)
+	bearerPattern = regexp.MustCompile(
+		`(?i)(authorization:\s*bearer\s+|bearer\s+)[^\s,;]+`,
+	)
+	credentialURLPattern = regexp.MustCompile(`(?i)(https?://)[^/\s@]+@`)
 )
 
 type rotatingLog struct {
@@ -23,6 +38,69 @@ type rotatingLog struct {
 	size    int64
 	maxSize int64
 	backups int
+}
+
+func logServiceFailure(
+	logger *slog.Logger,
+	route string,
+	failure *service.Error,
+	sensitiveValues []string,
+) {
+	if logger == nil || failure == nil || failure.Err == nil {
+		return
+	}
+	logger.Warn(
+		"daemon request failed",
+		"route", route,
+		"code", failure.Code,
+		"error", privateDiagnostic(failure.Err, sensitiveValues),
+	)
+}
+
+func privateDiagnostic(err error, sensitiveValues []string) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	for _, value := range sensitiveValues {
+		if value != "" {
+			message = strings.ReplaceAll(message, value, "[redacted]")
+		}
+	}
+	message = sensitiveAssignmentPattern.ReplaceAllString(message, "$1=[redacted]")
+	message = bearerPattern.ReplaceAllString(message, "$1[redacted]")
+	message = credentialURLPattern.ReplaceAllString(message, "$1[redacted]@")
+	if len(message) > maximumDiagnosticBytes {
+		message = message[:maximumDiagnosticBytes]
+	}
+	return message
+}
+
+func processDiagnosticSecrets(bearer string) []string {
+	values := make([]string, 0, 4)
+	if bearer != "" {
+		values = append(values, bearer)
+	}
+	for _, entry := range os.Environ() {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || value == "" || !sensitiveEnvironmentName(name) {
+			continue
+		}
+		values = append(values, value)
+	}
+	return values
+}
+
+func sensitiveEnvironmentName(name string) bool {
+	name = strings.ToUpper(name)
+	for _, marker := range []string{
+		"TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "API_KEY",
+	} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func openBackgroundLog(home string) (*rotatingLog, error) {

--- a/internal/daemon/log.go
+++ b/internal/daemon/log.go
@@ -25,10 +25,12 @@ var (
 	sensitiveAssignmentPattern = regexp.MustCompile(
 		`(?i)\b([a-z_][a-z0-9_]*(?:token|secret|password|passwd|credential|api_key)[a-z0-9_]*)=("[^"]*"|'[^']*'|[^\s]+)`,
 	)
-	bearerPattern = regexp.MustCompile(
-		`(?i)(authorization:\s*bearer\s+|bearer\s+)[^\s,;]+`,
+	authorizationHeaderPattern = regexp.MustCompile(
+		`(?i)(\b(?:proxy-)?authorization\s*:\s*)[^\r\n]*`,
 	)
-	credentialURLPattern = regexp.MustCompile(`(?i)(https?://)[^/\s@]+@`)
+	credentialURLPattern = regexp.MustCompile(
+		`(?i)([a-z][a-z0-9+.-]*://)[^/\s@]+@`,
+	)
 )
 
 type rotatingLog struct {
@@ -68,7 +70,7 @@ func privateDiagnostic(err error, sensitiveValues []string) string {
 		}
 	}
 	message = sensitiveAssignmentPattern.ReplaceAllString(message, "$1=[redacted]")
-	message = bearerPattern.ReplaceAllString(message, "$1[redacted]")
+	message = authorizationHeaderPattern.ReplaceAllString(message, "$1[redacted]")
 	message = credentialURLPattern.ReplaceAllString(message, "$1[redacted]@")
 	if len(message) > maximumDiagnosticBytes {
 		message = message[:maximumDiagnosticBytes]

--- a/internal/daemon/log.go
+++ b/internal/daemon/log.go
@@ -7,10 +7,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 
 	"go.kenn.io/kit/safefileio"
+	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/service"
 )
 
@@ -91,6 +94,41 @@ func processDiagnosticSecrets(bearer string) []string {
 		values = append(values, value)
 	}
 	return values
+}
+
+func invocationDiagnosticSecrets(home string, expansion kwt.ExpansionContext) []string {
+	values := make([]string, 0, 4)
+	for name, value := range expansion.Environment {
+		if value != "" && sensitiveEnvironmentName(name) {
+			values = append(values, value)
+		}
+	}
+	snapshot, err := config.LoadGlobalSnapshotAtWithExpansion(
+		home,
+		func(path string) (string, error) { return path, nil },
+	)
+	if err != nil || snapshot.Config.Fleet.TokenEnv == "" {
+		return values
+	}
+	if value := environmentValue(
+		expansion.Environment,
+		snapshot.Config.Fleet.TokenEnv,
+	); value != "" {
+		values = append(values, value)
+	}
+	return values
+}
+
+func environmentValue(environment map[string]string, name string) string {
+	if runtime.GOOS != "windows" {
+		return environment[name]
+	}
+	for candidate, value := range environment {
+		if strings.EqualFold(candidate, name) {
+			return value
+		}
+	}
+	return ""
 }
 
 func sensitiveEnvironmentName(name string) bool {

--- a/internal/daemon/log_test.go
+++ b/internal/daemon/log_test.go
@@ -40,7 +40,7 @@ func TestServiceFailureLogBoundsAndRedactsPrivateCause(t *testing.T) {
 	const bearerSecret = "bearer-secret-value"
 	cause := errors.New(
 		"KWT_API_TOKEN=" + environmentSecret +
-			" Authorization: Bearer " + bearerSecret + " " +
+			"\nAuthorization: Bearer " + bearerSecret + "\n" +
 			strings.Repeat("command-output-", 200),
 	)
 	failure := service.NewError(
@@ -66,6 +66,47 @@ func TestServiceFailureLogBoundsAndRedactsPrivateCause(t *testing.T) {
 	require.True(t, ok)
 	assert.LessOrEqual(t, len(diagnostic), maximumDiagnosticBytes)
 	assert.Contains(t, diagnostic, "[redacted]")
+}
+
+func TestPrivateDiagnosticRedactsAuthorizationAndURIUserinfo(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		message    string
+		secrets    []string
+		wantSuffix string
+	}{
+		{
+			name:    "basic authorization",
+			message: "request failed\nAuthorization: Basic dXNlcjpwYXNz\ncontinued",
+			secrets: []string{"Basic dXNlcjpwYXNz"}, wantSuffix: "\ncontinued",
+		},
+		{
+			name:    "proxy authorization",
+			message: "Proxy-Authorization: Negotiate opaque-credential\ncontinued",
+			secrets: []string{"Negotiate opaque-credential"}, wantSuffix: "\ncontinued",
+		},
+		{
+			name:    "ssh URI user information",
+			message: "clone ssh://user:password@host/repo",
+			secrets: []string{"user:password"},
+		},
+		{
+			name:    "git ssh URI user information",
+			message: "clone git+ssh://token@host/repo",
+			secrets: []string{"token"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := privateDiagnostic(errors.New(test.message), nil)
+			for _, secret := range test.secrets {
+				assert.NotContains(t, got, secret)
+			}
+			assert.Contains(t, got, "[redacted]")
+			if test.wantSuffix != "" {
+				assert.True(t, strings.HasSuffix(got, test.wantSuffix), got)
+			}
+		})
+	}
 }
 
 func TestRotatingLogRotatesAnOversizedExistingFileOnOpen(t *testing.T) {

--- a/internal/daemon/log_test.go
+++ b/internal/daemon/log_test.go
@@ -109,6 +109,22 @@ func TestPrivateDiagnosticRedactsAuthorizationAndURIUserinfo(t *testing.T) {
 	}
 }
 
+func TestPrivateDiagnosticRedactsStructureBeforeOverlappingValues(t *testing.T) {
+	const headerCredential = "private-header-credential"
+	got := privateDiagnostic(
+		errors.New(
+			"Authorization: Basic "+headerCredential+"\n"+
+				"overlapping abcdef and abc",
+		),
+		[]string{"Authorization", "abc", "abcdef", "abc"},
+	)
+
+	assert.NotContains(t, got, headerCredential)
+	assert.NotContains(t, got, "abcdef")
+	assert.NotContains(t, got, "[redacted]def")
+	assert.Contains(t, got, "[redacted]")
+}
+
 func TestRotatingLogRotatesAnOversizedExistingFileOnOpen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "daemon.log")
 	require.NoError(t, os.WriteFile(path, []byte("already-too-large"), 0o600))

--- a/internal/daemon/log_test.go
+++ b/internal/daemon/log_test.go
@@ -1,13 +1,19 @@
 package daemon
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/service"
 )
 
 func TestRotatingLogIsPrivateAndRetainsThreeBackups(t *testing.T) {
@@ -27,6 +33,39 @@ func TestRotatingLogIsPrivateAndRetainsThreeBackups(t *testing.T) {
 	assert.FileExists(t, path+".2")
 	assert.FileExists(t, path+".3")
 	assert.NoFileExists(t, path+".4")
+}
+
+func TestServiceFailureLogBoundsAndRedactsPrivateCause(t *testing.T) {
+	const environmentSecret = "environment-secret-value"
+	const bearerSecret = "bearer-secret-value"
+	cause := errors.New(
+		"KWT_API_TOKEN=" + environmentSecret +
+			" Authorization: Bearer " + bearerSecret + " " +
+			strings.Repeat("command-output-", 200),
+	)
+	failure := service.NewError(
+		service.Internal, "internal failure", false, nil, cause,
+	)
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+
+	logServiceFailure(
+		logger,
+		"/api/v1/inventory",
+		failure,
+		[]string{environmentSecret, bearerSecret},
+	)
+
+	assert.NotContains(t, output.String(), environmentSecret)
+	assert.NotContains(t, output.String(), bearerSecret)
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &record))
+	assert.Equal(t, "/api/v1/inventory", record["route"])
+	assert.Equal(t, string(service.Internal), record["code"])
+	diagnostic, ok := record["error"].(string)
+	require.True(t, ok)
+	assert.LessOrEqual(t, len(diagnostic), maximumDiagnosticBytes)
+	assert.Contains(t, diagnostic, "[redacted]")
 }
 
 func TestRotatingLogRotatesAnOversizedExistingFileOnOpen(t *testing.T) {

--- a/internal/daemon/removal_test.go
+++ b/internal/daemon/removal_test.go
@@ -112,7 +112,7 @@ func TestRemovalClientReconcilesLostSuccessfulResponse(t *testing.T) {
 	assert.True(t, reconciled.Load())
 	assert.True(t, result.WorktreeRemoved)
 	assert.True(t, git.WorktreeWasRemoved(err))
-	assert.True(t, service.IsCode(err, service.TransportFailure))
+	assert.True(t, service.IsCode(err, service.DaemonTransportFailed))
 }
 
 func TestRemovalClientMarksUnreconciledResponseLossForRefresh(t *testing.T) {
@@ -137,7 +137,7 @@ func TestRemovalClientMarksUnreconciledResponseLossForRefresh(t *testing.T) {
 	assert.False(t, result.WorktreeRemoved)
 	assert.False(t, git.WorktreeWasRemoved(err))
 	assert.True(t, RequiresRefresh(err))
-	assert.True(t, service.IsCode(err, service.TransportFailure))
+	assert.True(t, service.IsCode(err, service.DaemonTransportFailed))
 }
 
 func removalTestClient(t *testing.T, remover kwt.Remover) (*Client, func()) {

--- a/internal/daemon/removal_test.go
+++ b/internal/daemon/removal_test.go
@@ -52,33 +52,43 @@ func TestRemovalClientRoundTripsResult(t *testing.T) {
 }
 
 func TestRemovalClientPreservesPartialResultOnError(t *testing.T) {
-	remover := &fakeRemover{
-		result: kwt.RemovalResult{
-			Path: "/worktrees/topic", Branch: "topic", WorktreeRemoved: true,
-		},
-		err: service.NewError(
-			service.Internal,
-			"worktree removed but branch deletion failed",
-			false,
-			map[string]any{
-				"path": "/worktrees/topic", "branch": "topic",
-				"worktree_removed": true, "branch_deleted": false,
-				"registry_unregistered": true,
-			},
-			nil,
-		),
+	for _, code := range []service.Code{
+		service.Internal,
+		service.Conflict,
+		service.Busy,
+		service.ConnectionChanged,
+	} {
+		t.Run(string(code), func(t *testing.T) {
+			remover := &fakeRemover{
+				result: kwt.RemovalResult{
+					Path: "/worktrees/topic", Branch: "topic", WorktreeRemoved: true,
+				},
+				err: service.NewError(
+					code,
+					"worktree removed but cleanup failed",
+					code == service.Busy,
+					map[string]any{
+						"path": "/worktrees/topic", "branch": "topic",
+						"worktree_removed": true, "branch_deleted": false,
+						"registry_unregistered": true,
+					},
+					nil,
+				),
+			}
+			client, closeServer := removalTestClient(t, remover)
+			defer closeServer()
+
+			result, err := client.RemoveWorktree(context.Background(), kwt.RemovalRequest{})
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, code))
+			assert.True(t, git.WorktreeWasRemoved(err))
+			assert.Equal(t, "/worktrees/topic", result.Path)
+			assert.True(t, result.WorktreeRemoved)
+			assert.True(t, result.RegistryUnregistered)
+			assert.Equal(t, "topic", result.Branch)
+		})
 	}
-	client, closeServer := removalTestClient(t, remover)
-	defer closeServer()
-
-	result, err := client.RemoveWorktree(context.Background(), kwt.RemovalRequest{})
-
-	require.Error(t, err)
-	assert.True(t, service.IsCode(err, service.Internal))
-	assert.True(t, git.WorktreeWasRemoved(err))
-	assert.True(t, result.WorktreeRemoved)
-	assert.True(t, result.RegistryUnregistered)
-	assert.Equal(t, "topic", result.Branch)
 }
 
 func TestRemovalClientReconcilesLostSuccessfulResponse(t *testing.T) {

--- a/internal/daemon/removal_test.go
+++ b/internal/daemon/removal_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -89,6 +90,34 @@ func TestRemovalClientPreservesPartialResultOnError(t *testing.T) {
 			assert.Equal(t, "topic", result.Branch)
 		})
 	}
+}
+
+func TestRemovalClientHidesUnexpectedInternalCause(t *testing.T) {
+	const secret = "removal-password"
+	cause := errors.New("fetch ssh://user:" + secret + "@example.invalid/repository")
+	remover := &fakeRemover{err: service.NewError(
+		service.Internal,
+		cause.Error(),
+		false,
+		map[string]any{
+			"path": "/worktrees/topic", "branch": "topic",
+			"worktree_removed": true, "branch_deleted": false,
+			"registry_unregistered": true,
+		},
+		cause,
+	)}
+	client, closeServer := removalTestClient(t, remover)
+	defer closeServer()
+
+	result, err := client.RemoveWorktree(context.Background(), kwt.RemovalRequest{})
+
+	require.Error(t, err)
+	typed := service.AsError(err)
+	assert.Equal(t, service.Internal, typed.Code)
+	assert.Equal(t, "internal failure", typed.Message)
+	assert.NotContains(t, typed.Message, secret)
+	assert.True(t, result.WorktreeRemoved)
+	assert.True(t, result.RegistryUnregistered)
 }
 
 func TestRemovalClientReconcilesLostSuccessfulResponse(t *testing.T) {

--- a/internal/daemon/removal_test.go
+++ b/internal/daemon/removal_test.go
@@ -92,6 +92,52 @@ func TestRemovalClientPreservesPartialResultOnError(t *testing.T) {
 	}
 }
 
+func TestRemovalClientPreservesKnownRemovalFailure(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		message string
+		result  kwt.RemovalResult
+	}{
+		{
+			name: "failed before removal", message: "worktree has uncommitted changes",
+			result: kwt.RemovalResult{Path: "/worktrees/topic", Branch: "topic"},
+		},
+		{
+			name: "partial completion", message: "worktree removed but failed to delete branch",
+			result: kwt.RemovalResult{
+				Path: "/worktrees/topic", Branch: "topic", WorktreeRemoved: true,
+				RegistryUnregistered: true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			remover := &fakeRemover{result: test.result, err: service.NewError(
+				service.RemovalFailed,
+				test.message,
+				false,
+				map[string]any{
+					"path": test.result.Path, "branch": test.result.Branch,
+					"worktree_removed":      test.result.WorktreeRemoved,
+					"branch_deleted":        test.result.BranchDeleted,
+					"registry_unregistered": test.result.RegistryUnregistered,
+				},
+				errors.New("private removal cause"),
+			)}
+			client, closeServer := removalTestClient(t, remover)
+			defer closeServer()
+
+			result, err := client.RemoveWorktree(context.Background(), kwt.RemovalRequest{})
+
+			require.Error(t, err)
+			typed := service.AsError(err)
+			assert.Equal(t, service.RemovalFailed, typed.Code)
+			assert.Equal(t, test.message, typed.Message)
+			assert.Equal(t, test.result, result)
+			assert.Equal(t, test.result.WorktreeRemoved, git.WorktreeWasRemoved(err))
+		})
+	}
+}
+
 func TestRemovalClientHidesUnexpectedInternalCause(t *testing.T) {
 	const secret = "removal-password"
 	cause := errors.New("fetch ssh://user:" + secret + "@example.invalid/repository")

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -367,6 +367,10 @@ var allowedProblemDetailTypes = map[service.Code]map[string]problemDetailType{
 		"path": detailString, "branch": detailString, "worktree_removed": detailBool,
 		"branch_deleted": detailBool, "registry_unregistered": detailBool,
 	},
+	service.RemovalFailed: {
+		"path": detailString, "branch": detailString, "worktree_removed": detailBool,
+		"branch_deleted": detailBool, "registry_unregistered": detailBool,
+	},
 }
 
 func allowedProblemDetails(code service.Code, details map[string]any) map[string]any {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -162,24 +162,16 @@ func secureLocalHandler(next http.Handler, opts ServerOptions) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Host != opts.ExpectedHost {
 			w.Header().Set("Connection", "close")
-			writeProblem(w, Problem{
-				Type:   "https://kwt.dev/problems/invalid-request",
-				Title:  http.StatusText(http.StatusBadRequest),
-				Status: http.StatusBadRequest,
-				Detail: "request host does not match the daemon endpoint",
-				Code:   string(service.InvalidRequest),
-			})
+			writeProblem(w, newProblem(http.StatusBadRequest, service.Descriptor{
+				Code: service.InvalidRequest, Message: "request host does not match the daemon endpoint",
+			}))
 			return
 		}
 		if r.Header.Get("Origin") != "" {
 			w.Header().Set("Connection", "close")
-			writeProblem(w, Problem{
-				Type:   "https://kwt.dev/problems/permission-denied",
-				Title:  http.StatusText(http.StatusForbidden),
-				Status: http.StatusForbidden,
-				Detail: "browser-origin requests are not accepted",
-				Code:   string(service.PermissionDenied),
-			})
+			writeProblem(w, newProblem(http.StatusForbidden, service.Descriptor{
+				Code: service.PermissionDenied, Message: "browser-origin requests are not accepted",
+			}))
 			return
 		}
 		if r.URL.Path == "/api/ping" || r.URL.Path == "/openapi.json" {
@@ -193,23 +185,15 @@ func secureLocalHandler(next http.Handler, opts ServerOptions) http.Handler {
 			[]byte(expectedAuthorization),
 		) != 1 {
 			w.Header().Set("Connection", "close")
-			writeProblem(w, Problem{
-				Type:   "https://kwt.dev/problems/permission-denied",
-				Title:  http.StatusText(http.StatusUnauthorized),
-				Status: http.StatusUnauthorized,
-				Detail: "a valid daemon bearer token is required",
-				Code:   string(service.PermissionDenied),
-			})
+			writeProblem(w, newProblem(http.StatusUnauthorized, service.Descriptor{
+				Code: service.PermissionDenied, Message: "a valid daemon bearer token is required",
+			}))
 			return
 		}
 		if r.ContentLength > opts.MaxBodyBytes {
-			writeProblem(w, Problem{
-				Type:   "https://kwt.dev/problems/invalid-request",
-				Title:  http.StatusText(http.StatusRequestEntityTooLarge),
-				Status: http.StatusRequestEntityTooLarge,
-				Detail: "request body exceeds the daemon limit",
-				Code:   string(service.InvalidRequest),
-			})
+			writeProblem(w, newProblem(http.StatusRequestEntityTooLarge, service.Descriptor{
+				Code: service.InvalidRequest, Message: "request body exceeds the daemon limit",
+			}))
 			return
 		}
 		r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
@@ -232,15 +216,16 @@ func secureLocalHandler(next http.Handler, opts ServerOptions) http.Handler {
 				}
 				w.Header().Set("Retry-After", strconv.FormatInt(seconds, 10))
 			}
-			writeProblem(w, Problem{
-				Type:          "https://kwt.dev/problems/daemon-draining",
-				Title:         "Daemon draining",
-				Status:        http.StatusServiceUnavailable,
-				Detail:        "the kwt daemon is draining for replacement or shutdown",
-				Code:          "daemon_draining",
-				Retryable:     true,
-				DrainDeadline: status.DrainDeadline,
-			})
+			details := make(map[string]any)
+			if status.DrainDeadline != nil {
+				details["drain_deadline"] = status.DrainDeadline.Format(time.RFC3339Nano)
+			}
+			writeProblem(w, newProblem(http.StatusServiceUnavailable, service.Descriptor{
+				Code:      service.DaemonDraining,
+				Message:   "the kwt daemon is draining for replacement or shutdown",
+				Retryable: true,
+				Details:   details,
+			}))
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -251,6 +236,14 @@ func writeProblem(w http.ResponseWriter, problem Problem) {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(problem.Status)
 	_ = json.NewEncoder(w).Encode(problem)
+}
+
+func newProblem(status int, descriptor service.Descriptor) Problem {
+	return Problem{
+		Type:  "https://kwt.dev/problems/" + string(descriptor.Code),
+		Title: http.StatusText(status), Status: status, Detail: descriptor.Message,
+		Descriptor: descriptor,
+	}
 }
 
 func (p *Problem) Error() string { return p.Detail }
@@ -276,53 +269,111 @@ func problemFromError(err error) *Problem {
 		status = http.StatusNotFound
 	case service.Conflict, service.ConnectionChanged:
 		status = http.StatusConflict
+	case service.DaemonDowngradeRefused, service.DaemonBuildOrderUnknown:
+		status = http.StatusConflict
 	case service.InteractionRequired:
 		status = http.StatusPreconditionRequired
-	case service.Busy:
+	case service.Busy, service.DaemonStartFailed, service.DaemonUnresponsive,
+		service.DaemonDraining, service.InventoryTimeout:
 		status = http.StatusServiceUnavailable
 	case service.Unsupported:
 		status = http.StatusNotImplemented
-	case service.TransportFailure:
+	case service.DaemonIncompatible:
+		status = http.StatusUpgradeRequired
+	case service.TransportFailure, service.DaemonTransportFailed:
 		status = http.StatusBadGateway
 	}
-	problem := &Problem{
-		Type:      "https://kwt.dev/problems/" + string(typed.Code),
-		Title:     http.StatusText(status),
-		Status:    status,
-		Detail:    typed.Message,
-		Code:      string(typed.Code),
-		Retryable: typed.Retryable,
-		Details:   allowedProblemDetails(typed.Details),
-	}
-	if deadline, ok := typed.Details["drain_deadline"].(time.Time); ok {
-		problem.DrainDeadline = &deadline
-	}
-	if deadline, ok := typed.Details["drain_deadline"].(*time.Time); ok {
-		problem.DrainDeadline = deadline
-	}
-	return problem
+	problem := newProblem(status, service.Descriptor{
+		Code: typed.Code, Message: typed.Message, Retryable: typed.Retryable,
+		Details: allowedProblemDetails(typed.Code, typed.Details),
+	})
+	return &problem
 }
 
-func allowedProblemDetails(details map[string]any) map[string]any {
+type problemDetailType uint8
+
+const (
+	detailString problemDetailType = iota + 1
+	detailBool
+	detailNumber
+	detailRFC3339
+)
+
+var allowedProblemDetailTypes = map[service.Code]map[string]problemDetailType{
+	service.DaemonDraining: {"drain_deadline": detailRFC3339},
+	service.InteractionRequired: {
+		"kind": detailString, "path": detailString, "digest": detailString,
+		"size": detailNumber, "preview": detailString, "truncated": detailBool,
+	},
+	service.Conflict: {
+		"branch": detailString, "reason": detailString, "worktree_removed": detailBool,
+		"branch_deleted": detailBool, "registry_unregistered": detailBool,
+	},
+	service.ConnectionChanged: {
+		"branch": detailString, "reason": detailString, "worktree_removed": detailBool,
+		"branch_deleted": detailBool, "registry_unregistered": detailBool,
+	},
+	service.Internal: {
+		"path": detailString, "branch": detailString, "worktree_removed": detailBool,
+		"branch_deleted": detailBool, "registry_unregistered": detailBool,
+	},
+}
+
+func allowedProblemDetails(code service.Code, details map[string]any) map[string]any {
 	if len(details) == 0 {
 		return nil
 	}
-	allowed := map[string]bool{
-		"kind": true, "path": true, "digest": true, "size": true,
-		"preview": true, "truncated": true, "drain_deadline": true,
-		"branch": true, "reason": true, "worktree_removed": true,
-		"branch_deleted": true, "registry_unregistered": true,
+	allowed := allowedProblemDetailTypes[code]
+	if len(allowed) == 0 {
+		return nil
 	}
 	result := make(map[string]any)
 	for key, value := range details {
-		if allowed[key] {
-			result[key] = value
+		typeOf, ok := allowed[key]
+		if !ok {
+			continue
+		}
+		if normalized, ok := normalizeProblemDetail(typeOf, value); ok {
+			result[key] = normalized
 		}
 	}
 	if len(result) == 0 {
 		return nil
 	}
 	return result
+}
+
+func normalizeProblemDetail(kind problemDetailType, value any) (any, bool) {
+	switch kind {
+	case detailString:
+		result, ok := value.(string)
+		return result, ok
+	case detailBool:
+		result, ok := value.(bool)
+		return result, ok
+	case detailNumber:
+		switch value.(type) {
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64, float32, float64:
+			return value, true
+		default:
+			return nil, false
+		}
+	case detailRFC3339:
+		switch result := value.(type) {
+		case time.Time:
+			return result.Format(time.RFC3339Nano), true
+		case *time.Time:
+			if result != nil {
+				return result.Format(time.RFC3339Nano), true
+			}
+		case string:
+			if _, err := time.Parse(time.RFC3339Nano, result); err == nil {
+				return result, true
+			}
+		}
+	}
+	return nil, false
 }
 
 func init() {
@@ -342,13 +393,10 @@ func init() {
 		case http.StatusServiceUnavailable:
 			code = "busy"
 		}
-		return &Problem{
-			Type:      "https://kwt.dev/problems/" + code,
-			Title:     http.StatusText(status),
-			Status:    status,
-			Detail:    message,
-			Code:      code,
+		returnProblem := newProblem(status, service.Descriptor{
+			Code: service.Code(code), Message: message,
 			Retryable: status == http.StatusServiceUnavailable,
-		}
+		})
+		return &returnProblem
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -240,11 +240,30 @@ func writeProblem(w http.ResponseWriter, problem Problem) {
 }
 
 func newProblem(status int, descriptor service.Descriptor) Problem {
-	return Problem{
+	problem := Problem{
 		Type:  "https://kwt.dev/problems/" + string(descriptor.Code),
 		Title: http.StatusText(status), Status: status, Detail: descriptor.Message,
 		Descriptor: descriptor,
 	}
+	if deadline, ok := drainDeadlineDetail(descriptor.Details); ok {
+		problem.DrainDeadline = &deadline
+	}
+	return problem
+}
+
+func drainDeadlineDetail(details map[string]any) (time.Time, bool) {
+	switch deadline := details["drain_deadline"].(type) {
+	case time.Time:
+		return deadline, true
+	case *time.Time:
+		if deadline != nil {
+			return *deadline, true
+		}
+	case string:
+		parsed, err := time.Parse(time.RFC3339Nano, deadline)
+		return parsed, err == nil
+	}
+	return time.Time{}, false
 }
 
 func (p *Problem) Error() string { return p.Detail }
@@ -315,12 +334,19 @@ var allowedProblemDetailTypes = map[service.Code]map[string]problemDetailType{
 		"size": detailNumber, "preview": detailString, "truncated": detailBool,
 	},
 	service.Conflict: {
-		"branch": detailString, "reason": detailString, "worktree_removed": detailBool,
-		"branch_deleted": detailBool, "registry_unregistered": detailBool,
+		"path": detailString, "branch": detailString, "reason": detailString,
+		"worktree_removed": detailBool, "branch_deleted": detailBool,
+		"registry_unregistered": detailBool,
 	},
 	service.ConnectionChanged: {
-		"branch": detailString, "reason": detailString, "worktree_removed": detailBool,
-		"branch_deleted": detailBool, "registry_unregistered": detailBool,
+		"path": detailString, "branch": detailString, "reason": detailString,
+		"worktree_removed": detailBool, "branch_deleted": detailBool,
+		"registry_unregistered": detailBool,
+	},
+	service.Busy: {
+		"path": detailString, "branch": detailString, "reason": detailString,
+		"worktree_removed": detailBool, "branch_deleted": detailBool,
+		"registry_unregistered": detailBool,
 	},
 	service.Internal: {
 		"path": detailString, "branch": detailString, "worktree_removed": detailBool,

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -32,6 +32,7 @@ type ServerOptions struct {
 	Inventory    kwt.Inventory
 	Remover      kwt.Remover
 	Gate         *Gate
+	ReportError  func(string, *service.Error)
 }
 
 type emptyInput struct{}
@@ -81,12 +82,12 @@ func NewServer(opts ServerOptions) http.Handler {
 			func(ctx context.Context, input *inventoryInput) (*inventoryOutput, error) {
 				release, err := reserveInventoryWork(opts)
 				if err != nil {
-					return nil, problemFromError(err)
+					return nil, reportProblem(opts, "/api/v1/inventory", err)
 				}
 				defer release()
 				result, err := opts.Inventory.Query(ctx, input.Body)
 				if err != nil {
-					return nil, problemFromError(err)
+					return nil, reportProblem(opts, "/api/v1/inventory", err)
 				}
 				return &inventoryOutput{Body: result}, nil
 			},
@@ -97,11 +98,11 @@ func NewServer(opts ServerOptions) http.Handler {
 			func(ctx context.Context, input *configApprovalInput) (*configApprovalOutput, error) {
 				release, err := reserveInventoryWork(opts)
 				if err != nil {
-					return nil, problemFromError(err)
+					return nil, reportProblem(opts, "/api/v1/config/trust", err)
 				}
 				defer release()
 				if err := opts.Inventory.ApproveConfig(ctx, input.Body); err != nil {
-					return nil, problemFromError(err)
+					return nil, reportProblem(opts, "/api/v1/config/trust", err)
 				}
 				output := &configApprovalOutput{}
 				output.Body.Status = "approved"
@@ -119,12 +120,12 @@ func NewServer(opts ServerOptions) http.Handler {
 			func(ctx context.Context, input *removalInput) (*removalOutput, error) {
 				release, err := reserveInventoryWork(opts)
 				if err != nil {
-					return nil, problemFromError(err)
+					return nil, reportProblem(opts, "/api/v1/worktrees/remove", err)
 				}
 				defer release()
 				result, err := opts.Remover.Remove(ctx, input.Body)
 				if err != nil {
-					return nil, problemFromError(err)
+					return nil, reportProblem(opts, "/api/v1/worktrees/remove", err)
 				}
 				return &removalOutput{Body: result}, nil
 			},
@@ -140,7 +141,7 @@ func NewServer(opts ServerOptions) http.Handler {
 		func(ctx context.Context, input *shutdownInput) (*shutdownOutput, error) {
 			status, err := opts.Shutdown(ctx, input.Body)
 			if err != nil {
-				return nil, problemFromError(err)
+				return nil, reportProblem(opts, "/api/v1/daemon/shutdown", err)
 			}
 			return &shutdownOutput{Body: ShutdownResponse{Status: status}}, nil
 		},
@@ -288,6 +289,14 @@ func problemFromError(err error) *Problem {
 		Details: allowedProblemDetails(typed.Code, typed.Details),
 	})
 	return &problem
+}
+
+func reportProblem(opts ServerOptions, route string, err error) *Problem {
+	typed := service.AsError(err)
+	if opts.ReportError != nil {
+		opts.ReportError(route, typed)
+	}
+	return problemFromError(typed)
 }
 
 type problemDetailType uint8

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -32,7 +32,7 @@ type ServerOptions struct {
 	Inventory    kwt.Inventory
 	Remover      kwt.Remover
 	Gate         *Gate
-	ReportError  func(string, *service.Error)
+	ReportError  func(string, *service.Error, kwt.ExpansionContext)
 }
 
 type emptyInput struct{}
@@ -87,7 +87,9 @@ func NewServer(opts ServerOptions) http.Handler {
 				defer release()
 				result, err := opts.Inventory.Query(ctx, input.Body)
 				if err != nil {
-					return nil, reportProblem(opts, "/api/v1/inventory", err)
+					return nil, reportProblemWithExpansion(
+						opts, "/api/v1/inventory", err, input.Body.Expansion,
+					)
 				}
 				return &inventoryOutput{Body: result}, nil
 			},
@@ -303,17 +305,30 @@ func problemFromError(err error) *Problem {
 	case service.TransportFailure, service.DaemonTransportFailed:
 		status = http.StatusBadGateway
 	}
+	message := typed.Message
+	if typed.Code == service.Internal {
+		message = "internal failure"
+	}
 	problem := newProblem(status, service.Descriptor{
-		Code: typed.Code, Message: typed.Message, Retryable: typed.Retryable,
+		Code: typed.Code, Message: message, Retryable: typed.Retryable,
 		Details: allowedProblemDetails(typed.Code, typed.Details),
 	})
 	return &problem
 }
 
 func reportProblem(opts ServerOptions, route string, err error) *Problem {
+	return reportProblemWithExpansion(opts, route, err, kwt.ExpansionContext{})
+}
+
+func reportProblemWithExpansion(
+	opts ServerOptions,
+	route string,
+	err error,
+	expansion kwt.ExpansionContext,
+) *Problem {
 	typed := service.AsError(err)
 	if opts.ReportError != nil {
-		opts.ReportError(route, typed)
+		opts.ReportError(route, typed, expansion)
 	}
 	return problemFromError(typed)
 }

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -175,11 +175,16 @@ func TestDrainingServerReturnsRetryableProblemWithDeadline(t *testing.T) {
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	require.Equal(t, http.StatusServiceUnavailable, response.Code)
-	var problem Problem
+	var problem struct {
+		service.Descriptor
+		DrainDeadline *time.Time `json:"drain_deadline"`
+	}
 	require.NoError(t, json.NewDecoder(response.Body).Decode(&problem))
 	assert.Equal(t, service.DaemonDraining, problem.Code)
 	assert.True(t, problem.Retryable)
 	assert.Equal(t, deadline.Format(time.RFC3339), problem.Details["drain_deadline"])
+	require.NotNil(t, problem.DrainDeadline)
+	assert.Equal(t, deadline, *problem.DrainDeadline)
 }
 
 func TestProblemRoundTripsServiceDescriptor(t *testing.T) {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/service"
 )
 
 type testStatusProvider struct{ status Status }
@@ -92,7 +95,7 @@ func TestServerRejectsBrowserOriginAndOversizedBodies(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, response.Code)
 	var problem Problem
 	require.NoError(t, json.NewDecoder(response.Body).Decode(&problem))
-	assert.Equal(t, "invalid_request", problem.Code)
+	assert.Equal(t, service.InvalidRequest, problem.Code)
 }
 
 func TestServerDefaultBodyLimitAccommodatesClientExpansionContext(t *testing.T) {
@@ -174,8 +177,25 @@ func TestDrainingServerReturnsRetryableProblemWithDeadline(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, response.Code)
 	var problem Problem
 	require.NoError(t, json.NewDecoder(response.Body).Decode(&problem))
-	assert.Equal(t, "daemon_draining", problem.Code)
+	assert.Equal(t, service.DaemonDraining, problem.Code)
 	assert.True(t, problem.Retryable)
-	require.NotNil(t, problem.DrainDeadline)
-	assert.Equal(t, deadline, *problem.DrainDeadline)
+	assert.Equal(t, deadline.Format(time.RFC3339), problem.Details["drain_deadline"])
+}
+
+func TestProblemRoundTripsServiceDescriptor(t *testing.T) {
+	descriptor := service.Descriptor{
+		Code: service.DaemonDraining, Message: "the kwt daemon is draining", Retryable: true,
+		Details: map[string]any{"drain_deadline": "2026-08-10T01:02:03Z"},
+	}
+	problem := problemFromError(service.NewDescriptorError(descriptor, errors.New("private cause")))
+	encoded, err := json.Marshal(problem)
+	require.NoError(t, err)
+
+	decoded := decodeProblem(problem.Status, bytes.NewReader(encoded))
+	typed := service.AsError(decoded)
+	assert.Equal(t, descriptor.Code, typed.Code)
+	assert.Equal(t, descriptor.Message, typed.Message)
+	assert.Equal(t, descriptor.Retryable, typed.Retryable)
+	assert.Equal(t, descriptor.Details, typed.Details)
+	assert.NotContains(t, string(encoded), "private cause")
 }

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -63,5 +63,8 @@ type Problem struct {
 	Title  string `json:"title"`
 	Status int    `json:"status"`
 	Detail string `json:"detail"`
+	// DrainDeadline mirrors Descriptor.Details for API-major-1 clients. A
+	// future API-major-2 problem type need not carry this legacy top-level field.
+	DrainDeadline *time.Time `json:"drain_deadline,omitempty"`
 	service.Descriptor
 }

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -1,11 +1,15 @@
 package daemon
 
-import "time"
+import (
+	"time"
+
+	"go.kenn.io/kwt/service"
+)
 
 const (
 	ServiceName         = "kwt"
 	APISchemaMajor      = 1
-	APISchemaVersion    = "1.3.0"
+	APISchemaVersion    = "1.4.0"
 	CapabilityStatus    = "daemon.status"
 	CapabilityShutdown  = "daemon.shutdown"
 	CapabilityInventory = "worktree.inventory.v1"
@@ -55,12 +59,9 @@ type ShutdownResponse struct {
 }
 
 type Problem struct {
-	Type          string         `json:"type"`
-	Title         string         `json:"title"`
-	Status        int            `json:"status"`
-	Detail        string         `json:"detail"`
-	Code          string         `json:"code"`
-	Retryable     bool           `json:"retryable"`
-	DrainDeadline *time.Time     `json:"drain_deadline,omitempty"`
-	Details       map[string]any `json:"details,omitempty"`
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail"`
+	service.Descriptor
 }

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -44,6 +44,10 @@ type worktreeRemovedError struct {
 	err error
 }
 
+type worktreeRemovalCommandError struct {
+	err error
+}
+
 type incompleteWorktreeRemovalError struct {
 	path  string
 	cause error
@@ -89,6 +93,21 @@ func (e *worktreeRemovedError) Unwrap() error {
 
 func (e *worktreeRemovedError) WorktreeRemoved() bool {
 	return true
+}
+
+func (e *worktreeRemovalCommandError) Error() string {
+	return e.err.Error()
+}
+
+func (e *worktreeRemovalCommandError) Unwrap() error {
+	return e.err
+}
+
+// IsWorktreeRemovalCommandError reports a Git-owned removal-command failure
+// whose credential-sanitized message is safe to present to the caller.
+func IsWorktreeRemovalCommandError(err error) bool {
+	var commandError *worktreeRemovalCommandError
+	return errors.As(err, &commandError)
 }
 
 // GenerationStatus describes whether a durable kwt worktree generation was
@@ -1637,7 +1656,9 @@ func (g *Git) removeWorktree(
 			}
 			return nil
 		}
-		return fmt.Errorf("failed to remove worktree: %w", err)
+		return &worktreeRemovalCommandError{
+			err: fmt.Errorf("failed to remove worktree: %w", err),
+		}
 	}
 	return nil
 }

--- a/internal/lifecycle/removal.go
+++ b/internal/lifecycle/removal.go
@@ -175,7 +175,7 @@ func classifyRemovalError(err error, result RemovalResult) error {
 		return service.NewError(service.Busy, "worktree removal canceled", true, details, err)
 	}
 	if git.WorktreeWasRemoved(err) || git.IsWorktreeRemovalCommandError(err) {
-		return service.NewError(service.Internal, boundedDiagnostic(err), false, details, err)
+		return service.NewError(service.RemovalFailed, boundedDiagnostic(err), false, details, err)
 	}
 	return service.NewError(service.Internal, "internal failure", false, details, err)
 }

--- a/internal/lifecycle/removal.go
+++ b/internal/lifecycle/removal.go
@@ -174,7 +174,10 @@ func classifyRemovalError(err error, result RemovalResult) error {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return service.NewError(service.Busy, "worktree removal canceled", true, details, err)
 	}
-	return service.NewError(service.Internal, boundedDiagnostic(err), false, details, err)
+	if git.WorktreeWasRemoved(err) || git.IsWorktreeRemovalCommandError(err) {
+		return service.NewError(service.Internal, boundedDiagnostic(err), false, details, err)
+	}
+	return service.NewError(service.Internal, "internal failure", false, details, err)
 }
 
 func requestSafePath(path string) string {

--- a/internal/lifecycle/removal_test.go
+++ b/internal/lifecycle/removal_test.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -122,6 +123,24 @@ func TestRemovalServiceIgnoresDaemonRepositoryRoutingEnvironment(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.WorktreeRemoved)
 	assert.NoDirExists(t, worktreePath)
+}
+
+func TestClassifyRemovalErrorHidesUnexpectedCredentialBearingCause(t *testing.T) {
+	const secret = "removal-password"
+	cause := errors.New("fetch ssh://user:" + secret + "@example.invalid/repository")
+
+	err := classifyRemovalError(cause, RemovalResult{
+		Path: "/worktrees/topic", WorktreeRemoved: true,
+	})
+
+	var typed *service.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, service.Internal, typed.Code)
+	assert.Equal(t, "internal failure", typed.Message)
+	assert.NotContains(t, typed.Message, secret)
+	assert.Equal(t, "/worktrees/topic", typed.Details["path"])
+	assert.Equal(t, true, typed.Details["worktree_removed"])
+	assert.ErrorIs(t, err, cause)
 }
 
 func removalRepository(t *testing.T, branch string) (string, string) {

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -82,6 +82,7 @@ func (s *InventoryService) Query(ctx context.Context, request Request) (Result, 
 			}()
 		}
 		result, loadErr := s.source.Load(refreshContext, request)
+		loadErr = classifyInventoryError(loadErr)
 		if loadErr != nil {
 			if request.View == ViewDashboard {
 				s.setDashboardDiagnostic(generation, &Diagnostic{

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/pkg/models"
+	servicecontract "go.kenn.io/kwt/service"
 )
 
 type testCache struct {
@@ -212,6 +213,24 @@ func TestServiceFailedRefreshKeepsLastKnownGood(t *testing.T) {
 	cached, ok := cache.Current()
 	require.True(t, ok)
 	assert.Equal(t, "/old", cached.Snapshot.Entries[0].Path)
+}
+
+func TestServiceNormalizesUnexpectedCustomSourceError(t *testing.T) {
+	const secret = "custom-source-password"
+	cause := errors.New("fetch https://user:" + secret + "@example.invalid/repository")
+	inventory := NewInventoryService(InventoryServiceOptions{
+		Source: &testSource{err: cause},
+	})
+
+	_, err := inventory.Query(context.Background(), Request{View: ViewProjects})
+
+	require.Error(t, err)
+	var typed *servicecontract.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, servicecontract.Internal, typed.Code)
+	assert.Equal(t, "internal failure", typed.Message)
+	assert.NotContains(t, typed.Message, secret)
+	assert.ErrorIs(t, err, cause)
 }
 
 func TestServiceFreshDashboardSurvivesCacheWriteFailure(t *testing.T) {

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -54,7 +54,7 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 	expansion := request.Expansion
 	snapshot, err := config.LoadGlobalSnapshotAtWithExpansion(s.home, expansion.expandPath)
 	if err != nil {
-		return Result{}, err
+		return Result{}, inventorySourceFailure("load global configuration", err)
 	}
 	result = Result{Snapshot: Snapshot{
 		Config:     snapshot.Config,
@@ -65,30 +65,50 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 	switch request.View {
 	case ViewProjects:
 		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects, protectedNames...)
-		return result, err
+		return result, inventorySourceFailure("inspect registered projects", err)
 	case ViewGlobal:
 		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects, protectedNames...)
-		if err == nil {
-			result.Snapshot.Entries, err = s.loadGlobal(ctx, snapshot.Config)
+		if err != nil {
+			return Result{}, inventorySourceFailure("inspect registered projects", err)
+		}
+		result.Snapshot.Entries, err = s.loadGlobal(ctx, snapshot.Config)
+		if err != nil {
+			return Result{}, inventorySourceFailure("discover global worktrees", err)
 		}
 	case ViewRepository:
 		result, err = s.loadRepository(ctx, request, snapshot.Config, expansion.expandPath)
+		if err != nil {
+			return Result{}, inventorySourceFailure("load repository inventory", err)
+		}
 	case ViewDashboard:
 		result.Snapshot.Projects, err = CanonicalProjects(ctx, snapshot.Config.Projects, protectedNames...)
-		if err == nil {
-			result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
-				s.loadDashboard(ctx, request, snapshot.Config)
+		if err != nil {
+			return Result{}, inventorySourceFailure("inspect registered projects", err)
 		}
-	}
-	if err != nil {
-		return Result{}, err
+		result.Snapshot.Entries, result.Snapshot.LaunchEntries, err =
+			s.loadDashboard(ctx, request, snapshot.Config)
+		if err != nil {
+			return Result{}, inventorySourceFailure("load dashboard inventory", err)
+		}
 	}
 	if request.IncludeProtectedSockets {
 		if err := s.annotateProtectedSockets(ctx, result.Snapshot.Entries); err != nil {
-			return Result{}, err
+			return Result{}, inventorySourceFailure("failed to read pull-request provenance", err)
 		}
 	}
 	return result, nil
+}
+
+func inventorySourceFailure(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var typed *service.Error
+	if errors.As(err, &typed) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return service.NewError(service.InventoryFailed, message, false, nil, err)
 }
 
 func classifyInventoryError(err error) error {
@@ -110,7 +130,7 @@ func classifyInventoryError(err error) error {
 		)
 	}
 	return service.NewError(
-		service.InventoryFailed, boundedDiagnostic(err), false, nil, err,
+		service.Internal, "internal failure", false, nil, err,
 	)
 }
 

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -101,16 +101,16 @@ func classifyInventoryError(err error) error {
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return service.NewError(
-			service.Busy, "inventory refresh timed out", true, nil, err,
+			service.InventoryTimeout, "inventory refresh timed out", true, nil, err,
 		)
 	}
 	if errors.Is(err, context.Canceled) {
 		return service.NewError(
-			service.Busy, "inventory refresh canceled", true, nil, err,
+			service.InventoryFailed, "inventory refresh canceled", true, nil, err,
 		)
 	}
 	return service.NewError(
-		service.Internal, boundedDiagnostic(err), false, nil, err,
+		service.InventoryFailed, boundedDiagnostic(err), false, nil, err,
 	)
 }
 

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -67,6 +67,19 @@ func TestClassifyInventoryErrorPreservesTimeoutAndCancellation(t *testing.T) {
 	}
 }
 
+func TestClassifyInventoryErrorHidesUnexpectedCredentialBearingCause(t *testing.T) {
+	const secret = "inventory-password"
+	cause := errors.New("fetch https://user:" + secret + "@example.invalid/repository")
+
+	err := classifyInventoryError(cause)
+
+	typed := service.AsError(err)
+	assert.Equal(t, service.Internal, typed.Code)
+	assert.Equal(t, "internal failure", typed.Message)
+	assert.NotContains(t, typed.Message, secret)
+	assert.ErrorIs(t, err, cause)
+}
+
 func TestBoundedDiagnosticRemovesControlCharacters(t *testing.T) {
 	got := boundedDiagnostic(errors.New("unsafe\nmessage\twith\rcontrols"))
 

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -40,9 +40,31 @@ func TestSourceClassifiesInventoryFailuresWithActionableMessage(t *testing.T) {
 
 	var typed *service.Error
 	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, service.InventoryFailed, typed.Code)
+	assert.False(t, typed.Retryable)
 	assert.NotEqual(t, "internal failure", typed.Message)
 	assert.Contains(t, typed.Message, "config")
 	assert.LessOrEqual(t, len(typed.Message), 512)
+}
+
+func TestClassifyInventoryErrorPreservesTimeoutAndCancellation(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		cause error
+		code  service.Code
+	}{
+		{name: "deadline", cause: context.DeadlineExceeded, code: service.InventoryTimeout},
+		{name: "cancellation", cause: context.Canceled, code: service.InventoryFailed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := classifyInventoryError(test.cause)
+			var typed *service.Error
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, test.code, typed.Code)
+			assert.True(t, typed.Retryable)
+			assert.ErrorIs(t, err, test.cause)
+		})
+	}
 }
 
 func TestBoundedDiagnosticRemovesControlCharacters(t *testing.T) {

--- a/service/error.go
+++ b/service/error.go
@@ -16,19 +16,44 @@ const (
 	ConnectionChanged       Code = "connection_changed"
 	Unsupported             Code = "unsupported"
 	TransportFailure        Code = "transport_failure"
+	DaemonStartFailed       Code = "daemon_start_failed"
+	DaemonUnresponsive      Code = "daemon_unresponsive"
+	DaemonIncompatible      Code = "daemon_incompatible"
 	DaemonDowngradeRefused  Code = "daemon_downgrade_refused"
 	DaemonBuildOrderUnknown Code = "daemon_build_order_unknown"
-	Internal                Code = "internal"
+	DaemonDraining          Code = "daemon_draining"
+	DaemonTransportFailed   Code = "daemon_transport_failed"
+	InventoryTimeout        Code = "inventory_timeout"
+	InventoryFailed         Code = "inventory_failed"
+	// Reserved for API major 2 operation streaming; slice 2 does not emit
+	// these codes.
+	OperationIDConflict         Code = "operation_id_conflict"
+	OperationCapacityExhausted  Code = "operation_capacity_exhausted"
+	OperationJournalUnavailable Code = "operation_journal_unavailable"
+	OperationOutcomeUnknown     Code = "operation_outcome_unknown"
+	Internal                    Code = "internal"
 )
+
+// Descriptor is the stable, transport-neutral representation of a service
+// failure. Message is human-facing; Code, Retryable, and documented Details
+// are the machine contract.
+type Descriptor struct {
+	Code      Code           `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details,omitempty"`
+}
 
 // Error carries a stable category and retry policy across in-process and HTTP
 // service boundaries.
 type Error struct {
-	Code      Code
-	Message   string
-	Retryable bool
-	Details   map[string]any
-	Err       error
+	Descriptor
+	Err error `json:"-"`
+}
+
+// NewDescriptorError attaches a private cause to a stable descriptor.
+func NewDescriptorError(descriptor Descriptor, cause error) *Error {
+	return &Error{Descriptor: descriptor, Err: cause}
 }
 
 // NewError constructs a typed service failure.
@@ -39,13 +64,9 @@ func NewError(
 	details map[string]any,
 	cause error,
 ) *Error {
-	return &Error{
-		Code:      code,
-		Message:   message,
-		Retryable: retryable,
-		Details:   details,
-		Err:       cause,
-	}
+	return NewDescriptorError(Descriptor{
+		Code: code, Message: message, Retryable: retryable, Details: details,
+	}, cause)
 }
 
 func (e *Error) Error() string {

--- a/service/error.go
+++ b/service/error.go
@@ -25,6 +25,7 @@ const (
 	DaemonTransportFailed   Code = "daemon_transport_failed"
 	InventoryTimeout        Code = "inventory_timeout"
 	InventoryFailed         Code = "inventory_failed"
+	RemovalFailed           Code = "removal_failed"
 	// Reserved for API major 2 operation streaming; slice 2 does not emit
 	// these codes.
 	OperationIDConflict         Code = "operation_id_conflict"

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -10,6 +11,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/service"
 )
+
+func TestDescriptorIsTheTransportNeutralErrorValue(t *testing.T) {
+	descriptor := service.Descriptor{
+		Code: service.DaemonDraining, Message: "the kwt daemon is draining", Retryable: true,
+		Details: map[string]any{"drain_deadline": "2026-08-10T01:02:03Z"},
+	}
+	err := service.NewDescriptorError(descriptor, context.DeadlineExceeded)
+
+	assert.Equal(t, descriptor, err.Descriptor)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, service.DaemonDraining, err.Code)
+}
 
 func TestErrorPreservesCategoryRetryabilityAndCause(t *testing.T) {
 	cause := errors.New("locked")


### PR DESCRIPTION
Ghosthub needs to distinguish daemon ownership, compatibility, draining, transport, and inventory failures without parsing prose or confusing them with SSH exit 255. The previous generic busy/conflict/unsupported mappings lost that identity across HTTP, and list JSON failures fell back to Cobra prose even though successful inventory is a machine contract.

This establishes one descriptor across the embeddable service, RFC problem responses, and CLI JSON failures. Successful list/projects JSON remains a bare array, projects keeps its established mutation codes and exit behavior, and unknown HTTP codes fail closed as daemon transport errors. Unexpected causes stay out of public responses while owner-private diagnostics are bounded and credential-redacted.

Validated with the race-enabled service, daemon, command, and lifecycle suites; the full test, lint, build, docs, formatting, and diff checks; and subprocess fixtures for unresponsive, incompatible, draining, and inventory-source failures. Kata: 6gdf.