### PR TITLE
Repair and protect empty project registries

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -94,7 +94,9 @@ worktrees from anywhere.
 Automation and graphical clients can perform the same explicit registration
 without opening the dashboard by running `kwt projects add <path> --json`.
 They can unregister that metadata with `kwt projects remove <path> --json`;
-the command never deletes repository, worktree, or tmux-session data.
+the command never deletes repository, worktree, or tmux-session data. The
+project registry is structured metadata, so `kwt config set projects ...`
+refuses direct scalar writes that would corrupt it.
 
 Project entries are discovery metadata, not worktree-creation policy:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -96,7 +96,9 @@ without opening the dashboard by running `kwt projects add <path> --json`.
 They can unregister that metadata with `kwt projects remove <path> --json`;
 the command never deletes repository, worktree, or tmux-session data. The
 project registry is structured metadata, so `kwt config set projects ...`
-refuses direct scalar writes that would corrupt it.
+refuses direct scalar writes that would corrupt it. On startup, kwt also
+repairs the historical string-encoded empty value `projects = '[]'` to the
+canonical empty array. Other malformed project values still fail validation.
 
 Project entries are discovery metadata, not worktree-creation policy:
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
@@ -88,6 +89,10 @@ func runConfigList(cmd *cobra.Command, args []string) error {
 func runConfigSet(cmd *cobra.Command, args []string) error {
 	key := args[0]
 	value := args[1]
+	normalizedKey := strings.ToLower(key)
+	if normalizedKey == "projects" || strings.HasPrefix(normalizedKey, "projects.") {
+		return fmt.Errorf("projects is managed by kwt projects add and kwt projects remove")
+	}
 
 	// Convert string values to appropriate types
 	var typedValue any = value

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -41,9 +42,12 @@ func TestConfigSetRejectsDirectProjectRegistryWrites(t *testing.T) {
 			oldLocal := configSetLocal
 			configSetLocal = false
 			t.Cleanup(func() { configSetLocal = oldLocal })
+			projectPath := filepath.Join(t.TempDir(), "widget")
+			contents := "[[projects]]\nrepository = 'github.com/acme/widget'\nname = 'widget'\npath = " +
+				strconv.Quote(projectPath) + "\nlast_touched = 'before'\n"
 			require.NoError(t, os.WriteFile(
 				filepath.Join(configHome, "config.toml"),
-				[]byte("[[projects]]\nrepository = 'github.com/acme/widget'\nname = 'widget'\npath = '/code/widget'\nlast_touched = 'before'\n"),
+				[]byte(contents),
 				0o600,
 			))
 
@@ -58,7 +62,7 @@ func TestConfigSetRejectsDirectProjectRegistryWrites(t *testing.T) {
 			assert.Equal(t, []models.Project{{
 				Repository:  "github.com/acme/widget",
 				Name:        "widget",
-				Path:        "/code/widget",
+				Path:        projectPath,
 				LastTouched: "before",
 			}}, snapshot.Config.Projects)
 		})

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 func TestConfigSetRoundTripsDaemonDuration(t *testing.T) {
@@ -26,4 +29,38 @@ func TestConfigSetRoundTripsDaemonDuration(t *testing.T) {
 	snapshot, err := config.LoadGlobalSnapshot()
 	require.NoError(t, err)
 	assert.Equal(t, 2*time.Hour, snapshot.Config.Daemon.IdleTimeout)
+}
+
+func TestConfigSetRejectsDirectProjectRegistryWrites(t *testing.T) {
+	for _, key := range []string{"projects", "Projects", "projects.path"} {
+		t.Run(key, func(t *testing.T) {
+			configHome := t.TempDir()
+			t.Setenv("KWT_HOME", configHome)
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			oldLocal := configSetLocal
+			configSetLocal = false
+			t.Cleanup(func() { configSetLocal = oldLocal })
+			require.NoError(t, os.WriteFile(
+				filepath.Join(configHome, "config.toml"),
+				[]byte("[[projects]]\nrepository = 'github.com/acme/widget'\nname = 'widget'\npath = '/code/widget'\nlast_touched = 'before'\n"),
+				0o600,
+			))
+
+			err := runConfigSet(
+				&cobra.Command{},
+				[]string{key, "[]"},
+			)
+
+			require.ErrorContains(t, err, "kwt projects")
+			snapshot, err := config.LoadGlobalSnapshotAt(configHome)
+			require.NoError(t, err)
+			assert.Equal(t, []models.Project{{
+				Repository:  "github.com/acme/widget",
+				Name:        "widget",
+				Path:        "/code/widget",
+				LastTouched: "before",
+			}}, snapshot.Config.Projects)
+		})
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,6 +312,10 @@ func backfillWorkspaceConfig(configPath string) (bool, error) {
 	return (globalConfigStore{path: configPath}).mutate(
 		func(globalViper *viper.Viper) (bool, error) {
 			migrated := false
+			if projects, ok := globalViper.Get("projects").(string); ok && projects == "[]" {
+				globalViper.Set("projects", []map[string]any{})
+				migrated = true
+			}
 			agents := globalViper.GetStringMapString("agents")
 			if agents == nil {
 				agents = make(map[string]string)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1737,6 +1737,67 @@ auto_mkdir = true
 	assert.NotContains(t, text, "dangerously-skip-permissions")
 }
 
+func TestInitRepairsStringEncodedEmptyProjectRegistry(t *testing.T) {
+	kwtHome := t.TempDir()
+	t.Setenv("KWT_HOME", kwtHome)
+	require.NoError(t, os.WriteFile(filepath.Join(kwtHome, "config.toml"), []byte(`
+projects = '[]'
+
+[agents]
+codex = "codex"
+claude = "claude"
+roborev = "roborev tui"
+
+[layouts]
+auto_launch_on_add = true
+
+[naming]
+template = "{{.FullPath}}/{{.Branch}}"
+
+[custom]
+sentinel = "preserved"
+`), 0o600))
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	require.NoError(t, Init())
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Projects)
+	stored, err := readGlobalViper(filepath.Join(kwtHome, "config.toml"))
+	require.NoError(t, err)
+	assert.IsType(t, []any{}, stored.Get("projects"))
+	assert.Equal(t, "preserved", stored.GetString("custom.sentinel"))
+	projects, err := rawProjectEntries(stored)
+	require.NoError(t, err)
+	assert.Empty(t, projects)
+	migrated, err := backfillWorkspaceConfig(filepath.Join(kwtHome, "config.toml"))
+	require.NoError(t, err)
+	assert.False(t, migrated)
+}
+
+func TestInitDoesNotRepairOtherMalformedProjectRegistries(t *testing.T) {
+	for _, value := range []string{"' [] '", "'other'", "['not-a-project']"} {
+		t.Run(value, func(t *testing.T) {
+			kwtHome := t.TempDir()
+			t.Setenv("KWT_HOME", kwtHome)
+			require.NoError(t, os.WriteFile(
+				filepath.Join(kwtHome, "config.toml"),
+				[]byte("projects = "+value+"\n"),
+				0o600,
+			))
+
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			require.NoError(t, Init())
+
+			_, err := Load()
+			require.ErrorContains(t, err, "projects")
+		})
+	}
+}
+
 func TestInitLeavesExistingLayoutsUntouched(t *testing.T) {
 	kwtHome := t.TempDir()
 	t.Setenv("KWT_HOME", kwtHome)


### PR DESCRIPTION
The generic config setter can serialize an attempt to clear the project registry as a string instead of a structured empty array. Once that value is persisted, commands that load project metadata fail before users can repair the registry through normal kwt workflows. Preventing future writes alone would leave already-affected installations orphaned.

This change repairs only the exact historical string-encoded empty value during startup, using the existing locked atomic config mutation path. Unrelated settings are preserved, the repair is idempotent, and every other malformed registry shape continues to fail explicitly rather than risking data loss. Direct scalar, case-variant, and dotted writes to the managed project registry are rejected and callers are directed to the dedicated project commands.

Regression coverage exercises existing-user recovery, canonical persistence, idempotence, preservation of unrelated settings, rejected malformed alternatives, and Viper-equivalent config-key spellings. The full uncached Go test suite and repository build pass.