### PR TITLE
Keep daemon identity stable across WSL clock changes

### DIFF
--- a/internal/daemon/process_identity_linux.go
+++ b/internal/daemon/process_identity_linux.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+package daemon
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func readStableProcessIdentity(pid int) (string, bool) {
+	if pid <= 0 {
+		return "", false
+	}
+	bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil || strings.TrimSpace(string(bootID)) == "" {
+		return "", false
+	}
+	initTicks, err := readLinuxProcessStartTicks(1)
+	if err != nil {
+		return "", false
+	}
+	processTicks, err := readLinuxProcessStartTicks(pid)
+	if err != nil {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"%s:%s:%s",
+		strings.TrimSpace(string(bootID)),
+		initTicks,
+		processTicks,
+	), true
+}
+
+func readLinuxProcessStartTicks(pid int) (string, error) {
+	stat, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return "", err
+	}
+	return parseLinuxProcessStartTicks(stat)
+}
+
+func parseLinuxProcessStartTicks(stat []byte) (string, error) {
+	closing := bytes.LastIndexByte(stat, ')')
+	if closing < 0 || closing+1 >= len(stat) {
+		return "", errors.New("Linux process stat has no command terminator")
+	}
+	fields := strings.Fields(string(stat[closing+1:]))
+	const startTimeIndex = 19 // Field 22 after fields 1 (PID) and 2 (command).
+	if len(fields) <= startTimeIndex {
+		return "", errors.New("Linux process stat has no start time")
+	}
+	if _, err := strconv.ParseUint(fields[startTimeIndex], 10, 64); err != nil {
+		return "", errors.New("Linux process stat has an invalid start time")
+	}
+	return fields[startTimeIndex], nil
+}

--- a/internal/daemon/process_identity_linux_test.go
+++ b/internal/daemon/process_identity_linux_test.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLinuxProcessStartTicks(t *testing.T) {
+	ticks, err := parseLinuxProcessStartTicks(
+		[]byte("42 (kwt daemon (worker)) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 98765 20"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "98765", ticks)
+}

--- a/internal/daemon/process_identity_other.go
+++ b/internal/daemon/process_identity_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package daemon
+
+func readStableProcessIdentity(int) (string, bool) {
+	return "", false
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -18,14 +18,15 @@ import (
 )
 
 const (
-	RuntimePrefix         = "kwt"
-	metadataHome          = "home"
-	metadataRevision      = "revision"
-	metadataRevisionTime  = "revision_time"
-	metadataSchemaMajor   = "schema_major"
-	metadataSchemaVersion = "schema_version"
-	metadataCapabilities  = "capabilities"
-	metadataToken         = "bearer"
+	RuntimePrefix           = "kwt"
+	metadataHome            = "home"
+	metadataRevision        = "revision"
+	metadataRevisionTime    = "revision_time"
+	metadataSchemaMajor     = "schema_major"
+	metadataSchemaVersion   = "schema_version"
+	metadataCapabilities    = "capabilities"
+	metadataToken           = "bearer"
+	metadataProcessIdentity = "process_identity_linux_v1"
 )
 
 type Build struct {
@@ -99,6 +100,12 @@ func NewRuntimeRecord(
 		}, ","),
 		metadataToken: token,
 	}
+	if identity, ok := readStableProcessIdentity(rec.PID); ok {
+		rec.Metadata[metadataProcessIdentity] = identity
+		// Older clients must fail closed instead of deleting this record after
+		// WSL adjusts the wall clock used by kit's legacy Linux identity.
+		rec.ProcessIdentity = ""
+	}
 	return rec, token, nil
 }
 
@@ -123,7 +130,7 @@ func Inspect(
 			continue
 		}
 		var candidate Observation
-		switch kitdaemon.CompareProcessIdentity(rec.PID, rec.ProcessIdentity) {
+		switch compareRuntimeProcessIdentity(rec) {
 		case kitdaemon.ProcessIdentityMismatch:
 			if err := removeStaleRecord(store, rec); err != nil {
 				return Observation{}, err
@@ -153,6 +160,24 @@ func Inspect(
 		return Observation{State: RuntimeAbsent}, nil
 	}
 	return *found, nil
+}
+
+func compareRuntimeProcessIdentity(rec kitdaemon.RuntimeRecord) kitdaemon.ProcessIdentityStatus {
+	recorded, hasStableIdentity := rec.Metadata[metadataProcessIdentity]
+	if !hasStableIdentity {
+		return kitdaemon.CompareProcessIdentity(rec.PID, rec.ProcessIdentity)
+	}
+	if recorded == "" {
+		return kitdaemon.ProcessIdentityUnknown
+	}
+	live, ok := readStableProcessIdentity(rec.PID)
+	if !ok {
+		return kitdaemon.ProcessIdentityUnknown
+	}
+	if live == recorded {
+		return kitdaemon.ProcessIdentityMatch
+	}
+	return kitdaemon.ProcessIdentityMismatch
 }
 
 func inspectLiveRecord(

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -57,6 +58,52 @@ func TestNewRuntimeRecordAlwaysAdvertisesRevisionTime(t *testing.T) {
 	value, present = record.Metadata[metadataRevisionTime]
 	assert.True(t, present)
 	assert.Empty(t, value)
+}
+
+func TestInspectUsesStableProcessIdentityAcrossLegacyClockDrift(t *testing.T) {
+	if _, ok := readStableProcessIdentity(os.Getpid()); !ok {
+		t.Skip("platform does not expose a stable process identity")
+	}
+	home := t.TempDir()
+	store := RuntimeStore(home)
+	record, _, err := NewRuntimeRecord(
+		home,
+		Build{Version: "development"},
+		kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:1"},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, record.Metadata[metadataProcessIdentity])
+	assert.Empty(t, record.ProcessIdentity)
+	record.ProcessIdentity = "legacy-wall-clock-shifted"
+	path, err := store.Write(record)
+	require.NoError(t, err)
+
+	observation, err := Inspect(context.Background(), store, home)
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeUnresponsive, observation.State)
+	assert.FileExists(t, path)
+}
+
+func TestInspectRemovesMismatchedStableProcessIdentity(t *testing.T) {
+	if _, ok := readStableProcessIdentity(os.Getpid()); !ok {
+		t.Skip("platform does not expose a stable process identity")
+	}
+	home := t.TempDir()
+	store := RuntimeStore(home)
+	record, _, err := NewRuntimeRecord(
+		home,
+		Build{Version: "development"},
+		kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:1"},
+	)
+	require.NoError(t, err)
+	record.Metadata[metadataProcessIdentity] = "different-runtime:1:1"
+	path, err := store.Write(record)
+	require.NoError(t, err)
+
+	observation, err := Inspect(context.Background(), store, home)
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeAbsent, observation.State)
+	assert.NoFileExists(t, path)
 }
 
 func TestNewRuntimeRecordAdvertisesFirstDomainContracts(t *testing.T) {


### PR DESCRIPTION
- Prevents WSL clock corrections from making a live KWT daemon appear to be a replacement process, which previously deleted its runtime record while leaving the owner lock held.
- Identifies Linux daemons with kernel boot ID, PID 1 start ticks, and daemon start ticks so identity remains stable across wall-clock changes while still changing across WSL distro restarts and process reuse.
- Keeps existing runtime records compatible with the legacy identity check. New records omit the unstable legacy value so older clients fail closed instead of deleting newer daemon state.
- An isolated live WSL daemon remained ready after its legacy identity was deliberately corrupted, and the focused Linux daemon suite passes.