### PR TITLE
Pin Go 1.26.6 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/kwt
 
-go 1.26.3
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "latest"
+go = "1.26.6"
 prek = "latest"
 "golangci-lint" = "latest"
 "npm:oxfmt" = "latest"


### PR DESCRIPTION
Go 1.26.3 is affected by sumdb bypass and module-cache attack paths fixed in Go 1.26.6. This pins kwt's module and local mise toolchains to the patched release; CI and release workflows already read `go.mod`, so they now use the same version.

This deliberately changes only toolchain selection. Dependencies and kwt's broader Go 1.26+ source-build compatibility remain unchanged.

Advisory: https://freenode.net/article/go-1-26-6-and-1-25-13-fix-sumdb-bypass-and-module-cache-attacks
