### PR TITLE
Expose daemon-owned SSH connection leases

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -45,12 +45,13 @@ immediately, then continues reporting observed drain state while it waits.
 Active work and leases may finish until `daemon.replacement_grace`; the default
 is five minutes.
 
-The API schema is `1.8.0`. It exposes authenticated status, graceful shutdown,
+The API schema is `1.9.0`. It exposes authenticated status, graceful shutdown,
 worktree inventory, guarded project unregistration, and repository-config
 approval under `/api/v1`, proof-capable liveness at `/api/ping`, and
 credential-free OpenAPI at `/openapi.json`. Inventory clients require the
 `worktree.inventory.v1` capability; guarded unregistration requires
-`project.removal.v1`, and SSH route resolution requires `ssh.resolve.v1`.
+`project.removal.v1`, SSH route resolution requires `ssh.resolve.v1`, and
+daemon-owned connection leases require `ssh.lifecycle.v1`.
 Daemons advertise `operation.stream.v1` when they can
 carry ordered domain-operation events and bound prompt responses. Advertising
 that transport capability does not start a domain operation or move any
@@ -97,6 +98,14 @@ The daemon and inventory paths currently emit these stable codes:
 | `ssh_resolution_failed`                   | Effective OpenSSH configuration could not be observed.            |
 | `ssh_route_unreviewable`                  | A proxy route cannot be bound to independently reviewed hops.     |
 | `ssh_configuration_changed`               | A later lifecycle request observed a different route identity.    |
+| `ssh_unsupported_version`                 | The installed OpenSSH cannot support the required prompt policy.  |
+| `ssh_interaction_required`                | Connection preparation needs a prompt-capable client.             |
+| `ssh_prompt_rejected`                     | The client rejected an OpenSSH prompt.                            |
+| `ssh_prompt_timed_out`                    | A bound OpenSSH prompt exceeded its response deadline.            |
+| `ssh_connection_failed`                   | OpenSSH could not establish the reviewed route.                   |
+| `ssh_connection_changed`                  | A generation-bound lease is no longer usable.                     |
+| `ssh_control_path_occupied`               | A verified private control path is occupied unexpectedly.         |
+| `ssh_cleanup_failed`                      | Verified SSH connection cleanup did not complete.                 |
 | `internal`                                | An unexpected failure was withheld from the public response.      |
 
 `operation_journal_unavailable` remains reserved until kwt has a durable
@@ -110,7 +119,10 @@ prompt rounds; each response is accepted only for the exact current prompt ID,
 including an intentionally empty response. Stale, duplicate, and
 cross-operation responses fail closed. A client acknowledges a prompt sequence
 only after its bound response succeeds, so reconnect replays an unanswered
-prompt.
+prompt. Prompt events carry the daemon's response deadline. When that deadline
+expires, the client stops waiting for input, consumes the prompt sequence
+without a response, and continues reading until the daemon publishes the
+authoritative terminal failure.
 
 Each operation retains at most 256 events and 1 MiB of event payload. Public
 failure sanitization happens before admission, and each admitted event is

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -100,6 +100,18 @@ retains it in memory. Neither an operation ID nor a request digest authorizes a
 new daemon to adopt or replay work. Loss of that authority is reported as an
 unknown outcome rather than causing an automatic retry of a mutation.
 
+An SSH lease ID is likewise only a same-daemon routing handle. The daemon keeps
+the generation-bound lease and private projection state; clients receive only
+the arguments needed to reach that verified master. Lease touch and release
+require the owner-only bearer, and leases expire after thirty seconds without a
+heartbeat so a crashed CLI cannot pin authentication state indefinitely. During
+replacement, new leases are refused, existing leases may finish within the
+advertised grace period, and remaining lease handles are invalidated before the
+SSH owner is closed. Live masters are never transferred to the successor.
+Masterless direct arguments are never published through the daemon API. They
+remain available only to an in-process Go owner that assumes responsibility for
+the direct authentication, prompt, and trust boundary.
+
 Interactive SSH preparation uses the running kwt executable as a forced
 OpenSSH askpass helper only when its process environment contains a fresh,
 one-time channel handle. Helper dispatch occurs before configuration or Cobra

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -192,6 +192,11 @@ while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.
 
+Multiplexed-client arguments reapply the final target's reviewed
+`ForwardAgent`, `SendEnv`, `SetEnv`, and `EscapeChar` settings. Private
+`SetEnv` values remain in daemon-owned ephemeral configuration rather than
+appearing in argv.
+
 The daemon lease bridge requires a persistent OpenSSH master. A platform that
 cannot provide multiplexing returns `ssh_route_unreviewable` instead of
 publishing direct-connect arguments outside the daemon's prompt and trust

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -171,6 +171,42 @@ owner-private ephemeral configuration lines, not argv or diagnostics. Every
 unlisted directive—including forwards, commands, and user ControlMaster
 settings—still changes route identity but is never replayed for execution.
 
+## SSH connection leases
+
+```sh
+kwt ssh lease build.example.com \
+  --route-identity <identity-from-ssh-resolve> \
+  --projection-policy kwt.openssh.projection.v1 \
+  --json
+```
+
+`kwt ssh lease` is the long-lived native-client bridge to the same-machine
+daemon. It re-resolves the logical target, refuses a changed route, prepares
+every ProxyJump hop in order, and streams operation events as NDJSON. Prompt
+events may occur repeatedly; the client answers each with one
+`{"prompt_id":"...","value":"..."}` line on stdin. The completion event
+contains generation-bound OpenSSH arguments. Each prompt carries the daemon's
+deadline, so blocked input ends when the prompt expires and the command reports
+the daemon's terminal timeout. The process keeps the lease alive
+while stdin remains open, touches it every ten seconds, and releases it when
+stdin reaches EOF or the command is canceled. Progress and warnings are written
+as they occur rather than buffered.
+
+The daemon lease bridge requires a persistent OpenSSH master. A platform that
+cannot provide multiplexing returns `ssh_route_unreviewable` instead of
+publishing direct-connect arguments outside the daemon's prompt and trust
+boundary. The embeddable Go API may still return a masterless lease to an
+in-process owner that provides that direct execution boundary itself.
+
+The daemon expires a lease after thirty seconds without a successful touch.
+Release and expiry cleanup are bounded; a timed-out cleanup retains the lease
+for a later retry instead of releasing its daemon reservation.
+After final release, `ssh.idle_timeout` controls how long a non-agent-forwarding
+master remains warm. Agent-forwarding masters disconnect immediately. Daemon
+replacement reports its active lease count, waits through
+`daemon.replacement_grace`, then invalidates remaining leases and terminates
+their verified masters; a successor never adopts them as live connections.
+
 When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local
 `main`, then `master`, then the branch checked out in the primary worktree.

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/creack/pty v1.1.24
 	github.com/danielgtaylor/huma/v2 v2.39.1
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-github/v90 v90.0.0
 	github.com/ktr0731/go-fuzzyfinder v0.9.0
 	github.com/mattn/go-runewidth v0.0.27
+	github.com/muesli/cancelreader v0.2.2
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -46,7 +48,6 @@ require (
 	github.com/ktr0731/go-ansisgr v0.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/danielgtaylor/huma/v2 v2.39.1 h1:0kwF4ltQoYZ+IU55VPy+BcGekzgF44R64daTGde1H+g=
 github.com/danielgtaylor/huma/v2 v2.39.1/go.mod h1:zcnQ38duIJ3VUHwFaBoZ6x8T+KN/mr33oyqxcj0HTug=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	kwt "go.kenn.io/kwt"
@@ -22,6 +23,14 @@ var removeWorktreeWithDaemonClient = func(
 	request kwt.RemovalRequest,
 ) (kwt.RemovalResult, error) {
 	return client.RemoveWorktree(ctx, request)
+}
+var acquireSSHFromDaemon = func(
+	ctx context.Context,
+	client *kwtdaemon.Client,
+	request kwt.SSHLeaseRequest,
+	callbacks kwtdaemon.OperationCallbacks,
+) (kwtdaemon.SSHLeaseResult, error) {
+	return client.AcquireSSH(ctx, request, callbacks)
 }
 
 func resolveSSHViaDaemon(
@@ -65,6 +74,89 @@ func requireSSHResolveCapability(observation kwtdaemon.Observation) error {
 		)
 	}
 	return nil
+}
+
+type sshLeaseControl interface {
+	Touch(context.Context, string) error
+	Release(context.Context, string) error
+}
+
+type daemonSSHLeaseControl struct{ client *kwtdaemon.Client }
+
+func (c daemonSSHLeaseControl) Touch(ctx context.Context, leaseID string) error {
+	return c.client.TouchSSHLease(ctx, leaseID)
+}
+
+func (c daemonSSHLeaseControl) Release(ctx context.Context, leaseID string) error {
+	return c.client.ReleaseSSHLease(ctx, leaseID)
+}
+
+func acquireSSHLeaseViaDaemon(
+	ctx context.Context,
+	request kwt.SSHLeaseRequest,
+	callbacks kwtdaemon.OperationCallbacks,
+) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+	controller, err := newDaemonController()
+	if err != nil {
+		return kwtdaemon.SSHLeaseResult{}, nil, err
+	}
+	for {
+		observation, err := controller.Start(ctx)
+		if err != nil {
+			return kwtdaemon.SSHLeaseResult{}, nil, err
+		}
+		if observation.Client == nil || !slices.Contains(
+			observation.Status.Capabilities,
+			kwtdaemon.CapabilitySSHLifecycle,
+		) {
+			return kwtdaemon.SSHLeaseResult{}, nil, service.NewError(
+				service.DaemonIncompatible,
+				"the running kwt daemon does not provide SSH lifecycle management",
+				false, nil, nil,
+			)
+		}
+		var exposed atomic.Bool
+		trackedCallbacks := kwtdaemon.OperationCallbacks{
+			Event: func(event service.OperationEvent) error {
+				exposed.Store(true)
+				if callbacks.Event == nil {
+					return nil
+				}
+				return callbacks.Event(event)
+			},
+		}
+		if callbacks.Prompt != nil {
+			trackedCallbacks.Prompt = func(
+				promptContext context.Context,
+				prompt service.OperationPrompt,
+			) (string, error) {
+				exposed.Store(true)
+				return callbacks.Prompt(promptContext, prompt)
+			}
+		}
+		result, acquireErr := acquireSSHFromDaemon(
+			ctx, observation.Client, request, trackedCallbacks,
+		)
+		deadline, draining := inventoryDrainDeadline(acquireErr)
+		if !draining {
+			if acquireErr != nil {
+				if result.LeaseID == "" {
+					return result, nil, acquireErr
+				}
+				return result, daemonSSHLeaseControl{client: observation.Client}, acquireErr
+			}
+			return result, daemonSSHLeaseControl{client: observation.Client}, nil
+		}
+		if exposed.Load() {
+			if result.LeaseID == "" {
+				return result, nil, acquireErr
+			}
+			return result, daemonSSHLeaseControl{client: observation.Client}, acquireErr
+		}
+		if err := waitInventoryRetry(ctx, deadline); err != nil {
+			return kwtdaemon.SSHLeaseResult{}, nil, err
+		}
+	}
 }
 
 func removeProjectViaDaemon(

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -14,6 +14,84 @@ import (
 	"go.kenn.io/kwt/service"
 )
 
+func TestAcquireSSHLeaseDoesNotRetryDrainAfterExposingOperation(t *testing.T) {
+	for _, kind := range []service.OperationEventKind{
+		service.OperationEventProgress,
+		service.OperationEventPrompt,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			oldFactory := newDaemonController
+			oldAcquire := acquireSSHFromDaemon
+			t.Cleanup(func() {
+				newDaemonController = oldFactory
+				acquireSSHFromDaemon = oldAcquire
+			})
+			newDaemonController = func() (daemonController, error) {
+				return &fakeDaemonController{observation: kwtdaemon.Observation{
+					State:  kwtdaemon.RuntimeReady,
+					Client: &kwtdaemon.Client{},
+					Status: kwtdaemon.Status{Capabilities: []string{
+						kwtdaemon.CapabilitySSHLifecycle,
+					}},
+				}}, nil
+			}
+			attempts := 0
+			acquireSSHFromDaemon = func(
+				ctx context.Context,
+				_ *kwtdaemon.Client,
+				_ kwt.SSHLeaseRequest,
+				callbacks kwtdaemon.OperationCallbacks,
+			) (kwtdaemon.SSHLeaseResult, error) {
+				attempts++
+				if attempts > 1 {
+					return kwtdaemon.SSHLeaseResult{LeaseID: "duplicate"}, nil
+				}
+				event := service.OperationEvent{Kind: kind}
+				if kind == service.OperationEventPrompt {
+					event.Prompt = &service.OperationPrompt{ID: "prompt-1", Message: "Password:"}
+				}
+				require.NoError(t, callbacks.Event(event))
+				if event.Prompt != nil {
+					_, err := callbacks.Prompt(ctx, *event.Prompt)
+					require.NoError(t, err)
+				}
+				return kwtdaemon.SSHLeaseResult{}, service.NewError(
+					service.DaemonDraining,
+					"daemon is draining",
+					true,
+					map[string]any{"drain_deadline": time.Now().Add(5 * time.Millisecond)},
+					nil,
+				)
+			}
+			events := 0
+			prompts := 0
+			_, _, err := acquireSSHLeaseViaDaemon(
+				context.Background(),
+				kwt.SSHLeaseRequest{},
+				kwtdaemon.OperationCallbacks{
+					Event: func(service.OperationEvent) error {
+						events++
+						return nil
+					},
+					Prompt: func(context.Context, service.OperationPrompt) (string, error) {
+						prompts++
+						return "secret", nil
+					},
+				},
+			)
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.DaemonDraining), err)
+			assert.Equal(t, 1, attempts)
+			assert.Equal(t, 1, events)
+			if kind == service.OperationEventPrompt {
+				assert.Equal(t, 1, prompts)
+			} else {
+				assert.Equal(t, 0, prompts)
+			}
+		})
+	}
+}
+
 func TestInventoryDrainDeadlineRequiresDaemonDrainingCode(t *testing.T) {
 	deadline := time.Now().UTC().Add(time.Minute)
 	tests := []struct {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -1,21 +1,40 @@
 package cmd
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	kwt "go.kenn.io/kwt"
+	kwtdaemon "go.kenn.io/kwt/internal/daemon"
 	"go.kenn.io/kwt/service"
+	"golang.org/x/term"
 )
 
 var (
-	sshResolveJSON bool
-	sshResolveUser string
-	sshResolvePort int
+	sshResolveJSON           bool
+	sshResolveUser           string
+	sshResolvePort           int
+	sshLeaseJSON             bool
+	sshLeaseUser             string
+	sshLeasePort             int
+	sshLeaseRouteIdentity    string
+	sshLeaseProjectionPolicy string
 
-	resolveSSHThroughDaemon = resolveSSHViaDaemon
+	resolveSSHThroughDaemon      = resolveSSHViaDaemon
+	acquireSSHLeaseThroughDaemon = acquireSSHLeaseViaDaemon
 )
+
+const sshLeaseHeartbeatInterval = 10 * time.Second
+
+var sshLeaseHeartbeatEvery = sshLeaseHeartbeatInterval
 
 var sshCmd = &cobra.Command{
 	Use:               "ssh",
@@ -42,14 +61,48 @@ var sshResolveCmd = &cobra.Command{
 	RunE: withGracefulSignals(runSSHResolve),
 }
 
+var sshLeaseCmd = &cobra.Command{
+	Use:   "lease <hostname>",
+	Short: "Hold a daemon-owned SSH connection lease",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 {
+			return nil
+		}
+		return writeSSHLeaseFailure(cmd, service.NewError(
+			service.InvalidRequest,
+			fmt.Sprintf("expected one SSH hostname, received %d", len(args)),
+			false, nil, nil,
+		))
+	},
+	RunE: withGracefulSignals(runSSHLease),
+}
+
 func init() {
 	rootCmd.AddCommand(sshCmd)
 	sshCmd.AddCommand(sshResolveCmd)
+	sshCmd.AddCommand(sshLeaseCmd)
 	sshResolveCmd.Flags().StringVar(&sshResolveUser, "user", "", "Override the SSH user")
 	sshResolveCmd.Flags().IntVar(&sshResolvePort, "port", 0, "Override the SSH port")
 	sshResolveCmd.Flags().BoolVar(&sshResolveJSON, "json", false, "Output a machine-readable route snapshot")
 	sshResolveCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return writeSSHResolveFailure(cmd, service.NewError(
+			service.InvalidRequest, err.Error(), false, nil, err,
+		))
+	})
+	sshLeaseCmd.Flags().StringVar(&sshLeaseUser, "user", "", "Override the SSH user")
+	sshLeaseCmd.Flags().IntVar(&sshLeasePort, "port", 0, "Override the SSH port")
+	sshLeaseCmd.Flags().StringVar(
+		&sshLeaseRouteIdentity, "route-identity", "", "Require this resolved SSH route identity",
+	)
+	sshLeaseCmd.Flags().StringVar(
+		&sshLeaseProjectionPolicy, "projection-policy", kwt.SSHProjectionPolicyV1,
+		"Require this SSH execution projection policy",
+	)
+	sshLeaseCmd.Flags().BoolVar(
+		&sshLeaseJSON, "json", false, "Stream machine-readable lifecycle events",
+	)
+	sshLeaseCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return writeSSHLeaseFailure(cmd, service.NewError(
 			service.InvalidRequest, err.Error(), false, nil, err,
 		))
 	})
@@ -90,4 +143,184 @@ func writeSSHResolveFailure(cmd *cobra.Command, err error) error {
 		sshResolveJSON,
 		"ssh resolve",
 	)
+}
+
+func runSSHLease(cmd *cobra.Command, args []string) (returnErr error) {
+	if sshLeaseRouteIdentity == "" {
+		return writeSSHLeaseFailure(cmd, service.NewError(
+			service.InvalidRequest, "--route-identity is required", false, nil, nil,
+		))
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	input := cmd.InOrStdin()
+	inputReader := bufio.NewReader(input)
+	decoder := json.NewDecoder(inputReader)
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	terminalEventWritten := false
+	callbacks := kwtdaemon.OperationCallbacks{
+		Event: func(event service.OperationEvent) error {
+			if sshLeaseJSON {
+				if err := encoder.Encode(event); err != nil {
+					return err
+				}
+				if event.Kind == service.OperationEventComplete {
+					terminalEventWritten = true
+				}
+				return nil
+			}
+			if event.Kind == service.OperationEventProgress ||
+				event.Kind == service.OperationEventWarning {
+				_, err := fmt.Fprintln(cmd.ErrOrStderr(), event.Message)
+				return err
+			}
+			return nil
+		},
+		Prompt: func(ctx context.Context, prompt service.OperationPrompt) (string, error) {
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+			if sshLeaseJSON {
+				var response service.OperationResponse
+				if _, err := readSSHPrompt(ctx, func() (string, error) {
+					return "", decoder.Decode(&response)
+				}); err != nil {
+					return "", err
+				}
+				if response.PromptID != prompt.ID {
+					return "", service.NewError(
+						service.InvalidRequest,
+						"SSH prompt response does not match the active prompt",
+						false, nil, nil,
+					)
+				}
+				return response.Value, nil
+			}
+			if _, err := fmt.Fprint(cmd.ErrOrStderr(), terminalSafeSSHPrompt(prompt.Message)+" "); err != nil {
+				return "", err
+			}
+			if prompt.Sensitive {
+				if file, ok := input.(*os.File); ok && term.IsTerminal(int(file.Fd())) {
+					value, err := readTerminalPassword(ctx, file)
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+					return value, err
+				}
+			}
+			value, err := readSSHPrompt(ctx, func() (string, error) {
+				return inputReader.ReadString('\n')
+			})
+			return strings.TrimSuffix(strings.TrimSuffix(value, "\n"), "\r"), err
+		},
+	}
+	result, control, err := acquireSSHLeaseThroughDaemon(
+		ctx,
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{
+				Hostname: args[0], User: sshLeaseUser, Port: sshLeasePort,
+			},
+			RouteIdentity:    sshLeaseRouteIdentity,
+			ProjectionPolicy: sshLeaseProjectionPolicy,
+		}},
+		callbacks,
+	)
+	if err != nil {
+		if control != nil && result.LeaseID != "" {
+			releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+			err = errors.Join(err, control.Release(releaseCtx, result.LeaseID))
+			cancel()
+		}
+		return writeSSHLeaseFailureRecord(cmd, err, sshLeaseJSON && !terminalEventWritten)
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		defer cancel()
+		returnErr = errors.Join(returnErr, control.Release(releaseCtx, result.LeaseID))
+		if returnErr != nil {
+			returnErr = writeSSHLeaseFailureRecord(cmd, returnErr, sshLeaseJSON)
+		}
+	}()
+	if !sshLeaseJSON {
+		if err := encoder.Encode(result); err != nil {
+			return err
+		}
+	}
+	stdinDone := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, io.MultiReader(decoder.Buffered(), inputReader))
+		stdinDone <- err
+	}()
+	ticker := time.NewTicker(sshLeaseHeartbeatEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-stdinDone:
+			return err
+		case <-ticker.C:
+			if err := control.Touch(ctx, result.LeaseID); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func terminalSafeSSHPrompt(message string) string {
+	const hexadecimal = "0123456789abcdef"
+	var safe strings.Builder
+	for _, character := range message {
+		if character > 0x1f && (character < 0x7f || character > 0x9f) {
+			safe.WriteRune(character)
+			continue
+		}
+		safe.WriteString(`\x`)
+		safe.WriteByte(hexadecimal[byte(character)>>4])
+		safe.WriteByte(hexadecimal[byte(character)&0x0f])
+	}
+	return safe.String()
+}
+
+type sshPromptRead struct {
+	value string
+	err   error
+}
+
+func readSSHPrompt(ctx context.Context, read func() (string, error)) (string, error) {
+	result := make(chan sshPromptRead, 1)
+	go func() {
+		value, err := read()
+		result <- sshPromptRead{value: value, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case response := <-result:
+		return response.value, response.err
+	}
+}
+
+func writeSSHLeaseFailure(cmd *cobra.Command, err error) error {
+	return writeSSHLeaseFailureRecord(cmd, err, sshLeaseJSON)
+}
+
+func writeSSHLeaseFailureRecord(cmd *cobra.Command, err error, emitJSON bool) error {
+	typed := service.AsError(err)
+	exitCode := 1
+	if typed.Code == service.InvalidRequest || typed.Code == service.SSHInvalidTarget {
+		exitCode = 2
+	}
+	cmd.Root().SilenceUsage = true
+	cmd.Root().SilenceErrors = true
+	if emitJSON {
+		_ = json.NewEncoder(cmd.OutOrStdout()).Encode(jsonErrorEnvelope{Error: typed.Descriptor})
+	}
+	_, _ = fmt.Fprintf(
+		cmd.ErrOrStderr(),
+		"kwt ssh lease: %s: %s\n",
+		typed.Code,
+		typed.Message,
+	)
+	return errors.Join(&commandFailure{descriptor: typed.Descriptor, exitCode: exitCode}, err)
 }

--- a/internal/cmd/ssh_prompt.go
+++ b/internal/cmd/ssh_prompt.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/muesli/cancelreader"
+)
+
+func readTerminalPassword(
+	ctx context.Context,
+	terminal *os.File,
+) (value string, returnErr error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	reader, err := newTerminalPasswordReader(terminal)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, reader.Close())
+	}()
+
+	result := make(chan sshPromptRead, 1)
+	go func() {
+		line, readErr := bufio.NewReader(reader).ReadString('\n')
+		result <- sshPromptRead{
+			value: strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r"),
+			err:   readErr,
+		}
+	}()
+	select {
+	case response := <-result:
+		return response.value, response.err
+	case <-ctx.Done():
+		if reader.Cancel() {
+			<-result
+		}
+		return "", ctx.Err()
+	}
+}
+
+type terminalPasswordReader interface {
+	cancelreader.CancelReader
+}

--- a/internal/cmd/ssh_prompt_bsd.go
+++ b/internal/cmd/ssh_prompt_bsd.go
@@ -1,0 +1,17 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package cmd
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func getTerminalState(terminal *os.File) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(int(terminal.Fd()), unix.TIOCGETA)
+}
+
+func setTerminalState(terminal *os.File, state *unix.Termios) error {
+	return unix.IoctlSetTermios(int(terminal.Fd()), unix.TIOCSETA, state)
+}

--- a/internal/cmd/ssh_prompt_linux.go
+++ b/internal/cmd/ssh_prompt_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package cmd
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func getTerminalState(terminal *os.File) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(int(terminal.Fd()), unix.TCGETS)
+}
+
+func setTerminalState(terminal *os.File, state *unix.Termios) error {
+	return unix.IoctlSetTermios(int(terminal.Fd()), unix.TCSETS, state)
+}

--- a/internal/cmd/ssh_prompt_other.go
+++ b/internal/cmd/ssh_prompt_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !windows
+
+package cmd
+
+import (
+	"errors"
+	"os"
+)
+
+func newTerminalPasswordReader(*os.File) (terminalPasswordReader, error) {
+	return nil, errors.New("interruptible terminal password input is unsupported on this platform")
+}

--- a/internal/cmd/ssh_prompt_posix.go
+++ b/internal/cmd/ssh_prompt_posix.go
@@ -1,0 +1,52 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/muesli/cancelreader"
+	"golang.org/x/sys/unix"
+)
+
+func newTerminalPasswordReader(terminal *os.File) (terminalPasswordReader, error) {
+	original, err := getTerminalState(terminal)
+	if err != nil {
+		return nil, err
+	}
+	passwordState := *original
+	passwordState.Lflag &^= unix.ECHO
+	passwordState.Lflag |= unix.ICANON | unix.ISIG
+	passwordState.Iflag |= unix.ICRNL
+	if err := setTerminalState(terminal, &passwordState); err != nil {
+		return nil, err
+	}
+	reader, err := cancelreader.NewReader(terminal)
+	if err != nil {
+		return nil, errors.Join(err, setTerminalState(terminal, original))
+	}
+	return &restoringTerminalPasswordReader{
+		CancelReader: reader,
+		restore: func() error {
+			return setTerminalState(terminal, original)
+		},
+	}, nil
+}
+
+func terminalEchoEnabled(terminal *os.File) (bool, error) {
+	state, err := getTerminalState(terminal)
+	if err != nil {
+		return false, err
+	}
+	return state.Lflag&unix.ECHO != 0, nil
+}
+
+type restoringTerminalPasswordReader struct {
+	cancelreader.CancelReader
+	restore func() error
+}
+
+func (r *restoringTerminalPasswordReader) Close() error {
+	return errors.Join(r.CancelReader.Close(), r.restore())
+}

--- a/internal/cmd/ssh_prompt_posix_test.go
+++ b/internal/cmd/ssh_prompt_posix_test.go
@@ -1,0 +1,44 @@
+//go:build darwin || linux
+
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminalPasswordCancellationRestoresEcho(t *testing.T) {
+	master, terminal, err := pty.Open()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = master.Close()
+		_ = terminal.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, readErr := readTerminalPassword(ctx, terminal)
+		result <- readErr
+	}()
+	require.Eventually(t, func() bool {
+		enabled, stateErr := terminalEchoEnabled(terminal)
+		return stateErr == nil && !enabled
+	}, time.Second, time.Millisecond)
+	cancel()
+
+	select {
+	case readErr := <-result:
+		assert.ErrorIs(t, readErr, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("terminal password read did not stop after cancellation")
+	}
+	enabled, err := terminalEchoEnabled(terminal)
+	require.NoError(t, err)
+	assert.True(t, enabled)
+}

--- a/internal/cmd/ssh_prompt_windows.go
+++ b/internal/cmd/ssh_prompt_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/muesli/cancelreader"
+	"golang.org/x/sys/windows"
+)
+
+func newTerminalPasswordReader(terminal *os.File) (terminalPasswordReader, error) {
+	handle := windows.Handle(terminal.Fd())
+	var original uint32
+	if err := windows.GetConsoleMode(handle, &original); err != nil {
+		return nil, err
+	}
+	if err := windows.SetConsoleMode(handle, passwordConsoleMode(original)); err != nil {
+		return nil, err
+	}
+	reader, err := cancelreader.NewReader(terminal)
+	if err != nil {
+		return nil, errors.Join(err, windows.SetConsoleMode(handle, original))
+	}
+	return &windowsTerminalPasswordReader{
+		CancelReader: reader,
+		handle:       handle,
+		originalMode: original,
+	}, nil
+}
+
+func passwordConsoleMode(mode uint32) uint32 {
+	return mode &^ windows.ENABLE_ECHO_INPUT
+}
+
+type windowsTerminalPasswordReader struct {
+	cancelreader.CancelReader
+	handle       windows.Handle
+	originalMode uint32
+}
+
+func (r *windowsTerminalPasswordReader) Close() error {
+	return errors.Join(
+		r.CancelReader.Close(),
+		windows.SetConsoleMode(r.handle, r.originalMode),
+	)
+}

--- a/internal/cmd/ssh_prompt_windows_test.go
+++ b/internal/cmd/ssh_prompt_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestPasswordConsoleModeDisablesEcho(t *testing.T) {
+	original := uint32(
+		windows.ENABLE_ECHO_INPUT |
+			windows.ENABLE_LINE_INPUT |
+			windows.ENABLE_PROCESSED_INPUT,
+	)
+	mode := passwordConsoleMode(original)
+
+	assert.Zero(t, mode&windows.ENABLE_ECHO_INPUT)
+	assert.Equal(t, original&^uint32(windows.ENABLE_ECHO_INPUT), mode)
+}

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -97,6 +100,320 @@ func TestRequireSSHResolveCapabilityFailsClosed(t *testing.T) {
 	err := requireSSHResolveCapability(kwtdaemon.Observation{})
 	require.Error(t, err)
 	assert.True(t, service.IsCode(err, service.DaemonIncompatible))
+}
+
+type fakeSSHLeaseControl struct {
+	touches    int
+	releases   int
+	touchErr   error
+	releaseErr error
+}
+
+type failingSSHOutput struct{ err error }
+
+func (w failingSSHOutput) Write([]byte) (int, error) { return 0, w.err }
+
+func (c *fakeSSHLeaseControl) Touch(context.Context, string) error {
+	c.touches++
+	return c.touchErr
+}
+
+func (c *fakeSSHLeaseControl) Release(context.Context, string) error {
+	c.releases++
+	return c.releaseErr
+}
+
+func TestSSHLeaseCommandStreamsPromptsAndReleasesOnEOF(t *testing.T) {
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+	t.Cleanup(func() {
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+	})
+	sshLeaseJSON = true
+	sshLeaseRouteIdentity = "route-one"
+	control := &fakeSSHLeaseControl{}
+	acquireSSHLeaseThroughDaemon = func(
+		ctx context.Context,
+		request kwt.SSHLeaseRequest,
+		callbacks kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		assert.Equal(t, "route-one", request.Snapshot.RouteIdentity)
+		prompt := service.OperationPrompt{
+			ID: "prompt-1", Kind: "password", Message: "Password:\x1b]52;c;ignored\x07",
+			Sensitive: true,
+		}
+		require.NoError(t, callbacks.Event(service.OperationEvent{
+			OperationID: "operation-1", Sequence: 1,
+			Kind: service.OperationEventPrompt, Prompt: &prompt,
+		}))
+		value, err := callbacks.Prompt(ctx, prompt)
+		require.NoError(t, err)
+		assert.Equal(t, "secret", value)
+		result := kwtdaemon.SSHLeaseResult{
+			LeaseID: "lease-1", RouteIdentity: "route-one", Generation: 9,
+			Mode: kwt.SSHLeaseModeMultiplexed, Arguments: []string{"-S", "/private/control"},
+		}
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.NoError(t, callbacks.Event(service.OperationEvent{
+			OperationID: "operation-1", Sequence: 2,
+			Kind: service.OperationEventComplete, Result: encoded,
+		}))
+		return result, control, nil
+	}
+	command, stdout, stderr := sshResolveTestCommand()
+	command.SetIn(strings.NewReader(`{"prompt_id":"prompt-1","value":"secret"}` + "\n"))
+
+	require.NoError(t, runSSHLease(command, []string{"build.example.test"}))
+	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, 0, control.touches)
+	assert.Empty(t, stderr.String())
+	decoder := json.NewDecoder(stdout)
+	var promptEvent, completeEvent service.OperationEvent
+	require.NoError(t, decoder.Decode(&promptEvent))
+	require.NoError(t, decoder.Decode(&completeEvent))
+	assert.Equal(t, service.OperationEventPrompt, promptEvent.Kind)
+	require.NotNil(t, promptEvent.Prompt)
+	assert.Equal(t, "Password:\x1b]52;c;ignored\x07", promptEvent.Prompt.Message)
+	assert.Equal(t, service.OperationEventComplete, completeEvent.Kind)
+	_, err := decoder.Token()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestSSHLeaseHumanPromptEscapesTerminalControls(t *testing.T) {
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+	t.Cleanup(func() {
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+	})
+	sshLeaseJSON = false
+	sshLeaseRouteIdentity = "route-one"
+	message := "Password:\x1b]52;c;ignored\x07\r\nNext\x7f\u0085"
+	acquireSSHLeaseThroughDaemon = func(
+		ctx context.Context,
+		_ kwt.SSHLeaseRequest,
+		callbacks kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		value, err := callbacks.Prompt(ctx, service.OperationPrompt{
+			ID: "prompt-1", Message: message, Sensitive: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "secret", value)
+		return kwtdaemon.SSHLeaseResult{}, nil, service.NewError(
+			service.SSHPromptRejected, "SSH prompt rejected", false, nil, nil,
+		)
+	}
+	command, _, stderr := sshResolveTestCommand()
+	command.SetIn(strings.NewReader("secret\n"))
+
+	err := runSSHLease(command, []string{"build.example.test"})
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(),
+		`Password:\x1b]52;c;ignored\x07\x0d\x0aNext\x7f\x85 `)
+	assert.NotContains(t, stderr.String(), "\x1b")
+	assert.NotContains(t, stderr.String(), "\x07")
+	assert.NotContains(t, stderr.String(), "\r")
+	assert.NotContains(t, stderr.String(), "\x7f")
+	assert.NotContains(t, stderr.String(), "\u0085")
+}
+
+func TestSSHLeasePromptReadStopsWhenContextIsCanceled(t *testing.T) {
+	for _, jsonMode := range []bool{false, true} {
+		t.Run(fmt.Sprintf("json=%t", jsonMode), func(t *testing.T) {
+			oldAcquire := acquireSSHLeaseThroughDaemon
+			oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+			t.Cleanup(func() {
+				acquireSSHLeaseThroughDaemon = oldAcquire
+				sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+			})
+			sshLeaseJSON = jsonMode
+			sshLeaseRouteIdentity = "route-one"
+			promptStarted := make(chan struct{})
+			acquireSSHLeaseThroughDaemon = func(
+				ctx context.Context,
+				_ kwt.SSHLeaseRequest,
+				callbacks kwtdaemon.OperationCallbacks,
+			) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+				close(promptStarted)
+				_, err := callbacks.Prompt(ctx, service.OperationPrompt{
+					ID: "prompt-1", Message: "Password:", Sensitive: true,
+				})
+				return kwtdaemon.SSHLeaseResult{}, nil, err
+			}
+			reader, writer := io.Pipe()
+			t.Cleanup(func() {
+				_ = reader.Close()
+				_ = writer.Close()
+			})
+			ctx, cancel := context.WithCancel(context.Background())
+			command, _, _ := sshResolveTestCommand()
+			command.SetContext(ctx)
+			command.SetIn(reader)
+			done := make(chan error, 1)
+			go func() { done <- runSSHLease(command, []string{"build.example.test"}) }()
+			<-promptStarted
+			cancel()
+
+			select {
+			case err := <-done:
+				require.Error(t, err)
+			case <-time.After(time.Second):
+				t.Fatal("SSH prompt read did not stop after cancellation")
+			}
+		})
+	}
+}
+
+func TestSSHLeaseJSONWritesOneCompactFailureRecord(t *testing.T) {
+	for _, terminalEvent := range []bool{false, true} {
+		t.Run(fmt.Sprintf("terminal=%t", terminalEvent), func(t *testing.T) {
+			oldAcquire := acquireSSHLeaseThroughDaemon
+			oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+			t.Cleanup(func() {
+				acquireSSHLeaseThroughDaemon = oldAcquire
+				sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+			})
+			sshLeaseJSON = true
+			sshLeaseRouteIdentity = "route-one"
+			failure := service.Descriptor{
+				Code: service.SSHConnectionFailed, Message: "connection failed",
+			}
+			acquireSSHLeaseThroughDaemon = func(
+				_ context.Context,
+				_ kwt.SSHLeaseRequest,
+				callbacks kwtdaemon.OperationCallbacks,
+			) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+				if terminalEvent {
+					require.NoError(t, callbacks.Event(service.OperationEvent{
+						OperationID: "operation-1", Sequence: 1,
+						Kind: service.OperationEventComplete, Failure: &failure,
+					}))
+				}
+				return kwtdaemon.SSHLeaseResult{}, nil, service.NewDescriptorError(failure, nil)
+			}
+			command, stdout, _ := sshResolveTestCommand()
+
+			err := runSSHLease(command, []string{"build.example.test"})
+			require.Error(t, err)
+			assert.Equal(t, 1, strings.Count(stdout.String(), "\n"))
+			assert.NotContains(t, stdout.String(), "\n  ")
+			if terminalEvent {
+				var event service.OperationEvent
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &event))
+				assert.Equal(t, service.OperationEventComplete, event.Kind)
+			} else {
+				var envelope jsonErrorEnvelope
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+				assert.Equal(t, service.SSHConnectionFailed, envelope.Error.Code)
+			}
+		})
+	}
+}
+
+func TestSSHLeaseReleasesAcquiredLeaseWhenTerminalOutputFails(t *testing.T) {
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+	t.Cleanup(func() {
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+	})
+	sshLeaseJSON = true
+	sshLeaseRouteIdentity = "route-one"
+	control := &fakeSSHLeaseControl{}
+	writeErr := errors.New("output closed")
+	acquireSSHLeaseThroughDaemon = func(
+		_ context.Context,
+		_ kwt.SSHLeaseRequest,
+		callbacks kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		result := kwtdaemon.SSHLeaseResult{LeaseID: "lease-1"}
+		encoded, err := json.Marshal(result)
+		require.NoError(t, err)
+		err = callbacks.Event(service.OperationEvent{
+			OperationID: "operation-1", Sequence: 1,
+			Kind: service.OperationEventComplete, Result: encoded,
+		})
+		return result, control, err
+	}
+	command, _, _ := sshResolveTestCommand()
+	command.SetOut(failingSSHOutput{err: writeErr})
+
+	err := runSSHLease(command, []string{"build.example.test"})
+	require.Error(t, err)
+	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, 0, control.touches)
+}
+
+func TestSSHLeaseJSONWritesHeartbeatFailure(t *testing.T) {
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+	oldHeartbeat := sshLeaseHeartbeatEvery
+	t.Cleanup(func() {
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+		sshLeaseHeartbeatEvery = oldHeartbeat
+	})
+	sshLeaseJSON = true
+	sshLeaseRouteIdentity = "route-one"
+	sshLeaseHeartbeatEvery = time.Millisecond
+	control := &fakeSSHLeaseControl{touchErr: service.NewError(
+		service.SSHConnectionChanged, "SSH connection changed", false, nil, nil,
+	)}
+	acquireSSHLeaseThroughDaemon = func(
+		context.Context,
+		kwt.SSHLeaseRequest,
+		kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		return kwtdaemon.SSHLeaseResult{LeaseID: "lease-1"}, control, nil
+	}
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+	command, stdout, _ := sshResolveTestCommand()
+	command.SetIn(reader)
+
+	err := runSSHLease(command, []string{"build.example.test"})
+	require.Error(t, err)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.SSHConnectionChanged, envelope.Error.Code)
+	assert.Equal(t, 1, control.touches)
+	assert.Equal(t, 1, control.releases)
+}
+
+func TestSSHLeaseJSONWritesReleaseFailure(t *testing.T) {
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+	t.Cleanup(func() {
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+	})
+	sshLeaseJSON = true
+	sshLeaseRouteIdentity = "route-one"
+	control := &fakeSSHLeaseControl{releaseErr: service.NewError(
+		service.SSHCleanupFailed, "SSH cleanup failed", true, nil, nil,
+	)}
+	acquireSSHLeaseThroughDaemon = func(
+		context.Context,
+		kwt.SSHLeaseRequest,
+		kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		return kwtdaemon.SSHLeaseResult{LeaseID: "lease-1"}, control, nil
+	}
+	command, stdout, _ := sshResolveTestCommand()
+	command.SetIn(strings.NewReader(""))
+
+	err := runSSHLease(command, []string{"build.example.test"})
+	require.Error(t, err)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.SSHCleanupFailed, envelope.Error.Code)
+	assert.Equal(t, 0, control.touches)
+	assert.Equal(t, 1, control.releases)
 }
 
 func sshResolveTestCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {

--- a/internal/cmd/testdata/daemonfixture/main.go
+++ b/internal/cmd/testdata/daemonfixture/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -72,11 +73,19 @@ func main() {
 		log.Fatal(err)
 	}
 	if *mode == "unresponsive" {
-		_ = listener.Close()
 		if err := os.WriteFile(*ready, []byte("ready"), 0o600); err != nil {
 			log.Fatal(err)
 		}
-		select {}
+		for {
+			connection, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				log.Fatal(acceptErr)
+			}
+			go func(connection net.Conn) {
+				defer connection.Close()
+				_, _ = io.Copy(io.Discard, connection)
+			}(connection)
+		}
 	}
 
 	proof, err := kitdaemon.NewProof([]byte(token))

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -213,6 +213,108 @@ func (c *Client) ResolveSSH(
 	return result, err
 }
 
+func (c *Client) AcquireSSH(
+	ctx context.Context,
+	request kwt.SSHLeaseRequest,
+	callbacks OperationCallbacks,
+) (SSHLeaseResult, error) {
+	missingPromptHandler := errors.New("SSH prompt handler is unavailable")
+	if callbacks.Prompt == nil {
+		callbacks.Prompt = func(context.Context, service.OperationPrompt) (string, error) {
+			return "", missingPromptHandler
+		}
+	}
+	snapshot, err := config.LoadGlobalSnapshot()
+	if err != nil {
+		return SSHLeaseResult{}, err
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return SSHLeaseResult{}, err
+	}
+	workingDirectory, err = filepath.Abs(workingDirectory)
+	if err != nil {
+		return SSHLeaseResult{}, err
+	}
+	request.WorkingDirectory = workingDirectory
+	request.Environment = credentials.StripEnvironment(
+		os.Environ(),
+		credentials.ProtectedNames(snapshot.Config),
+	)
+	operationID, err := randomOperationID()
+	if err != nil {
+		return SSHLeaseResult{}, err
+	}
+	accepted := SSHLeaseOperation{OperationID: operationID}
+	startErr := c.doWith(
+		ctx,
+		c.operationHTTP,
+		controlResponseLimit,
+		http.MethodPost,
+		sshLeaseRoute,
+		SSHLeaseOperationRequest{OperationID: operationID, Lease: request},
+		&accepted,
+	)
+	if startErr != nil && !service.IsCode(startErr, service.DaemonTransportFailed) {
+		return SSHLeaseResult{}, startErr
+	}
+	raw, followErr := c.FollowOperation(ctx, operationID, 0, callbacks)
+	var result SSHLeaseResult
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &result); err != nil {
+			return SSHLeaseResult{}, errors.Join(followErr, service.NewError(
+				service.Internal,
+				"internal failure",
+				false,
+				nil,
+				err,
+			))
+		}
+	}
+	if errors.Is(followErr, missingPromptHandler) {
+		return result, service.NewError(
+			service.SSHInteractionRequired,
+			"SSH interaction is required",
+			false,
+			nil,
+			errors.Join(followErr, startErr),
+		)
+	}
+	if followErr != nil {
+		return result, errors.Join(followErr, startErr)
+	}
+	if len(raw) == 0 {
+		return SSHLeaseResult{}, service.NewError(
+			service.Internal,
+			"internal failure",
+			false,
+			nil,
+			errors.New("SSH lease operation returned an empty result"),
+		)
+	}
+	return result, nil
+}
+
+func (c *Client) TouchSSHLease(ctx context.Context, leaseID string) error {
+	if leaseID == "" {
+		return service.NewError(service.InvalidRequest, "SSH lease ID is empty", false, nil, nil)
+	}
+	return c.doWith(
+		ctx, c.controlHTTP, controlResponseLimit,
+		http.MethodPost, sshLeaseRoute+"/"+leaseID+"/touch", nil, nil,
+	)
+}
+
+func (c *Client) ReleaseSSHLease(ctx context.Context, leaseID string) error {
+	if leaseID == "" {
+		return service.NewError(service.InvalidRequest, "SSH lease ID is empty", false, nil, nil)
+	}
+	return c.doWith(
+		ctx, c.controlHTTP, controlResponseLimit,
+		http.MethodDelete, sshLeaseRoute+"/"+leaseID, nil, nil,
+	)
+}
+
 func (c *Client) RemoveWorktree(
 	ctx context.Context,
 	request kwt.RemovalRequest,
@@ -607,6 +709,14 @@ func problemCode(code service.Code) (service.Code, bool) {
 		service.SSHResolutionFailed,
 		service.SSHRouteUnreviewable,
 		service.SSHConfigurationChanged,
+		service.SSHUnsupportedVersion,
+		service.SSHInteractionRequired,
+		service.SSHPromptRejected,
+		service.SSHPromptTimedOut,
+		service.SSHConnectionFailed,
+		service.SSHConnectionChanged,
+		service.SSHControlPathOccupied,
+		service.SSHCleanupFailed,
 		service.Internal:
 		return code, true
 	default:

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -39,6 +40,7 @@ type ServeOptions struct {
 	Remover           kwt.Remover
 	ProjectRemover    kwt.ProjectRemover
 	SSHResolver       SSHResolver
+	SSHLifecycle      SSHLifecycle
 }
 
 type hostStatus struct {
@@ -176,6 +178,7 @@ func runHost(
 	remover := opts.Remover
 	projectRemover := opts.ProjectRemover
 	sshResolver := opts.SSHResolver
+	sshLifecycle := opts.SSHLifecycle
 	var cacheDiagnostic *kwt.Diagnostic
 	if inventory == nil {
 		cache, diagnostic, cacheErr := kwt.NewFileCache(opts.Home)
@@ -210,12 +213,19 @@ func runHost(
 		if executableErr != nil {
 			return executableErr
 		}
-		sshResolver = kwt.NewSSHService(kwt.SSHServiceOptions{
+		serviceOwner := kwt.NewSSHService(kwt.SSHServiceOptions{
 			Home:              opts.Home,
 			AskpassExecutable: executable,
 			Now:               opts.Now,
 		})
+		sshResolver = serviceOwner
+		if sshLifecycle == nil {
+			sshLifecycle = serviceOwner
+		}
+	} else if sshLifecycle == nil {
+		sshLifecycle, _ = sshResolver.(SSHLifecycle)
 	}
+	sshLeases := newSSHLeaseRegistry(gate, opts.Now, 0)
 	status := &hostStatus{
 		base: Status{
 			Service:       ServiceName,
@@ -233,6 +243,7 @@ func runHost(
 				CapabilityStatus,
 				CapabilityOperationStream,
 				CapabilityProjectRemoval,
+				CapabilitySSHLifecycle,
 				CapabilitySSHResolve,
 				CapabilityInventory,
 				CapabilityRemoval,
@@ -273,6 +284,8 @@ func runHost(
 		ProjectRemover: projectRemover,
 		Operations:     operations,
 		SSHResolver:    sshResolver,
+		SSHLifecycle:   sshLifecycle,
+		SSHLeases:      sshLeases,
 		Gate:           gate,
 		ReportError: func(
 			route string,
@@ -351,7 +364,10 @@ func runHost(
 	sshCleanupCtx, cancelSSHCleanup := context.WithTimeout(
 		context.Background(), forcedDrainCleanup,
 	)
-	sshCleanupErr := closeSSHResolver(sshCleanupCtx, sshResolver)
+	sshCleanupErr := errors.Join(
+		sshLeases.close(sshCleanupCtx),
+		closeSSHOwners(sshCleanupCtx, sshResolver, sshLifecycle),
+	)
 	cancelSSHCleanup()
 	var cleanupErr error
 	if drainResult != DrainReleased {
@@ -368,14 +384,33 @@ func runHost(
 	return stopErr
 }
 
-func closeSSHResolver(ctx context.Context, resolver SSHResolver) error {
-	owner, ok := resolver.(interface {
-		Close(context.Context) error
-	})
-	if !ok {
-		return nil
+type sshOwner interface {
+	Close(context.Context) error
+}
+
+func closeSSHOwners(
+	ctx context.Context,
+	resolver SSHResolver,
+	lifecycle SSHLifecycle,
+) error {
+	resolverOwner, resolverOwned := resolver.(sshOwner)
+	lifecycleOwner, lifecycleOwned := lifecycle.(sshOwner)
+	if resolverOwned && lifecycleOwned && sameSSHOwner(resolverOwner, lifecycleOwner) {
+		return resolverOwner.Close(ctx)
 	}
-	return owner.Close(ctx)
+	var resolverErr, lifecycleErr error
+	if resolverOwned {
+		resolverErr = resolverOwner.Close(ctx)
+	}
+	if lifecycleOwned {
+		lifecycleErr = lifecycleOwner.Close(ctx)
+	}
+	return errors.Join(resolverErr, lifecycleErr)
+}
+
+func sameSSHOwner(left, right sshOwner) bool {
+	leftType := reflect.TypeOf(left)
+	return leftType == reflect.TypeOf(right) && leftType.Comparable() && left == right
 }
 
 func newHostOperationContext(hostContext context.Context) (context.Context, context.CancelFunc) {

--- a/internal/daemon/operation.go
+++ b/internal/daemon/operation.go
@@ -689,6 +689,10 @@ func (h *OperationHub) finish(
 }
 
 func operationFailure(err error) service.Descriptor {
+	var typed *service.Error
+	if errors.As(err, &typed) {
+		return publicErrorDescriptor(err)
+	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return service.Descriptor{
 			Code: service.OperationOutcomeUnknown, Message: "operation was canceled", Retryable: false,

--- a/internal/daemon/operation_client.go
+++ b/internal/daemon/operation_client.go
@@ -51,7 +51,7 @@ func (c *Client) FollowOperation(
 		}
 		sequence = lastSequence
 		if !errors.Is(err, errOperationStreamInterrupted) {
-			return nil, err
+			return result, err
 		}
 		if ctx.Err() != nil || attempt == 1 {
 			return nil, operationOutcomeUnknown("operation stream outcome is unknown", err)
@@ -144,8 +144,18 @@ func (c *Client) followOperationAttempt(
 		sequence := event.Sequence
 		if event.Kind == service.OperationEventComplete {
 			acknowledgedSequence = sequence
+			var callbackErr error
 			if callbacks.Event != nil {
-				_ = callbacks.Event(event)
+				callbackErr = callbacks.Event(event)
+			}
+			if callbackErr != nil {
+				if event.Failure != nil {
+					callbackErr = errors.Join(
+						callbackErr,
+						service.NewDescriptorError(*event.Failure, nil),
+					)
+				}
+				return event.Result, acknowledgedSequence, callbackErr
 			}
 			if event.Failure != nil {
 				return nil, acknowledgedSequence, service.NewDescriptorError(*event.Failure, nil)
@@ -172,21 +182,42 @@ func (c *Client) followOperationAttempt(
 					nil,
 				)
 			}
-			value, err := callbacks.Prompt(ctx, *event.Prompt)
+			promptContext := ctx
+			cancelPrompt := func() {}
+			if event.Prompt.Deadline != nil {
+				promptContext, cancelPrompt = context.WithDeadline(ctx, *event.Prompt.Deadline)
+			}
+			value, err := callbacks.Prompt(promptContext, *event.Prompt)
+			promptTimedOut := errors.Is(promptContext.Err(), context.DeadlineExceeded) &&
+				ctx.Err() == nil
+			if promptTimedOut {
+				cancelPrompt()
+				acknowledgedSequence = sequence
+				continue
+			}
 			if err != nil {
+				cancelPrompt()
 				cancelErr := c.cancelOperationBestEffort(ctx, operationID)
 				return nil, acknowledgedSequence, operationOutcomeUnknown(
 					"operation outcome is unknown after prompt handling failed",
 					errors.Join(err, cancelErr),
 				)
 			}
-			if err := c.sendOperationResponse(ctx, operationID, service.OperationResponse{
+			responseErr := c.sendOperationResponse(promptContext, operationID, service.OperationResponse{
 				PromptID: event.Prompt.ID,
 				Value:    value,
-			}); err != nil {
+			})
+			promptTimedOut = errors.Is(promptContext.Err(), context.DeadlineExceeded) &&
+				ctx.Err() == nil
+			cancelPrompt()
+			if responseErr != nil {
+				if ctx.Err() == nil && (promptTimedOut || service.IsCode(responseErr, service.Conflict)) {
+					acknowledgedSequence = sequence
+					continue
+				}
 				return nil, acknowledgedSequence, operationOutcomeUnknown(
 					"operation prompt response outcome is unknown",
-					err,
+					responseErr,
 				)
 			}
 			acknowledgedSequence = sequence

--- a/internal/daemon/operation_client_test.go
+++ b/internal/daemon/operation_client_test.go
@@ -120,6 +120,103 @@ func TestOperationClientHandlesMultipleBoundPromptRounds(t *testing.T) {
 	assert.Equal(t, service.OperationResponse{PromptID: "prompt-2"}, second)
 }
 
+func TestOperationClientWaitsForTerminalFailureAfterPromptDeadline(t *testing.T) {
+	deadline := time.Now().Add(30 * time.Millisecond)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		flusher := w.(http.Flusher)
+		encoder := json.NewEncoder(w)
+		_ = encoder.Encode(service.OperationEvent{
+			OperationID: "operation-1", Sequence: 1,
+			Kind: service.OperationEventPrompt,
+			Prompt: &service.OperationPrompt{
+				ID: "prompt-1", Kind: "password", Message: "Password:",
+				Sensitive: true, Deadline: &deadline,
+			},
+		})
+		flusher.Flush()
+		time.Sleep(50 * time.Millisecond)
+		_ = encoder.Encode(service.OperationEvent{
+			OperationID: "operation-1", Sequence: 2,
+			Kind: service.OperationEventComplete,
+			Failure: &service.Descriptor{
+				Code: service.SSHPromptTimedOut, Message: "SSH prompt timed out",
+			},
+		})
+		flusher.Flush()
+	}))
+	defer server.Close()
+	client := clientForUnverifiedServer(t, server, "secret")
+	var observedDeadline time.Time
+
+	_, err := client.FollowOperation(
+		context.Background(), "operation-1", 0,
+		OperationCallbacks{Prompt: func(ctx context.Context, _ service.OperationPrompt) (string, error) {
+			observedDeadline, _ = ctx.Deadline()
+			<-ctx.Done()
+			return "", ctx.Err()
+		}},
+	)
+	assert.True(t, service.IsCode(err, service.SSHPromptTimedOut), err)
+	assert.WithinDuration(t, deadline, observedDeadline, time.Millisecond)
+}
+
+func TestOperationClientWaitsForTerminalFailureWhenPromptExpiresDuringResponse(t *testing.T) {
+	deadline := time.Now().Add(500 * time.Millisecond)
+	responseStarted := make(chan struct{})
+	responseFinished := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/events"):
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			flusher := w.(http.Flusher)
+			encoder := json.NewEncoder(w)
+			_ = encoder.Encode(service.OperationEvent{
+				OperationID: "operation-1", Sequence: 1,
+				Kind: service.OperationEventPrompt,
+				Prompt: &service.OperationPrompt{
+					ID: "prompt-1", Kind: "password", Message: "Password:",
+					Sensitive: true, Deadline: &deadline,
+				},
+			})
+			flusher.Flush()
+			<-responseFinished
+			_ = encoder.Encode(service.OperationEvent{
+				OperationID: "operation-1", Sequence: 2,
+				Kind: service.OperationEventComplete,
+				Failure: &service.Descriptor{
+					Code: service.SSHPromptTimedOut, Message: "SSH prompt timed out",
+				},
+			})
+			flusher.Flush()
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/responses"):
+			close(responseStarted)
+			time.Sleep(time.Until(deadline) + 10*time.Millisecond)
+			writeProblem(w, newProblem(http.StatusConflict, service.Descriptor{
+				Code: service.Conflict, Message: "operation prompt is no longer current",
+			}))
+			close(responseFinished)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := clientForUnverifiedServer(t, server, "secret")
+
+	_, err := client.FollowOperation(
+		context.Background(), "operation-1", 0,
+		OperationCallbacks{Prompt: func(context.Context, service.OperationPrompt) (string, error) {
+			return "secret", nil
+		}},
+	)
+	assert.True(t, service.IsCode(err, service.SSHPromptTimedOut), err)
+	select {
+	case <-responseStarted:
+	default:
+		require.Fail(t, "prompt response was not submitted")
+	}
+}
+
 func TestOperationClientReconnectReplaysUnansweredPrompt(t *testing.T) {
 	var streamRequests atomic.Int32
 	var promptCalls atomic.Int32
@@ -251,13 +348,14 @@ func TestOperationClientTerminalResultSurvivesEventCallbackFailure(t *testing.T)
 	defer server.Close()
 	client := clientForUnverifiedServer(t, server, "secret")
 
+	callbackErr := errors.New("completion writer failed")
 	result, err := client.FollowOperation(
 		context.Background(), "operation-1", 0,
 		OperationCallbacks{Event: func(service.OperationEvent) error {
-			return errors.New("completion writer failed")
+			return callbackErr
 		}},
 	)
-	require.NoError(t, err)
+	assert.ErrorIs(t, err, callbackErr)
 	assert.JSONEq(t, `{"status":"ready"}`, string(result))
 }
 

--- a/internal/daemon/operation_test.go
+++ b/internal/daemon/operation_test.go
@@ -78,6 +78,33 @@ func TestOperationHubPublishesSanitizedTerminalFailure(t *testing.T) {
 	}
 }
 
+func TestOperationHubPreservesTypedPromptTimeout(t *testing.T) {
+	hub := NewOperationHub(context.Background(), OperationHubOptions{})
+	operation, _, err := hub.Start(OperationStart{
+		RequestDigest: "request-1",
+		Run: func(context.Context, *Operation) (json.RawMessage, error) {
+			return nil, service.NewError(
+				service.SSHPromptTimedOut,
+				"SSH prompt timed out",
+				false,
+				nil,
+				context.DeadlineExceeded,
+			)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := collectOperationEvents(t, hub, operation.ID(), 0)
+	if len(events) != 1 || events[0].Failure == nil {
+		t.Fatalf("unexpected operation events: %#v", events)
+	}
+	failure := events[0].Failure
+	if failure.Code != service.SSHPromptTimedOut || failure.Message != "SSH prompt timed out" {
+		t.Fatalf("prompt-timeout failure = %#v", failure)
+	}
+}
+
 func TestOperationHubPublishesInternalFailureForMalformedResult(t *testing.T) {
 	hub := NewOperationHub(context.Background(), OperationHubOptions{})
 	operation, _, err := hub.Start(OperationStart{

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -96,6 +96,7 @@ func NewRuntimeRecord(
 			CapabilityStatus,
 			CapabilityOperationStream,
 			CapabilityProjectRemoval,
+			CapabilitySSHLifecycle,
 			CapabilitySSHResolve,
 			CapabilityInventory,
 			CapabilityRemoval,

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -26,22 +26,29 @@ type SSHResolver interface {
 	Resolve(context.Context, kwt.SSHResolveRequest) (kwt.SSHRouteSnapshot, error)
 }
 
+type SSHLifecycle interface {
+	Acquire(context.Context, kwt.SSHLeaseRequest) (kwt.SSHLease, error)
+}
+
 type ServerOptions struct {
-	Token          string
-	ExpectedHost   string
-	Status         StatusProvider
-	Shutdown       ShutdownFunc
-	Ping           http.Handler
-	Touch          func(time.Time)
-	Now            func() time.Time
-	MaxBodyBytes   int64
-	Inventory      kwt.Inventory
-	Remover        kwt.Remover
-	ProjectRemover kwt.ProjectRemover
-	Operations     *OperationHub
-	SSHResolver    SSHResolver
-	Gate           *Gate
-	ReportError    func(string, *service.Error, kwt.ExpansionContext)
+	Token           string
+	ExpectedHost    string
+	Status          StatusProvider
+	Shutdown        ShutdownFunc
+	Ping            http.Handler
+	Touch           func(time.Time)
+	Now             func() time.Time
+	MaxBodyBytes    int64
+	Inventory       kwt.Inventory
+	Remover         kwt.Remover
+	ProjectRemover  kwt.ProjectRemover
+	Operations      *OperationHub
+	SSHResolver     SSHResolver
+	SSHLifecycle    SSHLifecycle
+	SSHLeaseTimeout time.Duration
+	SSHLeases       *sshLeaseRegistry
+	Gate            *Gate
+	ReportError     func(string, *service.Error, kwt.ExpansionContext)
 }
 
 type emptyInput struct{}
@@ -74,6 +81,7 @@ func NewServer(opts ServerOptions) http.Handler {
 	}
 	mux := http.NewServeMux()
 	registerOperationRoutes(mux, opts.Operations, opts)
+	registerSSHLifecycleRoutes(mux, opts)
 	config := huma.DefaultConfig("kwt daemon API", APISchemaVersion)
 	config.OpenAPIPath = "/openapi"
 	config.DocsPath = ""
@@ -295,11 +303,12 @@ func secureLocalHandler(next http.Handler, opts ServerOptions) http.Handler {
 		status := opts.Status.Status(now)
 		shutdownPath := r.URL.Path == "/api/v1/daemon/shutdown"
 		operationPath := strings.HasPrefix(r.URL.Path, operationRoutePrefix)
+		leaseControlPath := drainingSSHLeaseControl(r.Method, r.URL.Path)
 		if opts.Touch != nil && (!shutdownPath || status.State != StateDraining) {
 			opts.Touch(now)
 		}
 		if status.State == StateDraining &&
-			r.URL.Path != "/api/v1/status" && !shutdownPath && !operationPath {
+			r.URL.Path != "/api/v1/status" && !shutdownPath && !operationPath && !leaseControlPath {
 			if status.DrainDeadline != nil {
 				retryAfter := status.DrainDeadline.Sub(now)
 				seconds := int64(retryAfter / time.Second)
@@ -325,6 +334,22 @@ func secureLocalHandler(next http.Handler, opts ServerOptions) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func drainingSSHLeaseControl(method, path string) bool {
+	const prefix = "/api/v1/ssh/leases/"
+	remainder, ok := strings.CutPrefix(path, prefix)
+	if !ok || remainder == "" {
+		return false
+	}
+	if method == http.MethodDelete {
+		return !strings.Contains(remainder, "/")
+	}
+	if method != http.MethodPost {
+		return false
+	}
+	leaseID, suffix, ok := strings.Cut(remainder, "/")
+	return ok && leaseID != "" && suffix == "touch"
 }
 
 func writeProblem(w http.ResponseWriter, problem Problem) {
@@ -383,7 +408,9 @@ func problemFromError(err error) *Problem {
 		status = http.StatusNotFound
 	case service.Conflict, service.ConnectionChanged, service.OperationIDConflict,
 		service.RegistrationChanged, service.ProtectedSessionLive,
-		service.SSHRouteUnreviewable, service.SSHConfigurationChanged:
+		service.SSHRouteUnreviewable, service.SSHConfigurationChanged,
+		service.SSHPromptRejected, service.SSHConnectionChanged,
+		service.SSHControlPathOccupied:
 		status = http.StatusConflict
 	case service.ProtectedEndpointInventoryIncomplete:
 		if descriptor.Retryable {
@@ -393,15 +420,18 @@ func problemFromError(err error) *Problem {
 		}
 	case service.DaemonDowngradeRefused, service.DaemonBuildOrderUnknown:
 		status = http.StatusConflict
-	case service.InteractionRequired:
+	case service.InteractionRequired, service.SSHInteractionRequired:
 		status = http.StatusPreconditionRequired
 	case service.Busy, service.DaemonStartFailed, service.DaemonUnresponsive,
 		service.DaemonDraining, service.InventoryTimeout,
-		service.OperationCapacityExhausted, service.SSHResolutionFailed:
+		service.OperationCapacityExhausted, service.SSHResolutionFailed,
+		service.SSHConnectionFailed, service.SSHCleanupFailed:
 		status = http.StatusServiceUnavailable
+	case service.SSHPromptTimedOut:
+		status = http.StatusRequestTimeout
 	case service.OperationOutcomeUnknown:
 		status = http.StatusConflict
-	case service.Unsupported:
+	case service.Unsupported, service.SSHUnsupportedVersion:
 		status = http.StatusNotImplemented
 	case service.DaemonIncompatible:
 		status = http.StatusUpgradeRequired

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -231,6 +231,34 @@ func TestProblemRoundTripsServiceDescriptor(t *testing.T) {
 	assert.NotContains(t, string(encoded), "private cause")
 }
 
+func TestSSHProblemCodesRoundTrip(t *testing.T) {
+	codes := []service.Code{
+		service.SSHInvalidTarget,
+		service.SSHResolutionFailed,
+		service.SSHRouteUnreviewable,
+		service.SSHConfigurationChanged,
+		service.SSHUnsupportedVersion,
+		service.SSHInteractionRequired,
+		service.SSHPromptRejected,
+		service.SSHPromptTimedOut,
+		service.SSHConnectionFailed,
+		service.SSHConnectionChanged,
+		service.SSHControlPathOccupied,
+		service.SSHCleanupFailed,
+	}
+	for _, code := range codes {
+		t.Run(string(code), func(t *testing.T) {
+			descriptor := service.Descriptor{Code: code, Message: "SSH lifecycle failure"}
+			problem := problemFromError(service.NewDescriptorError(descriptor, nil))
+			encoded, err := json.Marshal(problem)
+			require.NoError(t, err)
+			decoded := service.AsError(decodeProblem(problem.Status, bytes.NewReader(encoded)))
+			assert.Equal(t, code, decoded.Code)
+			assert.Equal(t, descriptor.Message, decoded.Message)
+		})
+	}
+}
+
 func TestProblemMakesUnknownOutcomeNonRetryable(t *testing.T) {
 	problem := problemFromError(service.NewError(
 		service.OperationOutcomeUnknown,

--- a/internal/daemon/ssh_lifecycle.go
+++ b/internal/daemon/ssh_lifecycle.go
@@ -1,0 +1,421 @@
+package daemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/service"
+)
+
+const sshLeaseRoute = "/api/v1/ssh/leases"
+const defaultSSHLeaseTimeout = 30 * time.Second
+const defaultSSHCleanupTimeout = 5 * time.Second
+
+type SSHLeaseOperationRequest struct {
+	OperationID string              `json:"operation_id"`
+	Lease       kwt.SSHLeaseRequest `json:"lease"`
+}
+
+type SSHLeaseOperation struct {
+	OperationID string `json:"operation_id"`
+}
+
+type SSHLeaseResult struct {
+	LeaseID       string           `json:"lease_id"`
+	RouteIdentity string           `json:"route_identity"`
+	Generation    uint64           `json:"generation"`
+	Mode          kwt.SSHLeaseMode `json:"mode"`
+	Arguments     []string         `json:"arguments"`
+}
+
+type sshLeaseRegistry struct {
+	gate           *Gate
+	now            func() time.Time
+	ttl            time.Duration
+	cleanupTimeout time.Duration
+
+	mu     sync.Mutex
+	leases map[string]*sshLeaseEntry
+	closed bool
+}
+
+type sshLeaseEntry struct {
+	lease       kwt.SSHLease
+	reservation func()
+	reserveOnce sync.Once
+
+	mu          sync.Mutex
+	released    bool
+	cleaning    bool
+	cleanupDone chan struct{}
+	expires     time.Time
+	timer       *time.Timer
+}
+
+func newSSHLeaseRegistry(gate *Gate, now func() time.Time, ttl time.Duration) *sshLeaseRegistry {
+	if now == nil {
+		now = time.Now
+	}
+	if ttl <= 0 {
+		ttl = defaultSSHLeaseTimeout
+	}
+	return &sshLeaseRegistry{
+		gate: gate, now: now, ttl: ttl, cleanupTimeout: defaultSSHCleanupTimeout,
+		leases: make(map[string]*sshLeaseEntry),
+	}
+}
+
+func (r *sshLeaseRegistry) add(lease kwt.SSHLease) (string, error) {
+	r.mu.Lock()
+	closed := r.closed
+	r.mu.Unlock()
+	if closed {
+		return "", service.NewError(service.DaemonDraining, "daemon is draining", true, nil, nil)
+	}
+	var reservation func()
+	if r.gate != nil {
+		var err error
+		reservation, err = r.gate.Reserve(ReservationLease, r.now())
+		if err != nil {
+			return "", err
+		}
+	}
+	for attempts := 0; attempts < 4; attempts++ {
+		id, err := randomOperationID()
+		if err != nil {
+			if reservation != nil {
+				reservation()
+			}
+			return "", err
+		}
+		r.mu.Lock()
+		if r.closed {
+			r.mu.Unlock()
+			if reservation != nil {
+				reservation()
+			}
+			return "", service.NewError(service.DaemonDraining, "daemon is draining", true, nil, nil)
+		}
+		if _, exists := r.leases[id]; !exists {
+			entry := &sshLeaseEntry{lease: lease, reservation: reservation}
+			r.leases[id] = entry
+			entry.mu.Lock()
+			r.scheduleExpiry(id, entry)
+			entry.mu.Unlock()
+			r.mu.Unlock()
+			return id, nil
+		}
+		r.mu.Unlock()
+	}
+	if reservation != nil {
+		reservation()
+	}
+	return "", errors.New("generate unique SSH lease ID")
+}
+
+func (r *sshLeaseRegistry) close(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.closed = true
+	entries := make([]*sshLeaseEntry, 0, len(r.leases))
+	for _, entry := range r.leases {
+		entries = append(entries, entry)
+	}
+	clear(r.leases)
+	r.mu.Unlock()
+	for _, entry := range entries {
+		entry.mu.Lock()
+		if !entry.released {
+			entry.released = true
+			if entry.timer != nil {
+				entry.timer.Stop()
+				entry.timer = nil
+			}
+		}
+		entry.mu.Unlock()
+		entry.releaseReservation()
+	}
+	return nil
+}
+
+func (r *sshLeaseRegistry) scheduleExpiry(id string, entry *sshLeaseEntry) {
+	entry.expires = r.now().Add(r.ttl)
+	expires := entry.expires
+	entry.timer = time.AfterFunc(r.ttl, func() {
+		r.expire(id, entry, expires)
+	})
+}
+
+func (r *sshLeaseRegistry) expire(id string, entry *sshLeaseEntry, expires time.Time) {
+	entry.mu.Lock()
+	if entry.released || entry.cleaning || !entry.expires.Equal(expires) {
+		entry.mu.Unlock()
+		return
+	}
+	r.beginCleanupLocked(entry)
+	entry.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), r.cleanupTimeout)
+	defer cancel()
+	_ = r.cleanup(ctx, id, entry)
+}
+
+func (r *sshLeaseRegistry) entry(id string) (*sshLeaseEntry, error) {
+	r.mu.Lock()
+	entry := r.leases[id]
+	r.mu.Unlock()
+	if entry == nil {
+		return nil, service.NewError(service.NotFound, "SSH lease was not found", false, nil, nil)
+	}
+	return entry, nil
+}
+
+func (r *sshLeaseRegistry) touch(id string) error {
+	entry, err := r.entry(id)
+	if err != nil {
+		return err
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.released || entry.cleaning {
+		return service.NewError(service.NotFound, "SSH lease was not found", false, nil, nil)
+	}
+	if err := entry.lease.Touch(); err != nil {
+		return err
+	}
+	if entry.timer != nil {
+		entry.timer.Stop()
+	}
+	r.scheduleExpiry(id, entry)
+	if r.gate != nil {
+		r.gate.Touch(r.now())
+	}
+	return nil
+}
+
+func (r *sshLeaseRegistry) release(ctx context.Context, id string) error {
+	ctx, cancel := context.WithTimeout(ctx, r.cleanupTimeout)
+	defer cancel()
+	entry, err := r.entry(id)
+	if err != nil {
+		return err
+	}
+	for {
+		entry.mu.Lock()
+		if entry.released {
+			entry.mu.Unlock()
+			return nil
+		}
+		if entry.cleaning {
+			done := entry.cleanupDone
+			entry.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return sshCleanupFailed(ctx.Err())
+			case <-done:
+				continue
+			}
+		}
+		r.beginCleanupLocked(entry)
+		entry.mu.Unlock()
+		return r.cleanup(ctx, id, entry)
+	}
+
+}
+
+func (r *sshLeaseRegistry) beginCleanupLocked(entry *sshLeaseEntry) {
+	entry.cleaning = true
+	entry.cleanupDone = make(chan struct{})
+	if entry.timer != nil {
+		entry.timer.Stop()
+		entry.timer = nil
+	}
+}
+
+func (r *sshLeaseRegistry) cleanup(
+	ctx context.Context,
+	id string,
+	entry *sshLeaseEntry,
+) error {
+	err := sshCleanupFailed(entry.lease.Release(ctx))
+	entry.mu.Lock()
+	done := entry.cleanupDone
+	entry.cleanupDone = nil
+	entry.cleaning = false
+	completed := err == nil && !entry.released
+	if completed {
+		entry.released = true
+	} else if err != nil && !entry.released {
+		r.scheduleExpiry(id, entry)
+	}
+	close(done)
+	entry.mu.Unlock()
+	if !completed {
+		return err
+	}
+	r.mu.Lock()
+	if r.leases[id] == entry {
+		delete(r.leases, id)
+	}
+	r.mu.Unlock()
+	entry.releaseReservation()
+	return nil
+}
+
+func sshCleanupFailed(err error) error {
+	if err == nil {
+		return nil
+	}
+	return service.NewError(
+		service.SSHCleanupFailed,
+		"SSH cleanup failed",
+		true,
+		nil,
+		err,
+	)
+}
+
+func (entry *sshLeaseEntry) releaseReservation() {
+	entry.reserveOnce.Do(func() {
+		if entry.reservation != nil {
+			entry.reservation()
+		}
+	})
+}
+
+func registerSSHLifecycleRoutes(mux *http.ServeMux, opts ServerOptions) {
+	if opts.SSHLifecycle == nil || opts.Operations == nil {
+		return
+	}
+	registry := opts.SSHLeases
+	if registry == nil {
+		registry = newSSHLeaseRegistry(opts.Gate, opts.Now, opts.SSHLeaseTimeout)
+	}
+	mux.HandleFunc(sshLeaseRoute, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeProblem(w, newProblem(http.StatusMethodNotAllowed, service.Descriptor{
+				Code: service.InvalidRequest, Message: "unsupported SSH lease request",
+			}))
+			return
+		}
+		startSSHLease(w, r, opts, registry)
+	})
+	mux.HandleFunc(sshLeaseRoute+"/", func(w http.ResponseWriter, r *http.Request) {
+		serveSSHLease(w, r, opts, registry)
+	})
+}
+
+func startSSHLease(
+	w http.ResponseWriter,
+	r *http.Request,
+	opts ServerOptions,
+	registry *sshLeaseRegistry,
+) {
+	var request SSHLeaseOperationRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil || requireJSONEnd(decoder) != nil {
+		writeProblem(w, newProblem(http.StatusBadRequest, service.Descriptor{
+			Code: service.InvalidRequest, Message: "decode SSH lease request",
+		}))
+		return
+	}
+	if request.OperationID == "" || request.Lease.Environment == nil ||
+		!filepath.IsAbs(request.Lease.WorkingDirectory) {
+		writeProblem(w, newProblem(http.StatusBadRequest, service.Descriptor{
+			Code:    service.InvalidRequest,
+			Message: "SSH lease requires an operation ID, invocation environment, and working directory",
+		}))
+		return
+	}
+	encoded, err := json.Marshal(request.Lease)
+	if err != nil {
+		writeProblem(w, *reportProblem(opts, r.URL.Path, err))
+		return
+	}
+	digestValue := sha256.Sum256(encoded)
+	operation, _, err := opts.Operations.Start(OperationStart{
+		ID: request.OperationID, RequestDigest: hex.EncodeToString(digestValue[:]),
+		Run: func(ctx context.Context, operation *Operation) (json.RawMessage, error) {
+			_ = operation.Progress("Preparing SSH connection")
+			leaseRequest := request.Lease
+			leaseRequest.Prompt = operation.Prompt
+			lease, acquireErr := opts.SSHLifecycle.Acquire(ctx, leaseRequest)
+			if acquireErr != nil {
+				return nil, acquireErr
+			}
+			if lease.Mode() != kwt.SSHLeaseModeMultiplexed {
+				return nil, errors.Join(
+					service.NewError(
+						service.SSHRouteUnreviewable,
+						"daemon SSH leases require a persistent OpenSSH master",
+						false,
+						nil,
+						nil,
+					),
+					lease.Release(ctx),
+				)
+			}
+			arguments, argumentErr := lease.Arguments(ctx)
+			if argumentErr != nil {
+				return nil, errors.Join(argumentErr, lease.Release(ctx))
+			}
+			leaseID, addErr := registry.add(lease)
+			if addErr != nil {
+				return nil, errors.Join(addErr, lease.Release(ctx))
+			}
+			result, marshalErr := json.Marshal(SSHLeaseResult{
+				LeaseID: leaseID, RouteIdentity: leaseRequest.Snapshot.RouteIdentity,
+				Generation: lease.Generation(), Mode: lease.Mode(), Arguments: arguments,
+			})
+			if marshalErr != nil {
+				return nil, errors.Join(marshalErr, registry.release(ctx, leaseID))
+			}
+			return result, nil
+		},
+	})
+	if err != nil {
+		writeProblem(w, *reportProblem(opts, r.URL.Path, err))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(SSHLeaseOperation{OperationID: operation.ID()})
+}
+
+func serveSSHLease(
+	w http.ResponseWriter,
+	r *http.Request,
+	opts ServerOptions,
+	registry *sshLeaseRegistry,
+) {
+	suffix := strings.TrimPrefix(r.URL.Path, sshLeaseRoute+"/")
+	parts := strings.Split(suffix, "/")
+	var err error
+	switch {
+	case len(parts) == 1 && parts[0] != "" && r.Method == http.MethodDelete:
+		err = registry.release(r.Context(), parts[0])
+	case len(parts) == 2 && parts[0] != "" && parts[1] == "touch" && r.Method == http.MethodPost:
+		err = registry.touch(parts[0])
+	default:
+		writeProblem(w, newProblem(http.StatusMethodNotAllowed, service.Descriptor{
+			Code: service.InvalidRequest, Message: "unsupported SSH lease request",
+		}))
+		return
+	}
+	if err != nil {
+		writeProblem(w, *reportProblem(opts, r.URL.Path, err))
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/daemon/ssh_lifecycle_test.go
+++ b/internal/daemon/ssh_lifecycle_test.go
@@ -1,0 +1,701 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
+	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
+)
+
+type fakeDaemonSSHLease struct {
+	mu         sync.Mutex
+	mode       kwt.SSHLeaseMode
+	touches    int
+	releases   int
+	touchErr   error
+	releaseErr error
+}
+
+type blockingDaemonSSHLease struct {
+	started chan struct{}
+	unblock chan struct{}
+	once    sync.Once
+}
+
+func (*blockingDaemonSSHLease) Mode() kwt.SSHLeaseMode { return kwt.SSHLeaseModeMultiplexed }
+func (*blockingDaemonSSHLease) Generation() uint64     { return 18 }
+func (*blockingDaemonSSHLease) Arguments(context.Context) ([]string, error) {
+	return []string{"-S", "/private/control"}, nil
+}
+func (*blockingDaemonSSHLease) Touch() error { return nil }
+func (l *blockingDaemonSSHLease) Release(ctx context.Context) error {
+	l.once.Do(func() { close(l.started) })
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-l.unblock:
+		return nil
+	}
+}
+
+func (l *fakeDaemonSSHLease) Mode() kwt.SSHLeaseMode {
+	if l.mode == "" {
+		return kwt.SSHLeaseModeMultiplexed
+	}
+	return l.mode
+}
+func (*fakeDaemonSSHLease) Generation() uint64 { return 17 }
+func (*fakeDaemonSSHLease) Arguments(context.Context) ([]string, error) {
+	return []string{"-S", "/private/control"}, nil
+}
+func (l *fakeDaemonSSHLease) Touch() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.touches++
+	return l.touchErr
+}
+func (l *fakeDaemonSSHLease) Release(context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.releases++
+	return l.releaseErr
+}
+
+type fakeDaemonSSHLifecycle struct {
+	lease    *fakeDaemonSSHLease
+	mu       sync.Mutex
+	requests []kwt.SSHLeaseRequest
+}
+
+type promptingDaemonSSHLifecycle struct {
+	lease   kwt.SSHLease
+	answers []string
+	done    chan error
+}
+
+type hostDaemonSSHLifecycle struct {
+	lease  *fakeDaemonSSHLease
+	closed chan struct{}
+}
+
+func (s *hostDaemonSSHLifecycle) Resolve(
+	_ context.Context,
+	request kwt.SSHResolveRequest,
+) (kwt.SSHRouteSnapshot, error) {
+	return kwt.SSHRouteSnapshot{
+		LogicalTarget: request.Target, RouteIdentity: "route-one",
+		ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+	}, nil
+}
+
+func (s *hostDaemonSSHLifecycle) Acquire(
+	context.Context,
+	kwt.SSHLeaseRequest,
+) (kwt.SSHLease, error) {
+	return s.lease, nil
+}
+
+func (s *hostDaemonSSHLifecycle) Close(ctx context.Context) error {
+	if err := s.lease.Release(ctx); err != nil {
+		return err
+	}
+	close(s.closed)
+	return nil
+}
+
+func (s *promptingDaemonSSHLifecycle) Acquire(
+	ctx context.Context,
+	request kwt.SSHLeaseRequest,
+) (kwt.SSHLease, error) {
+	for _, message := range []string{"Password:", "Verification code:"} {
+		answer, err := request.Prompt(ctx, service.OperationPrompt{
+			Kind: "authentication", Message: message, Sensitive: true,
+		})
+		if err != nil {
+			if s.done != nil {
+				s.done <- err
+			}
+			return nil, err
+		}
+		s.answers = append(s.answers, answer)
+	}
+	return s.lease, nil
+}
+
+func (s *fakeDaemonSSHLifecycle) Acquire(
+	_ context.Context,
+	request kwt.SSHLeaseRequest,
+) (kwt.SSHLease, error) {
+	s.mu.Lock()
+	s.requests = append(s.requests, request)
+	s.mu.Unlock()
+	return s.lease, nil
+}
+
+func TestServerAcquiresTouchesAndReleasesSSHLease(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	hub := NewOperationHub(context.Background(), OperationHubOptions{
+		IDSource: func() (string, error) { return "operation-1", nil },
+	})
+	gate := NewGate(now)
+	lease := &fakeDaemonSSHLease{}
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	handler := NewServer(ServerOptions{
+		Token:        "secret",
+		ExpectedHost: "127.0.0.1:43210",
+		Status:       provider,
+		Now:          func() time.Time { return now },
+		Operations:   hub,
+		Gate:         gate,
+		SSHLifecycle: &fakeDaemonSSHLifecycle{lease: lease},
+	})
+	requestBody, err := json.Marshal(SSHLeaseOperationRequest{
+		OperationID: "request-1",
+		Lease: kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget:    kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity:    "route-one",
+			ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+			Targets: []kwt.SSHResolvedTarget{{
+				LogicalTarget:   kwt.SSHTarget{Hostname: "build.example.test"},
+				EffectiveTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			}},
+		}, WorkingDirectory: "/workspace", Environment: []string{"PATH=/usr/bin"}},
+	})
+	require.NoError(t, err)
+	response := serveSSHRequest(
+		handler, http.MethodPost, "/api/v1/ssh/leases", requestBody,
+	)
+	require.Equal(t, http.StatusAccepted, response.Code, response.Body.String())
+	var accepted SSHLeaseOperation
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&accepted))
+	assert.Equal(t, "request-1", accepted.OperationID)
+
+	subscription, err := hub.Subscribe(accepted.OperationID, 0)
+	require.NoError(t, err)
+	defer subscription.Close()
+	var result SSHLeaseResult
+	for retained := range subscription.Events() {
+		var event service.OperationEvent
+		require.NoError(t, json.Unmarshal([]byte(retained.encoded), &event))
+		if event.Result != nil {
+			require.NoError(t, json.Unmarshal(event.Result, &result))
+			break
+		}
+	}
+	assert.NotEmpty(t, result.LeaseID)
+	assert.Equal(t, uint64(17), result.Generation)
+	assert.Equal(t, []string{"-S", "/private/control"}, result.Arguments)
+	assert.Equal(t, 1, gate.Snapshot().ActiveLeases)
+	deadline := now.Add(time.Minute)
+	provider.status = Status{State: StateDraining, DrainDeadline: &deadline}
+	response = serveSSHRequest(
+		handler, http.MethodPost, "/api/v1/ssh/leases", requestBody,
+	)
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code, response.Body.String())
+
+	response = serveSSHRequest(
+		handler, http.MethodPost, "/api/v1/ssh/leases/"+result.LeaseID+"/touch", nil,
+	)
+	assert.Equal(t, http.StatusNoContent, response.Code, response.Body.String())
+	response = serveSSHRequest(
+		handler, http.MethodDelete, "/api/v1/ssh/leases/"+result.LeaseID, nil,
+	)
+	assert.Equal(t, http.StatusNoContent, response.Code, response.Body.String())
+	assert.Equal(t, 0, gate.Snapshot().ActiveLeases)
+	lease.mu.Lock()
+	assert.Equal(t, 1, lease.touches)
+	assert.Equal(t, 1, lease.releases)
+	lease.mu.Unlock()
+}
+
+func TestServerRejectsMasterlessSSHLease(t *testing.T) {
+	hub := NewOperationHub(context.Background(), OperationHubOptions{})
+	gate := NewGate(time.Now())
+	lease := &fakeDaemonSSHLease{mode: kwt.SSHLeaseModeMasterless}
+	handler := NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: "127.0.0.1:43210",
+		Status:     &testStatusProvider{status: Status{State: StateReady}},
+		Operations: hub, Gate: gate,
+		SSHLifecycle: &fakeDaemonSSHLifecycle{lease: lease},
+	})
+	requestBody, err := json.Marshal(SSHLeaseOperationRequest{
+		OperationID: "masterless-operation",
+		Lease: kwt.SSHLeaseRequest{
+			Snapshot: kwt.SSHRouteSnapshot{
+				LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+				RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+			},
+			WorkingDirectory: "/workspace", Environment: []string{"PATH=/usr/bin"},
+		},
+	})
+	require.NoError(t, err)
+	response := serveSSHRequest(handler, http.MethodPost, sshLeaseRoute, requestBody)
+	require.Equal(t, http.StatusAccepted, response.Code, response.Body.String())
+	subscription, err := hub.Subscribe("masterless-operation", 0)
+	require.NoError(t, err)
+	defer subscription.Close()
+	var failure *service.Descriptor
+	for retained := range subscription.Events() {
+		var event service.OperationEvent
+		require.NoError(t, json.Unmarshal([]byte(retained.encoded), &event))
+		if event.Kind == service.OperationEventComplete {
+			failure = event.Failure
+			break
+		}
+	}
+	require.NotNil(t, failure)
+	assert.Equal(t, service.SSHRouteUnreviewable, failure.Code)
+	assert.False(t, failure.Retryable)
+	assert.Equal(t, 0, gate.Snapshot().ActiveLeases)
+	lease.mu.Lock()
+	assert.Equal(t, 1, lease.releases)
+	lease.mu.Unlock()
+}
+
+func TestClientFollowsSSHLeaseOperationAndReleasesLease(t *testing.T) {
+	lease := &fakeDaemonSSHLease{}
+	lifecycle := &fakeDaemonSSHLifecycle{lease: lease}
+	client, closeServer := newSSHLifecycleTestClient(t, lifecycle)
+	defer closeServer()
+	var events []service.OperationEventKind
+	result, err := client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{Event: func(event service.OperationEvent) error {
+			events = append(events, event.Kind)
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(17), result.Generation)
+	assert.Equal(t, []string{"-S", "/private/control"}, result.Arguments)
+	assert.Contains(t, events, service.OperationEventProgress)
+	assert.Contains(t, events, service.OperationEventComplete)
+	require.NoError(t, client.TouchSSHLease(context.Background(), result.LeaseID))
+	require.NoError(t, client.ReleaseSSHLease(context.Background(), result.LeaseID))
+
+	lifecycle.mu.Lock()
+	require.Len(t, lifecycle.requests, 1)
+	assert.True(t, filepath.IsAbs(lifecycle.requests[0].WorkingDirectory))
+	assert.NotNil(t, lifecycle.requests[0].Environment)
+	lifecycle.mu.Unlock()
+}
+
+func TestClientPrefersTerminalSSHFailureAfterLostStartResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == sshLeaseRoute:
+			connection, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack SSH lease response: %v", err)
+				return
+			}
+			_ = connection.Close()
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/events"):
+			operationID := strings.TrimSuffix(
+				strings.TrimPrefix(r.URL.Path, operationRoutePrefix),
+				"/events",
+			)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_ = json.NewEncoder(w).Encode(service.OperationEvent{
+				OperationID: operationID,
+				Sequence:    1,
+				Kind:        service.OperationEventComplete,
+				Failure: &service.Descriptor{
+					Code:      service.SSHPromptTimedOut,
+					Message:   "SSH prompt timed out",
+					Retryable: false,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := clientForUnverifiedServer(t, server, "secret")
+
+	_, err := client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{},
+	)
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.SSHPromptTimedOut), err)
+	assert.False(t, service.IsCode(err, service.DaemonTransportFailed), err)
+}
+
+func TestClientReturnsSSHLeaseResultWithTerminalCallbackFailure(t *testing.T) {
+	lease := &fakeDaemonSSHLease{}
+	client, closeServer := newSSHLifecycleTestClient(
+		t, &fakeDaemonSSHLifecycle{lease: lease},
+	)
+	defer closeServer()
+	writeErr := errors.New("output closed")
+	result, err := client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{Event: func(event service.OperationEvent) error {
+			if event.Kind == service.OperationEventComplete {
+				return writeErr
+			}
+			return nil
+		}},
+	)
+	assert.ErrorIs(t, err, writeErr)
+	assert.NotEmpty(t, result.LeaseID)
+	require.NoError(t, client.ReleaseSSHLease(context.Background(), result.LeaseID))
+}
+
+func TestClientRoundTripsSSHLeaseControlErrors(t *testing.T) {
+	lease := &fakeDaemonSSHLease{}
+	client, closeServer := newSSHLifecycleTestClient(
+		t, &fakeDaemonSSHLifecycle{lease: lease},
+	)
+	defer closeServer()
+	result, err := client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{},
+	)
+	require.NoError(t, err)
+
+	lease.mu.Lock()
+	lease.touchErr = service.NewError(
+		service.SSHConnectionChanged, "SSH connection changed", false, nil, nil,
+	)
+	lease.mu.Unlock()
+	err = client.TouchSSHLease(context.Background(), result.LeaseID)
+	assert.True(t, service.IsCode(err, service.SSHConnectionChanged), err)
+
+	lease.mu.Lock()
+	lease.touchErr = nil
+	lease.releaseErr = context.DeadlineExceeded
+	lease.mu.Unlock()
+	err = client.ReleaseSSHLease(context.Background(), result.LeaseID)
+	assert.True(t, service.IsCode(err, service.SSHCleanupFailed), err)
+	assert.True(t, service.AsError(err).Retryable)
+
+	lease.mu.Lock()
+	lease.releaseErr = nil
+	lease.mu.Unlock()
+	require.NoError(t, client.ReleaseSSHLease(context.Background(), result.LeaseID))
+}
+
+func TestClientCarriesMultipleBoundSSHPromptRounds(t *testing.T) {
+	lease := &fakeDaemonSSHLease{}
+	lifecycle := &promptingDaemonSSHLifecycle{lease: lease}
+	client, closeServer := newSSHLifecycleTestClient(t, lifecycle)
+	defer closeServer()
+	responses := []string{"secret", "123456"}
+	result, err := client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{Prompt: func(
+			_ context.Context,
+			_ service.OperationPrompt,
+		) (string, error) {
+			response := responses[0]
+			responses = responses[1:]
+			return response, nil
+		}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"secret", "123456"}, lifecycle.answers)
+	require.NoError(t, client.ReleaseSSHLease(context.Background(), result.LeaseID))
+}
+
+func TestClientCancelsSSHOperationWithoutPromptHandler(t *testing.T) {
+	lifecycle := &promptingDaemonSSHLifecycle{
+		lease: &fakeDaemonSSHLease{}, done: make(chan error, 1),
+	}
+	client, closeServer := newSSHLifecycleTestClient(t, lifecycle)
+	defer closeServer()
+
+	_, err := client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{},
+	)
+	assert.True(t, service.IsCode(err, service.SSHInteractionRequired), err)
+	select {
+	case operationErr := <-lifecycle.done:
+		assert.ErrorIs(t, operationErr, context.Canceled)
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "SSH operation was not canceled")
+	}
+}
+
+func TestServerExpiresSSHLeaseWhenClientStopsTouching(t *testing.T) {
+	now := time.Now()
+	hub := NewOperationHub(context.Background(), OperationHubOptions{})
+	gate := NewGate(now)
+	lease := &fakeDaemonSSHLease{}
+	handler := NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: "127.0.0.1:43210",
+		Status: &testStatusProvider{status: Status{State: StateReady}},
+		Now:    time.Now, Operations: hub, Gate: gate,
+		SSHLifecycle:    &fakeDaemonSSHLifecycle{lease: lease},
+		SSHLeaseTimeout: 20 * time.Millisecond,
+	})
+	requestBody, err := json.Marshal(SSHLeaseOperationRequest{
+		OperationID: "expiry-operation",
+		Lease: kwt.SSHLeaseRequest{
+			Snapshot: kwt.SSHRouteSnapshot{
+				LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+				RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+			},
+			WorkingDirectory: "/workspace", Environment: []string{"PATH=/usr/bin"},
+		},
+	})
+	require.NoError(t, err)
+	response := serveSSHRequest(handler, http.MethodPost, sshLeaseRoute, requestBody)
+	require.Equal(t, http.StatusAccepted, response.Code, response.Body.String())
+	subscription, err := hub.Subscribe("expiry-operation", 0)
+	require.NoError(t, err)
+	for retained := range subscription.Events() {
+		if retained.kind == service.OperationEventComplete {
+			break
+		}
+	}
+	subscription.Close()
+	require.Eventually(t, func() bool {
+		lease.mu.Lock()
+		defer lease.mu.Unlock()
+		return lease.releases == 1 && gate.Snapshot().ActiveLeases == 0
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestSSHLeaseRegistryCloseInvalidatesEveryDaemonLease(t *testing.T) {
+	gate := NewGate(time.Now())
+	registry := newSSHLeaseRegistry(gate, time.Now, time.Hour)
+	first := &fakeDaemonSSHLease{}
+	second := &fakeDaemonSSHLease{}
+	_, err := registry.add(first)
+	require.NoError(t, err)
+	_, err = registry.add(second)
+	require.NoError(t, err)
+	assert.Equal(t, 2, gate.Snapshot().ActiveLeases)
+
+	require.NoError(t, registry.close(context.Background()))
+	assert.Equal(t, 0, gate.Snapshot().ActiveLeases)
+}
+
+func TestSSHLeaseRegistryCloseDoesNotWaitForBlockedLeaseRelease(t *testing.T) {
+	gate := NewGate(time.Now())
+	registry := newSSHLeaseRegistry(gate, time.Now, time.Hour)
+	lease := &blockingDaemonSSHLease{
+		started: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+	defer close(lease.unblock)
+	leaseID, err := registry.add(lease)
+	require.NoError(t, err)
+	releaseDone := make(chan error, 1)
+	go func() { releaseDone <- registry.release(context.Background(), leaseID) }()
+	<-lease.started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- registry.close(ctx) }()
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "registry close waited for blocked SSH release")
+	}
+	assert.Equal(t, 0, gate.Snapshot().ActiveLeases)
+}
+
+func TestSSHLeaseReleaseDeadlineLeavesCleanupRetryable(t *testing.T) {
+	gate := NewGate(time.Now())
+	registry := newSSHLeaseRegistry(gate, time.Now, time.Hour)
+	registry.cleanupTimeout = 20 * time.Millisecond
+	lease := &blockingDaemonSSHLease{
+		started: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+	leaseID, err := registry.add(lease)
+	require.NoError(t, err)
+	releaseDone := make(chan error, 1)
+	go func() { releaseDone <- registry.release(context.Background(), leaseID) }()
+	<-lease.started
+
+	select {
+	case err = <-releaseDone:
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.True(t, service.IsCode(err, service.SSHCleanupFailed), err)
+		assert.True(t, service.AsError(err).Retryable)
+	case <-time.After(100 * time.Millisecond):
+		close(lease.unblock)
+		<-releaseDone
+		require.FailNow(t, "SSH lease release ignored its context deadline")
+	}
+	assert.Equal(t, 1, gate.Snapshot().ActiveLeases)
+	close(lease.unblock)
+	require.NoError(t, registry.release(context.Background(), leaseID))
+	assert.Equal(t, 0, gate.Snapshot().ActiveLeases)
+}
+
+func TestServeDrainsActiveSSHLeaseThenClosesLifecycleOwner(t *testing.T) {
+	home := t.TempDir()
+	owner := &hostDaemonSSHLifecycle{
+		lease: &fakeDaemonSSHLease{}, closed: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeOptions{
+			Home: home, Build: Build{Version: "v1.0.0", Revision: "abc"},
+			Config: models.DaemonConfig{
+				IdleTimeout: time.Hour, AutoRestart: "newer",
+				ReplacementGrace: 30 * time.Millisecond,
+			},
+			Foreground: true, Now: time.Now,
+			SSHResolver: owner, SSHLifecycle: owner,
+		})
+	}()
+	observation := waitForRuntime(t, home)
+	assert.Contains(t, observation.Status.Capabilities, CapabilitySSHLifecycle)
+	result, err := observation.Client.AcquireSSH(
+		context.Background(),
+		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
+			LogicalTarget: kwt.SSHTarget{Hostname: "build.example.test"},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}},
+		OperationCallbacks{},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.LeaseID)
+	status, err := observation.Client.Shutdown(context.Background(), "replacement")
+	require.NoError(t, err)
+	assert.Equal(t, StateDraining, status.Status.State)
+	assert.Equal(t, 1, status.Status.ActiveLeases)
+	require.NoError(t, <-done)
+	select {
+	case <-owner.closed:
+	default:
+		require.Fail(t, "SSH lifecycle owner was not closed")
+	}
+	assert.Empty(t, runtimeFiles(t, home))
+}
+
+func TestServeClosesDistinctSSHResolverAndLifecycleOwners(t *testing.T) {
+	home := t.TempDir()
+	resolver := &hostDaemonSSHLifecycle{
+		lease: &fakeDaemonSSHLease{}, closed: make(chan struct{}),
+	}
+	lifecycle := &hostDaemonSSHLifecycle{
+		lease: &fakeDaemonSSHLease{}, closed: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeOptions{
+			Home: home, Build: Build{Version: "v1.0.0", Revision: "abc"},
+			Config: models.DaemonConfig{
+				IdleTimeout: time.Hour, AutoRestart: "newer",
+				ReplacementGrace: 30 * time.Millisecond,
+			},
+			Foreground: true, Now: time.Now,
+			SSHResolver: resolver, SSHLifecycle: lifecycle,
+		})
+	}()
+	observation := waitForRuntime(t, home)
+	_, err := observation.Client.Shutdown(context.Background(), "replacement")
+	require.NoError(t, err)
+	require.NoError(t, <-done)
+	select {
+	case <-resolver.closed:
+	default:
+		require.Fail(t, "SSH resolver owner was not closed")
+	}
+	select {
+	case <-lifecycle.closed:
+	default:
+		require.Fail(t, "SSH lifecycle owner was not closed")
+	}
+}
+
+func newSSHLifecycleTestClient(
+	t *testing.T,
+	lifecycle SSHLifecycle,
+) (*Client, func()) {
+	t.Helper()
+	provider := &testStatusProvider{status: Status{State: StateReady}}
+	gate := NewGate(time.Now())
+	hubContext, cancelHub := context.WithCancel(context.Background())
+	hub := NewOperationHub(hubContext, OperationHubOptions{
+		Reserve: func() (func(), error) {
+			return gate.Reserve(ReservationWork, time.Now())
+		},
+	})
+	var server *httptest.Server
+	handler := NewServer(ServerOptions{
+		Token: "secret", Status: provider, Operations: hub,
+		Gate: gate, SSHLifecycle: lifecycle, Now: time.Now,
+	})
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		request.Host = server.Listener.Addr().String()
+		handler.ServeHTTP(w, request)
+	}))
+	handler = NewServer(ServerOptions{
+		Token: "secret", ExpectedHost: server.Listener.Addr().String(), Status: provider,
+		Operations: hub, Gate: gate, SSHLifecycle: lifecycle, Now: time.Now,
+	})
+	ep := kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: server.Listener.Addr().String()}
+	return newClient(ep, "secret", server.Client()), func() {
+		cancelHub()
+		server.Close()
+	}
+}
+
+func serveSSHRequest(
+	handler http.Handler,
+	method string,
+	path string,
+	body []byte,
+) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, "http://127.0.0.1:43210"+path, bytes.NewReader(body))
+	request.Host = "127.0.0.1:43210"
+	request.Header.Set("Authorization", "Bearer secret")
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}

--- a/internal/daemon/ssh_resolution_test.go
+++ b/internal/daemon/ssh_resolution_test.go
@@ -207,7 +207,7 @@ func TestSSHResolveRouteReservesDaemonWorkAndHonorsCancellation(t *testing.T) {
 }
 
 func TestSSHResolveCapabilityAndSchemaAreAdvertised(t *testing.T) {
-	assert.Equal(t, "1.8.0", APISchemaVersion)
+	assert.Equal(t, "1.9.0", APISchemaVersion)
 	record, _, err := NewRuntimeRecord(
 		t.TempDir(),
 		Build{Version: "development"},
@@ -216,6 +216,7 @@ func TestSSHResolveCapabilityAndSchemaAreAdvertised(t *testing.T) {
 	require.NoError(t, err)
 	capabilities := strings.Split(record.Metadata[metadataCapabilities], ",")
 	assert.Contains(t, capabilities, CapabilitySSHResolve)
+	assert.Contains(t, capabilities, CapabilitySSHLifecycle)
 }
 
 func TestSSHResolveResponseDoesNotPublishCanonicalOptions(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -9,7 +9,7 @@ import (
 const (
 	ServiceName               = "kwt"
 	APISchemaMajor            = 1
-	APISchemaVersion          = "1.8.0"
+	APISchemaVersion          = "1.9.0"
 	CapabilityStatus          = "daemon.status"
 	CapabilityShutdown        = "daemon.shutdown"
 	CapabilityProjectRemoval  = "project.removal.v1"
@@ -17,6 +17,7 @@ const (
 	CapabilityRemoval         = "worktree.removal.v1"
 	CapabilityGuardedRemoval  = "worktree.removal.v2"
 	CapabilityOperationStream = "operation.stream.v1"
+	CapabilitySSHLifecycle    = "ssh.lifecycle.v1"
 	CapabilitySSHResolve      = "ssh.resolve.v1"
 )
 

--- a/internal/ssh/askpass.go
+++ b/internal/ssh/askpass.go
@@ -287,6 +287,8 @@ func (a *Askpass) prompt(message string) (string, error) {
 	}
 	promptContext, cancel := context.WithTimeout(a.context, a.options.PromptTimeout)
 	defer cancel()
+	deadline, _ := promptContext.Deadline()
+	prompt.Deadline = &deadline
 	response, err := a.options.Prompt(promptContext, prompt)
 	if errors.Is(promptContext.Err(), context.DeadlineExceeded) {
 		return "", service.NewError(

--- a/internal/ssh/askpass_test.go
+++ b/internal/ssh/askpass_test.go
@@ -95,10 +95,14 @@ func TestAskpassPreservesTypedPromptRejection(t *testing.T) {
 }
 
 func TestAskpassTimesOutOnePromptRound(t *testing.T) {
+	deadlines := make(chan time.Time, 1)
 	transport, err := NewAskpass(context.Background(), t.TempDir(), AskpassOptions{
 		Version:       supportedAskpassVersion(),
 		PromptTimeout: 10 * time.Millisecond,
-		Prompt: func(ctx context.Context, _ service.OperationPrompt) (string, error) {
+		Prompt: func(ctx context.Context, prompt service.OperationPrompt) (string, error) {
+			if prompt.Deadline != nil {
+				deadlines <- *prompt.Deadline
+			}
 			<-ctx.Done()
 			return "", ctx.Err()
 		},
@@ -114,6 +118,12 @@ func TestAskpassTimesOutOnePromptRound(t *testing.T) {
 	assert.NotEqual(t, 0, exitCode)
 	require.NoError(t, transport.Close())
 	assert.True(t, service.IsCode(transport.Err(), service.SSHPromptTimedOut))
+	select {
+	case deadline := <-deadlines:
+		assert.WithinDuration(t, time.Now(), deadline, time.Second)
+	default:
+		t.Fatal("askpass prompt did not carry its deadline")
+	}
 }
 
 func TestAskpassRemovesPrivateOperationDirectory(t *testing.T) {

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -142,7 +142,8 @@ func (m *Manager) Acquire(
 			request.Snapshot, target, index, previousIdentity, request.Environment,
 		)
 		lease, acquireErr := m.acquireTarget(
-			ctx, request, target, identity, previousIdentity, index, resolve,
+			ctx, request, target, identity, previousIdentity, index,
+			index == len(request.Snapshot.Targets)-1, resolve,
 		)
 		if acquireErr != nil {
 			return nil, errors.Join(releaseAcquiredLeases(ctx, leases), acquireErr)
@@ -163,6 +164,7 @@ func (m *Manager) acquireTarget(
 	identity string,
 	upstreamIdentity string,
 	hopDepth int,
+	terminal bool,
 	resolve func(context.Context) (RouteSnapshot, error),
 ) (Lease, error) {
 	runner, err := m.runner(request, target)
@@ -280,8 +282,9 @@ func (m *Manager) acquireTarget(
 	}
 
 	m.mu.Lock()
-	if m.closed {
-		m.mu.Unlock()
+	closed = m.closed
+	m.mu.Unlock()
+	if closed {
 		event, cleanupErr := m.disconnectUnleased(
 			identity, generation, request.Snapshot.RouteIdentity, target.ForwardAgent,
 			upstreamIdentity, hopDepth,
@@ -290,6 +293,46 @@ func (m *Manager) acquireTarget(
 			releaseIdentity()
 			m.emitFailure(request.Snapshot.RouteIdentity, generation, cleanupErr)
 			return nil, cleanupErr
+		}
+		releaseIdentity()
+		m.emitOptional(event)
+		return nil, connectionChanged()
+	}
+	sessionProjection := ExecutionProjection{Arguments: []string{"-F", os.DevNull}}
+	if terminal {
+		sessionProjection = multiplexedSessionProjection(target.Projection)
+	}
+	sessionArguments, sessionCleanup, err := materializeProjection(
+		m.privateDirectory, sessionProjection,
+	)
+	if err != nil {
+		event, cleanupErr := m.disconnectUnleased(
+			identity, generation, request.Snapshot.RouteIdentity, target.ForwardAgent,
+			upstreamIdentity, hopDepth,
+		)
+		releaseIdentity()
+		m.emitOptional(event)
+		if cleanupErr != nil {
+			m.emitFailure(request.Snapshot.RouteIdentity, generation, cleanupErr)
+		}
+		return nil, errors.Join(connectionFailed(err), cleanupErr)
+	}
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		var projectionCleanupErr error
+		if sessionCleanup != nil {
+			projectionCleanupErr = sessionCleanup()
+		}
+		event, cleanupErr := m.disconnectUnleased(
+			identity, generation, request.Snapshot.RouteIdentity, target.ForwardAgent,
+			upstreamIdentity, hopDepth,
+		)
+		if projectionCleanupErr != nil || cleanupErr != nil {
+			failure := cleanupFailed(errors.Join(projectionCleanupErr, cleanupErr))
+			releaseIdentity()
+			m.emitFailure(request.Snapshot.RouteIdentity, generation, failure)
+			return nil, failure
 		}
 		releaseIdentity()
 		m.emitOptional(event)
@@ -328,6 +371,8 @@ func (m *Manager) acquireTarget(
 	}
 	return &managedLease{
 		manager: m, identity: identity, generation: generation,
+		routeIdentity:    request.Snapshot.RouteIdentity,
+		sessionArguments: sessionArguments, sessionCleanup: sessionCleanup,
 	}, nil
 }
 
@@ -491,13 +536,16 @@ func sameRoute(expected, current RouteSnapshot) bool {
 }
 
 type managedLease struct {
-	manager        *Manager
-	identity       string
-	generation     openssh.Generation
-	released       atomic.Bool
-	releaseStarted atomic.Bool
-	releaseMu      sync.Mutex
-	countReleased  bool
+	manager          *Manager
+	identity         string
+	routeIdentity    string
+	generation       openssh.Generation
+	sessionArguments []string
+	sessionCleanup   func() error
+	released         atomic.Bool
+	releaseStarted   atomic.Bool
+	releaseMu        sync.Mutex
+	countReleased    bool
 }
 
 func (l *managedLease) Mode() LeaseMode { return LeaseModeMultiplexed }
@@ -512,7 +560,7 @@ func (l *managedLease) Arguments(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, mapManagerError(err)
 	}
-	arguments = append([]string{"-F", os.DevNull}, arguments...)
+	arguments = append(append([]string(nil), l.sessionArguments...), arguments...)
 	arguments = append(arguments,
 		"-o", "BatchMode=yes",
 		"-o", "ProxyCommand="+proxyFailureCommand(),
@@ -534,6 +582,14 @@ func (l *managedLease) Release(ctx context.Context) error {
 		return nil
 	}
 	l.releaseStarted.Store(true)
+	if l.sessionCleanup != nil {
+		if err := l.sessionCleanup(); err != nil {
+			failure := cleanupFailed(err)
+			l.manager.emitFailure(l.routeIdentity, l.generation, failure)
+			return failure
+		}
+		l.sessionCleanup = nil
+	}
 	decremented, err := l.manager.release(
 		ctx, l.identity, l.generation, !l.countReleased,
 	)

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -13,6 +15,8 @@ import (
 	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kwt/service"
 )
+
+const leaseRollbackTimeout = 5 * time.Second
 
 type PersistentManager interface {
 	ConnectWithRunner(context.Context, string, openssh.Target, openssh.RunSSH) (openssh.Generation, error)
@@ -42,6 +46,7 @@ type Manager struct {
 	onEvent            func(Event)
 
 	mu                   sync.Mutex
+	idleCleanupMu        sync.Mutex
 	routes               map[string]*managedRoute
 	operations           map[string]*identityOperation
 	masterless           map[uint64]*masterlessLease
@@ -65,6 +70,15 @@ type managedRoute struct {
 	heartbeatCancel  context.CancelFunc
 	heartbeatDone    chan struct{}
 	forwardAgent     bool
+	hopDepth         int
+	upstreamIdentity string
+	idleDeadline     time.Time
+}
+
+type routeCleanupTarget struct {
+	identity   string
+	generation openssh.Generation
+	depth      int
 }
 
 func NewManager(options ManagerOptions) *Manager {
@@ -103,15 +117,58 @@ func (m *Manager) Acquire(
 		return nil, configurationChanged()
 	}
 	request.Snapshot = current
-	if len(request.Snapshot.Targets) != 1 {
-		return nil, routeUnreviewable(errors.New("SSH lifecycle requires one resolved target"))
+	if len(request.Snapshot.Targets) == 0 {
+		return nil, routeUnreviewable(errors.New("SSH lifecycle requires a resolved target"))
 	}
-	target := request.Snapshot.Targets[0]
+	leases := make([]Lease, 0, len(request.Snapshot.Targets))
+	previousIdentity := ""
+	for index, originalTarget := range request.Snapshot.Targets {
+		target := originalTarget
+		if index > 0 {
+			previous := leases[index-1]
+			if previous.Mode() != LeaseModeMultiplexed {
+				return nil, errors.Join(
+					releaseAcquiredLeases(ctx, leases),
+					routeUnreviewable(errors.New("masterless ProxyJump routes are unsupported")),
+				)
+			}
+			arguments, argumentErr := previous.Arguments(ctx)
+			if argumentErr != nil {
+				return nil, errors.Join(releaseAcquiredLeases(ctx, leases), argumentErr)
+			}
+			target = targetWithProxy(target, request.Snapshot.Targets[index-1], arguments)
+		}
+		identity := managerIdentityForTarget(
+			request.Snapshot, target, index, previousIdentity, request.Environment,
+		)
+		lease, acquireErr := m.acquireTarget(
+			ctx, request, target, identity, previousIdentity, index, resolve,
+		)
+		if acquireErr != nil {
+			return nil, errors.Join(releaseAcquiredLeases(ctx, leases), acquireErr)
+		}
+		leases = append(leases, lease)
+		previousIdentity = identity
+	}
+	if len(leases) == 1 {
+		return leases[0], nil
+	}
+	return &routeLease{leases: leases}, nil
+}
+
+func (m *Manager) acquireTarget(
+	ctx context.Context,
+	request LeaseRequest,
+	target ResolvedTarget,
+	identity string,
+	upstreamIdentity string,
+	hopDepth int,
+	resolve func(context.Context) (RouteSnapshot, error),
+) (Lease, error) {
 	runner, err := m.runner(request, target)
 	if err != nil {
 		return nil, connectionFailed(err)
 	}
-	identity := managerIdentityForLease(request.Snapshot, request.Environment)
 	unlockIdentity, err := m.lockIdentityContext(ctx, identity)
 	if err != nil {
 		return nil, err
@@ -125,7 +182,7 @@ func (m *Manager) Acquire(
 	}
 	defer releaseIdentity()
 	m.mu.Lock()
-	closed = m.closed
+	closed := m.closed
 	m.mu.Unlock()
 	if closed {
 		return nil, connectionChanged()
@@ -192,10 +249,11 @@ func (m *Manager) Acquire(
 	if err != nil {
 		return nil, mapManagerError(err)
 	}
-	current, err = resolve(ctx)
+	current, err := resolve(ctx)
 	if err != nil {
 		event, cleanupErr := m.disconnectUnleased(
 			identity, generation, request.Snapshot.RouteIdentity, target.ForwardAgent,
+			upstreamIdentity, hopDepth,
 		)
 		if cleanupErr != nil {
 			releaseIdentity()
@@ -209,6 +267,7 @@ func (m *Manager) Acquire(
 	if !sameRoute(request.Snapshot, current) {
 		event, cleanupErr := m.disconnectUnleased(
 			identity, generation, request.Snapshot.RouteIdentity, target.ForwardAgent,
+			upstreamIdentity, hopDepth,
 		)
 		if cleanupErr != nil {
 			releaseIdentity()
@@ -225,6 +284,7 @@ func (m *Manager) Acquire(
 		m.mu.Unlock()
 		event, cleanupErr := m.disconnectUnleased(
 			identity, generation, request.Snapshot.RouteIdentity, target.ForwardAgent,
+			upstreamIdentity, hopDepth,
 		)
 		if cleanupErr != nil {
 			releaseIdentity()
@@ -242,9 +302,11 @@ func (m *Manager) Acquire(
 			m.stopPersistenceHeartbeat(route)
 		}
 		route = &managedRoute{
-			routeIdentity: request.Snapshot.RouteIdentity,
-			generation:    generation,
-			forwardAgent:  target.ForwardAgent,
+			routeIdentity:    request.Snapshot.RouteIdentity,
+			generation:       generation,
+			forwardAgent:     target.ForwardAgent,
+			hopDepth:         hopDepth,
+			upstreamIdentity: upstreamIdentity,
 		}
 		m.routes[identity] = route
 	}
@@ -252,6 +314,7 @@ func (m *Manager) Acquire(
 		route.idle.Stop()
 		route.idle = nil
 	}
+	route.idleDeadline = time.Time{}
 	route.leases++
 	m.startPersistenceHeartbeat(identity, route)
 	m.mu.Unlock()
@@ -268,11 +331,75 @@ func (m *Manager) Acquire(
 	}, nil
 }
 
+type routeLease struct {
+	leases         []Lease
+	released       atomic.Bool
+	releaseStarted atomic.Bool
+	releaseMu      sync.Mutex
+}
+
+func (l *routeLease) Mode() LeaseMode { return l.leases[len(l.leases)-1].Mode() }
+
+func (l *routeLease) Generation() uint64 {
+	return l.leases[len(l.leases)-1].Generation()
+}
+
+func (l *routeLease) Arguments(ctx context.Context) ([]string, error) {
+	if l.releaseStarted.Load() {
+		return nil, connectionChanged()
+	}
+	return l.leases[len(l.leases)-1].Arguments(ctx)
+}
+
+func (l *routeLease) Touch() error {
+	if l.releaseStarted.Load() {
+		return connectionChanged()
+	}
+	for _, lease := range l.leases {
+		if err := lease.Touch(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *routeLease) Release(ctx context.Context) error {
+	l.releaseMu.Lock()
+	defer l.releaseMu.Unlock()
+	if l.released.Load() {
+		return nil
+	}
+	l.releaseStarted.Store(true)
+	if err := releaseLeases(ctx, l.leases); err != nil {
+		return err
+	}
+	l.released.Store(true)
+	return nil
+}
+
+func releaseLeases(ctx context.Context, leases []Lease) error {
+	var releaseErr error
+	for index := len(leases) - 1; index >= 0; index-- {
+		releaseErr = errors.Join(releaseErr, leases[index].Release(ctx))
+	}
+	return releaseErr
+}
+
+func releaseAcquiredLeases(ctx context.Context, leases []Lease) error {
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), leaseRollbackTimeout,
+	)
+	defer cancel()
+	return releaseLeases(cleanupCtx, leases)
+}
+
 func (m *Manager) disconnectUnleased(
 	identity string,
 	generation openssh.Generation,
 	routeIdentity string,
 	forwardAgent bool,
+	upstreamIdentity string,
+	hopDepth int,
 ) (*Event, *service.Error) {
 	m.mu.Lock()
 	route := m.routes[identity]
@@ -286,9 +413,11 @@ func (m *Manager) disconnectUnleased(
 	}
 	if route == nil {
 		route = &managedRoute{
-			routeIdentity: routeIdentity,
-			generation:    generation,
-			forwardAgent:  forwardAgent,
+			routeIdentity:    routeIdentity,
+			generation:       generation,
+			forwardAgent:     forwardAgent,
+			hopDepth:         hopDepth,
+			upstreamIdentity: upstreamIdentity,
 		}
 		m.routes[identity] = route
 	}
@@ -318,9 +447,22 @@ func managerIdentity(snapshot RouteSnapshot) string {
 	return snapshot.ProjectionPolicy + ":" + snapshot.RouteIdentity
 }
 
-func managerIdentityForLease(snapshot RouteSnapshot, environment []string) string {
+func managerIdentityForTarget(
+	snapshot RouteSnapshot,
+	target ResolvedTarget,
+	index int,
+	previousIdentity string,
+	environment []string,
+) string {
 	identity := managerIdentity(snapshot)
-	if len(snapshot.Targets) != 1 || !snapshot.Targets[0].ForwardAgent {
+	if len(snapshot.Targets) > 1 {
+		identity += ":hop:" + fmt.Sprint(index)
+	}
+	if previousIdentity != "" {
+		digest := sha256.Sum256([]byte(previousIdentity))
+		identity += ":via:" + hex.EncodeToString(digest[:])
+	}
+	if !target.ForwardAgent {
 		return identity
 	}
 	digest := sha256.New()
@@ -331,16 +473,31 @@ func managerIdentityForLease(snapshot RouteSnapshot, environment []string) strin
 	return identity + ":agent:" + hex.EncodeToString(digest.Sum(nil))
 }
 
+func targetWithProxy(
+	target ResolvedTarget,
+	previous ResolvedTarget,
+	connectionArguments []string,
+) ResolvedTarget {
+	target.Projection.Arguments = append(
+		append([]string(nil), target.Projection.Arguments...),
+		"-o", "ProxyCommand="+proxyCommand(previous.EffectiveTarget, connectionArguments),
+	)
+	return target
+}
+
 func sameRoute(expected, current RouteSnapshot) bool {
 	return expected.RouteIdentity == current.RouteIdentity &&
 		expected.ProjectionPolicy == current.ProjectionPolicy
 }
 
 type managedLease struct {
-	manager    *Manager
-	identity   string
-	generation openssh.Generation
-	released   atomic.Bool
+	manager        *Manager
+	identity       string
+	generation     openssh.Generation
+	released       atomic.Bool
+	releaseStarted atomic.Bool
+	releaseMu      sync.Mutex
+	countReleased  bool
 }
 
 func (l *managedLease) Mode() LeaseMode { return LeaseModeMultiplexed }
@@ -348,28 +505,46 @@ func (l *managedLease) Mode() LeaseMode { return LeaseModeMultiplexed }
 func (l *managedLease) Generation() uint64 { return uint64(l.generation) }
 
 func (l *managedLease) Arguments(ctx context.Context) ([]string, error) {
-	if l.released.Load() {
+	if l.releaseStarted.Load() {
 		return nil, connectionChanged()
 	}
 	arguments, err := l.manager.persistent.ConnectionArguments(l.identity, l.generation)
 	if err != nil {
 		return nil, mapManagerError(err)
 	}
+	arguments = append([]string{"-F", os.DevNull}, arguments...)
+	arguments = append(arguments,
+		"-o", "BatchMode=yes",
+		"-o", "ProxyCommand="+proxyFailureCommand(),
+	)
 	return arguments, nil
 }
 
 func (l *managedLease) Touch() error {
-	if l.released.Load() || !l.manager.persistent.TouchActivity(l.identity, l.generation) {
+	if l.releaseStarted.Load() || !l.manager.persistent.TouchActivity(l.identity, l.generation) {
 		return connectionChanged()
 	}
 	return nil
 }
 
-func (l *managedLease) Release() error {
-	if !l.released.CompareAndSwap(false, true) {
+func (l *managedLease) Release(ctx context.Context) error {
+	l.releaseMu.Lock()
+	defer l.releaseMu.Unlock()
+	if l.released.Load() {
 		return nil
 	}
-	return l.manager.release(l.identity, l.generation)
+	l.releaseStarted.Store(true)
+	decremented, err := l.manager.release(
+		ctx, l.identity, l.generation, !l.countReleased,
+	)
+	if decremented {
+		l.countReleased = true
+	}
+	if err != nil {
+		return err
+	}
+	l.released.Store(true)
+	return nil
 }
 
 // startPersistenceHeartbeat keeps OpenSSH's crash-fallback ControlPersist
@@ -459,43 +634,58 @@ func waitPersistenceHeartbeat(ctx context.Context, done <-chan struct{}) error {
 	}
 }
 
-func (m *Manager) release(identity string, generation openssh.Generation) error {
-	unlockIdentity := m.lockIdentity(identity)
+func (m *Manager) release(
+	ctx context.Context,
+	identity string,
+	generation openssh.Generation,
+	decrement bool,
+) (bool, error) {
+	unlockIdentity, err := m.lockIdentityContext(ctx, identity)
+	if err != nil {
+		return false, err
+	}
 
 	m.mu.Lock()
 	route := m.routes[identity]
 	if route == nil || route.generation != generation {
-		closed := m.closed
 		m.mu.Unlock()
 		unlockIdentity()
-		if closed {
-			return nil
-		}
-		return connectionChanged()
+		return false, nil
 	}
-	route.leases--
+	decremented := false
+	if decrement {
+		route.leases--
+		decremented = true
+	}
 	if route.leases > 0 {
 		m.mu.Unlock()
 		unlockIdentity()
-		return nil
+		return decremented, nil
 	}
 	if m.idleTimeout > 0 && !route.forwardAgent {
+		route.idleDeadline = time.Now().Add(m.idleTimeout)
+		routeIdentity := route.routeIdentity
 		route.idle = time.AfterFunc(m.idleTimeout, func() {
-			m.disconnectIdle(identity, generation)
+			m.disconnectIdleGroup(routeIdentity)
 		})
 		m.mu.Unlock()
 		unlockIdentity()
-		return nil
+		return decremented, nil
 	}
 	heartbeatDone := m.stopPersistenceHeartbeat(route)
 	routeIdentity := route.routeIdentity
 	m.mu.Unlock()
-	_ = waitPersistenceHeartbeat(context.Background(), heartbeatDone)
-	if err := m.persistent.Disconnect(context.Background(), identity); err != nil {
+	if err := waitPersistenceHeartbeat(ctx, heartbeatDone); err != nil {
 		failure := cleanupFailed(err)
 		unlockIdentity()
 		m.emitFailure(routeIdentity, generation, failure)
-		return failure
+		return decremented, failure
+	}
+	if err := m.persistent.Disconnect(ctx, identity); err != nil {
+		failure := cleanupFailed(err)
+		unlockIdentity()
+		m.emitFailure(routeIdentity, generation, failure)
+		return decremented, failure
 	}
 	m.mu.Lock()
 	if m.routes[identity] == route {
@@ -508,7 +698,35 @@ func (m *Manager) release(identity string, generation openssh.Generation) error 
 		Generation:    uint64(generation),
 		State:         EventStateDisconnected,
 	})
-	return nil
+	return decremented, nil
+}
+
+func (m *Manager) disconnectIdleGroup(routeIdentity string) {
+	m.idleCleanupMu.Lock()
+	defer m.idleCleanupMu.Unlock()
+
+	now := time.Now()
+	m.mu.Lock()
+	targets := make([]routeCleanupTarget, 0)
+	for identity, route := range m.routes {
+		if route.routeIdentity != routeIdentity || route.leases != 0 ||
+			route.idleDeadline.IsZero() || now.Before(route.idleDeadline) {
+			continue
+		}
+		targets = append(targets, routeCleanupTarget{
+			identity: identity, generation: route.generation, depth: route.hopDepth,
+		})
+	}
+	m.mu.Unlock()
+	sort.Slice(targets, func(left, right int) bool {
+		if targets[left].depth != targets[right].depth {
+			return targets[left].depth > targets[right].depth
+		}
+		return targets[left].identity < targets[right].identity
+	})
+	for _, target := range targets {
+		m.disconnectIdle(target.identity, target.generation)
+	}
 }
 
 func (m *Manager) disconnectIdle(identity string, generation openssh.Generation) {
@@ -516,12 +734,21 @@ func (m *Manager) disconnectIdle(identity string, generation openssh.Generation)
 
 	m.mu.Lock()
 	route := m.routes[identity]
-	if route == nil || route.generation != generation || route.leases != 0 {
+	if route == nil || route.generation != generation || route.leases != 0 ||
+		route.idleDeadline.IsZero() || time.Now().Before(route.idleDeadline) {
 		m.mu.Unlock()
 		unlockIdentity()
 		return
 	}
+	for _, downstream := range m.routes {
+		if downstream.upstreamIdentity == identity {
+			m.mu.Unlock()
+			unlockIdentity()
+			return
+		}
+	}
 	route.idle = nil
+	route.idleDeadline = time.Time{}
 	heartbeatDone := m.stopPersistenceHeartbeat(route)
 	routeIdentity := route.routeIdentity
 	m.mu.Unlock()
@@ -567,13 +794,16 @@ func (m *Manager) Close(ctx context.Context) error {
 		}
 		done := make(chan struct{})
 		m.closeDone = done
-		routeIdentities := make([]string, 0, len(m.routes))
+		routeTargets := make([]routeCleanupTarget, 0, len(m.routes))
 		for identity, route := range m.routes {
-			routeIdentities = append(routeIdentities, identity)
+			routeTargets = append(routeTargets, routeCleanupTarget{
+				identity: identity, generation: route.generation, depth: route.hopDepth,
+			})
 			if route.idle != nil {
 				route.idle.Stop()
 				route.idle = nil
 			}
+			route.idleDeadline = time.Time{}
 			m.stopPersistenceHeartbeat(route)
 		}
 		operationIdentities := make([]string, 0, len(m.operations))
@@ -590,7 +820,7 @@ func (m *Manager) Close(ctx context.Context) error {
 
 		events, closeErr := m.closeAttempt(
 			ctx,
-			routeIdentities,
+			routeTargets,
 			operationIdentities,
 			masterless,
 		)
@@ -607,16 +837,16 @@ func (m *Manager) Close(ctx context.Context) error {
 
 func (m *Manager) closeAttempt(
 	ctx context.Context,
-	routeIdentities []string,
+	routeTargets []routeCleanupTarget,
 	operationIdentities []string,
 	masterless []*masterlessLease,
 ) ([]Event, error) {
 	var closeErr error
-	events := make([]Event, 0, len(routeIdentities)+len(masterless))
+	events := make([]Event, 0, len(routeTargets)+len(masterless))
 
 	for _, lease := range masterless {
 		lease.released.Store(true)
-		cleaned, err := lease.cleanupTracked()
+		cleaned, err := lease.cleanupTracked(ctx)
 		if err != nil {
 			failure := cleanupFailed(err)
 			closeErr = errors.Join(closeErr, failure)
@@ -639,8 +869,14 @@ func (m *Manager) closeAttempt(
 		})
 	}
 
-	sort.Strings(routeIdentities)
-	for _, identity := range routeIdentities {
+	sort.Slice(routeTargets, func(left, right int) bool {
+		if routeTargets[left].depth != routeTargets[right].depth {
+			return routeTargets[left].depth > routeTargets[right].depth
+		}
+		return routeTargets[left].identity < routeTargets[right].identity
+	})
+	for _, target := range routeTargets {
+		identity := target.identity
 		unlockIdentity, err := m.lockIdentityContext(ctx, identity)
 		if err != nil {
 			closeErr = errors.Join(closeErr, err)
@@ -785,9 +1021,12 @@ func (l *masterlessLease) Touch() error {
 	return nil
 }
 
-func (l *masterlessLease) Release() error {
+func (l *masterlessLease) Release(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	l.released.Store(true)
-	cleaned, err := l.cleanupTracked()
+	cleaned, err := l.cleanupTracked(ctx)
 	if err != nil {
 		failure := cleanupFailed(err)
 		l.manager.emitFailure(l.routeIdentity, openssh.Generation(l.generation), failure)
@@ -804,9 +1043,12 @@ func (l *masterlessLease) Release() error {
 	return nil
 }
 
-func (l *masterlessLease) cleanupTracked() (bool, error) {
+func (l *masterlessLease) cleanupTracked(ctx context.Context) (bool, error) {
 	l.cleanupMu.Lock()
 	defer l.cleanupMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 
 	l.manager.mu.Lock()
 	tracked := l.manager.masterless[l.generation] == l

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -21,8 +21,10 @@ type fakePersistentManager struct {
 	generation                openssh.Generation
 	connectErr                error
 	argumentErr               error
+	connectionArguments       []string
 	connectCalls              int
 	connectIdentities         []string
+	disconnectIdentities      []string
 	argumentCalls             int
 	touchCalls                int
 	aliveCalls                int
@@ -45,23 +47,36 @@ type fakePersistentManager struct {
 	connectWait               <-chan struct{}
 	connectOnce               sync.Once
 	connectWaitFor            string
+	connectCancelCall         int
+	connectCancelStarted      chan struct{}
+	connectCancelOnce         sync.Once
 }
 
 func (m *fakePersistentManager) ConnectWithRunner(
-	_ context.Context,
+	ctx context.Context,
 	identity string,
 	_ openssh.Target,
 	_ openssh.RunSSH,
 ) (openssh.Generation, error) {
 	m.mu.Lock()
 	m.connectCalls++
+	connectCall := m.connectCalls
 	m.connectIdentities = append(m.connectIdentities, identity)
 	generation := m.generation
 	connectErr := m.connectErr
 	connectStart := m.connectStart
 	connectWait := m.connectWait
 	connectWaitFor := m.connectWaitFor
+	connectCancelCall := m.connectCancelCall
+	connectCancelStarted := m.connectCancelStarted
 	m.mu.Unlock()
+	if connectCall == connectCancelCall {
+		if connectCancelStarted != nil {
+			m.connectCancelOnce.Do(func() { close(connectCancelStarted) })
+		}
+		<-ctx.Done()
+		return generation, ctx.Err()
+	}
 	shouldWait := connectWait != nil && (connectWaitFor == "" || connectWaitFor == identity)
 	if shouldWait && connectStart != nil {
 		m.connectOnce.Do(func() { close(connectStart) })
@@ -79,6 +94,9 @@ func (m *fakePersistentManager) ConnectionArguments(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.argumentCalls++
+	if m.connectionArguments != nil {
+		return append([]string(nil), m.connectionArguments...), m.argumentErr
+	}
 	return []string{"-S", "control"}, m.argumentErr
 }
 
@@ -118,9 +136,10 @@ func (m *fakePersistentManager) IsAlive(
 	return true, nil
 }
 
-func (m *fakePersistentManager) Disconnect(context.Context, string) error {
+func (m *fakePersistentManager) Disconnect(_ context.Context, identity string) error {
 	m.mu.Lock()
 	m.disconnectCalls++
+	m.disconnectIdentities = append(m.disconnectIdentities, identity)
 	disconnectErr := m.disconnectErr
 	disconnectStart := m.disconnectStart
 	disconnectWait := m.disconnectWait
@@ -157,6 +176,12 @@ func (m *fakePersistentManager) identities() []string {
 	return append([]string(nil), m.connectIdentities...)
 }
 
+func (m *fakePersistentManager) disconnectedIdentities() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.disconnectIdentities...)
+}
+
 func directSnapshot(identity string) RouteSnapshot {
 	return RouteSnapshot{
 		LogicalTarget:    Target{Hostname: "build.example.test"},
@@ -170,6 +195,162 @@ func directSnapshot(identity string) RouteSnapshot {
 			}},
 		}},
 	}
+}
+
+func proxyJumpSnapshot(identity string) RouteSnapshot {
+	snapshot := directSnapshot(identity)
+	snapshot.LogicalTarget = Target{Hostname: "build.example.test"}
+	snapshot.Targets = []ResolvedTarget{
+		{
+			LogicalTarget:   Target{User: "relay", Hostname: "relay.example.test", Port: 2222},
+			EffectiveTarget: Target{User: "relay", Hostname: "relay.example.test", Port: 2222},
+			Projection: ExecutionProjection{Arguments: []string{
+				"-F", os.DevNull, "-o", "HostName=relay.example.test", "-p", "2222",
+			}},
+		},
+		{
+			LogicalTarget:   Target{Hostname: "build.example.test"},
+			EffectiveTarget: Target{User: "deploy", Hostname: "build.example.test", Port: 22},
+			Projection: ExecutionProjection{Arguments: []string{
+				"-F", os.DevNull, "-o", "HostName=build.example.test",
+			}},
+		},
+	}
+	return snapshot
+}
+
+func TestManagerAcquiresProxyJumpRouteAsOneCompositeLease(t *testing.T) {
+	persistent := &fakePersistentManager{generation: 41}
+	var prepared []ResolvedTarget
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(_ LeaseRequest, target ResolvedTarget) (openssh.RunSSH, error) {
+			prepared = append(prepared, target)
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := proxyJumpSnapshot("proxy-route")
+	lease, err := manager.Acquire(
+		context.Background(),
+		LeaseRequest{Snapshot: snapshot},
+		func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+	)
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	assert.NotContains(t, prepared[0].Projection.Arguments, "ProxyCommand")
+	assert.NotContains(t, prepared[1].Projection.Arguments, "ProxyJump=none")
+	proxyOption := prepared[1].Projection.Arguments[len(prepared[1].Projection.Arguments)-1]
+	assert.Contains(t, proxyOption, "ProxyCommand=")
+	assert.Contains(t, proxyOption, "'-F' '"+os.DevNull+"'")
+	assert.Contains(t, proxyOption, "'-S' 'control'")
+	assert.Contains(t, proxyOption, "relay@relay.example.test")
+
+	identities := persistent.identities()
+	require.Len(t, identities, 2)
+	assert.NotEqual(t, identities[0], identities[1])
+	assert.Equal(t, uint64(41), lease.Generation())
+	arguments, err := lease.Arguments(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"-F", os.DevNull,
+		"-S", "control",
+		"-o", "BatchMode=yes",
+		"-o", "ProxyCommand=" + proxyFailureCommand(),
+	}, arguments)
+	require.NoError(t, lease.Touch())
+	require.NoError(t, lease.Release(context.Background()))
+	assert.Equal(t, []string{identities[1], identities[0]}, persistent.disconnectedIdentities())
+}
+
+func TestManagerCloseDisconnectsProxyRouteDownstreamFirst(t *testing.T) {
+	persistent := &fakePersistentManager{generation: 41}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := proxyJumpSnapshot("proxy-close-order")
+	_, err := manager.Acquire(
+		context.Background(), LeaseRequest{Snapshot: snapshot},
+		func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+	)
+	require.NoError(t, err)
+	identities := persistent.identities()
+	require.Len(t, identities, 2)
+
+	require.NoError(t, manager.Close(context.Background()))
+	assert.Equal(t, []string{identities[1], identities[0]}, persistent.disconnectedIdentities())
+}
+
+func TestManagerIdleCleanupWaitsForDownstreamProxyTeardown(t *testing.T) {
+	disconnectStarted := make(chan struct{})
+	allowDisconnect := make(chan struct{})
+	var unblockOnce sync.Once
+	unblock := func() { unblockOnce.Do(func() { close(allowDisconnect) }) }
+	defer unblock()
+	persistent := &fakePersistentManager{
+		generation: 41, disconnectStart: disconnectStarted, disconnectWait: allowDisconnect,
+	}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent, IdleTimeout: time.Millisecond,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := proxyJumpSnapshot("proxy-idle-order")
+	lease, err := manager.Acquire(
+		context.Background(), LeaseRequest{Snapshot: snapshot},
+		func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+	)
+	require.NoError(t, err)
+	identities := persistent.identities()
+	require.Len(t, identities, 2)
+	require.NoError(t, lease.Release(context.Background()))
+
+	select {
+	case <-disconnectStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "downstream idle cleanup did not start")
+	}
+	assert.Equal(t, []string{identities[1]}, persistent.disconnectedIdentities())
+	assert.Never(t, func() bool {
+		return len(persistent.disconnectedIdentities()) > 1
+	}, 30*time.Millisecond, time.Millisecond)
+	unblock()
+	require.Eventually(t, func() bool {
+		return len(persistent.disconnectedIdentities()) == 2
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, []string{identities[1], identities[0]}, persistent.disconnectedIdentities())
+}
+
+func TestManagerPartitionsEveryProxyHopByForwardedAgentChain(t *testing.T) {
+	persistent := &fakePersistentManager{generation: 42}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := proxyJumpSnapshot("proxy-agent-route")
+	snapshot.Targets[0].ForwardAgent = true
+	resolve := func(context.Context) (RouteSnapshot, error) { return snapshot, nil }
+
+	first, err := manager.Acquire(context.Background(), LeaseRequest{
+		Snapshot: snapshot, Environment: []string{"SSH_AUTH_SOCK=/tmp/agent-one"},
+	}, resolve)
+	require.NoError(t, err)
+	second, err := manager.Acquire(context.Background(), LeaseRequest{
+		Snapshot: snapshot, Environment: []string{"SSH_AUTH_SOCK=/tmp/agent-two"},
+	}, resolve)
+	require.NoError(t, err)
+
+	identities := persistent.identities()
+	require.Len(t, identities, 4)
+	assert.NotEqual(t, identities[0], identities[2])
+	assert.NotEqual(t, identities[1], identities[3])
+	require.NoError(t, first.Release(context.Background()))
+	require.NoError(t, second.Release(context.Background()))
 }
 
 func TestManagerSharesGenerationUntilFinalLeaseRelease(t *testing.T) {
@@ -193,12 +374,17 @@ func TestManagerSharesGenerationUntilFinalLeaseRelease(t *testing.T) {
 
 	arguments, err := first.Arguments(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"-S", "control"}, arguments)
+	assert.Equal(t, []string{
+		"-F", os.DevNull,
+		"-S", "control",
+		"-o", "BatchMode=yes",
+		"-o", "ProxyCommand=" + proxyFailureCommand(),
+	}, arguments)
 	require.NoError(t, first.Touch())
-	require.NoError(t, first.Release())
+	require.NoError(t, first.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 0, disconnects)
-	require.NoError(t, second.Release())
+	require.NoError(t, second.Release(context.Background()))
 	connects, argumentCalls, touches, disconnects := persistent.counts()
 	assert.Equal(t, 2, connects)
 	assert.Equal(t, 1, argumentCalls)
@@ -223,7 +409,7 @@ func TestManagerKeepsFinalLeaseWarmUntilIdleTimeout(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 0, disconnects)
 	assert.Eventually(t, func() bool {
@@ -250,7 +436,7 @@ func TestManagerDisconnectsForwardAgentRouteOnFinalRelease(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 1, disconnects)
 }
@@ -296,8 +482,8 @@ func TestManagerPartitionsForwardAgentRoutesByExecutionEnvironment(t *testing.T)
 	identities := persistent.identities()
 	require.Len(t, identities, 2)
 	assert.NotEqual(t, identities[0], identities[1])
-	require.NoError(t, first.Release())
-	require.NoError(t, second.Release())
+	require.NoError(t, first.Release(context.Background()))
+	require.NoError(t, second.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 2, disconnects)
 }
@@ -328,7 +514,7 @@ func TestManagerRefreshesOpenSSHPersistenceWhileRouteIsTracked(t *testing.T) {
 	persistent.mu.Lock()
 	activeHeartbeats := persistent.aliveCalls
 	persistent.mu.Unlock()
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 	assert.Eventually(t, func() bool {
 		persistent.mu.Lock()
 		defer persistent.mu.Unlock()
@@ -343,7 +529,7 @@ func TestManagerWaitsForPersistenceHeartbeatBeforeTeardown(t *testing.T) {
 		stop func(*Manager, Lease) error
 	}{
 		{name: "final release", stop: func(_ *Manager, lease Lease) error {
-			return lease.Release()
+			return lease.Release(context.Background())
 		}},
 		{name: "manager close", stop: func(manager *Manager, _ Lease) error {
 			return manager.Close(context.Background())
@@ -440,7 +626,7 @@ func TestManagerRetriesFailedFinalAndIdleCleanupOnClose(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			releaseErr := lease.Release()
+			releaseErr := lease.Release(context.Background())
 			if test.idleTimeout == 0 {
 				require.Error(t, releaseErr)
 			} else {
@@ -459,6 +645,148 @@ func TestManagerRetriesFailedFinalAndIdleCleanupOnClose(t *testing.T) {
 			assert.Equal(t, 2, disconnects)
 		})
 	}
+}
+
+func TestLeaseReleaseRetriesFailedDisconnect(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		snapshot RouteSnapshot
+		hops     int
+	}{
+		{name: "direct route", snapshot: directSnapshot("direct-release-retry"), hops: 1},
+		{name: "proxy route", snapshot: proxyJumpSnapshot("proxy-release-retry"), hops: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			persistent := &fakePersistentManager{
+				generation:    17,
+				disconnectErr: errors.New("exit command failed"),
+			}
+			manager := NewManager(ManagerOptions{
+				Persistent: persistent,
+				Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+					return func(context.Context, []string) (int, error) { return 0, nil }, nil
+				},
+			})
+			lease, err := manager.Acquire(
+				context.Background(),
+				LeaseRequest{Snapshot: test.snapshot},
+				func(context.Context) (RouteSnapshot, error) { return test.snapshot, nil },
+			)
+			require.NoError(t, err)
+
+			require.Error(t, lease.Release(context.Background()))
+			persistent.mu.Lock()
+			persistent.disconnectErr = nil
+			persistent.mu.Unlock()
+			require.NoError(t, lease.Release(context.Background()))
+
+			_, _, _, disconnects := persistent.counts()
+			assert.Equal(t, 2*test.hops, disconnects)
+			manager.mu.Lock()
+			assert.Empty(t, manager.routes)
+			manager.mu.Unlock()
+		})
+	}
+}
+
+func TestProxyAcquireCancellationReleasesEarlierHops(t *testing.T) {
+	secondHopStarted := make(chan struct{})
+	persistent := &fakePersistentManager{
+		generation:           17,
+		connectCancelCall:    2,
+		connectCancelStarted: secondHopStarted,
+	}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := proxyJumpSnapshot("proxy-cancel-rollback")
+	ctx, cancel := context.WithCancel(context.Background())
+	acquireDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Acquire(
+			ctx,
+			LeaseRequest{Snapshot: snapshot},
+			func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+		)
+		acquireDone <- err
+	}()
+	select {
+	case <-secondHopStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "second ProxyJump hop did not start")
+	}
+	cancel()
+
+	assert.ErrorIs(t, <-acquireDone, context.Canceled)
+	_, _, _, disconnects := persistent.counts()
+	assert.Equal(t, 1, disconnects)
+	manager.mu.Lock()
+	assert.Empty(t, manager.routes)
+	manager.mu.Unlock()
+}
+
+func TestLeaseReleaseCompletesAfterFailedRouteIsReplaced(t *testing.T) {
+	persistent := &fakePersistentManager{
+		generation:    17,
+		disconnectErr: errors.New("exit command failed"),
+	}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := directSnapshot("release-after-replacement")
+	resolve := func(context.Context) (RouteSnapshot, error) { return snapshot, nil }
+	oldLease, err := manager.Acquire(
+		context.Background(), LeaseRequest{Snapshot: snapshot}, resolve,
+	)
+	require.NoError(t, err)
+	require.Error(t, oldLease.Release(context.Background()))
+
+	persistent.mu.Lock()
+	persistent.generation = 18
+	persistent.disconnectErr = nil
+	persistent.mu.Unlock()
+	newLease, err := manager.Acquire(
+		context.Background(), LeaseRequest{Snapshot: snapshot}, resolve,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, oldLease.Release(context.Background()))
+	require.NoError(t, newLease.Release(context.Background()))
+}
+
+func TestStaleLeaseFirstReleaseCompletesAfterRouteGenerationIsReplaced(t *testing.T) {
+	persistent := &fakePersistentManager{generation: 17}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := directSnapshot("release-stale-generation")
+	resolve := func(context.Context) (RouteSnapshot, error) { return snapshot, nil }
+	oldLease, err := manager.Acquire(
+		context.Background(), LeaseRequest{Snapshot: snapshot}, resolve,
+	)
+	require.NoError(t, err)
+
+	persistent.mu.Lock()
+	persistent.generation = 18
+	persistent.mu.Unlock()
+	newLease, err := manager.Acquire(
+		context.Background(), LeaseRequest{Snapshot: snapshot}, resolve,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, oldLease.Release(context.Background()))
+	require.NoError(t, newLease.Release(context.Background()))
+	_, _, _, disconnects := persistent.counts()
+	assert.Equal(t, 1, disconnects)
 }
 
 func TestManagerSerializesAcquireWithFinalAndIdleDisconnect(t *testing.T) {
@@ -505,7 +833,7 @@ func TestManagerSerializesAcquireWithFinalAndIdleDisconnect(t *testing.T) {
 			require.NoError(t, err)
 
 			releaseDone := make(chan error, 1)
-			go func() { releaseDone <- lease.Release() }()
+			go func() { releaseDone <- lease.Release(context.Background()) }()
 			select {
 			case <-disconnectStarted:
 			case <-time.After(time.Second):
@@ -562,7 +890,7 @@ func TestManagerCloseDisconnectsRoutesAndRejectsNewAcquires(t *testing.T) {
 	assert.True(t, service.IsCode(err, service.SSHConnectionChanged))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 1, disconnects)
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 }
 
 func TestManagerCloseSerializesWithFinalLeaseRelease(t *testing.T) {
@@ -622,7 +950,7 @@ func TestManagerCloseSerializesWithFinalLeaseRelease(t *testing.T) {
 	manager.mu.Unlock()
 
 	require.NoError(t, <-closeDone)
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 1, disconnects)
 }
@@ -729,7 +1057,7 @@ func TestManagerCloseCleansEstablishedRoutesBeforeWaitingOnOperations(t *testing
 	unblockConnect()
 	assert.True(t, service.IsCode(<-blockedDone, service.SSHConnectionChanged))
 	require.NoError(t, manager.Close(context.Background()))
-	require.NoError(t, establishedLease.Release())
+	require.NoError(t, establishedLease.Release(context.Background()))
 }
 
 func TestManagerPreservesTypedPromptFailure(t *testing.T) {
@@ -785,7 +1113,7 @@ func TestManagerEventCallbackCanAcquireSameRoute(t *testing.T) {
 					context.Background(), LeaseRequest{Snapshot: snapshot}, resolve,
 				)
 				if err == nil {
-					err = lease.Release()
+					err = lease.Release(context.Background())
 				}
 				callbackDone <- err
 			})
@@ -832,7 +1160,7 @@ func TestManagerReportsIdleCleanupFailure(t *testing.T) {
 		func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
 	)
 	require.NoError(t, err)
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 
 	assert.Eventually(t, func() bool {
 		select {
@@ -898,7 +1226,7 @@ func TestManagerFullyTearsDownWarmRouteAfterPostConnectChange(t *testing.T) {
 		func(context.Context) (RouteSnapshot, error) { return expected, nil },
 	)
 	require.NoError(t, err)
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 
 	resolveCalls := 0
 	_, err = manager.Acquire(
@@ -1035,7 +1363,7 @@ func TestManagerDoesNotDisconnectSharedMasterWhenSecondLeaseChanges(t *testing.T
 	assert.True(t, service.IsCode(err, service.SSHConfigurationChanged))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 0, disconnects)
-	require.NoError(t, first.Release())
+	require.NoError(t, first.Release(context.Background()))
 }
 
 func TestManagerReturnsMasterlessLeaseWhenPersistenceIsUnsupported(t *testing.T) {
@@ -1065,7 +1393,7 @@ func TestManagerReturnsMasterlessLeaseWhenPersistenceIsUnsupported(t *testing.T)
 		"-o", "ControlMaster=no", "-o", "ControlPersist=no", "-S", "none",
 	}, arguments)
 	require.NoError(t, lease.Touch())
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 0, disconnects)
 }
@@ -1132,7 +1460,7 @@ func TestMasterlessLeaseRetainsPrivateProjectionUntilRelease(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `IdentityFile "C:/keys/build"`+"\n", string(contents))
 
-	require.NoError(t, lease.Release())
+	require.NoError(t, lease.Release(context.Background()))
 	assert.NoFileExists(t, configPath)
 }
 
@@ -1183,7 +1511,7 @@ func TestMasterlessLeaseRetriesFailedCleanupOnClose(t *testing.T) {
 	}
 	manager.masterless[lease.generation] = lease
 
-	require.Error(t, lease.Release())
+	require.Error(t, lease.Release(context.Background()))
 	require.NoError(t, manager.Close(context.Background()))
 	assert.Equal(t, 2, cleanupCalls)
 }
@@ -1209,7 +1537,7 @@ func TestMasterlessReleaseAndCloseShareOneCleanupAttempt(t *testing.T) {
 	manager.masterless[lease.generation] = lease
 
 	releaseDone := make(chan error, 1)
-	go func() { releaseDone <- lease.Release() }()
+	go func() { releaseDone <- lease.Release(context.Background()) }()
 	select {
 	case <-cleanupStarted:
 	case <-time.After(time.Second):

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -260,6 +261,61 @@ func TestManagerAcquiresProxyJumpRouteAsOneCompositeLease(t *testing.T) {
 	require.NoError(t, lease.Touch())
 	require.NoError(t, lease.Release(context.Background()))
 	assert.Equal(t, []string{identities[1], identities[0]}, persistent.disconnectedIdentities())
+}
+
+func TestMultiplexedLeaseRetainsReviewedSessionProjection(t *testing.T) {
+	privateDirectory := filepath.Join(t.TempDir(), "private")
+	persistent := &fakePersistentManager{generation: 41}
+	manager := NewManager(ManagerOptions{
+		Persistent:       persistent,
+		PrivateDirectory: privateDirectory,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := proxyJumpSnapshot("session-projection")
+	snapshot.Targets[0].Projection.Arguments = append(
+		snapshot.Targets[0].Projection.Arguments, "-o", "SendEnv=UPSTREAM",
+	)
+	snapshot.Targets[0].Projection.PrivateConfig = []string{
+		`SetEnv "UPSTREAM=value"`,
+	}
+	snapshot.Targets[1].Projection.Arguments = append(
+		snapshot.Targets[1].Projection.Arguments,
+		"-o", "ForwardAgent=yes",
+		"-o", "SendEnv=LANG",
+		"-o", "EscapeChar=~",
+	)
+	snapshot.Targets[1].Projection.PrivateConfig = []string{
+		`IdentityFile "/credentials/id"`,
+		`SetEnv "CHANNEL=alpha beta"`,
+	}
+
+	lease, err := manager.Acquire(
+		context.Background(),
+		LeaseRequest{Snapshot: snapshot},
+		func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+	)
+	require.NoError(t, err)
+
+	arguments, err := lease.Arguments(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, arguments, "ForwardAgent=yes")
+	assert.Contains(t, arguments, "SendEnv=LANG")
+	assert.Contains(t, arguments, "EscapeChar=~")
+	assert.NotContains(t, arguments, "SendEnv=UPSTREAM")
+	configIndex := slices.Index(arguments, "-F")
+	require.GreaterOrEqual(t, configIndex, 0)
+	require.Less(t, configIndex+1, len(arguments))
+	configPath := arguments[configIndex+1]
+	assert.NotEqual(t, os.DevNull, configPath)
+	config, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "SetEnv \"CHANNEL=alpha beta\"\n", string(config))
+
+	require.NoError(t, lease.Release(context.Background()))
+	_, err = os.Stat(configPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestManagerCloseDisconnectsProxyRouteDownstreamFirst(t *testing.T) {

--- a/internal/ssh/projection.go
+++ b/internal/ssh/projection.go
@@ -24,6 +24,7 @@ type projectionOption struct {
 	name    string
 	openSSH string
 	private bool
+	session bool
 }
 
 var projectionOptionsV1 = []projectionOption{
@@ -48,7 +49,7 @@ var projectionOptionsV1 = []projectionOption{
 	{name: "addkeystoagent", openSSH: "AddKeysToAgent"},
 	{name: "certificatefile", openSSH: "CertificateFile", private: true},
 	{name: "enablesshkeysign", openSSH: "EnableSSHKeysign"},
-	{name: "forwardagent", openSSH: "ForwardAgent"},
+	{name: "forwardagent", openSSH: "ForwardAgent", session: true},
 	{name: "gssapiauthentication", openSSH: "GSSAPIAuthentication"},
 	{name: "gssapidelegatecredentials", openSSH: "GSSAPIDelegateCredentials"},
 	{name: "hostbasedacceptedalgorithms", openSSH: "HostbasedAcceptedAlgorithms"},
@@ -64,9 +65,41 @@ var projectionOptionsV1 = []projectionOption{
 	{name: "pubkeyauthentication", openSSH: "PubkeyAuthentication"},
 	{name: "securitykeyprovider", openSSH: "SecurityKeyProvider", private: true},
 	{name: "usekeychain", openSSH: "UseKeychain"},
-	{name: "escapechar", openSSH: "EscapeChar"},
-	{name: "sendenv", openSSH: "SendEnv"},
-	{name: "setenv", openSSH: "SetEnv", private: true},
+	{name: "escapechar", openSSH: "EscapeChar", session: true},
+	{name: "sendenv", openSSH: "SendEnv", session: true},
+	{name: "setenv", openSSH: "SetEnv", private: true, session: true},
+}
+
+func multiplexedSessionProjection(projected ExecutionProjection) ExecutionProjection {
+	result := ExecutionProjection{Arguments: []string{"-F", os.DevNull}}
+	for index := 0; index+1 < len(projected.Arguments); index++ {
+		if projected.Arguments[index] != "-o" {
+			continue
+		}
+		name, _, found := strings.Cut(projected.Arguments[index+1], "=")
+		if found && isSessionProjectionOption(name) {
+			result.Arguments = append(
+				result.Arguments, projected.Arguments[index], projected.Arguments[index+1],
+			)
+		}
+		index++
+	}
+	for _, line := range projected.PrivateConfig {
+		name, _, _ := strings.Cut(line, " ")
+		if isSessionProjectionOption(name) {
+			result.PrivateConfig = append(result.PrivateConfig, line)
+		}
+	}
+	return result
+}
+
+func isSessionProjectionOption(name string) bool {
+	for _, option := range projectionOptionsV1 {
+		if option.session && strings.EqualFold(option.openSSH, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func projectConfig(config openssh.EffectiveConfig) (projection, error) {

--- a/internal/ssh/proxy_command.go
+++ b/internal/ssh/proxy_command.go
@@ -1,0 +1,32 @@
+package ssh
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func proxyCommand(previous Target, connectionArguments []string) string {
+	destination, port := previous.CommandDestination()
+	arguments := []string{
+		"ssh",
+		"-F", os.DevNull,
+		"-o", "CanonicalizeHostname=no",
+	}
+	arguments = append(arguments, connectionArguments...)
+	arguments = append(arguments,
+		"-o", "BatchMode=yes",
+		"-o", "ControlMaster=no",
+		"-o", "ControlPersist=no",
+		"-o", "ProxyCommand="+proxyFailureCommand(),
+	)
+	if port != 0 {
+		arguments = append(arguments, "-p", strconv.Itoa(port))
+	}
+	arguments = append(arguments, "-W", "[%h]:%p", "--", destination)
+	quoted := make([]string, len(arguments))
+	for index, argument := range arguments {
+		quoted[index] = quoteProxyArgument(argument)
+	}
+	return strings.Join(quoted, " ")
+}

--- a/internal/ssh/proxy_command_posix.go
+++ b/internal/ssh/proxy_command_posix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package ssh
+
+func quoteProxyArgument(value string) string { return shellQuote(value) }
+
+func proxyFailureCommand() string { return "/usr/bin/false" }

--- a/internal/ssh/proxy_command_posix_test.go
+++ b/internal/ssh/proxy_command_posix_test.go
@@ -1,0 +1,142 @@
+//go:build !windows
+
+package ssh
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/openssh"
+)
+
+func TestTargetProxyCommandWinsOpenSSHEffectiveConfiguration(t *testing.T) {
+	previous := ResolvedTarget{
+		EffectiveTarget: Target{User: "relay", Hostname: "relay.example.test", Port: 2222},
+	}
+	target := targetWithProxy(
+		ResolvedTarget{
+			EffectiveTarget: Target{User: "deploy", Hostname: "build.example.test", Port: 22},
+			Projection: ExecutionProjection{Arguments: []string{
+				"-F", os.DevNull,
+				"-o", "HostName=build.example.test",
+			}},
+		},
+		previous,
+		[]string{"-S", filepath.Join(t.TempDir(), "control")},
+	)
+
+	arguments := append([]string{"-G"}, target.Projection.Arguments...)
+	arguments = append(arguments, "--", "build.example.test")
+	output, err := exec.Command("ssh", arguments...).CombinedOutput()
+	require.NoError(t, err, string(output))
+	config := openssh.ParseConfig(output)
+	proxyCommandValue := ""
+	for _, option := range config.Options {
+		if option.Name == "proxycommand" {
+			proxyCommandValue = option.Value
+			break
+		}
+	}
+	assert.Contains(t, proxyCommandValue, "-S")
+	assert.Contains(t, proxyCommandValue, "relay@relay.example.test")
+}
+
+func TestProxyCommandDoesNotConnectDirectlyWhenControlSocketIsMissing(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, listener.Close()) }()
+	port := listener.Addr().(*net.TCPAddr).Port
+	accepted := make(chan struct{})
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = connection.Close()
+			close(accepted)
+		}
+	}()
+
+	commandText := proxyCommand(
+		Target{User: "relay", Hostname: "127.0.0.1", Port: port},
+		[]string{"-S", filepath.Join(t.TempDir(), "missing-control")},
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "/bin/sh", "-c", commandText)
+	err = command.Run()
+	require.Error(t, err)
+	assert.NotEqual(t, context.DeadlineExceeded, ctx.Err())
+
+	select {
+	case <-accepted:
+		t.Fatal("proxy transport connected directly after the control socket was absent")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestMultiplexedLeaseDoesNotConnectDirectlyWhenControlSocketIsMissing(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, listener.Close()) }()
+	port := listener.Addr().(*net.TCPAddr).Port
+	accepted := make(chan struct{})
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = connection.Close()
+			close(accepted)
+		}
+	}()
+
+	persistent := &fakePersistentManager{
+		generation: 1,
+		connectionArguments: []string{
+			"-o", "ControlMaster=no",
+			"-o", "ControlPersist=no",
+			"-S", filepath.Join(
+				os.TempDir(), "kwt-missing-"+strconv.FormatInt(time.Now().UnixNano(), 10),
+			),
+		},
+	}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := directSnapshot("fail-closed-route")
+	lease, err := manager.Acquire(
+		context.Background(),
+		LeaseRequest{Snapshot: snapshot},
+		func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+	)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, lease.Release(context.Background())) }()
+	arguments, err := lease.Arguments(context.Background())
+	require.NoError(t, err)
+	arguments = append(arguments,
+		"-o", "ConnectTimeout=1",
+		"-p", strconv.Itoa(port),
+		"--", "127.0.0.1",
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "ssh", arguments...)
+	err = command.Run()
+	require.Error(t, err)
+	assert.NotEqual(t, context.DeadlineExceeded, ctx.Err())
+
+	select {
+	case <-accepted:
+		t.Fatal("multiplexed lease connected directly after the control socket was absent")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/internal/ssh/proxy_command_windows.go
+++ b/internal/ssh/proxy_command_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package ssh
+
+import "golang.org/x/sys/windows"
+
+func quoteProxyArgument(value string) string { return windows.EscapeArg(value) }
+
+func proxyFailureCommand() string { return "cmd.exe /d /c exit 255" }

--- a/internal/ssh/proxy_command_windows_test.go
+++ b/internal/ssh/proxy_command_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestProxyCommandWindowsRoundTripsControlPath(t *testing.T) {
+	controlPath := `C:\Users\User Name\kwt\control "quoted"`
+	command := proxyCommand(
+		Target{User: "relay", Hostname: "relay.example.test", Port: 2222},
+		[]string{"-S", controlPath},
+	)
+	arguments, err := windows.DecomposeCommandLine(command)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(arguments), 3)
+	assert.Equal(t, "ssh", arguments[0])
+	for index, argument := range arguments {
+		if argument == "-S" && index+1 < len(arguments) {
+			assert.Equal(t, controlPath, arguments[index+1])
+			return
+		}
+	}
+	t.Fatal("proxy command did not contain a control path")
+}

--- a/internal/ssh/public_service_test.go
+++ b/internal/ssh/public_service_test.go
@@ -200,8 +200,8 @@ func TestPublicServiceBuildsOneOwnerScopedPersistentManager(t *testing.T) {
 	require.NoError(t, err)
 	second, err := service.Acquire(context.Background(), LeaseRequest{Snapshot: snapshot})
 	require.NoError(t, err)
-	require.NoError(t, first.Release())
-	require.NoError(t, second.Release())
+	require.NoError(t, first.Release(context.Background()))
+	require.NoError(t, second.Release(context.Background()))
 	require.NoError(t, service.Close(context.Background()))
 
 	assert.Equal(t, 1, created)

--- a/internal/ssh/service_test.go
+++ b/internal/ssh/service_test.go
@@ -41,8 +41,8 @@ func (fixedLease) Arguments(context.Context) ([]string, error) {
 	return []string{"-S", "socket"}, nil
 }
 
-func (fixedLease) Touch() error   { return nil }
-func (fixedLease) Release() error { return nil }
+func (fixedLease) Touch() error                  { return nil }
+func (fixedLease) Release(context.Context) error { return nil }
 
 func (r *fixedObservationResolver) Resolve(
 	context.Context,

--- a/internal/ssh/types.go
+++ b/internal/ssh/types.go
@@ -82,7 +82,7 @@ type Lease interface {
 	Generation() uint64
 	Arguments(context.Context) ([]string, error)
 	Touch() error
-	Release() error
+	Release(context.Context) error
 }
 
 type Event struct {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -427,12 +427,8 @@ func (t *TmuxCommand) SessionEnvironmentContext(
 	return t.RunCommandOutputContext(ctx, "show-environment", "-t", session)
 }
 
-// sessionOption reads a session-local user option without falling back to a
-// global value. Missing options return the tmux command error to the caller.
-func (t *TmuxCommand) sessionOption(session, option string) (string, error) {
-	return t.sessionOptionContext(context.Background(), session, option)
-}
-
+// sessionOptionContext reads a session-local user option without falling back
+// to a global value. Missing options return the tmux command error to the caller.
 func (t *TmuxCommand) sessionOptionContext(
 	ctx context.Context,
 	session string,
@@ -464,10 +460,6 @@ func (t *TmuxCommand) sessionUserOption(
 		"="+session+":",
 		"#{"+option+"}",
 	)
-}
-
-func (t *TmuxCommand) globalOption(option string) (string, error) {
-	return t.globalOptionContext(context.Background(), option)
 }
 
 func (t *TmuxCommand) globalOptionContext(

--- a/service/operation.go
+++ b/service/operation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 )
 
 const (
@@ -35,6 +36,7 @@ type OperationPrompt struct {
 	Kind      string         `json:"kind"`
 	Message   string         `json:"message"`
 	Sensitive bool           `json:"sensitive"`
+	Deadline  *time.Time     `json:"deadline,omitempty"`
 	Details   map[string]any `json:"details,omitempty"`
 }
 


### PR DESCRIPTION
Ghosthub cannot remove its Swift SSH lifecycle owner until kwt can keep a reviewed OpenSSH route alive across authentication and session startup.

- Gives native clients generation-bound daemon leases with ordered progress and multi-round authentication prompts.
- Prepares every ProxyJump hop through the preceding verified master, so execution cannot bypass the resolved route.
- Keeps active leases alive with heartbeats, expires abandoned clients, and drains connections during daemon replacement instead of transferring authentication state.
- Adds `kwt ssh lease --json` as the subprocess bridge while keeping system OpenSSH and kit authoritative.
- Validates the complete stream, prompt, and release contract from Ghosthub's migration branch; the production Ghosthub cutover remains deliberately separate.
