### PR TITLE
Guard protected attachment with inventory authority

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -584,6 +584,12 @@ identity, creates or repairs that protected blank session when needed, and
 uses `attach-session -E`. This is an interactive exception to the PR JSON
 contract: failures before attachment remain structured, but after a successful
 Unix process replacement tmux owns terminal output and the final exit status.
+Automation clients may additionally pass `--expected-repository`,
+`--expected-registration`, `--expected-generation`, `--expected-session`, and
+`--expected-socket` together. Kwt revalidates that exact inventory authority
+under the project lifecycle fence before creating or repairing the protected
+session; a mismatch fails with retryable `registration_changed` and does not
+touch tmux. Omit all five flags for ordinary interactive attachment.
 Provenance with a durable generation applies only to that exact worktree
 incarnation. If the path is later reused, stale provenance neither protects the
 replacement from ordinary `kwt open` nor authorizes `kwt pr attach` or merged

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -34,6 +34,25 @@ kwt's protected path:
 kwt pr attach <workspace.path>
 ```
 
+Automation clients that already hold a `kwt list --json` snapshot can bind
+session establishment to that exact authority by supplying all five expected
+values together:
+
+```sh
+kwt pr attach <workspace.path> \
+  --expected-repository <project.repository> \
+  --expected-registration <project.registration_fingerprint> \
+  --expected-generation <workspace.generation> \
+  --expected-session <workspace.session_name> \
+  --expected-socket <workspace.tmux_socket_name>
+```
+
+Kwt revalidates those values while holding the project lifecycle fence and
+before it creates or repairs the protected tmux session. A changed project,
+worktree incarnation, session name, or socket returns the retryable
+`registration_changed` error without touching tmux. The five flags are an
+all-or-nothing contract; ordinary interactive use may omit all of them.
+
 `kwt pr attach` is an interactive exception to the JSON automation contract.
 Validation and session-establishment failures that occur before attachment
 still use the structured error envelope and stable PR exit status. On

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -34,9 +34,19 @@ kwt's protected path:
 kwt pr attach <workspace.path>
 ```
 
-Automation clients that already hold a `kwt list --json` snapshot can bind
-session establishment to that exact authority by supplying all five expected
+Automation clients bind session establishment to current `kwt list --json` and
+`kwt projects --json` snapshots. The worktree list is flat and does not contain
+a nested project record or registration fingerprint. Match its `repository`
+field to the project record with the same `repository`, then supply these five
 values together:
+
+| Attach flag | Source |
+| --- | --- |
+| `--expected-repository` | Matching project's `repository` from `kwt projects --json` |
+| `--expected-registration` | Matching project's `registration_fingerprint` from `kwt projects --json` |
+| `--expected-generation` | Selected worktree's `generation` from `kwt list --json` |
+| `--expected-session` | Selected worktree's `session_name` from `kwt list --json` |
+| `--expected-socket` | Selected worktree's `tmux_socket_name` from `kwt list --json` |
 
 ```sh
 kwt pr attach <workspace.path> \

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -54,6 +54,7 @@ var (
 	readPRWorkspaceGeneration        = func(projectPath, path string) (string, error) {
 		return gitadapter.New(projectPath).ReadWorktreeGeneration(path)
 	}
+	withPRWorkspaceGeneration     = defaultWithPRWorkspaceGeneration
 	errImportedPRWorkspaceChanged = errors.New(
 		"imported pull-request workspace changed",
 	)
@@ -334,9 +335,31 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 			)
 		}
 		record = current
-		socketName, currentErr = ensurePRWorkspaceSession(
-			cmd.Context(), record.Workspace, cfg,
+		establish := func() error {
+			socketName, currentErr = ensurePRWorkspaceSession(
+				cmd.Context(), record.Workspace, cfg,
+			)
+			return currentErr
+		}
+		if !guarded {
+			return establish()
+		}
+		currentErr = withPRWorkspaceGeneration(
+			cmd.Context(),
+			record.Project.Path,
+			record.Workspace.Path,
+			record.Workspace.Generation,
+			establish,
 		)
+		var conditionErr *gitadapter.ConditionError
+		if errors.As(currentErr, &conditionErr) &&
+			conditionErr.Reason == gitadapter.ReasonGenerationChanged {
+			return service.NewError(
+				service.RegistrationChanged,
+				"the imported workspace changed before attachment",
+				true, nil, currentErr,
+			)
+		}
 		return currentErr
 	})
 	if service.IsCode(err, service.RegistrationChanged) {
@@ -361,6 +384,20 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 		))
 	}
 	return nil
+}
+
+func defaultWithPRWorkspaceGeneration(
+	ctx context.Context,
+	projectPath string,
+	workspacePath string,
+	generation string,
+	establish func() error,
+) error {
+	return gitadapter.NewWithContext(ctx, projectPath).WithWorktreeGeneration(
+		workspacePath,
+		generation,
+		establish,
+	)
 }
 
 func guardedPRAttachError(err error, guarded bool) error {
@@ -512,36 +549,38 @@ func importedWorkspaceProvenance(
 			err,
 		)
 	}
-	liveGeneration := ""
+	type generationObservation struct {
+		generation string
+		err        error
+	}
+	observations := make(map[string]generationObservation, len(pathMatches))
+	matches := make([]pullrequest.Provenance, 0, len(pathMatches))
 	for _, record := range pathMatches {
 		if record.Workspace.Generation == "" {
+			matches = append(matches, record)
 			continue
 		}
-		liveGeneration, err = readPRWorkspaceGeneration(
-			record.Project.Path,
-			workspacePath,
-		)
-		if err != nil {
-			cause := err
-			if errors.Is(err, os.ErrNotExist) ||
-				errors.Is(err, gitadapter.ErrWorktreeNotFound) {
-				cause = fmt.Errorf("%w: %v", errImportedPRWorkspaceChanged, err)
+		projectKey := utils.PathKey(record.Project.Path)
+		observation, observed := observations[projectKey]
+		if !observed {
+			observation.generation, observation.err = readPRWorkspaceGeneration(
+				record.Project.Path,
+				workspacePath,
+			)
+			observations[projectKey] = observation
+		}
+		if observation.err != nil {
+			if errors.Is(observation.err, gitadapter.ErrWorktreeNotFound) {
+				continue
 			}
 			return pullrequest.Provenance{}, pullrequest.NewError(
 				pullrequest.CodeWorkspaceCreation,
 				"failed to inspect live workspace generation",
 				false,
-				cause,
+				observation.err,
 			)
 		}
-		break
-	}
-	matches := make([]pullrequest.Provenance, 0, len(pathMatches))
-	for _, record := range pathMatches {
-		if provenanceGenerationMatches(
-			record.Workspace.Generation,
-			liveGeneration,
-		) {
+		if record.Workspace.Generation == observation.generation {
 			matches = append(matches, record)
 		}
 	}

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -568,10 +568,6 @@ func importedWorkspaceProvenance(
 	observations := make(map[string]generationObservation, len(pathMatches))
 	matches := make([]pullrequest.Provenance, 0, len(pathMatches))
 	for _, record := range pathMatches {
-		if record.Workspace.Generation == "" {
-			matches = append(matches, record)
-			continue
-		}
 		projectKey := utils.PathKey(record.Project.Path)
 		observation, observed := observations[projectKey]
 		if !observed {
@@ -597,7 +593,8 @@ func importedWorkspaceProvenance(
 				observation.err,
 			)
 		}
-		if record.Workspace.Generation == observation.generation {
+		if record.Workspace.Generation == "" ||
+			record.Workspace.Generation == observation.generation {
 			matches = append(matches, record)
 		}
 	}

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -51,8 +51,8 @@ var (
 	validatePRWorkspaceSessionConfig = defaultValidatePRWorkspaceSessionConfig
 	ensurePRWorkspaceSession         = defaultStartPRWorkspaceSession
 	attachExistingPRWorkspaceSession = defaultAttachExistingPRWorkspaceSession
-	readPRWorkspaceGeneration        = func(path string) (string, error) {
-		return gitadapter.New(path).ReadWorktreeGeneration(path)
+	readPRWorkspaceGeneration        = func(projectPath, path string) (string, error) {
+		return gitadapter.New(projectPath).ReadWorktreeGeneration(path)
 	}
 	errImportedPRWorkspaceChanged = errors.New(
 		"imported pull-request workspace changed",
@@ -517,7 +517,10 @@ func importedWorkspaceProvenance(
 		if record.Workspace.Generation == "" {
 			continue
 		}
-		liveGeneration, err = readPRWorkspaceGeneration(workspacePath)
+		liveGeneration, err = readPRWorkspaceGeneration(
+			record.Project.Path,
+			workspacePath,
+		)
 		if err != nil {
 			cause := err
 			if errors.Is(err, os.ErrNotExist) ||
@@ -608,7 +611,10 @@ func rejectProtectedWorkspaceOpen(
 		pathMatched = pathMatched || samePRPath(workspace.Path, workspacePath)
 	}
 	if pathMatched {
-		liveGeneration, err = readPRWorkspaceGeneration(workspacePath)
+		liveGeneration, err = readPRWorkspaceGeneration(
+			workspacePath,
+			workspacePath,
+		)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to verify live generation for pull-request workspace: %w",
@@ -668,7 +674,8 @@ func defaultInspectPRProjectClone(
 	}
 	if len(registered) > 1 {
 		return pullrequest.Project{}, nil, fmt.Errorf(
-			"recorded project is not uniquely registered",
+			"%w: recorded project is not uniquely registered",
+			errImportedPRWorkspaceChanged,
 		)
 	}
 	if len(registered) == 1 &&
@@ -681,7 +688,8 @@ func defaultInspectPRProjectClone(
 			publishableProjectRepository(registered[0]),
 		) {
 		return pullrequest.Project{}, nil, fmt.Errorf(
-			"registered project conflicts with recorded identity",
+			"%w: registered project conflicts with recorded identity",
+			errImportedPRWorkspaceChanged,
 		)
 	}
 	g := gitadapter.New(project.Path)
@@ -714,7 +722,8 @@ func defaultInspectPRProjectClone(
 		project.Identity,
 	) {
 		return pullrequest.Project{}, nil, fmt.Errorf(
-			"live project conflicts with recorded identity",
+			"%w: live project conflicts with recorded identity",
+			errImportedPRWorkspaceChanged,
 		)
 	}
 	return project, livePRWorkspaces(info, project, live), nil

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -30,6 +30,11 @@ type prService interface {
 	Import(context.Context, pullrequest.Project, string) (pullrequest.ImportResult, error)
 }
 
+type verifiedPRProvenance struct {
+	record         pullrequest.Provenance
+	liveGeneration string
+}
+
 var (
 	prProject      string
 	prState        string
@@ -272,13 +277,14 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	record, err := importedWorkspaceProvenance(
+	verified, err := importedWorkspaceProvenance(
 		cmd.Context(),
 		args[0],
 	)
 	if err != nil {
 		return writePRError(cmd, guardedPRAttachError(err, guarded))
 	}
+	record := verified.record
 	cfg, err := loadPRTargetConfig(record.Project.Path, false)
 	if err != nil {
 		return writePRError(cmd, pullrequest.NewError(
@@ -314,12 +320,13 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 	}
 	var socketName string
 	err = guard.run(cmd.Context(), func() error {
-		current, currentErr := importedWorkspaceProvenance(
+		currentVerified, currentErr := importedWorkspaceProvenance(
 			cmd.Context(), args[0],
 		)
 		if currentErr != nil {
 			return guardedPRAttachError(currentErr, guarded)
 		}
+		current := currentVerified.record
 		if !provenanceMatchesProjectClaim(current, guard.claim) {
 			return service.NewError(
 				service.RegistrationChanged,
@@ -327,12 +334,17 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 				true, nil, nil,
 			)
 		}
-		if guarded && !expectedPRAttachMatches(current, guard.claim) {
-			return service.NewError(
-				service.RegistrationChanged,
-				"the imported workspace changed before attachment",
-				true, nil, nil,
-			)
+		if guarded {
+			guardedCurrent := current
+			guardedCurrent.Workspace.Generation = currentVerified.liveGeneration
+			if !expectedPRAttachMatches(guardedCurrent, guard.claim) {
+				return service.NewError(
+					service.RegistrationChanged,
+					"the imported workspace changed before attachment",
+					true, nil, nil,
+				)
+			}
+			current.Workspace.Generation = currentVerified.liveGeneration
 		}
 		record = current
 		establish := func() error {
@@ -348,7 +360,7 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 			cmd.Context(),
 			record.Project.Path,
 			record.Workspace.Path,
-			record.Workspace.Generation,
+			currentVerified.liveGeneration,
 			establish,
 		)
 		var conditionErr *gitadapter.ConditionError
@@ -527,7 +539,7 @@ func provenanceMatchesProjectClaim(
 func importedWorkspaceProvenance(
 	ctx context.Context,
 	workspacePath string,
-) (pullrequest.Provenance, error) {
+) (verifiedPRProvenance, error) {
 	path := utils.CanonicalPath(workspacePath)
 	var pathMatches []pullrequest.Provenance
 	err := pullrequest.NewFileStore(prStorePath()).View(
@@ -542,7 +554,7 @@ func importedWorkspaceProvenance(
 		},
 	)
 	if err != nil {
-		return pullrequest.Provenance{}, pullrequest.NewError(
+		return verifiedPRProvenance{}, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation,
 			"failed to read pull-request provenance",
 			false,
@@ -570,10 +582,11 @@ func importedWorkspaceProvenance(
 			observations[projectKey] = observation
 		}
 		if observation.err != nil {
-			if errors.Is(observation.err, gitadapter.ErrWorktreeNotFound) {
+			if errors.Is(observation.err, gitadapter.ErrWorktreeNotFound) ||
+				prProjectCheckoutMissing(record.Project.Path) {
 				continue
 			}
-			return pullrequest.Provenance{}, pullrequest.NewError(
+			return verifiedPRProvenance{}, pullrequest.NewError(
 				pullrequest.CodeWorkspaceCreation,
 				"failed to inspect live workspace generation",
 				false,
@@ -585,7 +598,7 @@ func importedWorkspaceProvenance(
 		}
 	}
 	if len(matches) != 1 {
-		return pullrequest.Provenance{}, pullrequest.NewError(
+		return verifiedPRProvenance{}, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation,
 			"workspace is not a uniquely verified pull-request import",
 			false,
@@ -598,7 +611,7 @@ func importedWorkspaceProvenance(
 		record,
 	)
 	if err != nil {
-		return pullrequest.Provenance{}, pullrequest.NewError(
+		return verifiedPRProvenance{}, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation,
 			"failed to verify imported workspace provenance",
 			false,
@@ -610,15 +623,25 @@ func importedWorkspaceProvenance(
 		record,
 	)
 	if !samePRProjectClone(record, liveProject) || !workspaceMatches {
-		return pullrequest.Provenance{}, pullrequest.NewError(
+		return verifiedPRProvenance{}, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation,
 			"workspace no longer matches its pull-request provenance",
 			false,
 			errImportedPRWorkspaceChanged,
 		)
 	}
-	record.Workspace.Generation = verifiedWorkspace.Generation
-	return record, nil
+	return verifiedPRProvenance{
+		record:         record,
+		liveGeneration: verifiedWorkspace.Generation,
+	}, nil
+}
+
+func prProjectCheckoutMissing(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return errors.Is(err, os.ErrNotExist)
 }
 
 func rejectProtectedWorkspaceOpen(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -54,6 +54,9 @@ var (
 	readPRWorkspaceGeneration        = func(path string) (string, error) {
 		return gitadapter.New(path).ReadWorktreeGeneration(path)
 	}
+	errImportedPRWorkspaceChanged = errors.New(
+		"imported pull-request workspace changed",
+	)
 )
 
 func provenanceGenerationMatches(recorded, live string) bool {
@@ -273,7 +276,7 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 		args[0],
 	)
 	if err != nil {
-		return writePRError(cmd, err)
+		return writePRError(cmd, guardedPRAttachError(err, guarded))
 	}
 	cfg, err := loadPRTargetConfig(record.Project.Path, false)
 	if err != nil {
@@ -314,7 +317,7 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 			cmd.Context(), args[0],
 		)
 		if currentErr != nil {
-			return currentErr
+			return guardedPRAttachError(currentErr, guarded)
 		}
 		if !provenanceMatchesProjectClaim(current, guard.claim) {
 			return service.NewError(
@@ -358,6 +361,19 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 		))
 	}
 	return nil
+}
+
+func guardedPRAttachError(err error, guarded bool) error {
+	if !guarded || !errors.Is(err, errImportedPRWorkspaceChanged) {
+		return err
+	}
+	return service.NewError(
+		service.RegistrationChanged,
+		"the imported workspace changed before attachment",
+		true,
+		nil,
+		err,
+	)
 }
 
 func validateExpectedPRAttachFlags(cmd *cobra.Command) (bool, error) {
@@ -452,7 +468,10 @@ func expectedPRAttachMatches(
 	}
 	return record.Workspace.Generation == prAttachExpectedGeneration &&
 		record.Workspace.SessionName == prAttachExpectedSession &&
-		record.Workspace.TmuxSocketName == prAttachExpectedSocket
+		tmux.ProtectedWorkspaceSocketName(
+			record.Workspace.SessionName,
+			record.Workspace.Path,
+		) == prAttachExpectedSocket
 }
 
 func provenanceMatchesProjectClaim(
@@ -500,11 +519,16 @@ func importedWorkspaceProvenance(
 		}
 		liveGeneration, err = readPRWorkspaceGeneration(workspacePath)
 		if err != nil {
+			cause := err
+			if errors.Is(err, os.ErrNotExist) ||
+				errors.Is(err, gitadapter.ErrWorktreeNotFound) {
+				cause = fmt.Errorf("%w: %v", errImportedPRWorkspaceChanged, err)
+			}
 			return pullrequest.Provenance{}, pullrequest.NewError(
 				pullrequest.CodeWorkspaceCreation,
 				"failed to inspect live workspace generation",
 				false,
-				err,
+				cause,
 			)
 		}
 		break
@@ -523,7 +547,7 @@ func importedWorkspaceProvenance(
 			pullrequest.CodeWorkspaceCreation,
 			"workspace is not a uniquely verified pull-request import",
 			false,
-			nil,
+			errImportedPRWorkspaceChanged,
 		)
 	}
 	record := matches[0]
@@ -539,15 +563,19 @@ func importedWorkspaceProvenance(
 			err,
 		)
 	}
-	if !samePRProjectClone(record, liveProject) ||
-		!containsPRWorkspace(liveWorkspaces, record) {
+	verifiedWorkspace, workspaceMatches := verifiedPRWorkspace(
+		liveWorkspaces,
+		record,
+	)
+	if !samePRProjectClone(record, liveProject) || !workspaceMatches {
 		return pullrequest.Provenance{}, pullrequest.NewError(
 			pullrequest.CodeWorkspaceCreation,
 			"workspace no longer matches its pull-request provenance",
 			false,
-			nil,
+			errImportedPRWorkspaceChanged,
 		)
 	}
+	record.Workspace.Generation = verifiedWorkspace.Generation
 	return record, nil
 }
 
@@ -753,6 +781,14 @@ func containsPRWorkspace(
 	live []pullrequest.Workspace,
 	recorded pullrequest.Provenance,
 ) bool {
+	_, ok := verifiedPRWorkspace(live, recorded)
+	return ok
+}
+
+func verifiedPRWorkspace(
+	live []pullrequest.Workspace,
+	recorded pullrequest.Provenance,
+) (pullrequest.Workspace, bool) {
 	for _, candidate := range live {
 		if utils.CanonicalPath(candidate.Path) ==
 			utils.CanonicalPath(recorded.Workspace.Path) &&
@@ -762,10 +798,10 @@ func containsPRWorkspace(
 				candidate.Generation,
 			) &&
 			prWorkspaceIdentityMatches(candidate, recorded) {
-			return true
+			return candidate, true
 		}
 	}
-	return false
+	return pullrequest.Workspace{}, false
 }
 
 func prWorkspaceIdentityMatches(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -36,6 +36,12 @@ var (
 	prJSON         bool
 	prStartSession bool
 
+	prAttachExpectedRepository   string
+	prAttachExpectedRegistration string
+	prAttachExpectedGeneration   string
+	prAttachExpectedSession      string
+	prAttachExpectedSocket       string
+
 	loadPRConfig                     = config.Load
 	loadPRTargetConfig               = config.LoadForTarget
 	newPRService                     = defaultNewPRService
@@ -105,6 +111,36 @@ func init() {
 		"start-session",
 		false,
 		"ensure the imported workspace's tmux session exists without attaching",
+	)
+	prAttachCmd.Flags().StringVar(
+		&prAttachExpectedRepository,
+		"expected-repository",
+		"",
+		"require this registered project identity before attaching",
+	)
+	prAttachCmd.Flags().StringVar(
+		&prAttachExpectedRegistration,
+		"expected-registration",
+		"",
+		"require this project registration fingerprint before attaching",
+	)
+	prAttachCmd.Flags().StringVar(
+		&prAttachExpectedGeneration,
+		"expected-generation",
+		"",
+		"require this worktree generation before attaching",
+	)
+	prAttachCmd.Flags().StringVar(
+		&prAttachExpectedSession,
+		"expected-session",
+		"",
+		"require this protected tmux session name before attaching",
+	)
+	prAttachCmd.Flags().StringVar(
+		&prAttachExpectedSocket,
+		"expected-socket",
+		"",
+		"require this protected tmux socket name before attaching",
 	)
 	prCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return writePRError(cmd, pullrequest.NewError(pullrequest.CodeInvalidSelector, err.Error(), false, nil))
@@ -228,6 +264,10 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return prExactArgs(1)(cmd, args)
 	}
+	guarded, err := validateExpectedPRAttachFlags(cmd)
+	if err != nil {
+		return writePRError(cmd, err)
+	}
 	record, err := importedWorkspaceProvenance(
 		cmd.Context(),
 		args[0],
@@ -252,10 +292,19 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	guard, err := observeRequiredGuardedProjectOperation(
-		cmd.Context(), home, record.Project.Path, expansion,
-		pullrequest.ProvenanceRepositoryIdentities(record)...,
-	)
+	var guard *guardedProjectOperation
+	if guarded {
+		guard, err = observeExpectedGuardedProjectOperation(
+			cmd.Context(), home, record.Project.Path, expansion,
+			prAttachExpectedRepository,
+			prAttachExpectedRegistration,
+		)
+	} else {
+		guard, err = observeRequiredGuardedProjectOperation(
+			cmd.Context(), home, record.Project.Path, expansion,
+			pullrequest.ProvenanceRepositoryIdentities(record)...,
+		)
+	}
 	if err != nil {
 		return writePRError(cmd, err)
 	}
@@ -271,6 +320,13 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 			return service.NewError(
 				service.RegistrationChanged,
 				"the imported workspace changed projects before attachment",
+				true, nil, nil,
+			)
+		}
+		if guarded && !expectedPRAttachMatches(current, guard.claim) {
+			return service.NewError(
+				service.RegistrationChanged,
+				"the imported workspace changed before attachment",
 				true, nil, nil,
 			)
 		}
@@ -302,6 +358,101 @@ func runPRAttach(cmd *cobra.Command, args []string) error {
 		))
 	}
 	return nil
+}
+
+func validateExpectedPRAttachFlags(cmd *cobra.Command) (bool, error) {
+	names := []string{
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	}
+	values := []string{
+		prAttachExpectedRepository,
+		prAttachExpectedRegistration,
+		prAttachExpectedGeneration,
+		prAttachExpectedSession,
+		prAttachExpectedSocket,
+	}
+	changed := 0
+	for _, name := range names {
+		if commandFlagChanged(cmd, name) {
+			changed++
+		}
+	}
+	if changed == 0 {
+		return false, nil
+	}
+	if changed != len(names) {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected repository, registration, generation, session, and socket must be provided together",
+			false, nil, nil,
+		)
+	}
+	for _, value := range values {
+		if value == "" {
+			return false, service.NewError(
+				service.InvalidRequest,
+				"expected repository, registration, generation, session, and socket must be nonempty",
+				false, nil, nil,
+			)
+		}
+	}
+	if !lifecycle.EqualProjectIdentity(
+		prAttachExpectedRepository,
+		prAttachExpectedRepository,
+	) {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected repository identity is invalid",
+			false, nil, nil,
+		)
+	}
+	if !config.ValidProjectRegistrationFingerprint(prAttachExpectedRegistration) {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected project registration fingerprint is invalid",
+			false, nil, nil,
+		)
+	}
+	if err := gitadapter.ValidateWorktreeGeneration(prAttachExpectedGeneration); err != nil {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected worktree generation is invalid",
+			false, nil, err,
+		)
+	}
+	if strings.ContainsAny(prAttachExpectedSession, "\t\r\n") ||
+		strings.TrimSpace(prAttachExpectedSocket) != prAttachExpectedSocket ||
+		strings.ContainsAny(prAttachExpectedSocket, "\t\r\n/\\") {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected protected session identity is invalid",
+			false, nil, nil,
+		)
+	}
+	return true, nil
+}
+
+func expectedPRAttachMatches(
+	record pullrequest.Provenance,
+	claim *lifecycle.ProjectClaim,
+) bool {
+	if claim == nil || !projectClaimHasExpectedIdentity(
+		claim,
+		[]string{prAttachExpectedRepository},
+	) {
+		return false
+	}
+	fingerprint, err := claim.Registration.Fingerprint()
+	if err != nil || fingerprint != prAttachExpectedRegistration {
+		return false
+	}
+	return record.Workspace.Generation == prAttachExpectedGeneration &&
+		record.Workspace.SessionName == prAttachExpectedSession &&
+		record.Workspace.TmuxSocketName == prAttachExpectedSocket
 }
 
 func provenanceMatchesProjectClaim(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -583,6 +583,10 @@ func importedWorkspaceProvenance(
 		}
 		if observation.err != nil {
 			if errors.Is(observation.err, gitadapter.ErrWorktreeNotFound) ||
+				errors.Is(
+					observation.err,
+					gitadapter.ErrWorktreeRepositoryMismatch,
+				) ||
 				prProjectCheckoutMissing(record.Project.Path) {
 				continue
 			}

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -578,6 +578,16 @@ func importedWorkspaceProvenance(
 			observations[projectKey] = observation
 		}
 		if observation.err != nil {
+			if record.Workspace.Generation == "" && errors.Is(
+				observation.err,
+				gitadapter.ErrWorktreeGenerationNotFound,
+			) {
+				// Ownership was proven before the missing marker was reported.
+				// The project inventory below initializes the generation under
+				// the repository worktree lock and verifies the legacy record.
+				matches = append(matches, record)
+				continue
+			}
 			if errors.Is(observation.err, gitadapter.ErrWorktreeNotFound) ||
 				errors.Is(
 					observation.err,

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -733,6 +733,7 @@ func TestRunPRAttachPreservesLegacyGenerationForUnguardedSession(t *testing.T) {
 	))
 	cfg := testPRConfig()
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(t, recorded.Path, live.Generation)
 	inspectPRProjectClone = func(
 		context.Context,
 		pullrequest.Provenance,
@@ -1579,6 +1580,20 @@ func TestImportedWorkspaceProvenanceEvaluatesEachCandidateProject(t *testing.T) 
 }
 
 func TestImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(t *testing.T) {
+	testImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(t, true)
+}
+
+func TestImportedWorkspaceProvenanceDiscardsLegacyAnotherRepositoryOwner(
+	t *testing.T,
+) {
+	testImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(t, false)
+}
+
+func testImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(
+	t *testing.T,
+	staleHasGeneration bool,
+) {
+	t.Helper()
 	t.Setenv("KWT_HOME", t.TempDir())
 	staleRepo := newPRInspectionRepo(t)
 	currentRepo := newPRInspectionRepo(t)
@@ -1603,13 +1618,18 @@ func TestImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(t *testing.T)
 	)
 	require.NoError(t, err)
 	require.NotEqual(t, staleGeneration, currentGeneration)
+	staleRecordGeneration := staleGeneration
+	if !staleHasGeneration {
+		staleRecordGeneration = ""
+	}
 	stale := pullrequest.Provenance{
 		Project: pullrequest.Project{
 			Identity: "github.com/acme/stale", Path: staleRepo,
 		},
 		Workspace: pullrequest.Workspace{
 			Path: worktreePath, Repository: "github.com/acme/stale",
-			Generation: staleGeneration, SessionName: "kwt-workspace-stale",
+			Generation:  staleRecordGeneration,
+			SessionName: "kwt-workspace-stale",
 		},
 	}
 	current := pullrequest.Provenance{

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -24,6 +24,7 @@ import (
 	kwt "go.kenn.io/kwt"
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/credentials"
+	gitadapter "go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/lifecycle"
 	"go.kenn.io/kwt/internal/pullrequest"
 	"go.kenn.io/kwt/internal/template"
@@ -698,6 +699,90 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	assert.True(t, attached)
 }
 
+func TestRunPRAttachGuardUsesVerifiedLiveWorkspaceIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     "/repos/widget",
+	}
+	recorded := pullrequest.Workspace{
+		Path:        "/worktrees/pr-verified",
+		Branch:      "pr-verified",
+		Repository:  project.Identity,
+		SessionName: "kwt-workspace-pr-verified",
+	}
+	live := recorded
+	live.Generation = "0123456789abcdef0123456789abcdef"
+	expectedSocket := tmux.ProtectedWorkspaceSocketName(
+		recorded.SessionName,
+		recorded.Path,
+	)
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-verified"] = pullrequest.Provenance{
+				Project: project, Workspace: recorded,
+			}
+			return nil
+		},
+	))
+	cfg := &models.Config{Projects: []models.Project{{
+		Repository: project.Identity, Name: project.Name, Path: project.Path,
+	}}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return project, []pullrequest.Workspace{live}, nil
+	}
+	snapshot, err := config.LoadGlobalSnapshotAt(home)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	fingerprint, err := snapshot.Projects[0].Fingerprint()
+	require.NoError(t, err)
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = fingerprint
+	prAttachExpectedGeneration = live.Generation
+	prAttachExpectedSession = recorded.SessionName
+	prAttachExpectedSocket = expectedSocket
+	cmd, _, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	ensurePRWorkspaceSession = func(
+		_ context.Context,
+		got pullrequest.Workspace,
+		_ *models.Config,
+	) (string, error) {
+		assert.Equal(t, live.Generation, got.Generation)
+		assert.Empty(t, got.TmuxSocketName)
+		return expectedSocket, nil
+	}
+	attached := false
+	attachExistingPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+		string,
+	) error {
+		attached = true
+		return nil
+	}
+
+	err = runPRAttach(cmd, []string{recorded.Path})
+
+	require.NoError(t, err)
+	assert.True(t, attached)
+}
+
 func TestRunPRAttachRejectsStaleGuardBeforeEnsuringSession(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KWT_HOME", home)
@@ -904,6 +989,95 @@ func TestRunPRAttachRejectsProvenanceReplacementWhileWaitingForProjectFence(t *t
 	cmd, stdout, _ := prTestCommand()
 
 	err := runPRAttach(cmd, []string{workspace.Path})
+
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.False(t, ensured)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
+func TestRunPRAttachClassifiesDisappearanceWhileWaitingAsRegistrationChanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     "/repos/widget",
+	}
+	workspace := pullrequest.Workspace{
+		Path:        "/worktrees/pr-disappeared",
+		Branch:      "pr-disappeared",
+		Repository:  project.Identity,
+		Generation:  "0123456789abcdef0123456789abcdef",
+		SessionName: "kwt-workspace-pr-disappeared",
+		TmuxSocketName: tmux.ProtectedWorkspaceSocketName(
+			"kwt-workspace-pr-disappeared",
+			"/worktrees/pr-disappeared",
+		),
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-disappeared"] = pullrequest.Provenance{
+				Project: project, Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	cfg := &models.Config{Projects: []models.Project{{
+		Repository: project.Identity, Name: project.Name, Path: project.Path,
+	}}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	disappeared := false
+	readPRWorkspaceGeneration = func(string) (string, error) {
+		if disappeared {
+			return "", fmt.Errorf(
+				"read worktree identity: %w",
+				gitadapter.ErrWorktreeNotFound,
+			)
+		}
+		return workspace.Generation, nil
+	}
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return project, []pullrequest.Workspace{workspace}, nil
+	}
+	oldBeforeAcquire := beforeProjectGuardAcquire
+	t.Cleanup(func() { beforeProjectGuardAcquire = oldBeforeAcquire })
+	beforeProjectGuardAcquire = func() { disappeared = true }
+	snapshot, err := config.LoadGlobalSnapshotAt(home)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	fingerprint, err := snapshot.Projects[0].Fingerprint()
+	require.NoError(t, err)
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = fingerprint
+	prAttachExpectedGeneration = workspace.Generation
+	prAttachExpectedSession = workspace.SessionName
+	prAttachExpectedSocket = workspace.TmuxSocketName
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	ensured := false
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		ensured = true
+		return workspace.TmuxSocketName, nil
+	}
+
+	err = runPRAttach(cmd, []string{workspace.Path})
 
 	assert.True(t, service.IsCode(err, service.RegistrationChanged))
 	assert.False(t, ensured)

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -148,7 +148,7 @@ func stubPRWorkspaceGeneration(t *testing.T, path, generation string) {
 	t.Helper()
 	oldRead := readPRWorkspaceGeneration
 	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
-	readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+	readPRWorkspaceGeneration = func(_, gotPath string) (string, error) {
 		assert.Equal(t, path, gotPath)
 		return generation, nil
 	}
@@ -1030,7 +1030,7 @@ func TestRunPRAttachClassifiesDisappearanceWhileWaitingAsRegistrationChanged(t *
 	}}}
 	withPRCommandDeps(t, cfg, &fakePRService{})
 	disappeared := false
-	readPRWorkspaceGeneration = func(string) (string, error) {
+	readPRWorkspaceGeneration = func(string, string) (string, error) {
 		if disappeared {
 			return "", fmt.Errorf(
 				"read worktree identity: %w",
@@ -1078,6 +1078,173 @@ func TestRunPRAttachClassifiesDisappearanceWhileWaitingAsRegistrationChanged(t *
 	}
 
 	err = runPRAttach(cmd, []string{workspace.Path})
+
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.False(t, ensured)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
+func TestRunPRAttachClassifiesDeletedWorkspaceAsRegistrationChanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	repo := newPRInspectionRepo(t)
+	runPRInspectionGit(
+		t,
+		repo,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/acme/widget.git",
+	)
+	branch := "pr-deleted"
+	workspacePath := filepath.Join(t.TempDir(), branch)
+	runPRInspectionGit(t, repo, "branch", branch)
+	runPRInspectionGit(t, repo, "worktree", "add", workspacePath, branch)
+	generation, err := gitadapter.New(repo).WorktreeGeneration(workspacePath)
+	require.NoError(t, err)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	workspace := pullrequest.Workspace{
+		Path:        workspacePath,
+		Branch:      branch,
+		Repository:  project.Identity,
+		Generation:  generation,
+		SessionName: "kwt-workspace-pr-deleted",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[branch] = pullrequest.Provenance{
+				Project: project, Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	registered, err := config.RegisterProjectWithIdentity(models.Project{
+		Repository: project.Identity,
+		Name:       project.Name,
+		Path:       project.Path,
+	})
+	require.NoError(t, err)
+	cfg := &models.Config{Projects: []models.Project{registered.Project}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = registered.Fingerprint
+	prAttachExpectedGeneration = generation
+	prAttachExpectedSession = workspace.SessionName
+	prAttachExpectedSocket = tmux.ProtectedWorkspaceSocketName(
+		workspace.SessionName,
+		workspace.Path,
+	)
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	require.NoError(t, os.RemoveAll(workspacePath))
+	ensured := false
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		ensured = true
+		return "", nil
+	}
+
+	err = runPRAttach(cmd, []string{workspacePath})
+
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.False(t, ensured)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
+func TestRunPRAttachClassifiesReplacedProjectRegistrationAsChanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	repo := newPRInspectionRepo(t)
+	branch := "pr-replaced-registration"
+	workspacePath := filepath.Join(t.TempDir(), branch)
+	runPRInspectionGit(t, repo, "branch", branch)
+	runPRInspectionGit(t, repo, "worktree", "add", workspacePath, branch)
+	generation, err := gitadapter.New(repo).WorktreeGeneration(workspacePath)
+	require.NoError(t, err)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	workspace := pullrequest.Workspace{
+		Path:        workspacePath,
+		Branch:      branch,
+		Repository:  project.Identity,
+		Generation:  generation,
+		SessionName: "kwt-workspace-pr-replaced-registration",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[branch] = pullrequest.Provenance{
+				Project: project, Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	expected, err := config.RegisterProjectWithIdentity(models.Project{
+		Repository: project.Identity,
+		Name:       project.Name,
+		Path:       project.Path,
+	})
+	require.NoError(t, err)
+	replacement, err := config.RegisterProjectWithIdentity(models.Project{
+		Repository: "github.com/other/widget",
+		Name:       project.Name,
+		Path:       project.Path,
+	})
+	require.NoError(t, err)
+	cfg := &models.Config{Projects: []models.Project{replacement.Project}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	validatePRProjectRoot = defaultValidatePRProjectRoot
+	inspectPRProjectClone = defaultInspectPRProjectClone
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = expected.Fingerprint
+	prAttachExpectedGeneration = generation
+	prAttachExpectedSession = workspace.SessionName
+	prAttachExpectedSocket = tmux.ProtectedWorkspaceSocketName(
+		workspace.SessionName,
+		workspace.Path,
+	)
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	ensured := false
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		ensured = true
+		return "", nil
+	}
+
+	err = runPRAttach(cmd, []string{workspacePath})
 
 	assert.True(t, service.IsCode(err, service.RegistrationChanged))
 	assert.False(t, ensured)
@@ -1430,7 +1597,7 @@ func TestRunPRAttachIgnoresStaleGenerationBeforeCounting(t *testing.T) {
 		},
 	))
 	withPRCommandDeps(t, testPRConfig(), &fakePRService{})
-	readPRWorkspaceGeneration = func(string) (string, error) {
+	readPRWorkspaceGeneration = func(string, string) (string, error) {
 		return live.Generation, nil
 	}
 	inspectPRProjectClone = func(
@@ -1473,7 +1640,7 @@ func TestImportedWorkspaceProvenanceRejectsUnreadableLiveGeneration(t *testing.T
 	))
 	oldRead := readPRWorkspaceGeneration
 	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
-	readPRWorkspaceGeneration = func(string) (string, error) {
+	readPRWorkspaceGeneration = func(string, string) (string, error) {
 		return "", errors.New("generation unavailable")
 	}
 
@@ -1521,7 +1688,7 @@ func TestProtectedWorkspaceOpenMatchesGeneration(t *testing.T) {
 			oldRead := readPRWorkspaceGeneration
 			t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
 			readCalls := 0
-			readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+			readPRWorkspaceGeneration = func(_, gotPath string) (string, error) {
 				readCalls++
 				assert.Equal(t, path, gotPath)
 				return tt.liveGeneration, nil
@@ -1554,7 +1721,7 @@ func TestProtectedWorkspaceOpenFailsClosedWhenLiveGenerationIsUnavailable(t *tes
 	))
 	oldRead := readPRWorkspaceGeneration
 	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
-	readPRWorkspaceGeneration = func(string) (string, error) {
+	readPRWorkspaceGeneration = func(string, string) (string, error) {
 		return "", errors.New("generation unavailable")
 	}
 
@@ -1583,7 +1750,7 @@ func TestProtectedWorkspaceOpenUsesPlatformPathIdentity(t *testing.T) {
 	))
 	oldRead := readPRWorkspaceGeneration
 	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
-	readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+	readPRWorkspaceGeneration = func(_, gotPath string) (string, error) {
 		assert.Equal(t, path, gotPath)
 		return generation, nil
 	}
@@ -1610,7 +1777,7 @@ func TestProtectedWorkspaceOpenRecognizesMovedWorkspaceByGeneration(t *testing.T
 	))
 	oldRead := readPRWorkspaceGeneration
 	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
-	readPRWorkspaceGeneration = func(gotPath string) (string, error) {
+	readPRWorkspaceGeneration = func(_, gotPath string) (string, error) {
 		return "", fmt.Errorf("unexpected generation read for %s", gotPath)
 	}
 
@@ -1625,7 +1792,7 @@ func TestProtectedWorkspaceOpenSkipsGenerationReadWithoutProvenance(t *testing.T
 	oldRead := readPRWorkspaceGeneration
 	t.Cleanup(func() { readPRWorkspaceGeneration = oldRead })
 	readCalls := 0
-	readPRWorkspaceGeneration = func(string) (string, error) {
+	readPRWorkspaceGeneration = func(string, string) (string, error) {
 		readCalls++
 		return "", errors.New("must not be called")
 	}

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -75,6 +75,11 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldProject := prProject
 	oldState := prState
 	oldStartSession := prStartSession
+	oldAttachExpectedRepository := prAttachExpectedRepository
+	oldAttachExpectedRegistration := prAttachExpectedRegistration
+	oldAttachExpectedGeneration := prAttachExpectedGeneration
+	oldAttachExpectedSession := prAttachExpectedSession
+	oldAttachExpectedSocket := prAttachExpectedSocket
 	oldValidateSessionConfig := validatePRWorkspaceSessionConfig
 	oldStartWorkspaceSession := ensurePRWorkspaceSession
 	oldAttachWorkspaceSession := attachExistingPRWorkspaceSession
@@ -89,6 +94,11 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		prProject = oldProject
 		prState = oldState
 		prStartSession = oldStartSession
+		prAttachExpectedRepository = oldAttachExpectedRepository
+		prAttachExpectedRegistration = oldAttachExpectedRegistration
+		prAttachExpectedGeneration = oldAttachExpectedGeneration
+		prAttachExpectedSession = oldAttachExpectedSession
+		prAttachExpectedSocket = oldAttachExpectedSocket
 		validatePRWorkspaceSessionConfig = oldValidateSessionConfig
 		ensurePRWorkspaceSession = oldStartWorkspaceSession
 		attachExistingPRWorkspaceSession = oldAttachWorkspaceSession
@@ -114,6 +124,11 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	prProject = "widget"
 	prState = "open"
 	prStartSession = false
+	prAttachExpectedRepository = ""
+	prAttachExpectedRegistration = ""
+	prAttachExpectedGeneration = ""
+	prAttachExpectedSession = ""
+	prAttachExpectedSocket = ""
 	validatePRWorkspaceSessionConfig = func(*models.Config) error {
 		return nil
 	}
@@ -681,6 +696,80 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, attached)
+}
+
+func TestRunPRAttachRejectsStaleGuardBeforeEnsuringSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     "/repos/widget",
+	}
+	workspace := pullrequest.Workspace{
+		Path:           "/worktrees/pr-guarded",
+		Branch:         "pr-guarded",
+		Repository:     project.Identity,
+		Generation:     "0123456789abcdef0123456789abcdef",
+		SessionName:    "kwt-workspace-pr-guarded",
+		TmuxSocketName: "kwt-pr-protected",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["pr-guarded"] = pullrequest.Provenance{
+				Project: project, Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	cfg := &models.Config{Projects: []models.Project{{
+		Repository: project.Identity, Name: project.Name, Path: project.Path,
+	}}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(t, workspace.Path, workspace.Generation)
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return project, []pullrequest.Workspace{workspace}, nil
+	}
+	snapshot, err := config.LoadGlobalSnapshotAt(home)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	fingerprint, err := snapshot.Projects[0].Fingerprint()
+	require.NoError(t, err)
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = fingerprint
+	prAttachExpectedGeneration = "fedcba9876543210fedcba9876543210"
+	prAttachExpectedSession = workspace.SessionName
+	prAttachExpectedSocket = workspace.TmuxSocketName
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	ensured := false
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		ensured = true
+		return workspace.TmuxSocketName, nil
+	}
+
+	err = runPRAttach(cmd, []string{workspace.Path})
+
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.False(t, ensured)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
 }
 
 func TestRunPRAttachRejectsRemovedRegistrationBeforeEnsuringSession(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -86,6 +86,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldAttachWorkspaceSession := attachExistingPRWorkspaceSession
 	oldInspectProjectClone := inspectPRProjectClone
 	oldReadWorkspaceGeneration := readPRWorkspaceGeneration
+	oldWithWorkspaceGeneration := withPRWorkspaceGeneration
 	t.Cleanup(func() {
 		loadPRConfig = oldLoad
 		loadPRTargetConfig = oldTargetLoad
@@ -105,6 +106,7 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		attachExistingPRWorkspaceSession = oldAttachWorkspaceSession
 		inspectPRProjectClone = oldInspectProjectClone
 		readPRWorkspaceGeneration = oldReadWorkspaceGeneration
+		withPRWorkspaceGeneration = oldWithWorkspaceGeneration
 	})
 	loadPRConfig = func() (*models.Config, error) { return cfg, nil }
 	loadPRTargetConfig = func(string, bool) (*models.Config, error) { return cfg, nil }
@@ -141,6 +143,13 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		return tmux.ProtectedWorkspaceSocketName(
 			workspace.SessionName, workspace.Path,
 		), nil
+	}
+	withPRWorkspaceGeneration = func(
+		_ context.Context,
+		_, _, _ string,
+		establish func() error,
+	) error {
+		return establish()
 	}
 }
 
@@ -1251,6 +1260,186 @@ func TestRunPRAttachClassifiesReplacedProjectRegistrationAsChanged(t *testing.T)
 	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
 	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
+func TestRunPRAttachHoldsWorktreeGenerationThroughSessionEstablishment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	repo := newPRInspectionRepo(t)
+	branch := "pr-attach-removal-race"
+	workspacePath := filepath.Join(t.TempDir(), branch)
+	runPRInspectionGit(t, repo, "branch", branch)
+	runPRInspectionGit(t, repo, "worktree", "add", workspacePath, branch)
+	g := gitadapter.New(repo)
+	generation, err := g.WorktreeGeneration(workspacePath)
+	require.NoError(t, err)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	workspace := pullrequest.Workspace{
+		Path:        workspacePath,
+		Branch:      branch,
+		Repository:  project.Identity,
+		Generation:  generation,
+		SessionName: "kwt-workspace-pr-attach-removal-race",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[branch] = pullrequest.Provenance{
+				Project: project, Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	registered, err := config.RegisterProjectWithIdentity(models.Project{
+		Repository: project.Identity,
+		Name:       project.Name,
+		Path:       project.Path,
+	})
+	require.NoError(t, err)
+	cfg := &models.Config{Projects: []models.Project{registered.Project}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	withPRWorkspaceGeneration = defaultWithPRWorkspaceGeneration
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return project, []pullrequest.Workspace{workspace}, nil
+	}
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = registered.Fingerprint
+	prAttachExpectedGeneration = generation
+	prAttachExpectedSession = workspace.SessionName
+	prAttachExpectedSocket = tmux.ProtectedWorkspaceSocketName(
+		workspace.SessionName,
+		workspace.Path,
+	)
+	cmd, _, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	establishmentStarted := make(chan struct{})
+	finishEstablishment := make(chan struct{})
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		close(establishmentStarted)
+		<-finishEstablishment
+		return prAttachExpectedSocket, nil
+	}
+	attachExistingPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+		string,
+	) error {
+		return nil
+	}
+	attachDone := make(chan error, 1)
+	go func() {
+		attachDone <- runPRAttach(cmd, []string{workspacePath})
+	}()
+	<-establishmentStarted
+	mutationEntered := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- gitadapter.New(repo).WithWorktreeGeneration(
+			workspacePath,
+			generation,
+			func() error {
+				close(mutationEntered)
+				return nil
+			},
+		)
+	}()
+	mutationEnteredBeforeEstablishment := false
+	select {
+	case <-mutationEntered:
+		mutationEnteredBeforeEstablishment = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(finishEstablishment)
+	require.NoError(t, <-attachDone)
+
+	require.NoError(t, <-mutationDone)
+	assert.False(t, mutationEnteredBeforeEstablishment)
+}
+
+func TestImportedWorkspaceProvenanceEvaluatesEachCandidateProject(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	workspacePath := "/worktrees/reused"
+	currentGeneration := "0123456789abcdef0123456789abcdef"
+	staleGeneration := "fedcba9876543210fedcba9876543210"
+	current := pullrequest.Provenance{
+		Project: pullrequest.Project{
+			Identity: "github.com/acme/current",
+			Path:     "/repos/current",
+		},
+		Workspace: pullrequest.Workspace{
+			Path: workspacePath, Repository: "github.com/acme/current",
+			Generation: currentGeneration, SessionName: "kwt-workspace-current",
+		},
+	}
+	stale := pullrequest.Provenance{
+		Project: pullrequest.Project{
+			Identity: "github.com/acme/stale",
+			Path:     "/repos/stale",
+		},
+		Workspace: pullrequest.Workspace{
+			Path: workspacePath, Repository: "github.com/acme/stale",
+			Generation: staleGeneration, SessionName: "kwt-workspace-stale",
+		},
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["current"] = current
+			records["stale"] = stale
+			return nil
+		},
+	))
+	oldRead := readPRWorkspaceGeneration
+	oldInspect := inspectPRProjectClone
+	t.Cleanup(func() {
+		readPRWorkspaceGeneration = oldRead
+		inspectPRProjectClone = oldInspect
+	})
+	inspectedProjects := map[string]bool{}
+	readPRWorkspaceGeneration = func(projectPath, gotWorkspacePath string) (string, error) {
+		assert.Equal(t, workspacePath, gotWorkspacePath)
+		inspectedProjects[projectPath] = true
+		if projectPath == stale.Project.Path {
+			return "", fmt.Errorf("inspect stale candidate: %w", gitadapter.ErrWorktreeNotFound)
+		}
+		return currentGeneration, nil
+	}
+	inspectPRProjectClone = func(
+		_ context.Context,
+		got pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		assert.Equal(t, current, got)
+		return current.Project, []pullrequest.Workspace{current.Workspace}, nil
+	}
+
+	record, err := importedWorkspaceProvenance(
+		context.Background(),
+		workspacePath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, current, record)
+	assert.True(t, inspectedProjects[current.Project.Path])
+	assert.True(t, inspectedProjects[stale.Project.Path])
 }
 
 func TestProtectedAttachReleasesFenceBeforeBlockingClient(t *testing.T) {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -1599,6 +1599,82 @@ func TestImportedWorkspaceProvenanceDiscardsLegacyAnotherRepositoryOwner(
 	testImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(t, false)
 }
 
+func TestImportedWorkspaceProvenanceInitializesOwnedLegacyGeneration(
+	t *testing.T,
+) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	repo := newPRInspectionRepo(t)
+	runPRInspectionGit(
+		t,
+		repo,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/acme/widget.git",
+	)
+	branch := "legacy-import"
+	worktreePath := filepath.Join(t.TempDir(), branch)
+	runPRInspectionGit(t, repo, "branch", branch)
+	runPRInspectionGit(t, repo, "worktree", "add", worktreePath, branch)
+	_, err := gitadapter.New(repo).ReadWorktreeGeneration(worktreePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	repository := "github.com/acme/widget"
+	info, ok := urlutil.CanonicalRepositoryInfo(repository)
+	require.True(t, ok)
+	record := pullrequest.Provenance{
+		Repository: repository,
+		Project: pullrequest.Project{
+			Identity: repository,
+			Name:     "widget",
+			Path:     repo,
+		},
+		Workspace: pullrequest.Workspace{
+			Path:        worktreePath,
+			Branch:      branch,
+			Repository:  repository,
+			SessionName: tmux.WorkspaceSessionName(info, branch, worktreePath),
+		},
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[branch] = record
+			return nil
+		},
+	))
+	oldInspect := inspectPRProjectClone
+	oldLoad := loadPRConfig
+	t.Cleanup(func() {
+		inspectPRProjectClone = oldInspect
+		loadPRConfig = oldLoad
+	})
+	inspectPRProjectClone = defaultInspectPRProjectClone
+	loadPRConfig = func() (*models.Config, error) {
+		return &models.Config{Projects: []models.Project{{
+			Repository: repository,
+			Name:       record.Project.Name,
+			Path:       repo,
+		}}}, nil
+	}
+
+	verified, err := importedWorkspaceProvenance(
+		context.Background(),
+		worktreePath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, record, verified.record)
+	require.NoError(t, gitadapter.ValidateWorktreeGeneration(
+		verified.liveGeneration,
+	))
+	persistedGeneration, err := gitadapter.New(repo).ReadWorktreeGeneration(
+		worktreePath,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, verified.liveGeneration, persistedGeneration)
+}
+
 func testImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(
 	t *testing.T,
 	staleHasGeneration bool,

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -682,6 +682,9 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	cfg := testPRConfig()
 	cfg.Fleet.TokenEnv = "CUSTOM_FLEET_TOKEN"
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(
+		t, workspace.Path, "0123456789abcdef0123456789abcdef",
+	)
 	inspectPRProjectClone = func(
 		context.Context,
 		pullrequest.Provenance,
@@ -801,6 +804,7 @@ func TestRunPRAttachGuardUsesVerifiedLiveWorkspaceIdentity(t *testing.T) {
 		Repository: project.Identity, Name: project.Name, Path: project.Path,
 	}}}
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(t, recorded.Path, live.Generation)
 	inspectPRProjectClone = func(
 		context.Context,
 		pullrequest.Provenance,
@@ -953,6 +957,9 @@ func TestRunPRAttachRejectsRemovedRegistrationBeforeEnsuringSession(t *testing.T
 		Repository: project.Identity, Name: "widget", Path: project.Path,
 	}}}
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(
+		t, workspace.Path, "0123456789abcdef0123456789abcdef",
+	)
 	inspectPRProjectClone = func(
 		context.Context,
 		pullrequest.Provenance,
@@ -1021,6 +1028,9 @@ func TestRunPRAttachRejectsProvenanceReplacementWhileWaitingForProjectFence(t *t
 		Repository: projectA.Identity, Name: projectA.Name, Path: projectA.Path,
 	}}}
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(
+		t, workspace.Path, "0123456789abcdef0123456789abcdef",
+	)
 	inspectPRProjectClone = func(
 		_ context.Context,
 		got pullrequest.Provenance,
@@ -1703,6 +1713,9 @@ func TestProtectedAttachReleasesFenceBeforeBlockingClient(t *testing.T) {
 		Repository: project.Identity, Name: project.Name, Path: project.Path,
 	}}}
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(
+		t, workspace.Path, "0123456789abcdef0123456789abcdef",
+	)
 	inspectPRProjectClone = func(
 		context.Context,
 		pullrequest.Provenance,
@@ -1906,6 +1919,9 @@ func TestRunPRAttachUsesTransferredProvenanceAliasHistory(t *testing.T) {
 	cfg := testPRConfig()
 	cfg.Projects[0].Repository = registeredIdentity
 	withPRCommandDeps(t, cfg, &fakePRService{})
+	stubPRWorkspaceGeneration(
+		t, workspacePath, "0123456789abcdef0123456789abcdef",
+	)
 	inspectPRProjectClone = func(
 		_ context.Context,
 		got pullrequest.Provenance,
@@ -1967,6 +1983,9 @@ func TestRunPRAttachRejectsStaleProvenanceAgainstLiveInventory(t *testing.T) {
 		},
 	))
 	withPRCommandDeps(t, testPRConfig(), &fakePRService{})
+	stubPRWorkspaceGeneration(
+		t, recorded.Path, "0123456789abcdef0123456789abcdef",
+	)
 	inspectPRProjectClone = func(
 		context.Context,
 		pullrequest.Provenance,

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -1578,6 +1578,77 @@ func TestImportedWorkspaceProvenanceEvaluatesEachCandidateProject(t *testing.T) 
 	assert.True(t, inspectedProjects[stale.Project.Path])
 }
 
+func TestImportedWorkspaceProvenanceDiscardsAnotherRepositoryOwner(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	staleRepo := newPRInspectionRepo(t)
+	currentRepo := newPRInspectionRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "reused-worktree")
+	runPRInspectionGit(t, staleRepo, "branch", "stale-owner")
+	runPRInspectionGit(
+		t, staleRepo, "worktree", "add", worktreePath, "stale-owner",
+	)
+	staleGeneration, err := gitadapter.New(staleRepo).WorktreeGeneration(
+		worktreePath,
+	)
+	require.NoError(t, err)
+	runPRInspectionGit(
+		t, staleRepo, "worktree", "remove", "--force", worktreePath,
+	)
+	runPRInspectionGit(t, currentRepo, "branch", "current-owner")
+	runPRInspectionGit(
+		t, currentRepo, "worktree", "add", worktreePath, "current-owner",
+	)
+	currentGeneration, err := gitadapter.New(currentRepo).WorktreeGeneration(
+		worktreePath,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, staleGeneration, currentGeneration)
+	stale := pullrequest.Provenance{
+		Project: pullrequest.Project{
+			Identity: "github.com/acme/stale", Path: staleRepo,
+		},
+		Workspace: pullrequest.Workspace{
+			Path: worktreePath, Repository: "github.com/acme/stale",
+			Generation: staleGeneration, SessionName: "kwt-workspace-stale",
+		},
+	}
+	current := pullrequest.Provenance{
+		Project: pullrequest.Project{
+			Identity: "github.com/acme/current", Path: currentRepo,
+		},
+		Workspace: pullrequest.Workspace{
+			Path: worktreePath, Repository: "github.com/acme/current",
+			Generation: currentGeneration, SessionName: "kwt-workspace-current",
+		},
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records["stale"] = stale
+			records["current"] = current
+			return nil
+		},
+	))
+	oldInspect := inspectPRProjectClone
+	t.Cleanup(func() { inspectPRProjectClone = oldInspect })
+	inspectPRProjectClone = func(
+		_ context.Context,
+		got pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		assert.Equal(t, current, got)
+		return current.Project, []pullrequest.Workspace{current.Workspace}, nil
+	}
+
+	verified, err := importedWorkspaceProvenance(
+		context.Background(),
+		worktreePath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, current, verified.record)
+	assert.Equal(t, currentGeneration, verified.liveGeneration)
+}
+
 func TestProtectedAttachReleasesFenceBeforeBlockingClient(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KWT_HOME", home)

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -708,6 +708,65 @@ func TestRunPRAttachUsesPersistedWorkspaceIdentity(t *testing.T) {
 	assert.True(t, attached)
 }
 
+func TestRunPRAttachPreservesLegacyGenerationForUnguardedSession(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	recorded := pullrequest.Workspace{
+		Path:        "/worktrees/pr-legacy",
+		Branch:      "pr-legacy",
+		Repository:  "github.com/acme/widget",
+		SessionName: "kwt-workspace-pr-legacy",
+	}
+	live := recorded
+	live.Generation = "0123456789abcdef0123456789abcdef"
+	project := pullrequest.Project{
+		Identity: recorded.Repository,
+		Path:     "/repos/widget",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[recorded.Branch] = pullrequest.Provenance{
+				Project: project, Workspace: recorded,
+			}
+			return nil
+		},
+	))
+	cfg := testPRConfig()
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	inspectPRProjectClone = func(
+		context.Context,
+		pullrequest.Provenance,
+	) (pullrequest.Project, []pullrequest.Workspace, error) {
+		return project, []pullrequest.Workspace{live}, nil
+	}
+	ensurePRWorkspaceSession = func(
+		_ context.Context,
+		got pullrequest.Workspace,
+		_ *models.Config,
+	) (string, error) {
+		if got.Generation != "" {
+			return "", fmt.Errorf(
+				"legacy session cannot accept generation %q",
+				got.Generation,
+			)
+		}
+		return tmux.ProtectedWorkspaceSocketName(got.SessionName, got.Path), nil
+	}
+	attachExistingPRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+		string,
+	) error {
+		return nil
+	}
+	cmd, _, _ := prTestCommand()
+
+	err := runPRAttach(cmd, []string{recorded.Path})
+
+	require.NoError(t, err)
+}
+
 func TestRunPRAttachGuardUsesVerifiedLiveWorkspaceIdentity(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KWT_HOME", home)
@@ -1179,6 +1238,82 @@ func TestRunPRAttachClassifiesDeletedWorkspaceAsRegistrationChanged(t *testing.T
 	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
 }
 
+func TestRunPRAttachClassifiesDeletedProjectCheckoutAsChanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	repo := newPRInspectionRepo(t)
+	branch := "pr-project-deleted"
+	workspacePath := filepath.Join(t.TempDir(), branch)
+	runPRInspectionGit(t, repo, "branch", branch)
+	runPRInspectionGit(t, repo, "worktree", "add", workspacePath, branch)
+	generation, err := gitadapter.New(repo).WorktreeGeneration(workspacePath)
+	require.NoError(t, err)
+	project := pullrequest.Project{
+		Identity: "github.com/acme/widget",
+		Name:     "widget",
+		Path:     repo,
+	}
+	workspace := pullrequest.Workspace{
+		Path:        workspacePath,
+		Branch:      branch,
+		Repository:  project.Identity,
+		Generation:  generation,
+		SessionName: "kwt-workspace-pr-project-deleted",
+	}
+	require.NoError(t, pullrequest.NewFileStore(prStorePath()).Update(
+		context.Background(),
+		func(records map[string]pullrequest.Provenance) error {
+			records[branch] = pullrequest.Provenance{
+				Project: project, Workspace: workspace,
+			}
+			return nil
+		},
+	))
+	registered, err := config.RegisterProjectWithIdentity(models.Project{
+		Repository: project.Identity,
+		Name:       project.Name,
+		Path:       project.Path,
+	})
+	require.NoError(t, err)
+	cfg := &models.Config{Projects: []models.Project{registered.Project}}
+	withPRCommandDeps(t, cfg, &fakePRService{})
+	prAttachExpectedRepository = project.Identity
+	prAttachExpectedRegistration = registered.Fingerprint
+	prAttachExpectedGeneration = generation
+	prAttachExpectedSession = workspace.SessionName
+	prAttachExpectedSocket = tmux.ProtectedWorkspaceSocketName(
+		workspace.SessionName,
+		workspace.Path,
+	)
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+		"expected-generation",
+		"expected-session",
+		"expected-socket",
+	)
+	require.NoError(t, os.RemoveAll(repo))
+	ensured := false
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		ensured = true
+		return "", nil
+	}
+
+	err = runPRAttach(cmd, []string{workspacePath})
+
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.False(t, ensured)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
 func TestRunPRAttachClassifiesReplacedProjectRegistrationAsChanged(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KWT_HOME", home)
@@ -1431,13 +1566,14 @@ func TestImportedWorkspaceProvenanceEvaluatesEachCandidateProject(t *testing.T) 
 		return current.Project, []pullrequest.Workspace{current.Workspace}, nil
 	}
 
-	record, err := importedWorkspaceProvenance(
+	verified, err := importedWorkspaceProvenance(
 		context.Background(),
 		workspacePath,
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, current, record)
+	assert.Equal(t, current, verified.record)
+	assert.Equal(t, currentGeneration, verified.liveGeneration)
 	assert.True(t, inspectedProjects[current.Project.Path])
 	assert.True(t, inspectedProjects[stale.Project.Path])
 }

--- a/internal/daemon/controller.go
+++ b/internal/daemon/controller.go
@@ -53,7 +53,7 @@ func NewController(options ControllerOptions) *Controller {
 		options.PollInterval = 50 * time.Millisecond
 	}
 	if options.StartTimeout <= 0 {
-		options.StartTimeout = 5 * time.Second
+		options.StartTimeout = 10 * time.Second
 	}
 	if options.CleanupAllowance <= 0 {
 		options.CleanupAllowance = 5 * time.Second

--- a/internal/daemon/controller_test.go
+++ b/internal/daemon/controller_test.go
@@ -128,6 +128,26 @@ func TestControllerStartsAbsentDaemonAndWaitsForReady(t *testing.T) {
 	assert.Equal(t, 1, launches)
 }
 
+func TestControllerDefaultStartupBudgetToleratesLoadedLaunch(t *testing.T) {
+	options := testControllerOptions(t)
+	options.StartTimeout = 0
+	options.Inspect = scriptedInspector(t, Observation{State: RuntimeAbsent})
+	launchCompleted := errors.New("launch completed")
+	insufficientBudget := errors.New("insufficient startup budget")
+	options.Launch = func(ctx context.Context) error {
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) < 9*time.Second {
+			return insufficientBudget
+		}
+		return launchCompleted
+	}
+
+	_, err := NewController(options).Start(context.Background())
+
+	assert.ErrorIs(t, err, launchCompleted)
+	assert.NotErrorIs(t, err, insufficientBudget)
+}
+
 func TestControllerLaunchFailsWhenDaemonReportsFailed(t *testing.T) {
 	options := testControllerOptions(t)
 	options.Inspect = scriptedInspector(

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1457,6 +1457,17 @@ func TestReadWorktreeGenerationRejectsAnotherWorktreeAdministrativeDirectory(
 	assert.Equal(t, firstGeneration, generation)
 }
 
+func TestReadWorktreeGenerationClassifiesMissingWorktree(t *testing.T) {
+	repo := NewTestRepository(t)
+
+	_, err := New(repo.Path).ReadWorktreeGeneration(
+		filepath.Join(t.TempDir(), "missing-worktree"),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrWorktreeNotFound)
+}
+
 func TestWorktreeGitDirRejectsDuplicateAdministrativeBacklinks(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1468,6 +1468,28 @@ func TestReadWorktreeGenerationClassifiesMissingWorktree(t *testing.T) {
 	assert.ErrorIs(t, err, ErrWorktreeNotFound)
 }
 
+func TestReadWorktreeGenerationClassifiesAnotherRepositoryOwner(t *testing.T) {
+	staleRepo := NewTestRepository(t)
+	currentRepo := NewTestRepository(t)
+	staleRepo.CreateBranch(t, "stale-owner")
+	currentRepo.CreateBranch(t, "current-owner")
+	worktreePath := filepath.Join(t.TempDir(), "reused-worktree")
+	staleRepo.CreateWorktree(t, worktreePath, "stale-owner")
+	_, err := New(staleRepo.Path).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	require.NoError(t, staleRepo.run(
+		"worktree", "remove", "--force", worktreePath,
+	))
+	currentRepo.CreateWorktree(t, worktreePath, "current-owner")
+	_, err = New(currentRepo.Path).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+
+	_, err = New(staleRepo.Path).ReadWorktreeGeneration(worktreePath)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrWorktreeRepositoryMismatch)
+}
+
 func TestWorktreeGitDirRejectsDuplicateAdministrativeBacklinks(t *testing.T) {
 	repo := NewTestRepository(t)
 	g := New(repo.Path)

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -38,6 +38,9 @@ var (
 	ErrWorktreeRepositoryMismatch = errors.New(
 		"worktree belongs to a different repository",
 	)
+	// ErrWorktreeGenerationNotFound reports that the selected repository owns
+	// the worktree but its durable KWT generation has not been initialized.
+	ErrWorktreeGenerationNotFound = errors.New("worktree generation not found")
 )
 
 type worktreeCreationReservation struct {
@@ -1848,6 +1851,12 @@ func (g *Git) readWorktreeGenerationWithoutCredentials(
 	}
 	data, err := os.ReadFile(filepath.Join(gitDir, "kwt-generation"))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf(
+				"read worktree identity: %w",
+				errors.Join(ErrWorktreeGenerationNotFound, err),
+			)
+		}
 		return "", fmt.Errorf("read worktree identity: %w", err)
 	}
 	generation := strings.TrimSpace(string(data))

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -29,6 +29,10 @@ const (
 var (
 	inspectWorktreeStat = os.Stat
 	inspectDotGitRead   = os.ReadFile
+
+	// ErrWorktreeNotFound reports that no worktree administrative record owns
+	// the requested path.
+	ErrWorktreeNotFound = errors.New("worktree not found")
 )
 
 type worktreeCreationReservation struct {
@@ -1976,7 +1980,10 @@ func (g *Git) worktreeGitDirWithoutCredentials(
 			path,
 		)
 	}
-	return "", fmt.Errorf("resolve worktree Git directory: worktree not found")
+	return "", fmt.Errorf(
+		"resolve worktree Git directory: %w",
+		ErrWorktreeNotFound,
+	)
 }
 
 func worktreeAdminDirMatchesPath(

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -33,6 +33,11 @@ var (
 	// ErrWorktreeNotFound reports that no worktree administrative record owns
 	// the requested path.
 	ErrWorktreeNotFound = errors.New("worktree not found")
+	// ErrWorktreeRepositoryMismatch reports that another repository owns the
+	// requested worktree path.
+	ErrWorktreeRepositoryMismatch = errors.New(
+		"worktree belongs to a different repository",
+	)
 )
 
 type worktreeCreationReservation struct {
@@ -1890,8 +1895,8 @@ func (g *Git) worktreeGitDirWithoutCredentials(
 				directCommonClaim = true
 			} else {
 				return "", fmt.Errorf(
-					"resolve worktree Git directory: %s belongs to a different repository",
-					path,
+					"resolve worktree Git directory for %s: %w",
+					path, ErrWorktreeRepositoryMismatch,
 				)
 			}
 		}
@@ -1931,8 +1936,8 @@ func (g *Git) worktreeGitDirWithoutCredentials(
 	}
 	if pointsOutsideCommon {
 		return "", fmt.Errorf(
-			"resolve worktree Git directory: %s belongs to a different repository",
-			path,
+			"resolve worktree Git directory for %s: %w",
+			path, ErrWorktreeRepositoryMismatch,
 		)
 	}
 


### PR DESCRIPTION
- Adds an all-or-nothing guarded mode to `kwt pr attach` for automation clients that combine current `kwt list --json` and `kwt projects --json` snapshots.
- Documents the repository-key join and exact source field for every guarded attachment flag.
- Revalidates project identity, registration fingerprint, live worktree generation, protected session name, and derived socket while holding KWT's project lifecycle fence.
- Holds the worktree mutation lock through protected tmux session creation or repair, preventing concurrent removal between verification and launch.
- Evaluates same-path provenance records against their own project repositories, discards stale durable and generation-less records owned by another repository, and selects only the unique live workspace.
- Preserves legacy protected sessions: an owned pre-generation worktree receives its durable generation through locked project inventory, while the persisted legacy record remains compatible with its unmarked tmux session.
- Treats a deleted worktree or main project checkout as stale reviewed authority and returns retryable `registration_changed` errors.
- Preserves genuine storage, permission, and inspection failures instead of misclassifying them as stale authority.
- Accepts fresh and legacy provenance records that omit inventory-derived generation or socket fields.
- Gives detached daemons ten seconds to publish readiness so loaded Windows hosts do not report healthy startup as `daemon_start_failed`.
- Preserves the existing unguarded interactive attach command and documents the guarded flags.