### PR TITLE
Attribute SSH prompts to reviewed route targets

### DIFF
--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -124,6 +124,10 @@ stdout back to the waiting OpenSSH process; they are not placed in arguments,
 environment values, daemon events, logs, or persistent state. Deliberate empty
 responses remain distinct from rejection. Kwt creates no channel state unless
 the selected system OpenSSH satisfies the 8.4 forced-askpass floor.
+OpenSSH's own askpass confirmation hint distinguishes host-key confirmation
+from credential input without parsing server-controlled prompt text. Published
+prompt details contain only the already reviewed route targets and hop position;
+they contain no credentials or environment values.
 
 SSH route resolution validates user, hostname, and port before invoking
 OpenSSH. POSIX resolution quotes the validated argv into the account login

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,7 +187,13 @@ events may occur repeatedly; the client answers each with one
 `{"prompt_id":"...","value":"..."}` line on stdin. The completion event
 contains generation-bound OpenSSH arguments. Each prompt carries the daemon's
 deadline, so blocked input ends when the prompt expires and the command reports
-the daemon's terminal timeout. The process keeps the lease alive
+the daemon's terminal timeout. OpenSSH confirmation requests use the
+`ssh_host_key` kind and are not sensitive; credential and keyboard-interactive
+requests use `ssh_authentication` and are sensitive. Every prompt includes its
+credential-free logical target, effective target, display target, zero-based
+hop index, and route hop count in `details`, so a native client can identify
+which direct or ProxyJump target controls the prompt. The prompt message remains
+OpenSSH's original text. The process keeps the lease alive
 while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.

--- a/internal/daemon/operation_test.go
+++ b/internal/daemon/operation_test.go
@@ -167,6 +167,57 @@ func TestOperationHubRetainsImmutablePromptPayload(t *testing.T) {
 	_ = receiveOperationEvent(t, first.Events())
 }
 
+func TestOperationHubDeliversSSHPromptTargetDetails(t *testing.T) {
+	hub := NewOperationHub(context.Background(), OperationHubOptions{})
+	operation, _, err := hub.Start(OperationStart{
+		RequestDigest: "ssh-prompt-targets",
+		Run: func(ctx context.Context, operation *Operation) (json.RawMessage, error) {
+			_, promptErr := operation.Prompt(ctx, service.OperationPrompt{
+				Kind:      "ssh_host_key",
+				Message:   "Continue connecting?",
+				Sensitive: false,
+				Details: map[string]any{
+					"logical_target": map[string]any{
+						"hostname": "relay.example.test",
+					},
+					"effective_target": map[string]any{
+						"hostname": "192.0.2.10",
+						"user":     "deploy",
+						"port":     2200,
+					},
+					"display_target": "relay.example.test",
+					"hop_index":      0,
+					"hop_count":      1,
+				},
+			})
+			return json.RawMessage(`{}`), promptErr
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscription, err := hub.Subscribe(operation.ID(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer subscription.Close()
+	prompt := receiveOperationEvent(t, subscription.Events())
+	if prompt.Prompt == nil {
+		t.Fatalf("unexpected prompt event: %#v", prompt)
+	}
+	logical, ok := prompt.Prompt.Details["logical_target"].(map[string]any)
+	if !ok || logical["hostname"] != "relay.example.test" {
+		t.Fatalf("logical target details = %#v", prompt.Prompt.Details["logical_target"])
+	}
+	if err := hub.Respond(operation.ID(), service.OperationResponse{
+		PromptID: prompt.Prompt.ID,
+		Value:    "yes",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = receiveOperationEvent(t, subscription.Events())
+}
+
 func TestOperationHubResumesAfterSequence(t *testing.T) {
 	hub := NewOperationHub(context.Background(), OperationHubOptions{})
 	op, _, err := hub.Start(OperationStart{

--- a/internal/ssh/askpass.go
+++ b/internal/ssh/askpass.go
@@ -166,6 +166,7 @@ func askpassEnvironment(options AskpassOptions, handle string) []string {
 	protected := append([]string(nil), options.ProtectedNames...)
 	protected = append(protected,
 		"SSH_ASKPASS",
+		"SSH_ASKPASS_PROMPT",
 		"SSH_ASKPASS_REQUIRE",
 		"DISPLAY",
 		askpassHandleEnvironment,

--- a/internal/ssh/askpass.go
+++ b/internal/ssh/askpass.go
@@ -21,16 +21,17 @@ import (
 )
 
 const (
-	askpassHandleEnvironment = "KWT_SSH_ASKPASS_HANDLE"
-	defaultPromptTimeout     = 2 * time.Minute
-	defaultMaxPromptRounds   = 32
-	askpassIOTimeout         = 5 * time.Second
-	askpassHelperTimeout     = 5 * time.Minute
-	maxAskpassHandleBytes    = 4 << 10
-	maxAskpassConnections    = 8
+	askpassHandleEnvironment  = "KWT_SSH_ASKPASS_HANDLE"
+	defaultPromptTimeout      = 2 * time.Minute
+	defaultMaxPromptRounds    = 32
+	askpassIOTimeout          = 5 * time.Second
+	askpassHelperTimeout      = 5 * time.Minute
+	maxAskpassHandleBytes     = 4 << 10
+	maxAskpassPromptHintBytes = 64
+	maxAskpassConnections     = 8
 )
 
-var askpassProtocolMagic = [6]byte{'K', 'W', 'T', 'A', 'P', '1'} //nolint:gochecknoglobals
+var askpassProtocolMagic = [6]byte{'K', 'W', 'T', 'A', 'P', '2'} //nolint:gochecknoglobals
 
 type InteractiveVersionPolicy interface {
 	RequireInteractive(context.Context) error
@@ -43,7 +44,7 @@ type AskpassOptions struct {
 	ProtectedNames []string
 	PromptTimeout  time.Duration
 	MaxRounds      int
-	Describe       func(string) (service.OperationPrompt, error)
+	Describe       func(string, string) (service.OperationPrompt, error)
 	Prompt         func(context.Context, service.OperationPrompt) (string, error)
 }
 
@@ -242,8 +243,12 @@ func (a *Askpass) handleConnection(connection net.Conn) {
 	if err != nil {
 		return
 	}
+	promptHint, err := readAskpassFrame(connection, maxAskpassPromptHintBytes)
+	if err != nil {
+		return
+	}
 	_ = connection.SetReadDeadline(time.Time{})
-	response, promptErr := a.prompt(promptMessage)
+	response, promptErr := a.prompt(promptMessage, promptHint)
 	_ = connection.SetWriteDeadline(time.Now().Add(askpassIOTimeout))
 	if promptErr != nil {
 		a.setError(promptErr)
@@ -255,7 +260,7 @@ func (a *Askpass) handleConnection(connection net.Conn) {
 	}
 }
 
-func (a *Askpass) prompt(message string) (string, error) {
+func (a *Askpass) prompt(message, hint string) (string, error) {
 	a.mu.Lock()
 	a.rounds++
 	round := a.rounds
@@ -263,13 +268,10 @@ func (a *Askpass) prompt(message string) (string, error) {
 	if round > a.options.MaxRounds {
 		return "", connectionFailed(errors.New("SSH prompt round limit exceeded"))
 	}
-	prompt := service.OperationPrompt{
-		Kind:      "ssh_authentication",
-		Message:   message,
-		Sensitive: true,
-	}
+	prompt := describeSSHPrompt(hint)
+	prompt.Message = message
 	if a.options.Describe != nil {
-		described, err := a.options.Describe(message)
+		described, err := a.options.Describe(message, hint)
 		if err != nil {
 			return "", err
 		}
@@ -349,6 +351,13 @@ func RunAskpassHelper(arguments, environment []string, output io.Writer) (int, b
 	if err := writeAskpassFrame(connection, arguments[1]); err != nil {
 		return 1, true
 	}
+	promptHint, _ := environmentValue(environment, "SSH_ASKPASS_PROMPT")
+	if len(promptHint) > maxAskpassPromptHintBytes {
+		return 1, true
+	}
+	if err := writeAskpassFrame(connection, promptHint); err != nil {
+		return 1, true
+	}
 	status := []byte{0}
 	if _, err := io.ReadFull(connection, status); err != nil {
 		return 1, true
@@ -361,6 +370,13 @@ func RunAskpassHelper(arguments, environment []string, output io.Writer) (int, b
 		return 1, true
 	}
 	return 0, true
+}
+
+func describeSSHPrompt(hint string) service.OperationPrompt {
+	if hint == "confirm" {
+		return service.OperationPrompt{Kind: "ssh_host_key", Sensitive: false}
+	}
+	return service.OperationPrompt{Kind: "ssh_authentication", Sensitive: true}
 }
 
 func encodeAskpassHandle(handle askpassHandle) (string, error) {

--- a/internal/ssh/askpass_test.go
+++ b/internal/ssh/askpass_test.go
@@ -28,6 +28,7 @@ func TestAskpassCarriesMultipleBoundRoundsIncludingEmptyResponse(t *testing.T) {
 			"PATH=/usr/bin",
 			"GHOSTHUB_AUTH=secret",
 			"SSH_ASKPASS=/old/helper",
+			"SSH_ASKPASS_PROMPT=confirm",
 		},
 		ProtectedNames: []string{"GHOSTHUB_AUTH"},
 		Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
@@ -43,6 +44,7 @@ func TestAskpassCarriesMultipleBoundRoundsIncludingEmptyResponse(t *testing.T) {
 	assert.Contains(t, environment, "SSH_ASKPASS_REQUIRE=force")
 	assert.False(t, slices.Contains(environment, "GHOSTHUB_AUTH=secret"))
 	assert.False(t, slices.Contains(environment, "SSH_ASKPASS=/old/helper"))
+	assert.False(t, slices.Contains(environment, "SSH_ASKPASS_PROMPT=confirm"))
 
 	var first bytes.Buffer
 	exitCode, handled := RunAskpassHelper(

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -167,6 +167,8 @@ func (m *Manager) acquireTarget(
 	terminal bool,
 	resolve func(context.Context) (RouteSnapshot, error),
 ) (Lease, error) {
+	request.promptTargetIndex = hopDepth
+	request.promptTargetCount = len(request.Snapshot.Targets)
 	runner, err := m.runner(request, target)
 	if err != nil {
 		return nil, connectionFailed(err)

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -223,10 +223,15 @@ func proxyJumpSnapshot(identity string) RouteSnapshot {
 func TestManagerAcquiresProxyJumpRouteAsOneCompositeLease(t *testing.T) {
 	persistent := &fakePersistentManager{generation: 41}
 	var prepared []ResolvedTarget
+	var promptPositions [][2]int
 	manager := NewManager(ManagerOptions{
 		Persistent: persistent,
-		Runner: func(_ LeaseRequest, target ResolvedTarget) (openssh.RunSSH, error) {
+		Runner: func(request LeaseRequest, target ResolvedTarget) (openssh.RunSSH, error) {
 			prepared = append(prepared, target)
+			promptPositions = append(promptPositions, [2]int{
+				request.promptTargetIndex,
+				request.promptTargetCount,
+			})
 			return func(context.Context, []string) (int, error) { return 0, nil }, nil
 		},
 	})
@@ -238,6 +243,7 @@ func TestManagerAcquiresProxyJumpRouteAsOneCompositeLease(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
+	assert.Equal(t, [][2]int{{0, 2}, {1, 2}}, promptPositions)
 	assert.NotContains(t, prepared[0].Projection.Arguments, "ProxyCommand")
 	assert.NotContains(t, prepared[1].Projection.Arguments, "ProxyJump=none")
 	proxyOption := prepared[1].Projection.Arguments[len(prepared[1].Projection.Arguments)-1]

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -8,6 +8,7 @@ import (
 	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kit/safefileio"
 	"go.kenn.io/kwt/internal/credentials"
+	"go.kenn.io/kwt/service"
 )
 
 type sshProcessRunner func(
@@ -64,6 +65,21 @@ func newRunner(
 			Executable:  options.Executable,
 			Environment: environment,
 			Prompt:      request.Prompt,
+			Describe: func(_ string, hint string) (service.OperationPrompt, error) {
+				prompt := describeSSHPrompt(hint)
+				hopCount := request.promptTargetCount
+				if hopCount == 0 {
+					hopCount = 1
+				}
+				prompt.Details = map[string]any{
+					"logical_target":   target.LogicalTarget,
+					"effective_target": target.EffectiveTarget,
+					"display_target":   target.DisplayTarget,
+					"hop_index":        request.promptTargetIndex,
+					"hop_count":        hopCount,
+				}
+				return prompt, nil
+			},
 		})
 		if err != nil {
 			return -1, errors.Join(err, cleanup())

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -72,8 +72,8 @@ func newRunner(
 					hopCount = 1
 				}
 				prompt.Details = map[string]any{
-					"logical_target":   target.LogicalTarget,
-					"effective_target": target.EffectiveTarget,
+					"logical_target":   promptTargetDetails(target.LogicalTarget),
+					"effective_target": promptTargetDetails(target.EffectiveTarget),
 					"display_target":   target.DisplayTarget,
 					"hop_index":        request.promptTargetIndex,
 					"hop_count":        hopCount,
@@ -94,6 +94,17 @@ func newRunner(
 		closeErr := askpass.Close()
 		return exitCode, errors.Join(runErr, askpass.Err(), closeErr, cleanup())
 	}, nil
+}
+
+func promptTargetDetails(target Target) map[string]any {
+	details := map[string]any{"hostname": target.Hostname}
+	if target.User != "" {
+		details["user"] = target.User
+	}
+	if target.Port != 0 {
+		details["port"] = target.Port
+	}
+	return details
 }
 
 func runSSHVersion(

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -225,8 +225,14 @@ func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) 
 	assert.Equal(t, "ssh_host_key", captured.Kind)
 	assert.False(t, captured.Sensitive)
 	assert.Equal(t, "Continue connecting (yes/no)?", captured.Message)
-	assert.Equal(t, target.LogicalTarget, captured.Details["logical_target"])
-	assert.Equal(t, target.EffectiveTarget, captured.Details["effective_target"])
+	assert.Equal(t, map[string]any{
+		"hostname": target.LogicalTarget.Hostname,
+	}, captured.Details["logical_target"])
+	assert.Equal(t, map[string]any{
+		"hostname": target.EffectiveTarget.Hostname,
+		"user":     target.EffectiveTarget.User,
+		"port":     target.EffectiveTarget.Port,
+	}, captured.Details["effective_target"])
 	assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
 	assert.Equal(t, 0, captured.Details["hop_index"])
 	assert.Equal(t, 2, captured.Details["hop_count"])

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -124,12 +124,22 @@ func TestRunnerCarriesPromptThroughAskpassHelperProcess(t *testing.T) {
 		Environment:      []string{"PATH=" + os.Getenv("PATH")},
 		Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
 			assert.Equal(t, "Password:", prompt.Message)
+			assert.Equal(t, "ssh_authentication", prompt.Kind)
+			assert.True(t, prompt.Sensitive)
+			assert.Equal(t, "build.example.test", prompt.Details["display_target"])
+			assert.Equal(t, 0, prompt.Details["hop_index"])
+			assert.Equal(t, 1, prompt.Details["hop_count"])
 			return "secret", nil
 		},
 	}
-	target := ResolvedTarget{Projection: ExecutionProjection{
-		Arguments: []string{"-F", os.DevNull},
-	}}
+	target := ResolvedTarget{
+		LogicalTarget:   Target{Hostname: "build"},
+		EffectiveTarget: Target{Hostname: "build.internal", User: "deploy", Port: 2200},
+		DisplayTarget:   "build.example.test",
+		Projection: ExecutionProjection{
+			Arguments: []string{"-F", os.DevNull},
+		},
+	}
 	var output bytes.Buffer
 	runner, err := newRunner(
 		t.TempDir(),
@@ -165,6 +175,61 @@ func TestRunnerCarriesPromptThroughAskpassHelperProcess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "secret\n", output.String())
+}
+
+func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) {
+	var captured service.OperationPrompt
+	request := LeaseRequest{
+		WorkingDirectory: t.TempDir(),
+		Environment:      []string{"PATH=" + os.Getenv("PATH")},
+		Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
+			captured = prompt
+			return "yes", nil
+		},
+		promptTargetIndex: 0,
+		promptTargetCount: 2,
+	}
+	target := ResolvedTarget{
+		LogicalTarget:   Target{Hostname: "relay"},
+		EffectiveTarget: Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
+		DisplayTarget:   "relay.example.test",
+		Projection: ExecutionProjection{
+			Arguments: []string{"-F", os.DevNull},
+		},
+	}
+	runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
+		Version: supportedAskpassVersion(),
+		Run: func(
+			_ context.Context,
+			_ []string,
+			_ string,
+			environment []string,
+		) (int, error) {
+			var output bytes.Buffer
+			exitCode, handled := RunAskpassHelper(
+				[]string{"kwt", "Continue connecting (yes/no)?"},
+				append(environment, "SSH_ASKPASS_PROMPT=confirm"),
+				&output,
+			)
+			require.True(t, handled)
+			assert.Equal(t, "yes\n", output.String())
+			return exitCode, nil
+		},
+	})
+	require.NoError(t, err)
+
+	exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "ssh_host_key", captured.Kind)
+	assert.False(t, captured.Sensitive)
+	assert.Equal(t, "Continue connecting (yes/no)?", captured.Message)
+	assert.Equal(t, target.LogicalTarget, captured.Details["logical_target"])
+	assert.Equal(t, target.EffectiveTarget, captured.Details["effective_target"])
+	assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
+	assert.Equal(t, 0, captured.Details["hop_index"])
+	assert.Equal(t, 2, captured.Details["hop_count"])
 }
 
 func TestRunnerPropagatesPromptFailure(t *testing.T) {

--- a/internal/ssh/types.go
+++ b/internal/ssh/types.go
@@ -62,10 +62,12 @@ type RouteSnapshot struct {
 }
 
 type LeaseRequest struct {
-	Snapshot         RouteSnapshot `json:"snapshot"`
-	WorkingDirectory string        `json:"working_directory"`
-	Environment      []string      `json:"environment"`
-	Prompt           PromptHandler `json:"-"`
+	Snapshot          RouteSnapshot `json:"snapshot"`
+	WorkingDirectory  string        `json:"working_directory"`
+	Environment       []string      `json:"environment"`
+	Prompt            PromptHandler `json:"-"`
+	promptTargetIndex int
+	promptTargetCount int
 }
 
 type PromptHandler func(context.Context, service.OperationPrompt) (string, error)


### PR DESCRIPTION
Ghosthub cannot remove its Swift trust and authentication owner until kwt identifies what OpenSSH is asking and which reviewed route hop owns the interaction.

- Classifies OpenSSH confirmation prompts as host-key review and all other askpass prompts as authentication
- Attaches credential-free logical/effective targets and ProxyJump hop position to every prompt
- Preserves the original OpenSSH prompt text, sensitivity, bounded transport, and daemon-only credential flow
- Pins the private askpass protocol to the richer message shape without a legacy fallback