### PR TITLE
Guard pull-request imports with project authority

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,8 @@ kwt open /path/to/worktree --start-session
 kwt status
 kwt pr list --project github.com/acme/widget --json
 kwt pr import 17 --project github.com/acme/widget \
+  --expected-repository github.com/acme/widget \
+  --expected-registration <project.registration_fingerprint> \
   --start-session --json
 kwt sync status
 kwt exec fix/parser-race -- go test ./internal/parser
@@ -626,6 +628,11 @@ Every imported workspace record includes `tmux_socket_name`.
 `pr import --start-session` additionally establishes a blank shell-only
 session without attaching, for clients that provide their own ordinary tmux
 presentation. It does not execute configured layouts or agent commands.
+Automation clients may pass `--expected-repository` and
+`--expected-registration` together to bind an import to the selected
+`kwt projects --json` record. Kwt revalidates that authority under the project
+lifecycle fence before creating the worktree; a mismatch fails with retryable
+`registration_changed` and does not import anything.
 Attach with `kwt pr attach <workspace.path>`, which verifies the persisted
 identity, creates or repairs that protected blank session when needed, and
 uses `attach-session -E`. This is an interactive exception to the PR JSON

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -23,6 +23,22 @@ kwt pr import 17 --project github.com/acme/widget \
   --start-session --json
 ```
 
+Automation clients should bind the import to the project record that the user
+selected. Supply the matching `repository` and `registration_fingerprint`
+from `kwt projects --json` together:
+
+```sh
+kwt pr import 17 --project github.com/acme/widget \
+  --expected-repository <project.repository> \
+  --expected-registration <project.registration_fingerprint> \
+  --start-session --json
+```
+
+Kwt revalidates both values while holding the project lifecycle fence and
+before creating the worktree. A changed or replaced project returns the
+retryable `registration_changed` error without importing anything. The two
+flags are an all-or-nothing contract; ordinary interactive use may omit both.
+
 Every successful import response includes the deterministic
 `tmux_socket_name`, whether or not a session was started. `--start-session`
 creates or repairs the returned `session_name` as a single blank shell session

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -1057,9 +1057,12 @@ func prepareGuardedPRImportProject(
 	}
 
 	selected, err := resolvePRProject(snapshot.Config, prProject)
-	if err != nil || !samePRPath(selected.Path, expected.Effective.Path) ||
+	if err != nil {
+		return pullrequest.Project{}, err
+	}
+	if !samePRPath(selected.Path, expected.Effective.Path) ||
 		!lifecycle.EqualProjectIdentity(selected.Identity, expectedIdentity) {
-		return pullrequest.Project{}, changedPRImportRegistration(err)
+		return pullrequest.Project{}, changedPRImportRegistration(nil)
 	}
 	selected.Identity = expectedIdentity
 	return selected, nil

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -201,11 +201,20 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	project, err := preparePRProject()
+	number, err := pullrequest.ParseSelectorNumber(args[0])
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	number, err := pullrequest.ParseSelectorNumber(args[0])
+	var home string
+	var project pullrequest.Project
+	if guarded {
+		home, err = config.CanonicalHome()
+		if err == nil {
+			project, err = prepareGuardedPRImportProject(cmd.Context(), home)
+		}
+	} else {
+		project, err = preparePRProject()
+	}
 	if err != nil {
 		return writePRError(cmd, err)
 	}
@@ -229,9 +238,11 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 			))
 		}
 	}
-	home, err := config.CanonicalHome()
-	if err != nil {
-		return writePRError(cmd, err)
+	if home == "" {
+		home, err = config.CanonicalHome()
+		if err != nil {
+			return writePRError(cmd, err)
+		}
 	}
 	expansion, err := kwt.CaptureExpansionContext()
 	if err != nil {
@@ -997,6 +1008,71 @@ func preparePRProject() (pullrequest.Project, error) {
 		return pullrequest.Project{}, err
 	}
 	return project, nil
+}
+
+func prepareGuardedPRImportProject(
+	ctx context.Context,
+	home string,
+) (pullrequest.Project, error) {
+	snapshot, err := config.LoadGlobalSnapshotAt(home)
+	if err != nil {
+		return pullrequest.Project{}, pullrequest.NewError(
+			pullrequest.CodeWorkspaceCreation,
+			"failed to load kwt project registrations",
+			false,
+			err,
+		)
+	}
+
+	var expected *config.ProjectRegistration
+	for index := range snapshot.Projects {
+		fingerprint, fingerprintErr := snapshot.Projects[index].Fingerprint()
+		if fingerprintErr != nil {
+			return pullrequest.Project{}, pullrequest.NewError(
+				pullrequest.CodeWorkspaceCreation,
+				"failed to inspect kwt project registration",
+				false,
+				fingerprintErr,
+			)
+		}
+		if fingerprint == prImportExpectedRegistration {
+			expected = &snapshot.Projects[index]
+			break
+		}
+	}
+	if expected == nil {
+		return pullrequest.Project{}, changedPRImportRegistration(nil)
+	}
+
+	expectedIdentity, err := lifecycle.ResolveProjectRegistrationIdentity(
+		ctx,
+		*expected,
+		credentials.ProtectedNames(snapshot.Config)...,
+	)
+	if err != nil || !lifecycle.EqualProjectIdentity(
+		expectedIdentity,
+		prImportExpectedRepository,
+	) {
+		return pullrequest.Project{}, changedPRImportRegistration(err)
+	}
+
+	selected, err := resolvePRProject(snapshot.Config, prProject)
+	if err != nil || !samePRPath(selected.Path, expected.Effective.Path) ||
+		!lifecycle.EqualProjectIdentity(selected.Identity, expectedIdentity) {
+		return pullrequest.Project{}, changedPRImportRegistration(err)
+	}
+	selected.Identity = expectedIdentity
+	return selected, nil
+}
+
+func changedPRImportRegistration(cause error) error {
+	return service.NewError(
+		service.RegistrationChanged,
+		"the project registration changed before the operation began",
+		true,
+		nil,
+		cause,
+	)
 }
 
 func preparePRService(

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -41,6 +41,9 @@ var (
 	prJSON         bool
 	prStartSession bool
 
+	prImportExpectedRepository   string
+	prImportExpectedRegistration string
+
 	prAttachExpectedRepository   string
 	prAttachExpectedRegistration string
 	prAttachExpectedGeneration   string
@@ -121,6 +124,18 @@ func init() {
 		false,
 		"ensure the imported workspace's tmux session exists without attaching",
 	)
+	prImportCmd.Flags().StringVar(
+		&prImportExpectedRepository,
+		"expected-repository",
+		"",
+		"require this registered project identity before importing",
+	)
+	prImportCmd.Flags().StringVar(
+		&prImportExpectedRegistration,
+		"expected-registration",
+		"",
+		"require this project registration fingerprint before importing",
+	)
 	prAttachCmd.Flags().StringVar(
 		&prAttachExpectedRepository,
 		"expected-repository",
@@ -182,6 +197,10 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return prExactArgs(1)(cmd, args)
 	}
+	guarded, err := validateExpectedPRImportFlags(cmd)
+	if err != nil {
+		return writePRError(cmd, err)
+	}
 	project, err := preparePRProject()
 	if err != nil {
 		return writePRError(cmd, err)
@@ -218,10 +237,19 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return writePRError(cmd, err)
 	}
-	guard, err := observeRequiredGuardedProjectOperation(
-		cmd.Context(), home, project.Path, expansion,
-		registeredIdentity, project.Identity,
-	)
+	var guard *guardedProjectOperation
+	if guarded {
+		guard, err = observeExpectedGuardedProjectOperation(
+			cmd.Context(), home, project.Path, expansion,
+			prImportExpectedRepository,
+			prImportExpectedRegistration,
+		)
+	} else {
+		guard, err = observeRequiredGuardedProjectOperation(
+			cmd.Context(), home, project.Path, expansion,
+			registeredIdentity, project.Identity,
+		)
+	}
 	if err != nil {
 		return writePRError(cmd, err)
 	}
@@ -267,6 +295,46 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 	}
 	result.PullRequest.Workspace = &result.Workspace
 	return writePRJSON(cmd, result)
+}
+
+func validateExpectedPRImportFlags(cmd *cobra.Command) (bool, error) {
+	repositoryChanged := commandFlagChanged(cmd, "expected-repository")
+	registrationChanged := commandFlagChanged(cmd, "expected-registration")
+	if !repositoryChanged && !registrationChanged {
+		return false, nil
+	}
+	if !repositoryChanged || !registrationChanged {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected repository and registration must be provided together",
+			false, nil, nil,
+		)
+	}
+	if prImportExpectedRepository == "" || prImportExpectedRegistration == "" {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected repository and registration must be nonempty",
+			false, nil, nil,
+		)
+	}
+	if !lifecycle.EqualProjectIdentity(
+		prImportExpectedRepository,
+		prImportExpectedRepository,
+	) {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected repository identity is invalid",
+			false, nil, nil,
+		)
+	}
+	if !config.ValidProjectRegistrationFingerprint(prImportExpectedRegistration) {
+		return false, service.NewError(
+			service.InvalidRequest,
+			"expected project registration fingerprint is invalid",
+			false, nil, nil,
+		)
+	}
+	return true, nil
 }
 
 func runPRAttach(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -722,6 +722,87 @@ func TestGuardedPRImportRejectsRegistrationReplacementBeforeMutation(t *testing.
 	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
 }
 
+func TestGuardedPRImportResolvesExpectedRegistrationBeforeProjectSelector(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		replacement *models.Project
+	}{
+		{name: "registration removed"},
+		{
+			name: "repository replaced under the same selector",
+			replacement: &models.Project{
+				Repository: "github.com/other/widget",
+				Name:       "widget",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("KWT_HOME", home)
+			projectPath := filepath.Join(t.TempDir(), "widget")
+			original := models.Project{
+				Repository: "github.com/acme/widget",
+				Name:       "widget",
+				Path:       projectPath,
+			}
+			serviceImpl := &fakePRService{}
+			withPRCommandDeps(
+				t,
+				&models.Config{Projects: []models.Project{original}},
+				serviceImpl,
+			)
+			snapshot, err := config.LoadGlobalSnapshotAt(home)
+			require.NoError(t, err)
+			require.Len(t, snapshot.Projects, 1)
+			fingerprint, err := snapshot.Projects[0].Fingerprint()
+			require.NoError(t, err)
+
+			var replacementConfig *models.Config
+			var replacementProject *models.Project
+			if test.replacement != nil {
+				replacement := *test.replacement
+				replacement.Path = projectPath
+				replacementProject = &replacement
+				replacementConfig = &models.Config{
+					Projects: []models.Project{replacement},
+				}
+			}
+			changed, err := config.CompareAndSwapProjectAt(
+				home,
+				snapshot.Projects[0],
+				replacementProject,
+			)
+			require.NoError(t, err)
+			require.True(t, changed)
+			loadPRConfig = func() (*models.Config, error) {
+				if replacementConfig == nil {
+					return &models.Config{}, nil
+				}
+				return replacementConfig, nil
+			}
+
+			prImportExpectedRepository = original.Repository
+			prImportExpectedRegistration = fingerprint
+			prProject = original.Repository
+			cmd, stdout, _ := prTestCommand()
+			markCommandFlagsChanged(
+				t,
+				cmd,
+				"expected-repository",
+				"expected-registration",
+			)
+
+			err = runPRImport(cmd, []string{"17"})
+
+			assert.True(t, service.IsCode(err, service.RegistrationChanged))
+			assert.Empty(t, serviceImpl.gotSelector)
+			var envelope jsonErrorEnvelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+			assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+		})
+	}
+}
+
 func TestPRImportExpectedAuthorityIsAllOrNothing(t *testing.T) {
 	for _, test := range []struct {
 		name         string

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -803,6 +803,45 @@ func TestGuardedPRImportResolvesExpectedRegistrationBeforeProjectSelector(t *tes
 	}
 }
 
+func TestGuardedPRImportPreservesUnsupportedProviderError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	project := models.Project{
+		Repository: "gitlab.com/acme/widget",
+		Name:       "widget",
+		Path:       filepath.Join(t.TempDir(), "widget"),
+	}
+	serviceImpl := &fakePRService{}
+	withPRCommandDeps(
+		t,
+		&models.Config{Projects: []models.Project{project}},
+		serviceImpl,
+	)
+	snapshot, err := config.LoadGlobalSnapshotAt(home)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	fingerprint, err := snapshot.Projects[0].Fingerprint()
+	require.NoError(t, err)
+	prImportExpectedRepository = project.Repository
+	prImportExpectedRegistration = fingerprint
+	prProject = project.Repository
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t,
+		cmd,
+		"expected-repository",
+		"expected-registration",
+	)
+
+	err = runPRImport(cmd, []string{"17"})
+
+	assertPRCode(t, err, pullrequest.CodeUnsupportedProvider)
+	assert.Empty(t, serviceImpl.gotSelector)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, string(pullrequest.CodeUnsupportedProvider), string(envelope.Error.Code))
+}
+
 func TestPRImportExpectedAuthorityIsAllOrNothing(t *testing.T) {
 	for _, test := range []struct {
 		name         string

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -76,6 +76,8 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	oldProject := prProject
 	oldState := prState
 	oldStartSession := prStartSession
+	oldImportExpectedRepository := prImportExpectedRepository
+	oldImportExpectedRegistration := prImportExpectedRegistration
 	oldAttachExpectedRepository := prAttachExpectedRepository
 	oldAttachExpectedRegistration := prAttachExpectedRegistration
 	oldAttachExpectedGeneration := prAttachExpectedGeneration
@@ -96,6 +98,8 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 		prProject = oldProject
 		prState = oldState
 		prStartSession = oldStartSession
+		prImportExpectedRepository = oldImportExpectedRepository
+		prImportExpectedRegistration = oldImportExpectedRegistration
 		prAttachExpectedRepository = oldAttachExpectedRepository
 		prAttachExpectedRegistration = oldAttachExpectedRegistration
 		prAttachExpectedGeneration = oldAttachExpectedGeneration
@@ -127,6 +131,8 @@ func withPRCommandDeps(t *testing.T, cfg *models.Config, service prService) {
 	prProject = "widget"
 	prState = "open"
 	prStartSession = false
+	prImportExpectedRepository = ""
+	prImportExpectedRegistration = ""
 	prAttachExpectedRepository = ""
 	prAttachExpectedRegistration = ""
 	prAttachExpectedGeneration = ""
@@ -630,6 +636,141 @@ func TestRegisteredPRImportLosesToProjectRemoval(t *testing.T) {
 	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
 	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
+func TestGuardedPRImportRejectsStaleProjectAuthorityBeforeMutation(t *testing.T) {
+	for _, mismatch := range []string{"repository", "registration"} {
+		t.Run(mismatch, func(t *testing.T) {
+			t.Setenv("KWT_HOME", t.TempDir())
+			serviceImpl := &fakePRService{}
+			withPRCommandDeps(t, testPRConfig(), serviceImpl)
+			home, err := config.CanonicalHome()
+			require.NoError(t, err)
+			snapshot, err := config.LoadGlobalSnapshotAt(home)
+			require.NoError(t, err)
+			require.Len(t, snapshot.Projects, 1)
+			fingerprint, err := snapshot.Projects[0].Fingerprint()
+			require.NoError(t, err)
+			prImportExpectedRepository = "github.com/acme/widget"
+			prImportExpectedRegistration = fingerprint
+			if mismatch == "repository" {
+				prImportExpectedRepository = "github.com/other/widget"
+			} else {
+				prImportExpectedRegistration = "v1:" + strings.Repeat("a", 64)
+			}
+			cmd, stdout, _ := prTestCommand()
+			markCommandFlagsChanged(
+				t, cmd,
+				"expected-repository",
+				"expected-registration",
+			)
+
+			err = runPRImport(cmd, []string{"17"})
+
+			assert.True(t, service.IsCode(err, service.RegistrationChanged))
+			assert.Empty(t, serviceImpl.gotSelector)
+			var envelope jsonErrorEnvelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+			assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+		})
+	}
+}
+
+func TestGuardedPRImportRejectsRegistrationReplacementBeforeMutation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KWT_HOME", home)
+	projectPath := filepath.Join(t.TempDir(), "widget")
+	cfg := &models.Config{Projects: []models.Project{{
+		Repository: "github.com/acme/widget", Name: "widget", Path: projectPath,
+	}}}
+	serviceImpl := &fakePRService{}
+	withPRCommandDeps(t, cfg, serviceImpl)
+	snapshot, err := config.LoadGlobalSnapshotAt(home)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Projects, 1)
+	fingerprint, err := snapshot.Projects[0].Fingerprint()
+	require.NoError(t, err)
+	prImportExpectedRepository = "github.com/acme/widget"
+	prImportExpectedRegistration = fingerprint
+	cmd, stdout, _ := prTestCommand()
+	markCommandFlagsChanged(
+		t, cmd,
+		"expected-repository",
+		"expected-registration",
+	)
+	oldBeforeAcquire := beforeProjectGuardAcquire
+	t.Cleanup(func() { beforeProjectGuardAcquire = oldBeforeAcquire })
+	beforeProjectGuardAcquire = func() {
+		replacement := models.Project{
+			Repository: "github.com/other/widget",
+			Name:       "widget",
+			Path:       projectPath,
+		}
+		changed, replaceErr := config.CompareAndSwapProjectAt(
+			home, snapshot.Projects[0], &replacement,
+		)
+		require.NoError(t, replaceErr)
+		require.True(t, changed)
+	}
+
+	err = runPRImport(cmd, []string{"17"})
+
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.Empty(t, serviceImpl.gotSelector)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+}
+
+func TestPRImportExpectedAuthorityIsAllOrNothing(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		repository   string
+		registration string
+		changed      []string
+		wantGuarded  bool
+		wantCode     service.Code
+	}{
+		{
+			name:        "unguarded",
+			wantGuarded: false,
+		},
+		{
+			name:       "repository only",
+			repository: "github.com/acme/widget",
+			changed:    []string{"expected-repository"},
+			wantCode:   service.InvalidRequest,
+		},
+		{
+			name:     "empty values",
+			changed:  []string{"expected-repository", "expected-registration"},
+			wantCode: service.InvalidRequest,
+		},
+		{
+			name:         "valid authority",
+			repository:   "github.com/acme/widget",
+			registration: "v1:" + strings.Repeat("a", 64),
+			changed:      []string{"expected-repository", "expected-registration"},
+			wantGuarded:  true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			withPRCommandDeps(t, testPRConfig(), &fakePRService{})
+			prImportExpectedRepository = test.repository
+			prImportExpectedRegistration = test.registration
+			cmd, _, _ := prTestCommand()
+			markCommandFlagsChanged(t, cmd, test.changed...)
+
+			guarded, err := validateExpectedPRImportFlags(cmd)
+
+			assert.Equal(t, test.wantGuarded, guarded)
+			if test.wantCode == "" {
+				require.NoError(t, err)
+			} else {
+				assert.True(t, service.IsCode(err, test.wantCode))
+			}
+		})
+	}
 }
 
 func tryRequireWorkspace(


### PR DESCRIPTION
- Lets automation bind a pull-request import to the exact project repository and registration it displayed to the user.
- Revalidates that authority under KWT's project lifecycle fence before creating a worktree.
- Returns retryable `registration_changed` without invoking the import service when the project was removed, replaced, or re-registered.
- Keeps ordinary interactive imports unchanged when the two guard flags are omitted.
- Documents how clients obtain and pass the guarded project fields.