### PR TITLE
Make daemon SSH leases portable and interactive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	go.kenn.io/kit v0.21.2-0.20260816003011-444a72688d14
+	go.kenn.io/kit v0.21.2
 	golang.org/x/mod v0.39.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	go.kenn.io/kit v0.21.1
+	go.kenn.io/kit v0.21.2-0.20260816003011-444a72688d14
 	golang.org/x/mod v0.39.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -133,10 +133,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.kenn.io/kit v0.21.1 h1:YIdLvMN2Ad/BOp0+oH2vzObBOsIAv8Hmok043Kh+wPk=
-go.kenn.io/kit v0.21.1/go.mod h1:Cg1V5dG+XaSDYr/nE0tvmCxotfpYtW1vPhyc+Ph9Ny0=
-go.kenn.io/kit v0.21.2-0.20260816003011-444a72688d14 h1:5vt8cTRiMrEVwlDKYT6Jg6Et/Dc1cGBwpGqklj2/S28=
-go.kenn.io/kit v0.21.2-0.20260816003011-444a72688d14/go.mod h1:sUFJe7d25a3FYwjL3mlHx/qzHhF8//xNnR920jzoejw=
+go.kenn.io/kit v0.21.2 h1:wbTnzFlMgvapU4KTZHt8Ntgfakpv3T/Bvg036P+YjFY=
+go.kenn.io/kit v0.21.2/go.mod h1:sUFJe7d25a3FYwjL3mlHx/qzHhF8//xNnR920jzoejw=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.kenn.io/kit v0.21.1 h1:YIdLvMN2Ad/BOp0+oH2vzObBOsIAv8Hmok043Kh+wPk=
 go.kenn.io/kit v0.21.1/go.mod h1:Cg1V5dG+XaSDYr/nE0tvmCxotfpYtW1vPhyc+Ph9Ny0=
+go.kenn.io/kit v0.21.2-0.20260816003011-444a72688d14 h1:5vt8cTRiMrEVwlDKYT6Jg6Et/Dc1cGBwpGqklj2/S28=
+go.kenn.io/kit v0.21.2-0.20260816003011-444a72688d14/go.mod h1:sUFJe7d25a3FYwjL3mlHx/qzHhF8//xNnR920jzoejw=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/ssh/askpass.go
+++ b/internal/ssh/askpass.go
@@ -269,7 +269,7 @@ func (a *Askpass) prompt(message, hint string) (string, error) {
 	if round > a.options.MaxRounds {
 		return "", connectionFailed(errors.New("SSH prompt round limit exceeded"))
 	}
-	prompt := describeSSHPrompt(hint)
+	prompt := describeSSHPrompt(message, hint)
 	prompt.Message = message
 	if a.options.Describe != nil {
 		described, err := a.options.Describe(message, hint)
@@ -373,11 +373,25 @@ func RunAskpassHelper(arguments, environment []string, output io.Writer) (int, b
 	return 0, true
 }
 
-func describeSSHPrompt(hint string) service.OperationPrompt {
-	if hint == "confirm" {
+func describeSSHPrompt(message, hint string) service.OperationPrompt {
+	if hint == "confirm" || isOpenSSHHostKeyPrompt(message) {
 		return service.OperationPrompt{Kind: "ssh_host_key", Sensitive: false}
 	}
 	return service.OperationPrompt{Kind: "ssh_authentication", Sensitive: true}
+}
+
+func isOpenSSHHostKeyPrompt(message string) bool {
+	message = strings.TrimSpace(message)
+	return strings.HasPrefix(message, "The authenticity of host '") &&
+		strings.Contains(message, "\n") &&
+		strings.Contains(message, " key fingerprint is") &&
+		(strings.HasSuffix(
+			message,
+			"Are you sure you want to continue connecting (yes/no/[fingerprint])?",
+		) || strings.HasSuffix(
+			message,
+			"Are you sure you want to continue connecting (yes/no)?",
+		))
 }
 
 func encodeAskpassHandle(handle askpassHandle) (string, error) {

--- a/internal/ssh/askpass.go
+++ b/internal/ssh/askpass.go
@@ -373,25 +373,11 @@ func RunAskpassHelper(arguments, environment []string, output io.Writer) (int, b
 	return 0, true
 }
 
-func describeSSHPrompt(message, hint string) service.OperationPrompt {
-	if hint == "confirm" || isOpenSSHHostKeyPrompt(message) {
+func describeSSHPrompt(_ string, hint string) service.OperationPrompt {
+	if hint == "confirm" {
 		return service.OperationPrompt{Kind: "ssh_host_key", Sensitive: false}
 	}
 	return service.OperationPrompt{Kind: "ssh_authentication", Sensitive: true}
-}
-
-func isOpenSSHHostKeyPrompt(message string) bool {
-	message = strings.TrimSpace(message)
-	return strings.HasPrefix(message, "The authenticity of host '") &&
-		strings.Contains(message, "\n") &&
-		strings.Contains(message, " key fingerprint is") &&
-		(strings.HasSuffix(
-			message,
-			"Are you sure you want to continue connecting (yes/no/[fingerprint])?",
-		) || strings.HasSuffix(
-			message,
-			"Are you sure you want to continue connecting (yes/no)?",
-		))
 }
 
 func encodeAskpassHandle(handle askpassHandle) (string, error) {

--- a/internal/ssh/askpass_test.go
+++ b/internal/ssh/askpass_test.go
@@ -70,6 +70,34 @@ func TestAskpassCarriesMultipleBoundRoundsIncludingEmptyResponse(t *testing.T) {
 	assert.True(t, prompts[0].Sensitive)
 }
 
+func TestAskpassTreatsUnhintedHostKeyTextAsSensitive(t *testing.T) {
+	var captured service.OperationPrompt
+	transport, err := NewAskpass(context.Background(), t.TempDir(), AskpassOptions{
+		Version: supportedAskpassVersion(),
+		Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
+			captured = prompt
+			return "credential", nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+
+	var output bytes.Buffer
+	exitCode, handled := RunAskpassHelper(
+		[]string{"kwt", `The authenticity of host 'example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
+		transport.Environment(),
+		&output,
+	)
+
+	assert.True(t, handled)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "credential\n", output.String())
+	assert.Equal(t, "ssh_authentication", captured.Kind)
+	assert.True(t, captured.Sensitive)
+}
+
 func TestAskpassPreservesTypedPromptRejection(t *testing.T) {
 	transport, err := NewAskpass(context.Background(), t.TempDir(), AskpassOptions{
 		Version: supportedAskpassVersion(),

--- a/internal/ssh/manager_directory_unix.go
+++ b/internal/ssh/manager_directory_unix.go
@@ -1,0 +1,9 @@
+//go:build unix
+
+package ssh
+
+import "os"
+
+func newManagerDirectory() (string, error) {
+	return os.MkdirTemp("/tmp", "kwt-ssh-")
+}

--- a/internal/ssh/manager_directory_windows.go
+++ b/internal/ssh/manager_directory_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package ssh
+
+import "os"
+
+func newManagerDirectory() (string, error) {
+	return os.MkdirTemp("", "kwt-ssh-")
+}

--- a/internal/ssh/public_service.go
+++ b/internal/ssh/public_service.go
@@ -2,8 +2,6 @@ package ssh
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
@@ -39,7 +37,6 @@ type PublicService struct {
 	askpassExecutable string
 	build             func(ResolverOptions) snapshotResolver
 	leases            *Manager
-	managerID         string
 	managerErr        error
 	managerMu         sync.Mutex
 	closed            bool
@@ -60,8 +57,8 @@ func NewPublicService(options PublicServiceOptions) *PublicService {
 	if environment == nil {
 		environment = os.Environ
 	}
-	managerID, managerErr := randomManagerID()
-	if managerErr == nil && options.AskpassExecutable == "" {
+	var managerErr error
+	if options.AskpassExecutable == "" {
 		managerErr = errors.New("SSH askpass helper executable is required")
 	}
 	if managerErr == nil && !filepath.IsAbs(options.AskpassExecutable) {
@@ -78,7 +75,6 @@ func NewPublicService(options PublicServiceOptions) *PublicService {
 				Now:      options.Now,
 			})
 		},
-		managerID:  managerID,
 		managerErr: managerErr,
 		onEvent:    options.OnEvent,
 		newPersistent: func(
@@ -88,14 +84,6 @@ func NewPublicService(options PublicServiceOptions) *PublicService {
 			return openssh.NewPersistentManager(directory, persistentConfig)
 		},
 	}
-}
-
-func randomManagerID() (string, error) {
-	var value [16]byte
-	if _, err := rand.Read(value[:]); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(value[:]), nil
 }
 
 func (s *PublicService) Resolve(
@@ -186,9 +174,12 @@ func (s *PublicService) initializeManager(idleTimeout time.Duration) error {
 	if s.home == "" {
 		return connectionFailed(errors.New("kwt home is required for SSH lifecycle"))
 	}
-	managerDirectory := filepath.Join(s.home, "runtime", "ssh-"+s.managerID)
-	controlDirectory := filepath.Join(managerDirectory, "control")
-	privateDirectory := filepath.Join(managerDirectory, "private")
+	managerDirectory, err := newManagerDirectory()
+	if err != nil {
+		return connectionFailed(err)
+	}
+	controlDirectory := filepath.Join(managerDirectory, "c")
+	privateDirectory := filepath.Join(managerDirectory, "p")
 	connectionOptions := openssh.DefaultConnectionOptions()
 	persistenceTimeout := max(idleTimeout, minimumCrashPersistenceTimeout)
 	connectionOptions.ControlPersistTimeout = persistenceTimeout
@@ -196,7 +187,7 @@ func (s *PublicService) initializeManager(idleTimeout time.Duration) error {
 		ConnectionOptions: &connectionOptions,
 	})
 	if err != nil {
-		return connectionFailed(err)
+		return connectionFailed(errors.Join(err, os.RemoveAll(managerDirectory)))
 	}
 	s.leases = NewManager(ManagerOptions{
 		Persistent:       persistent,

--- a/internal/ssh/public_service.go
+++ b/internal/ssh/public_service.go
@@ -181,6 +181,7 @@ func (s *PublicService) initializeManager(idleTimeout time.Duration) error {
 	controlDirectory := filepath.Join(managerDirectory, "c")
 	privateDirectory := filepath.Join(managerDirectory, "p")
 	connectionOptions := openssh.DefaultConnectionOptions()
+	connectionOptions.AllowInteraction = true
 	persistenceTimeout := max(idleTimeout, minimumCrashPersistenceTimeout)
 	connectionOptions.ControlPersistTimeout = persistenceTimeout
 	persistent, err := s.newPersistent(controlDirectory, openssh.PersistentConfig{

--- a/internal/ssh/public_service_test.go
+++ b/internal/ssh/public_service_test.go
@@ -209,6 +209,7 @@ func TestPublicServiceBuildsOneOwnerScopedPersistentManager(t *testing.T) {
 	assert.NotEqual(t, home, filepath.Dir(filepath.Dir(controlDirectory)))
 	assert.Equal(t, "c", filepath.Base(controlDirectory))
 	require.NotNil(t, persistentConfig.ConnectionOptions)
+	assert.True(t, persistentConfig.ConnectionOptions.AllowInteraction)
 	assert.Equal(t, time.Hour, persistentConfig.ConnectionOptions.ControlPersistTimeout)
 	assert.NoDirExists(t, filepath.Dir(controlDirectory))
 }

--- a/internal/ssh/public_service_test.go
+++ b/internal/ssh/public_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -205,14 +206,46 @@ func TestPublicServiceBuildsOneOwnerScopedPersistentManager(t *testing.T) {
 	require.NoError(t, service.Close(context.Background()))
 
 	assert.Equal(t, 1, created)
-	assert.True(t, strings.HasPrefix(
-		controlDirectory,
-		filepath.Join(home, "runtime")+string(filepath.Separator)+"ssh-",
-	))
-	assert.Equal(t, "control", filepath.Base(controlDirectory))
+	assert.NotEqual(t, home, filepath.Dir(filepath.Dir(controlDirectory)))
+	assert.Equal(t, "c", filepath.Base(controlDirectory))
 	require.NotNil(t, persistentConfig.ConnectionOptions)
 	assert.Equal(t, time.Hour, persistentConfig.ConnectionOptions.ControlPersistTimeout)
 	assert.NoDirExists(t, filepath.Dir(controlDirectory))
+}
+
+func TestPublicServiceControlPathLeavesOpenSSHTemporarySocketHeadroom(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows OpenSSH does not use Unix-domain control sockets")
+	}
+	home := t.TempDir()
+	snapshot := directSnapshot("route-one")
+	service := NewPublicService(PublicServiceOptions{
+		Home:              home,
+		AskpassExecutable: filepath.Join(home, "kwt"),
+	})
+	service.build = func(ResolverOptions) snapshotResolver {
+		return fixedPublicResolver{snapshot: snapshot}
+	}
+	controlDirectory := ""
+	service.newPersistent = func(
+		directory string,
+		_ openssh.PersistentConfig,
+	) (PersistentManager, error) {
+		controlDirectory = directory
+		return publicTestPersistentManager{}, nil
+	}
+
+	lease, err := service.Acquire(context.Background(), LeaseRequest{Snapshot: snapshot})
+	require.NoError(t, err)
+	require.NoError(t, lease.Release(context.Background()))
+	defer func() { require.NoError(t, service.Close(context.Background())) }()
+
+	controlPath := filepath.Join(
+		controlDirectory,
+		openssh.ControlName(strings.Repeat("route", 16))+".sock",
+	)
+	openSSHTemporaryPath := controlPath + "." + strings.Repeat("x", 16)
+	assert.LessOrEqual(t, len([]byte(openSSHTemporaryPath)), 103)
 }
 
 func TestPublicServiceClosePreventsManagerReinitialization(t *testing.T) {

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -65,8 +65,8 @@ func newRunner(
 			Executable:  options.Executable,
 			Environment: environment,
 			Prompt:      request.Prompt,
-			Describe: func(_ string, hint string) (service.OperationPrompt, error) {
-				prompt := describeSSHPrompt(hint)
+			Describe: func(message, hint string) (service.OperationPrompt, error) {
+				prompt := describeSSHPrompt(message, hint)
 				hopCount := request.promptTargetCount
 				if hopCount == 0 {
 					hopCount = 1

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -84,7 +84,7 @@ func newRunner(
 		if err != nil {
 			return -1, errors.Join(err, cleanup())
 		}
-		arguments = append(arguments, managerArguments...)
+		arguments = append(arguments, allowAskpassAuthentication(managerArguments)...)
 		exitCode, runErr := run(
 			ctx,
 			arguments,
@@ -94,6 +94,16 @@ func newRunner(
 		closeErr := askpass.Close()
 		return exitCode, errors.Join(runErr, askpass.Err(), closeErr, cleanup())
 	}, nil
+}
+
+func allowAskpassAuthentication(arguments []string) []string {
+	resolved := append([]string(nil), arguments...)
+	for index := 0; index+1 < len(resolved); index++ {
+		if resolved[index] == "-o" && resolved[index+1] == "BatchMode=yes" {
+			resolved[index+1] = "BatchMode=no"
+		}
+	}
+	return resolved
 }
 
 func promptTargetDetails(target Target) map[string]any {

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -75,6 +75,41 @@ func TestRunnerAppliesProjectionAndPrivateConfigToEveryManagerCommand(t *testing
 	assert.NoFileExists(t, capturedArguments[1])
 }
 
+func TestRunnerAllowsAskpassAuthenticationForPersistentMasters(t *testing.T) {
+	request := LeaseRequest{
+		WorkingDirectory: t.TempDir(),
+		Environment:      []string{"PATH=/usr/bin"},
+	}
+	target := ResolvedTarget{Projection: ExecutionProjection{
+		Arguments: []string{"-F", os.DevNull},
+	}}
+	var capturedArguments []string
+	runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
+		Version: supportedAskpassVersion(),
+		Run: func(
+			_ context.Context,
+			arguments []string,
+			_ string,
+			_ []string,
+		) (int, error) {
+			capturedArguments = append([]string(nil), arguments...)
+			return 0, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = runner(context.Background(), []string{
+		"-MNf", "-o", "BatchMode=yes", "--", "build.internal",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(
+		strings.Join(capturedArguments, " "),
+		"-MNf -o BatchMode=no -- build.internal",
+	))
+	assert.NotContains(t, capturedArguments, "BatchMode=yes")
+}
+
 func TestRunnerEnforcesResolvedHostKeyPolicyWithoutAmbientAskpass(t *testing.T) {
 	request := LeaseRequest{
 		WorkingDirectory: t.TempDir(),

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -206,11 +206,15 @@ func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) 
 			environment []string,
 		) (int, error) {
 			var output bytes.Buffer
+			confirmEnvironment := append(
+				append([]string(nil), environment...),
+				"SSH_ASKPASS_PROMPT=confirm",
+			)
 			exitCode, handled := RunAskpassHelper(
 				[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
-				environment,
+				confirmEnvironment,
 				&output,
 			)
 			require.True(t, handled)

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -207,8 +207,10 @@ func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) 
 		) (int, error) {
 			var output bytes.Buffer
 			exitCode, handled := RunAskpassHelper(
-				[]string{"kwt", "Continue connecting (yes/no)?"},
-				append(environment, "SSH_ASKPASS_PROMPT=confirm"),
+				[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
+				environment,
 				&output,
 			)
 			require.True(t, handled)
@@ -224,7 +226,7 @@ func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) 
 	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "ssh_host_key", captured.Kind)
 	assert.False(t, captured.Sensitive)
-	assert.Equal(t, "Continue connecting (yes/no)?", captured.Message)
+	assert.Contains(t, captured.Message, "The authenticity of host")
 	assert.Equal(t, map[string]any{
 		"hostname": target.LogicalTarget.Hostname,
 	}, captured.Details["logical_target"])


### PR DESCRIPTION
Daemon-owned SSH leases must establish reliably on macOS and expose OpenSSH prompts through kwt’s bounded askpass channel.

- Keep lifecycle-owned control sockets within the effective Unix-domain path budget.
- Opt persistent masters into explicit caller-owned interaction while preserving kit’s noninteractive default.
- Classify standard OpenSSH host-key prompts when macOS omits the askpass hint.
- Clean up private runtime state during rollback and service shutdown.
- Prove direct, ProxyJump, unknown-host, and encrypted-key acquisition in the isolated Docker cutover harness.