### PR TITLE
Publish structured SSH host-key prompt details

### DIFF
--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -126,11 +126,13 @@ responses remain distinct from rejection. Kwt creates no channel state unless
 the selected system OpenSSH satisfies the 8.4 forced-askpass floor.
 OpenSSH's own askpass confirmation hint distinguishes host-key confirmation
 from credential input before kwt parses the confirmation text into a reviewed
-host, algorithm, and fingerprint for native clients. Unhinted text is always
-treated as sensitive authentication input, even when it resembles a host-key
-prompt. Published prompt details contain only that host-key review identity,
-the already reviewed route targets, and hop position; they contain no
-credentials or environment values.
+host, algorithm, and fingerprint for native clients. When macOS omits that
+hint, kwt recognizes the complete standard confirmation shape only for a
+reviewed target whose effective policy is `StrictHostKeyChecking=ask`.
+Unhinted text on every other route remains sensitive authentication input.
+Published prompt details contain only that host-key review identity, the
+already reviewed route targets, and hop position; they contain no credentials
+or environment values.
 
 SSH route resolution validates user, hostname, and port before invoking
 OpenSSH. POSIX resolution quotes the validated argv into the account login

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -125,9 +125,12 @@ environment values, daemon events, logs, or persistent state. Deliberate empty
 responses remain distinct from rejection. Kwt creates no channel state unless
 the selected system OpenSSH satisfies the 8.4 forced-askpass floor.
 OpenSSH's own askpass confirmation hint distinguishes host-key confirmation
-from credential input without parsing server-controlled prompt text. Published
-prompt details contain only the already reviewed route targets and hop position;
-they contain no credentials or environment values.
+from credential input before kwt parses the confirmation text into a reviewed
+host, algorithm, and fingerprint for native clients. Unhinted text is always
+treated as sensitive authentication input, even when it resembles a host-key
+prompt. Published prompt details contain only that host-key review identity,
+the already reviewed route targets, and hop position; they contain no
+credentials or environment values.
 
 SSH route resolution validates user, hostname, and port before invoking
 OpenSSH. POSIX resolution quotes the validated argv into the account login

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -130,6 +130,9 @@ host, algorithm, and fingerprint for native clients. When macOS omits that
 hint, kwt recognizes the complete standard confirmation shape only for a
 reviewed target whose effective policy is `StrictHostKeyChecking=ask`.
 Unhinted text on every other route remains sensitive authentication input.
+Confirmation requests outside the complete unknown-host shape also remain
+sensitive authentication input, so they reach the client without claiming a
+host-key identity or enabling echoed input.
 Published prompt details contain only that host-key review identity, the
 already reviewed route targets, and hop position; they contain no credentials
 or environment values.

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -126,10 +126,9 @@ responses remain distinct from rejection. Kwt creates no channel state unless
 the selected system OpenSSH satisfies the 8.4 forced-askpass floor.
 OpenSSH's own askpass confirmation hint distinguishes host-key confirmation
 from credential input before kwt parses the confirmation text into a reviewed
-host, algorithm, and fingerprint for native clients. When macOS omits that
-hint, kwt recognizes the complete standard confirmation shape only for a
-reviewed target whose effective policy is `StrictHostKeyChecking=ask`.
-Unhinted text on every other route remains sensitive authentication input.
+host, algorithm, and fingerprint for native clients. Every unhinted prompt
+remains sensitive authentication input, even when its text matches OpenSSH's
+standard host-key question; server-controlled prose is not trusted provenance.
 Confirmation requests outside the complete unknown-host shape also remain
 sensitive authentication input, so they reach the client without claiming a
 host-key identity or enabling echoed input.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -194,8 +194,10 @@ the daemon's terminal timeout. OpenSSH confirmation requests use the
 requests use `ssh_authentication` and are sensitive. Every prompt includes its
 credential-free logical target, effective target, display target, zero-based
 hop index, and route hop count in `details`, so a native client can identify
-which direct or ProxyJump target controls the prompt. The prompt message remains
-OpenSSH's original text. The process keeps the lease alive
+which direct or ProxyJump target controls the prompt. Host-key prompts also
+include a `host_key` object containing the reviewed `host`, `algorithm`, and
+`fingerprint`, so native clients do not parse OpenSSH prose. The prompt message
+remains OpenSSH's original text. The process keeps the lease alive
 while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -197,7 +197,9 @@ hop index, and route hop count in `details`, so a native client can identify
 which direct or ProxyJump target controls the prompt. Host-key prompts also
 include a `host_key` object containing the reviewed `host`, `algorithm`, and
 `fingerprint`, so native clients do not parse OpenSSH prose. The prompt message
-remains OpenSSH's original text. The process keeps the lease alive
+remains OpenSSH's original text. Other OpenSSH confirmation shapes are
+preserved as sensitive `ssh_authentication` prompts without a claimed host-key
+identity. The process keeps the lease alive
 while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,7 +199,8 @@ include a `host_key` object containing the reviewed `host`, `algorithm`, and
 `fingerprint`, so native clients do not parse OpenSSH prose. The prompt message
 remains OpenSSH's original text. Other OpenSSH confirmation shapes are
 preserved as sensitive `ssh_authentication` prompts without a claimed host-key
-identity. The process keeps the lease alive
+identity. Unhinted prompts are always handled this way, even when their prose
+resembles a host-key question. The process keeps the lease alive
 while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -1,0 +1,55 @@
+package ssh
+
+import (
+	"errors"
+	"strings"
+)
+
+type hostKeyPromptDetails struct {
+	Host        string
+	Algorithm   string
+	Fingerprint string
+}
+
+func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
+	const (
+		hostPrefix = "The authenticity of host '"
+		hostSuffix = "' can't be established."
+	)
+	fingerprintMarkers := []string{
+		" key fingerprint is: ",
+		" key fingerprint is ",
+	}
+
+	var details hostKeyPromptDetails
+	for _, rawLine := range strings.Split(message, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if details.Host == "" {
+			start := strings.Index(line, hostPrefix)
+			if start >= 0 {
+				start += len(hostPrefix)
+				if end := strings.Index(line[start:], hostSuffix); end > 0 {
+					details.Host = line[start : start+end]
+				}
+			}
+		}
+		if details.Algorithm == "" {
+			for _, marker := range fingerprintMarkers {
+				index := strings.Index(line, marker)
+				if index < 0 {
+					continue
+				}
+				details.Algorithm = strings.TrimSpace(line[:index])
+				details.Fingerprint = strings.TrimSuffix(
+					strings.TrimSpace(line[index+len(marker):]),
+					".",
+				)
+				break
+			}
+		}
+	}
+	if details.Host == "" || details.Algorithm == "" || details.Fingerprint == "" {
+		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
+	}
+	return details, nil
+}

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -27,10 +27,15 @@ func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
 		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
 	}
 	lines := strings.Split(message, "\n")
-	if len(lines) != 3 ||
+	if len(lines) < 3 ||
 		!strings.HasPrefix(lines[0], hostPrefix) ||
 		!strings.HasSuffix(lines[0], hostSuffix) ||
-		strings.TrimRight(lines[2], " \t") != question {
+		strings.TrimRight(lines[len(lines)-1], " \t") != question {
+		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
+	}
+	reviewLines := lines[2 : len(lines)-1]
+	if len(reviewLines) > 1 ||
+		len(reviewLines) == 1 && reviewLines[0] != "This key is not known by any other names." {
 		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
 	}
 

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -47,7 +47,7 @@ func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
 	}
 	for _, marker := range fingerprintMarkers {
 		index := strings.Index(lines[1], marker)
-		if index < 0 || !strings.HasSuffix(lines[1], ".") {
+		if index < 0 {
 			continue
 		}
 		details.Algorithm = strings.TrimSpace(lines[1][:index])

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -34,8 +35,7 @@ func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
 		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
 	}
 	reviewLines := lines[2 : len(lines)-1]
-	if len(reviewLines) > 1 ||
-		len(reviewLines) == 1 && reviewLines[0] != "This key is not known by any other names." {
+	if !validHostKeyReviewLines(reviewLines) {
 		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
 	}
 
@@ -60,4 +60,35 @@ func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
 		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
 	}
 	return details, nil
+}
+
+func validHostKeyReviewLines(lines []string) bool {
+	if len(lines) == 0 {
+		return true
+	}
+	if len(lines) == 1 {
+		return lines[0] == "This key is not known by any other names."
+	}
+	if lines[0] != "This host key is known by the following other names/addresses:" {
+		return false
+	}
+	for _, line := range lines[1:] {
+		if !strings.HasPrefix(line, "    ") {
+			return false
+		}
+		reference := strings.TrimSpace(line)
+		hostSeparator := strings.Index(reference, ": ")
+		if hostSeparator < 0 || strings.TrimSpace(reference[hostSeparator+2:]) == "" {
+			return false
+		}
+		location := reference[:hostSeparator]
+		lineColon := strings.LastIndex(location, ":")
+		if lineColon < 1 || strings.TrimSpace(location[:lineColon]) == "" {
+			return false
+		}
+		if _, err := strconv.ParseUint(location[lineColon+1:], 10, 64); err != nil {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -68,6 +68,13 @@ func validHostKeyReviewLines(lines []string) bool {
 		return false
 	}
 	lines = remaining
+	if len(lines) > 0 {
+		switch lines[0] {
+		case "Matching host key fingerprint found in DNS.",
+			"No matching host key fingerprint found in DNS.":
+			lines = lines[1:]
+		}
+	}
 	if len(lines) == 0 {
 		return true
 	}

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -15,38 +15,41 @@ func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
 	const (
 		hostPrefix = "The authenticity of host '"
 		hostSuffix = "' can't be established."
+		question   = "Are you sure you want to continue connecting (yes/no/[fingerprint])?"
 	)
 	fingerprintMarkers := []string{
 		" key fingerprint is: ",
 		" key fingerprint is ",
 	}
 
-	var details hostKeyPromptDetails
-	for _, rawLine := range strings.Split(message, "\n") {
-		line := strings.TrimSpace(rawLine)
-		if details.Host == "" {
-			start := strings.Index(line, hostPrefix)
-			if start >= 0 {
-				start += len(hostPrefix)
-				if end := strings.Index(line[start:], hostSuffix); end > 0 {
-					details.Host = line[start : start+end]
-				}
-			}
+	message = strings.ReplaceAll(message, "\r\n", "\n")
+	if strings.ContainsRune(message, '\r') {
+		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
+	}
+	lines := strings.Split(message, "\n")
+	if len(lines) != 3 ||
+		!strings.HasPrefix(lines[0], hostPrefix) ||
+		!strings.HasSuffix(lines[0], hostSuffix) ||
+		strings.TrimRight(lines[2], " \t") != question {
+		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")
+	}
+
+	details := hostKeyPromptDetails{
+		Host: strings.TrimSuffix(
+			strings.TrimPrefix(lines[0], hostPrefix),
+			hostSuffix,
+		),
+	}
+	for _, marker := range fingerprintMarkers {
+		index := strings.Index(lines[1], marker)
+		if index < 0 || !strings.HasSuffix(lines[1], ".") {
+			continue
 		}
-		if details.Algorithm == "" {
-			for _, marker := range fingerprintMarkers {
-				index := strings.Index(line, marker)
-				if index < 0 {
-					continue
-				}
-				details.Algorithm = strings.TrimSpace(line[:index])
-				details.Fingerprint = strings.TrimSuffix(
-					strings.TrimSpace(line[index+len(marker):]),
-					".",
-				)
-				break
-			}
-		}
+		details.Algorithm = strings.TrimSpace(lines[1][:index])
+		details.Fingerprint = strings.TrimSpace(
+			strings.TrimSuffix(lines[1][index+len(marker):], "."),
+		)
+		break
 	}
 	if details.Host == "" || details.Algorithm == "" || details.Fingerprint == "" {
 		return hostKeyPromptDetails{}, errors.New("OpenSSH host-key prompt is missing review details")

--- a/internal/ssh/host_key_prompt.go
+++ b/internal/ssh/host_key_prompt.go
@@ -63,6 +63,11 @@ func parseHostKeyPrompt(message string) (hostKeyPromptDetails, error) {
 }
 
 func validHostKeyReviewLines(lines []string) bool {
+	remaining, valid := consumeHostKeyRandomart(lines)
+	if !valid {
+		return false
+	}
+	lines = remaining
 	if len(lines) == 0 {
 		return true
 	}
@@ -87,6 +92,56 @@ func validHostKeyReviewLines(lines []string) bool {
 			return false
 		}
 		if _, err := strconv.ParseUint(location[lineColon+1:], 10, 64); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func consumeHostKeyRandomart(lines []string) ([]string, bool) {
+	const (
+		lineWidth  = 19
+		fieldLines = 9
+		blockLines = fieldLines + 2
+		fieldChars = " .o+=*BOX@%&#/^SE"
+	)
+	if len(lines) == 0 || !strings.HasPrefix(lines[0], "+") {
+		return lines, true
+	}
+	if len(lines) < blockLines ||
+		!validHostKeyRandomartFrame(lines[0], lineWidth) ||
+		!validHostKeyRandomartFrame(lines[blockLines-1], lineWidth) {
+		return nil, false
+	}
+	for _, line := range lines[1 : blockLines-1] {
+		if len(line) != lineWidth || line[0] != '|' || line[len(line)-1] != '|' {
+			return nil, false
+		}
+		for _, character := range line[1 : len(line)-1] {
+			if !strings.ContainsRune(fieldChars, character) {
+				return nil, false
+			}
+		}
+	}
+	return lines[blockLines:], true
+}
+
+func validHostKeyRandomartFrame(line string, width int) bool {
+	if len(line) != width || line[0] != '+' || line[len(line)-1] != '+' {
+		return false
+	}
+	labelStart := strings.IndexByte(line, '[')
+	labelEnd := strings.IndexByte(line, ']')
+	if labelStart < 1 || labelEnd <= labelStart+1 || labelEnd >= len(line)-1 {
+		return false
+	}
+	for _, character := range line[1:labelStart] + line[labelEnd+1:len(line)-1] {
+		if character != '-' {
+			return false
+		}
+	}
+	for _, character := range line[labelStart+1 : labelEnd] {
+		if character < 0x20 || character > 0x7e || character == '[' || character == ']' {
 			return false
 		}
 	}

--- a/internal/ssh/host_key_prompt_test.go
+++ b/internal/ssh/host_key_prompt_test.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHostKeyPrompt(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     string
+		expectation hostKeyPromptDetails
+	}{
+		{
+			name: "portable OpenSSH",
+			message: `The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+			expectation: hostKeyPromptDetails{
+				Host:        "build.example.test",
+				Algorithm:   "ED25519",
+				Fingerprint: "SHA256:fixture",
+			},
+		},
+		{
+			name: "host with effective address and colon marker",
+			message: `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
+ECDSA key fingerprint is: SHA256:relay-fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+			expectation: hostKeyPromptDetails{
+				Host:        "relay.example.test (100.64.0.7)",
+				Algorithm:   "ECDSA",
+				Fingerprint: "SHA256:relay-fixture",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := parseHostKeyPrompt(test.message)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expectation, actual)
+		})
+	}
+}
+
+func TestParseHostKeyPromptRejectsUnstructuredConfirmation(t *testing.T) {
+	_, err := parseHostKeyPrompt("Continue connecting?")
+
+	require.Error(t, err)
+}

--- a/internal/ssh/host_key_prompt_test.go
+++ b/internal/ssh/host_key_prompt_test.go
@@ -49,6 +49,18 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 				Fingerprint: "SHA256:build-fixture",
 			},
 		},
+		{
+			name: "matching SSHFP record",
+			message: `The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:dns-fixture.
+Matching host key fingerprint found in DNS.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+			expectation: hostKeyPromptDetails{
+				Host:        "build.example.test",
+				Algorithm:   "ED25519",
+				Fingerprint: "SHA256:dns-fixture",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/ssh/host_key_prompt_test.go
+++ b/internal/ssh/host_key_prompt_test.go
@@ -36,6 +36,19 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 				Fingerprint: "SHA256:relay-fixture",
 			},
 		},
+		{
+			name: "host known by another address",
+			message: `The authenticity of host 'build.example.test (<no hostip for proxy command>)' can't be established.
+ED25519 key fingerprint is: SHA256:build-fixture
+This host key is known by the following other names/addresses:
+    /tmp/known_hosts:7: [127.0.0.1]:2200
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+			expectation: hostKeyPromptDetails{
+				Host:        "build.example.test (<no hostip for proxy command>)",
+				Algorithm:   "ED25519",
+				Fingerprint: "SHA256:build-fixture",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -60,6 +73,10 @@ ED25519 key fingerprint is SHA256:fixture.`,
 ED25519 key fingerprint is SHA256:fixture.
 Are you sure you want to continue connecting (yes/no/[fingerprint])?
 Password:`,
+		`The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Password:
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 	} {
 		_, err := parseHostKeyPrompt(message)
 

--- a/internal/ssh/host_key_prompt_test.go
+++ b/internal/ssh/host_key_prompt_test.go
@@ -48,7 +48,20 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 }
 
 func TestParseHostKeyPromptRejectsUnstructuredConfirmation(t *testing.T) {
-	_, err := parseHostKeyPrompt("Continue connecting?")
+	for _, message := range []string{
+		"Continue connecting?",
+		`Password for The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+		`The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.`,
+		`The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])?
+Password:`,
+	} {
+		_, err := parseHostKeyPrompt(message)
 
-	require.Error(t, err)
+		require.Error(t, err)
+	}
 }

--- a/internal/ssh/host_key_prompt_test.go
+++ b/internal/ssh/host_key_prompt_test.go
@@ -27,7 +27,7 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 		{
 			name: "host with effective address and colon marker",
 			message: `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
-ECDSA key fingerprint is: SHA256:relay-fixture.
+ECDSA key fingerprint is: SHA256:relay-fixture
 This key is not known by any other names.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 			expectation: hostKeyPromptDetails{

--- a/internal/ssh/host_key_prompt_test.go
+++ b/internal/ssh/host_key_prompt_test.go
@@ -28,6 +28,7 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 			name: "host with effective address and colon marker",
 			message: `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
 ECDSA key fingerprint is: SHA256:relay-fixture.
+This key is not known by any other names.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 			expectation: hostKeyPromptDetails{
 				Host:        "relay.example.test (100.64.0.7)",

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 
 	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kit/safefileio"
@@ -78,11 +79,24 @@ func newRunner(
 					"hop_index":        request.promptTargetIndex,
 					"hop_count":        hopCount,
 				}
+				var hostKey *hostKeyPromptDetails
 				if prompt.Kind == "ssh_host_key" {
-					hostKey, err := parseHostKeyPrompt(message)
+					parsed, err := parseHostKeyPrompt(message)
 					if err != nil {
 						return service.OperationPrompt{}, err
 					}
+					hostKey = &parsed
+				} else if hint == "" && strings.EqualFold(
+					target.StrictHostKeyChecking,
+					"ask",
+				) {
+					if parsed, err := parseHostKeyPrompt(message); err == nil {
+						prompt.Kind = "ssh_host_key"
+						prompt.Sensitive = false
+						hostKey = &parsed
+					}
+				}
+				if hostKey != nil {
 					details["host_key"] = map[string]any{
 						"host":        hostKey.Host,
 						"algorithm":   hostKey.Algorithm,

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -83,9 +83,11 @@ func newRunner(
 				if prompt.Kind == "ssh_host_key" {
 					parsed, err := parseHostKeyPrompt(message)
 					if err != nil {
-						return service.OperationPrompt{}, err
+						prompt.Kind = "ssh_authentication"
+						prompt.Sensitive = true
+					} else {
+						hostKey = &parsed
 					}
-					hostKey = &parsed
 				} else if hint == "" && strings.EqualFold(
 					target.StrictHostKeyChecking,
 					"ask",

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"strings"
 
 	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kit/safefileio"
@@ -86,15 +85,6 @@ func newRunner(
 						prompt.Kind = "ssh_authentication"
 						prompt.Sensitive = true
 					} else {
-						hostKey = &parsed
-					}
-				} else if hint == "" && strings.EqualFold(
-					target.StrictHostKeyChecking,
-					"ask",
-				) {
-					if parsed, err := parseHostKeyPrompt(message); err == nil {
-						prompt.Kind = "ssh_host_key"
-						prompt.Sensitive = false
 						hostKey = &parsed
 					}
 				}

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -71,13 +71,25 @@ func newRunner(
 				if hopCount == 0 {
 					hopCount = 1
 				}
-				prompt.Details = map[string]any{
+				details := map[string]any{
 					"logical_target":   promptTargetDetails(target.LogicalTarget),
 					"effective_target": promptTargetDetails(target.EffectiveTarget),
 					"display_target":   target.DisplayTarget,
 					"hop_index":        request.promptTargetIndex,
 					"hop_count":        hopCount,
 				}
+				if prompt.Kind == "ssh_host_key" {
+					hostKey, err := parseHostKeyPrompt(message)
+					if err != nil {
+						return service.OperationPrompt{}, err
+					}
+					details["host_key"] = map[string]any{
+						"host":        hostKey.Host,
+						"algorithm":   hostKey.Algorithm,
+						"fingerprint": hostKey.Fingerprint,
+					}
+				}
+				prompt.Details = details
 				return prompt, nil
 			},
 		})

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -177,7 +177,7 @@ func TestRunnerCarriesPromptThroughAskpassHelperProcess(t *testing.T) {
 	assert.Equal(t, "secret\n", output.String())
 }
 
-func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) {
+func TestRunnerClassifiesVisualHostKeyConfirmationAndAttributesProxyHop(t *testing.T) {
 	t.Run("explicit confirmation hint", func(t *testing.T) {
 		var captured service.OperationPrompt
 		request := LeaseRequest{
@@ -216,6 +216,17 @@ func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) 
 				exitCode, handled := RunAskpassHelper(
 					[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
++--[ED25519 256]--+
+|      .          |
+|     . o         |
+|      +          |
+|     o .         |
+|    . S          |
+|                 |
+|                 |
+|                 |
+|                 |
++----[SHA256]-----+
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
 					promptEnvironment,
 					&output,

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -178,75 +178,89 @@ func TestRunnerCarriesPromptThroughAskpassHelperProcess(t *testing.T) {
 }
 
 func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) {
-	var captured service.OperationPrompt
-	request := LeaseRequest{
-		WorkingDirectory: t.TempDir(),
-		Environment:      []string{"PATH=" + os.Getenv("PATH")},
-		Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
-			captured = prompt
-			return "yes", nil
-		},
-		promptTargetIndex: 0,
-		promptTargetCount: 2,
-	}
-	target := ResolvedTarget{
-		LogicalTarget:   Target{Hostname: "relay"},
-		EffectiveTarget: Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
-		DisplayTarget:   "relay.example.test",
-		Projection: ExecutionProjection{
-			Arguments: []string{"-F", os.DevNull},
-		},
-	}
-	runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
-		Version: supportedAskpassVersion(),
-		Run: func(
-			_ context.Context,
-			_ []string,
-			_ string,
-			environment []string,
-		) (int, error) {
-			var output bytes.Buffer
-			confirmEnvironment := append(
-				append([]string(nil), environment...),
-				"SSH_ASKPASS_PROMPT=confirm",
-			)
-			exitCode, handled := RunAskpassHelper(
-				[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
+	for _, test := range []struct {
+		name string
+		hint string
+	}{
+		{name: "explicit confirmation hint", hint: "confirm"},
+		{name: "reviewed ask policy without hint"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var captured service.OperationPrompt
+			request := LeaseRequest{
+				WorkingDirectory: t.TempDir(),
+				Environment:      []string{"PATH=" + os.Getenv("PATH")},
+				Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
+					captured = prompt
+					return "yes", nil
+				},
+				promptTargetIndex: 0,
+				promptTargetCount: 2,
+			}
+			target := ResolvedTarget{
+				LogicalTarget:         Target{Hostname: "relay"},
+				EffectiveTarget:       Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
+				DisplayTarget:         "relay.example.test",
+				StrictHostKeyChecking: "ask",
+				Projection: ExecutionProjection{
+					Arguments: []string{"-F", os.DevNull},
+				},
+			}
+			runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
+				Version: supportedAskpassVersion(),
+				Run: func(
+					_ context.Context,
+					_ []string,
+					_ string,
+					environment []string,
+				) (int, error) {
+					var output bytes.Buffer
+					promptEnvironment := append([]string(nil), environment...)
+					if test.hint != "" {
+						promptEnvironment = append(
+							promptEnvironment,
+							"SSH_ASKPASS_PROMPT="+test.hint,
+						)
+					}
+					exitCode, handled := RunAskpassHelper(
+						[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
-				confirmEnvironment,
-				&output,
-			)
-			require.True(t, handled)
-			assert.Equal(t, "yes\n", output.String())
-			return exitCode, nil
-		},
-	})
-	require.NoError(t, err)
+						promptEnvironment,
+						&output,
+					)
+					require.True(t, handled)
+					assert.Equal(t, "yes\n", output.String())
+					return exitCode, nil
+				},
+			})
+			require.NoError(t, err)
 
-	exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
+			exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
 
-	require.NoError(t, err)
-	assert.Equal(t, 0, exitCode)
-	assert.Equal(t, "ssh_host_key", captured.Kind)
-	assert.False(t, captured.Sensitive)
-	assert.Contains(t, captured.Message, "The authenticity of host")
-	assert.Equal(t, map[string]any{
-		"hostname": target.LogicalTarget.Hostname,
-	}, captured.Details["logical_target"])
-	assert.Equal(t, map[string]any{
-		"hostname": target.EffectiveTarget.Hostname,
-		"user":     target.EffectiveTarget.User,
-		"port":     target.EffectiveTarget.Port,
-	}, captured.Details["effective_target"])
-	assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
-	assert.Equal(t, 0, captured.Details["hop_index"])
-	assert.Equal(t, 2, captured.Details["hop_count"])
-	assert.Equal(t, map[string]any{
-		"host":        "relay.example.test (100.64.0.7)",
-		"algorithm":   "ED25519",
-		"fingerprint": "SHA256:fixture",
-	}, captured.Details["host_key"])
+			require.NoError(t, err)
+			assert.Equal(t, 0, exitCode)
+			assert.Equal(t, "ssh_host_key", captured.Kind)
+			assert.False(t, captured.Sensitive)
+			assert.Contains(t, captured.Message, "The authenticity of host")
+			assert.Equal(t, map[string]any{
+				"hostname": target.LogicalTarget.Hostname,
+			}, captured.Details["logical_target"])
+			assert.Equal(t, map[string]any{
+				"hostname": target.EffectiveTarget.Hostname,
+				"user":     target.EffectiveTarget.User,
+				"port":     target.EffectiveTarget.Port,
+			}, captured.Details["effective_target"])
+			assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
+			assert.Equal(t, 0, captured.Details["hop_index"])
+			assert.Equal(t, 2, captured.Details["hop_count"])
+			assert.Equal(t, map[string]any{
+				"host":        "relay.example.test (100.64.0.7)",
+				"algorithm":   "ED25519",
+				"fingerprint": "SHA256:fixture",
+			}, captured.Details["host_key"])
+		})
+	}
 }
 
 func TestRunnerPropagatesPromptFailure(t *testing.T) {

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -242,6 +242,11 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
 	assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
 	assert.Equal(t, 0, captured.Details["hop_index"])
 	assert.Equal(t, 2, captured.Details["hop_count"])
+	assert.Equal(t, map[string]any{
+		"host":        "relay.example.test (100.64.0.7)",
+		"algorithm":   "ED25519",
+		"fingerprint": "SHA256:fixture",
+	}, captured.Details["host_key"])
 }
 
 func TestRunnerPropagatesPromptFailure(t *testing.T) {

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -227,6 +227,7 @@ ED25519 key fingerprint is SHA256:fixture.
 |                 |
 |                 |
 +----[SHA256]-----+
+Matching host key fingerprint found in DNS.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
 					promptEnvironment,
 					&output,

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -263,6 +263,82 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
 	}
 }
 
+func TestRunnerKeepsUnsupportedConfirmationSensitive(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		message string
+		hint    string
+	}{
+		{
+			name:    "explicit unsupported confirmation",
+			message: "The host address key changed. Continue connecting?",
+			hint:    "confirm",
+		},
+		{
+			name: "unhinted server-controlled spoof",
+			message: `Password for The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var captured service.OperationPrompt
+			request := LeaseRequest{
+				WorkingDirectory: t.TempDir(),
+				Environment:      []string{"PATH=" + os.Getenv("PATH")},
+				Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
+					captured = prompt
+					return "yes", nil
+				},
+			}
+			target := ResolvedTarget{
+				StrictHostKeyChecking: "ask",
+				Projection: ExecutionProjection{
+					Arguments: []string{"-F", os.DevNull},
+				},
+			}
+			runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
+				Version: supportedAskpassVersion(),
+				Run: func(
+					_ context.Context,
+					_ []string,
+					_ string,
+					environment []string,
+				) (int, error) {
+					var output bytes.Buffer
+					promptEnvironment := append([]string(nil), environment...)
+					if test.hint != "" {
+						promptEnvironment = append(
+							promptEnvironment,
+							"SSH_ASKPASS_PROMPT="+test.hint,
+						)
+					}
+					exitCode, handled := RunAskpassHelper(
+						[]string{"kwt", test.message},
+						promptEnvironment,
+						&output,
+					)
+					require.True(t, handled)
+					assert.Equal(t, "yes\n", output.String())
+					return exitCode, nil
+				},
+			})
+			require.NoError(t, err)
+
+			exitCode, err := runner(
+				context.Background(),
+				[]string{"-MNf", "--", "build.internal"},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, 0, exitCode)
+			assert.Equal(t, "ssh_authentication", captured.Kind)
+			assert.True(t, captured.Sensitive)
+			assert.NotContains(t, captured.Details, "host_key")
+		})
+	}
+}
+
 func TestRunnerPropagatesPromptFailure(t *testing.T) {
 	promptFailure := service.NewError(
 		service.SSHPromptRejected,

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -178,92 +178,82 @@ func TestRunnerCarriesPromptThroughAskpassHelperProcess(t *testing.T) {
 }
 
 func TestRunnerClassifiesHostKeyConfirmationAndAttributesProxyHop(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		hint string
-	}{
-		{name: "explicit confirmation hint", hint: "confirm"},
-		{name: "reviewed ask policy without hint"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			var captured service.OperationPrompt
-			request := LeaseRequest{
-				WorkingDirectory: t.TempDir(),
-				Environment:      []string{"PATH=" + os.Getenv("PATH")},
-				Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
-					captured = prompt
-					return "yes", nil
-				},
-				promptTargetIndex: 0,
-				promptTargetCount: 2,
-			}
-			target := ResolvedTarget{
-				LogicalTarget:         Target{Hostname: "relay"},
-				EffectiveTarget:       Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
-				DisplayTarget:         "relay.example.test",
-				StrictHostKeyChecking: "ask",
-				Projection: ExecutionProjection{
-					Arguments: []string{"-F", os.DevNull},
-				},
-			}
-			runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
-				Version: supportedAskpassVersion(),
-				Run: func(
-					_ context.Context,
-					_ []string,
-					_ string,
-					environment []string,
-				) (int, error) {
-					var output bytes.Buffer
-					promptEnvironment := append([]string(nil), environment...)
-					if test.hint != "" {
-						promptEnvironment = append(
-							promptEnvironment,
-							"SSH_ASKPASS_PROMPT="+test.hint,
-						)
-					}
-					exitCode, handled := RunAskpassHelper(
-						[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
+	t.Run("explicit confirmation hint", func(t *testing.T) {
+		var captured service.OperationPrompt
+		request := LeaseRequest{
+			WorkingDirectory: t.TempDir(),
+			Environment:      []string{"PATH=" + os.Getenv("PATH")},
+			Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
+				captured = prompt
+				return "yes", nil
+			},
+			promptTargetIndex: 0,
+			promptTargetCount: 2,
+		}
+		target := ResolvedTarget{
+			LogicalTarget:         Target{Hostname: "relay"},
+			EffectiveTarget:       Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
+			DisplayTarget:         "relay.example.test",
+			StrictHostKeyChecking: "ask",
+			Projection: ExecutionProjection{
+				Arguments: []string{"-F", os.DevNull},
+			},
+		}
+		runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
+			Version: supportedAskpassVersion(),
+			Run: func(
+				_ context.Context,
+				_ []string,
+				_ string,
+				environment []string,
+			) (int, error) {
+				var output bytes.Buffer
+				promptEnvironment := append([]string(nil), environment...)
+				promptEnvironment = append(
+					promptEnvironment,
+					"SSH_ASKPASS_PROMPT=confirm",
+				)
+				exitCode, handled := RunAskpassHelper(
+					[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
-						promptEnvironment,
-						&output,
-					)
-					require.True(t, handled)
-					assert.Equal(t, "yes\n", output.String())
-					return exitCode, nil
-				},
-			})
-			require.NoError(t, err)
-
-			exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
-
-			require.NoError(t, err)
-			assert.Equal(t, 0, exitCode)
-			assert.Equal(t, "ssh_host_key", captured.Kind)
-			assert.False(t, captured.Sensitive)
-			assert.Contains(t, captured.Message, "The authenticity of host")
-			assert.Equal(t, map[string]any{
-				"hostname": target.LogicalTarget.Hostname,
-			}, captured.Details["logical_target"])
-			assert.Equal(t, map[string]any{
-				"hostname": target.EffectiveTarget.Hostname,
-				"user":     target.EffectiveTarget.User,
-				"port":     target.EffectiveTarget.Port,
-			}, captured.Details["effective_target"])
-			assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
-			assert.Equal(t, 0, captured.Details["hop_index"])
-			assert.Equal(t, 2, captured.Details["hop_count"])
-			assert.Equal(t, map[string]any{
-				"host":        "relay.example.test (100.64.0.7)",
-				"algorithm":   "ED25519",
-				"fingerprint": "SHA256:fixture",
-			}, captured.Details["host_key"])
+					promptEnvironment,
+					&output,
+				)
+				require.True(t, handled)
+				assert.Equal(t, "yes\n", output.String())
+				return exitCode, nil
+			},
 		})
-	}
+		require.NoError(t, err)
+
+		exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, exitCode)
+		assert.Equal(t, "ssh_host_key", captured.Kind)
+		assert.False(t, captured.Sensitive)
+		assert.Contains(t, captured.Message, "The authenticity of host")
+		assert.Equal(t, map[string]any{
+			"hostname": target.LogicalTarget.Hostname,
+		}, captured.Details["logical_target"])
+		assert.Equal(t, map[string]any{
+			"hostname": target.EffectiveTarget.Hostname,
+			"user":     target.EffectiveTarget.User,
+			"port":     target.EffectiveTarget.Port,
+		}, captured.Details["effective_target"])
+		assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
+		assert.Equal(t, 0, captured.Details["hop_index"])
+		assert.Equal(t, 2, captured.Details["hop_count"])
+		assert.Equal(t, map[string]any{
+			"host":        "relay.example.test (100.64.0.7)",
+			"algorithm":   "ED25519",
+			"fingerprint": "SHA256:fixture",
+		}, captured.Details["host_key"])
+	})
 }
 
-func TestRunnerKeepsUnsupportedConfirmationSensitive(t *testing.T) {
+func TestRunnerKeepsUntrustedConfirmationSensitive(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		message string
@@ -277,6 +267,12 @@ func TestRunnerKeepsUnsupportedConfirmationSensitive(t *testing.T) {
 		{
 			name: "unhinted server-controlled spoof",
 			message: `Password for The authenticity of host 'build.example.test' can't be established.
+ED25519 key fingerprint is SHA256:fixture.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
+		},
+		{
+			name: "unhinted standard host-key text",
+			message: `The authenticity of host 'build.example.test' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 		},


### PR DESCRIPTION
Native clients should not independently parse OpenSSH host-key confirmation prose.

- Publishes reviewed host, algorithm, and fingerprint fields only when OpenSSH supplies its trusted confirmation hint.
- Validates complete, ordered unknown-host transcripts, including VisualHostKey randomart, VerifyHostKeyDNS results, and alternate-address review blocks.
- Keeps every unhinted, malformed, or unsupported confirmation in the sensitive `ssh_authentication` path.
- Lets Ghosthub remove its Swift parser while preserving direct, ProxyJump, and encrypted-key authentication behavior.