### PR TITLE
Require explicit host-key policy for SSH leases

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -45,7 +45,7 @@ immediately, then continues reporting observed drain state while it waits.
 Active work and leases may finish until `daemon.replacement_grace`; the default
 is five minutes.
 
-The API schema is `1.9.0`. It exposes authenticated status, graceful shutdown,
+The API schema is `1.10.0`. It exposes authenticated status, graceful shutdown,
 worktree inventory, guarded project unregistration, and repository-config
 approval under `/api/v1`, proof-capable liveness at `/api/ping`, and
 credential-free OpenAPI at `/openapi.json`. Inventory clients require the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -179,13 +179,18 @@ settings—still changes route identity but is never replayed for execution.
 kwt ssh lease build.example.com \
   --route-identity <identity-from-ssh-resolve> \
   --projection-policy kwt.openssh.projection.v1 \
+  --host-key-policy review \
   --json
 ```
 
 `kwt ssh lease` is the long-lived native-client bridge to the same-machine
 daemon. It re-resolves the logical target, refuses a changed route, prepares
 every ProxyJump hop in order, and streams operation events as NDJSON. Prompt
-events may occur repeatedly; the client answers each with one
+capable clients use `--host-key-policy review`, which requires an explicit
+OpenSSH review prompt unless the route already requires a known key.
+Unattended clients use `--host-key-policy strict`, which accepts only keys
+already trusted by OpenSSH and never modifies an empty known-hosts file.
+Events may occur repeatedly; the client answers each with one
 `{"prompt_id":"...","value":"..."}` line on stdin. The completion event
 contains generation-bound OpenSSH arguments. Each prompt carries the daemon's
 deadline, so blocked input ends when the prompt expires and the command reports

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -27,6 +27,7 @@ var (
 	sshLeasePort             int
 	sshLeaseRouteIdentity    string
 	sshLeaseProjectionPolicy string
+	sshLeaseHostKeyPolicy    string
 
 	resolveSSHThroughDaemon      = resolveSSHViaDaemon
 	acquireSSHLeaseThroughDaemon = acquireSSHLeaseViaDaemon
@@ -97,6 +98,10 @@ func init() {
 	sshLeaseCmd.Flags().StringVar(
 		&sshLeaseProjectionPolicy, "projection-policy", kwt.SSHProjectionPolicyV1,
 		"Require this SSH execution projection policy",
+	)
+	sshLeaseCmd.Flags().StringVar(
+		&sshLeaseHostKeyPolicy, "host-key-policy", string(kwt.SSHHostKeyPolicyReview),
+		"Host-key handling: review or strict",
 	)
 	sshLeaseCmd.Flags().BoolVar(
 		&sshLeaseJSON, "json", false, "Stream machine-readable lifecycle events",
@@ -216,13 +221,16 @@ func runSSHLease(cmd *cobra.Command, args []string) (returnErr error) {
 	}
 	result, control, err := acquireSSHLeaseThroughDaemon(
 		ctx,
-		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{
-			LogicalTarget: kwt.SSHTarget{
-				Hostname: args[0], User: sshLeaseUser, Port: sshLeasePort,
+		kwt.SSHLeaseRequest{
+			HostKeyPolicy: kwt.SSHHostKeyPolicy(sshLeaseHostKeyPolicy),
+			Snapshot: kwt.SSHRouteSnapshot{
+				LogicalTarget: kwt.SSHTarget{
+					Hostname: args[0], User: sshLeaseUser, Port: sshLeasePort,
+				},
+				RouteIdentity:    sshLeaseRouteIdentity,
+				ProjectionPolicy: sshLeaseProjectionPolicy,
 			},
-			RouteIdentity:    sshLeaseRouteIdentity,
-			ProjectionPolicy: sshLeaseProjectionPolicy,
-		}},
+		},
 		callbacks,
 	)
 	if err != nil {

--- a/internal/daemon/ssh_resolution_test.go
+++ b/internal/daemon/ssh_resolution_test.go
@@ -207,7 +207,7 @@ func TestSSHResolveRouteReservesDaemonWorkAndHonorsCancellation(t *testing.T) {
 }
 
 func TestSSHResolveCapabilityAndSchemaAreAdvertised(t *testing.T) {
-	assert.Equal(t, "1.9.0", APISchemaVersion)
+	assert.Equal(t, "1.10.0", APISchemaVersion)
 	record, _, err := NewRuntimeRecord(
 		t.TempDir(),
 		Build{Version: "development"},

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -9,7 +9,7 @@ import (
 const (
 	ServiceName               = "kwt"
 	APISchemaMajor            = 1
-	APISchemaVersion          = "1.9.0"
+	APISchemaVersion          = "1.10.0"
 	CapabilityStatus          = "daemon.status"
 	CapabilityShutdown        = "daemon.shutdown"
 	CapabilityProjectRemoval  = "project.removal.v1"

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -120,10 +120,13 @@ func (m *Manager) Acquire(
 	if len(request.Snapshot.Targets) == 0 {
 		return nil, routeUnreviewable(errors.New("SSH lifecycle requires a resolved target"))
 	}
+	if err := validateHostKeyPolicy(request.HostKeyPolicy); err != nil {
+		return nil, err
+	}
 	leases := make([]Lease, 0, len(request.Snapshot.Targets))
 	previousIdentity := ""
 	for index, originalTarget := range request.Snapshot.Targets {
-		target := originalTarget
+		target := targetWithHostKeyPolicy(originalTarget, request.HostKeyPolicy)
 		if index > 0 {
 			previous := leases[index-1]
 			if previous.Mode() != LeaseModeMultiplexed {
@@ -155,6 +158,32 @@ func (m *Manager) Acquire(
 		return leases[0], nil
 	}
 	return &routeLease{leases: leases}, nil
+}
+
+func validateHostKeyPolicy(policy HostKeyPolicy) error {
+	switch policy {
+	case "", HostKeyPolicyReview, HostKeyPolicyStrict:
+		return nil
+	default:
+		return service.NewError(
+			service.InvalidRequest,
+			"unsupported SSH host-key policy",
+			false,
+			nil,
+			nil,
+		)
+	}
+}
+
+func targetWithHostKeyPolicy(target ResolvedTarget, policy HostKeyPolicy) ResolvedTarget {
+	if policy == HostKeyPolicyStrict {
+		target.StrictHostKeyChecking = "yes"
+		return target
+	}
+	if target.StrictHostKeyChecking != "yes" {
+		target.StrictHostKeyChecking = "ask"
+	}
+	return target
 }
 
 func (m *Manager) acquireTarget(

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -143,6 +143,7 @@ func (m *Manager) Acquire(
 		}
 		identity := managerIdentityForTarget(
 			request.Snapshot, target, index, previousIdentity, request.Environment,
+			request.HostKeyPolicy,
 		)
 		lease, acquireErr := m.acquireTarget(
 			ctx, request, target, identity, previousIdentity, index,
@@ -529,8 +530,12 @@ func managerIdentityForTarget(
 	index int,
 	previousIdentity string,
 	environment []string,
+	hostKeyPolicy HostKeyPolicy,
 ) string {
 	identity := managerIdentity(snapshot)
+	if hostKeyPolicy == HostKeyPolicyStrict {
+		identity += ":host-key-policy:strict"
+	}
 	if len(snapshot.Targets) > 1 {
 		identity += ":hop:" + fmt.Sprint(index)
 	}

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -1498,6 +1498,40 @@ func TestManagerAppliesLeaseHostKeyPolicyBeforeConnecting(t *testing.T) {
 	}
 }
 
+func TestManagerSeparatesReviewAndStrictHostKeyPolicies(t *testing.T) {
+	persistent := &fakePersistentManager{}
+	manager := NewManager(ManagerOptions{
+		Persistent: persistent,
+		Runner: func(LeaseRequest, ResolvedTarget) (openssh.RunSSH, error) {
+			return func(context.Context, []string) (int, error) { return 0, nil }, nil
+		},
+	})
+	snapshot := directSnapshot("route-host-key-policy")
+	snapshot.Targets[0].StrictHostKeyChecking = "accept-new"
+	resolve := func(context.Context) (RouteSnapshot, error) { return snapshot, nil }
+
+	review, err := manager.Acquire(
+		context.Background(),
+		LeaseRequest{Snapshot: snapshot, HostKeyPolicy: HostKeyPolicyReview},
+		resolve,
+	)
+	require.NoError(t, err)
+	strict, err := manager.Acquire(
+		context.Background(),
+		LeaseRequest{Snapshot: snapshot, HostKeyPolicy: HostKeyPolicyStrict},
+		resolve,
+	)
+	require.NoError(t, err)
+
+	connects, _, _, _ := persistent.counts()
+	assert.Equal(t, 2, connects)
+	identities := persistent.identities()
+	require.Len(t, identities, 2)
+	assert.NotEqual(t, identities[0], identities[1])
+	require.NoError(t, review.Release(context.Background()))
+	require.NoError(t, strict.Release(context.Background()))
+}
+
 func TestManagerRejectsMasterlessRouteChangeAfterProjectionPreparation(t *testing.T) {
 	persistent := &fakePersistentManager{connectErr: openssh.ErrPersistentUnsupported}
 	privateDirectory := filepath.Join(t.TempDir(), "private")

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -1353,7 +1353,9 @@ func TestManagerExecutesFreshResolvedSnapshotInsteadOfCallerFields(t *testing.T)
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	assert.Equal(t, current, runnerRequest.Snapshot)
-	assert.Equal(t, current.Targets[0], runnerTarget)
+	expectedTarget := current.Targets[0]
+	expectedTarget.StrictHostKeyChecking = "ask"
+	assert.Equal(t, expectedTarget, runnerTarget)
 }
 
 func TestManagerReportsCleanupFailureAfterRouteChange(t *testing.T) {
@@ -1458,6 +1460,42 @@ func TestManagerReturnsMasterlessLeaseWhenPersistenceIsUnsupported(t *testing.T)
 	require.NoError(t, lease.Release(context.Background()))
 	_, _, _, disconnects := persistent.counts()
 	assert.Equal(t, 0, disconnects)
+}
+
+func TestManagerAppliesLeaseHostKeyPolicyBeforeConnecting(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy HostKeyPolicy
+		want   string
+	}{
+		{name: "prompt capable reviews accept-new", policy: HostKeyPolicyReview, want: "ask"},
+		{name: "unattended requires known key", policy: HostKeyPolicyStrict, want: "yes"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			persistent := &fakePersistentManager{}
+			var runnerTarget ResolvedTarget
+			manager := NewManager(ManagerOptions{
+				Persistent: persistent,
+				Runner: func(_ LeaseRequest, target ResolvedTarget) (openssh.RunSSH, error) {
+					runnerTarget = target
+					return func(context.Context, []string) (int, error) { return 0, nil }, nil
+				},
+			})
+			snapshot := directSnapshot("route-host-key-policy")
+			snapshot.Targets[0].StrictHostKeyChecking = "accept-new"
+
+			lease, err := manager.Acquire(
+				context.Background(),
+				LeaseRequest{Snapshot: snapshot, HostKeyPolicy: test.policy},
+				func(context.Context) (RouteSnapshot, error) { return snapshot, nil },
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, runnerTarget.StrictHostKeyChecking)
+			require.NoError(t, lease.Release(context.Background()))
+		})
+	}
 }
 
 func TestManagerRejectsMasterlessRouteChangeAfterProjectionPreparation(t *testing.T) {

--- a/internal/ssh/types.go
+++ b/internal/ssh/types.go
@@ -63,12 +63,23 @@ type RouteSnapshot struct {
 
 type LeaseRequest struct {
 	Snapshot          RouteSnapshot `json:"snapshot"`
+	HostKeyPolicy     HostKeyPolicy `json:"host_key_policy"`
 	WorkingDirectory  string        `json:"working_directory"`
 	Environment       []string      `json:"environment"`
 	Prompt            PromptHandler `json:"-"`
 	promptTargetIndex int
 	promptTargetCount int
 }
+
+type HostKeyPolicy string
+
+const (
+	// HostKeyPolicyReview requires OpenSSH to prompt before trusting an
+	// unknown key. It is the safe default for prompt-capable clients.
+	HostKeyPolicyReview HostKeyPolicy = "review"
+	// HostKeyPolicyStrict permits only keys already trusted by OpenSSH.
+	HostKeyPolicyStrict HostKeyPolicy = "strict"
+)
 
 type PromptHandler func(context.Context, service.OperationPrompt) (string, error)
 

--- a/ssh.go
+++ b/ssh.go
@@ -13,12 +13,18 @@ type (
 	SSHResolvedTarget      = internalssh.ResolvedTarget
 	SSHRouteSnapshot       = internalssh.RouteSnapshot
 	SSHLeaseRequest        = internalssh.LeaseRequest
+	SSHHostKeyPolicy       = internalssh.HostKeyPolicy
 	SSHPromptHandler       = internalssh.PromptHandler
 	SSHLease               = internalssh.Lease
 	SSHLeaseMode           = internalssh.LeaseMode
 	SSHEvent               = internalssh.Event
 	SSHServiceOptions      = internalssh.PublicServiceOptions
 	SSHService             = internalssh.PublicService
+)
+
+const (
+	SSHHostKeyPolicyReview = internalssh.HostKeyPolicyReview
+	SSHHostKeyPolicyStrict = internalssh.HostKeyPolicyStrict
 )
 
 const (


### PR DESCRIPTION
Prevent unattended native clients from silently trusting first-seen SSH host keys.

- Adds explicit `review` and `strict` lease policies.
- Forces prompt-capable leases to review unknown keys through OpenSSH.
- Forces unattended leases to accept only keys that are already trusted.
- Applies the policy after route revalidation and before each direct or ProxyJump connection.
- Documents the native-client contract without adding a fallback path.