### PR TITLE
Move KWT sessions to a dedicated tmux server

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -49,7 +49,7 @@ The API schema is `1.11.0`. It exposes authenticated status, graceful shutdown,
 worktree inventory, guarded project unregistration, and repository-config
 approval under `/api/v1`, proof-capable liveness at `/api/ping`, and
 credential-free OpenAPI at `/openapi.json`. Inventory clients require the
-`worktree.inventory.v1` capability; guarded unregistration requires
+`worktree.inventory.v3` capability; guarded unregistration requires
 `project.removal.v1`, SSH route resolution requires `ssh.resolve.v1`, and
 daemon-owned connection leases require `ssh.lifecycle.v1`. Clients that bind
 short commands to a connection-owned hold additionally require
@@ -205,11 +205,12 @@ expiry. The client releases the daemon lease under a separate cleanup deadline.
 `kwt projects` and `kwt list` auto-start or reuse the daemon and require a
 current inventory result. They fail instead of falling back to cached or direct
 filesystem data. The TUI may paint immediately from the derived last-known-good
-cache at `<kwt-home>/cache/inventory-v1.json`, then requests one current
+cache at `<kwt-home>/cache/inventory-v3.json`, then requests one current
 snapshot. Failure to initialize or publish the disposable cache is diagnostic;
-current inventory remains available without it. The cache is never mutation
-authority. Git status and fetch remain in the foreground client so their
-credential environment is unchanged.
+current inventory remains available without it. Only dashboard snapshots with
+protected tmux sockets resolved may replace the shared cache. The cache is never
+mutation authority. Git status and fetch remain in the foreground client so
+their credential environment is unchanged.
 
 A current snapshot carries the effective global configuration used for its
 discovery. Before enabling actions, the TUI installs that configuration,

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -49,7 +49,7 @@ The API schema is `1.11.0`. It exposes authenticated status, graceful shutdown,
 worktree inventory, guarded project unregistration, and repository-config
 approval under `/api/v1`, proof-capable liveness at `/api/ping`, and
 credential-free OpenAPI at `/openapi.json`. Inventory clients require the
-`worktree.inventory.v3` capability; guarded unregistration requires
+`worktree.inventory.v2` capability; guarded unregistration requires
 `project.removal.v1`, SSH route resolution requires `ssh.resolve.v1`, and
 daemon-owned connection leases require `ssh.lifecycle.v1`. Clients that bind
 short commands to a connection-owned hold additionally require
@@ -205,7 +205,7 @@ expiry. The client releases the daemon lease under a separate cleanup deadline.
 `kwt projects` and `kwt list` auto-start or reuse the daemon and require a
 current inventory result. They fail instead of falling back to cached or direct
 filesystem data. The TUI may paint immediately from the derived last-known-good
-cache at `<kwt-home>/cache/inventory-v3.json`, then requests one current
+cache at `<kwt-home>/cache/inventory-v2.json`, then requests one current
 snapshot. Failure to initialize or publish the disposable cache is diagnostic;
 current inventory remains available without it. Only dashboard snapshots with
 protected tmux sockets resolved may replace the shared cache. The cache is never

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,6 +6,10 @@ stable command surface.
 Kwt requires Git 2.20 or newer. `kwt doctor` and the `kwt prune --expired` or
 `--merged` policies require Git 2.31 or newer: maintenance inventory relies on
 `git worktree list --expire`, and structural repair uses `git worktree repair`.
+Workspace attachment requires tmux 2.1 or newer. Kwt identifies the current
+client's server with tmux's `#{pid}` format; it does not run a separate version
+preflight. A non-numeric PID response blocks attachment with tmux 2.1 guidance.
+Other PID lookup failures report the underlying tmux error.
 
 | Command          | Purpose                                                |
 | ---------------- | ------------------------------------------------------ |
@@ -297,29 +301,50 @@ acknowledgement that opts in to its layout and pane commands.
 With no argument, `kwt open` fuzzy-picks a worktree. A pattern narrows the
 cross-project list and opens the sole match directly. An exact registered
 directory workspace path resolves before Git worktree discovery. Kwt creates
-or repairs the canonical tmux workspace with its resolved layout before
-attaching.
+or repairs the canonical tmux workspace on the dedicated `kwt` server with its
+resolved layout before attaching. On POSIX systems, the equivalent manual
+inventory command is:
+
+```sh
+env -u TMUX_TMPDIR tmux -L kwt list-sessions
+```
+
+Kwt deliberately removes `TMUX_TMPDIR` for the canonical server, so clients
+that attach independently, including remote clients, must do the same.
 
 An exact worktree-root path is resolved directly from Git before pattern
 matching, including registered primary checkouts and linked worktrees outside
 the configured global worktree base.
 
-On Unix-like systems, an external ordinary or protected attachment replaces
+On Unix-like systems, an external direct or protected attachment replaces
 the `kwt` process with the tmux client. tmux therefore owns signal handling and
 the final exit status, and no waiting `kwt` parent remains. Windows retains a
 waiting parent because it has no Unix process-replacement primitive.
-An ordinary open from inside tmux switches the current client instead.
-Protected attachment always remains external because it targets a separate
-workspace-specific socket.
+A direct open from a client already on the resolved server switches that
+client. From a different tmux server, kwt removes `TMUX` and `TMUX_PANE` and
+starts a nested client on the resolved endpoint. Detaching returns to the outer
+server; because both clients normally use the same prefix, reaching the inner
+client may require sending the prefix twice. Protected attachment uses the same
+cross-server nesting mechanism while retaining its stricter environment rules.
 
 `kwt open <exact-workspace-path> --start-session` performs the same layout and
 session bootstrap without attaching a client. Use it before an external
-ordinary tmux client attaches to a session that may not exist yet. Registered
+direct tmux client attaches to a session that may not exist yet. Registered
 directory paths resolve from the workspace registry; worktree paths resolve
 directly from Git rather than the global worktree base. This keeps automation
 noninteractive and supports both plain directories and linked worktrees stored
 outside that base.
 Protected pull-request imports remain restricted to `kwt pr attach`.
+
+During rollout, a verified matching session on the default server is adopted
+instead of creating a parallel session. If matching sessions
+exist on both servers, the `kwt` server wins. Mixed old and new Kwt binaries can
+still create parallel same-name sessions because older binaries neither use nor
+inspect the dedicated server. Once a new binary has created canonical sessions,
+do not run destructive workspace operations such as remove, prune, or repair
+with an older Kwt binary: its removal guard cannot see those sessions. A
+coordinated upgrade of all cooperating clients is required before enabling the
+new topology on a shared host.
 
 ## `kwt workspace`
 
@@ -342,21 +367,42 @@ remote shell invokes kwt. Its human output and machine-readable schema are
 unchanged; freshness metadata stays in the daemon API envelope and is not
 added to the top-level JSON array.
 
-`--json` emits an array of objects with `path`, `branch`, `commit_hash`, `is_main`,
-`created_at` (worktree directory mtime), `generation` (the durable identity for
-conditional removal), `repository` (the `host/owner/name` slug, or a
-`local/<path>` fallback for a repository without a usable remote — see below),
-and `session_name` (the tmux workspace session name kwt attaches to).
-An imported pull-request worktree additionally includes `tmux_socket_name` for
-its protected workspace-specific server. To converge on the same session, run
-`kwt open <path> --start-session` before an ordinary attach-only client, or
-`kwt pr attach <path>` when `tmux_socket_name` is present. This lets kwt create
-the session when needed without a client creating it bare or bypassing its
-protected attach policy. See [Attaching from other
-tools](#attaching-from-other-tools) before using `new-session`.
+`--json` emits an array of objects with `path`, `branch`, `commit_hash`,
+`is_main`, `created_at` (worktree directory mtime), `generation` (the durable
+identity for conditional removal), `repository` (the `host/owner/name` slug,
+or a `local/<path>` fallback for a repository without a usable remote — see
+below), `session_name`, `tmux_socket_name`, and `tmux_attach_mode`.
+`tmux_socket_name` selects the endpoint; `tmux_attach_mode` selects direct or
+protected attachment behavior. For a stopped workspace, inventory
+reports the intended `kwt`/`direct` endpoint. It reports the empty default
+socket with `direct` only while a matching adopted session is live. Protected
+pull-request worktrees report their workspace-specific socket with
+`protected` once provenance verifies that endpoint. An unresolved protected
+entry omits `tmux_socket_name`; clients must use `tmux_attach_mode` to
+distinguish that unattachable state from an adopted default-server session.
+
+Inventory is a snapshot. `kwt open <exact-path> --start-session --json` is the
+authority for the immediately following direct attachment because it reports
+the endpoint where the session was actually established. Run it before an
+attach-only client, or use `kwt pr attach <path>` when
+`tmux_attach_mode` is `protected`. This lets kwt create the session when needed
+without a client creating it bare or bypassing protected attach policy. See
+[Attaching from other tools](#attaching-from-other-tools) before using
+`new-session`.
 `kwt open` and dashboard open actions refuse protected pull-request imports
 and direct the user through `kwt pr attach`.
 `created_at` and `generation` are populated in both local and `-g` mode.
+
+## `kwt tmux`
+
+`kwt tmux list` temporarily unions Kwt-managed standalone and workspace
+sessions from the dedicated `kwt` server and the default server during the
+adoption window. Human,
+picker, attach, and kill surfaces display `[kwt]` or `[default]` so equal-name
+sessions remain distinguishable; JSON includes `tmux_socket_name` and
+`tmux_attach_mode`. New standalone sessions are created only on the dedicated
+server. Attach and kill retain the selected endpoint rather than inferring it
+from the session name.
 
 ## `kwt remove`
 
@@ -622,7 +668,7 @@ protected endpoints, including connected repository-transfer aliases, under
 the shared project fence before performing a final raw registry
 compare-and-swap. Any persisted-field change, including `last_touched`,
 invalidates the fingerprint. A live protected tmux session or incomplete
-endpoint authority fails closed. Ordinary/default-server tmux sessions do not
+endpoint authority fails closed. KWT/default-server tmux sessions do not
 block removal and are never killed.
 
 Unregistration is metadata-only: it never deletes repositories or worktrees
@@ -671,9 +717,12 @@ for pull-request clients. kwt owns provider calls, ref handling, branch and
 workspace naming, normal worktree creation and setup, push configuration,
 provenance, and tmux session naming. See [Pull-request
 automation](pull-requests.md) for the JSON and exit-status contract.
-Every imported workspace record includes `tmux_socket_name`.
+Every imported workspace record includes `tmux_attach_mode: "protected"`.
+An attachable record also includes `tmux_socket_name`; an empty socket means the
+protected endpoint is unresolved, not that the default tmux server should be
+used.
 `pr import --start-session` additionally establishes a blank shell-only
-session without attaching, for clients that provide their own ordinary tmux
+session without attaching, for clients that provide their own direct tmux
 presentation. It does not execute configured layouts or agent commands.
 Automation clients may pass `--expected-repository` and
 `--expected-registration` together to bind an import to the selected
@@ -784,9 +833,16 @@ match kwt's until repaired.
 
 Two rules keep external tools consistent with kwt:
 
-- **When the session already exists, attach only:** use `tmux attach-session -t
-<session_name>` (or `switch-client -t` from inside tmux). Attach-only commands
-  never create a bare session, so there is nothing to repair.
+- **When the session already exists, attach only:** for the canonical direct
+  endpoint on POSIX, unset `TMUX_TMPDIR`, then run
+  `tmux -L kwt attach-session -t <session_name>`.
+  Use the empty/default endpoint only when the immediately preceding Kwt JSON
+  result returned `tmux_attach_mode: "direct"` with an empty
+  `tmux_socket_name`. A protected result with an empty socket is unresolved and
+  must not be attached. From a client
+  on the same server, `switch-client -t <session_name>` is sufficient.
+  Attach-only commands never create a bare session, so there is nothing to
+  repair.
 - **If your tool creates the session itself, apply the equivalent bootstrap:**
   set `default-command` to `""` and add a session-scoped remove-marker
   (`set-environment -r <name>`) for each launcher variable listed above
@@ -801,6 +857,20 @@ already running, it re-applies the safe bootstrap subset (`default-command`
 plus the remove-markers — never construction or pane commands), so a session
 another tool created bare converges on consistent behavior for windows opened
 after that attach.
+
+The canonical endpoint ignores ambient `TMUX_TMPDIR`; this is why the manual
+commands above explicitly unset it. A remote client must follow the same rule
+as the remote Kwt process or it will address a different socket path.
+
+An external client must also sanitize every attach and reconnect environment;
+unsetting only `TMUX_TMPDIR` is insufficient because tmux can copy client
+variables named by `update-environment` into session state. Apply the same
+policy as Kwt's `AttachSanitizedEnviron`: remove every launcher variable listed
+above, Kwt's GitHub and fleet token variables, and the dynamically configured
+`fleet.token_env` name before executing tmux. This requirement applies to
+shared `direct` endpoints as well as protected ones. A client that cannot
+reproduce the current policy should delegate attachment to Kwt instead of
+launching tmux directly.
 
 PR imports use a stricter reuse boundary. Every import reports a deterministic,
 workspace-specific socket. `pr import --start-session` and `pr attach` create

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -403,6 +403,8 @@ sessions remain distinguishable; JSON includes `tmux_socket_name` and
 `tmux_attach_mode`. New standalone sessions are created only on the dedicated
 server. Attach and kill retain the selected endpoint rather than inferring it
 from the session name.
+`kwt tmux run --context` rejects `wt` and `workspace`, which are reserved for
+managed worktree and directory-workspace session names.
 
 ## `kwt remove`
 

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -15,7 +15,7 @@ kwt pr import github:github.com/acme/widget#17 \
   --project github.com/acme/widget --json
 ```
 
-Clients that present their own ordinary tmux client can ask kwt to establish
+Clients that present their own direct tmux client can ask kwt to establish
 the canonical workspace session without attaching kwt's process:
 
 ```sh
@@ -39,12 +39,20 @@ before creating the worktree. A changed or replaced project returns the
 retryable `registration_changed` error without importing anything. The two
 flags are an all-or-nothing contract; ordinary interactive use may omit both.
 
-Every successful import response includes the deterministic
-`tmux_socket_name`, whether or not a session was started. `--start-session`
-creates or repairs the returned `session_name` as a single blank shell session
-and leaves it detached for the caller. It never runs configured layouts, agent
-commands, or commands from the imported checkout. Clients must attach through
-kwt's protected path:
+Every successful import response includes `tmux_attach_mode: "protected"`.
+When repository identity verifies the session name, it also includes the
+deterministic `tmux_socket_name`. A protected result with no socket is protected
+but unresolved: it is not the default tmux server, and clients must not attach
+or create a session from that result. `--start-session` reports a
+`session_start_error` for this state. `kwt pr attach` may resolve the endpoint
+later, but only after it revalidates the live workspace provenance.
+
+The socket name selects the endpoint; the attach mode selects Kwt's protected
+attachment policy and must not be inferred from the presence of a named socket.
+`--start-session` creates or repairs the returned `session_name` as a single
+blank shell session and leaves it detached for the caller. It never runs
+configured layouts, agent commands, or commands from the imported checkout.
+Clients must attach through Kwt's protected path:
 
 ```sh
 kwt pr attach <workspace.path>
@@ -56,13 +64,13 @@ a nested project record or registration fingerprint. Match its `repository`
 field to the project record with the same `repository`, then supply these five
 values together:
 
-| Attach flag | Source |
-| --- | --- |
-| `--expected-repository` | Matching project's `repository` from `kwt projects --json` |
+| Attach flag               | Source                                                                   |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `--expected-repository`   | Matching project's `repository` from `kwt projects --json`               |
 | `--expected-registration` | Matching project's `registration_fingerprint` from `kwt projects --json` |
-| `--expected-generation` | Selected worktree's `generation` from `kwt list --json` |
-| `--expected-session` | Selected worktree's `session_name` from `kwt list --json` |
-| `--expected-socket` | Selected worktree's `tmux_socket_name` from `kwt list --json` |
+| `--expected-generation`   | Selected worktree's `generation` from `kwt list --json`                  |
+| `--expected-session`      | Selected worktree's `session_name` from `kwt list --json`                |
+| `--expected-socket`       | Selected worktree's `tmux_socket_name` from `kwt list --json`            |
 
 ```sh
 kwt pr attach <workspace.path> \
@@ -96,14 +104,16 @@ never runs configured layout or agent commands. This makes the command converge
 imports created without `--start-session`, imports whose startup failed, and
 sessions that disappeared after import. A parent tmux client identity is
 removed before attachment, so the command also works when invoked from a pane
-connected to another tmux server. A
+connected to another tmux server. This nests the protected client; detaching
+returns to the outer server, and the shared prefix may need to be sent twice to
+reach the inner client. A
 deleted project, reused path, or branch, repository, or session-name mismatch
 fails closed. Prunable entries and paths without a live Git worktree are not
 accepted. The registered project's canonical identity remains authoritative
 when its checkout's origin points to a fork, matching kwt's other inventory
 surfaces. An import created from an unregistered repository remains attachable
 when its live Git identity matches the recorded repository; ambiguous or
-conflicting registrations fail closed. Ordinary `kwt open` and dashboard open
+conflicting registrations fail closed. Direct `kwt open` and dashboard open
 actions refuse imported workspaces because they use the normal tmux server;
 use `kwt pr attach <workspace.path>` instead. The protected attach path is
 idempotent for an already imported worktree or a verified session that kwt
@@ -133,8 +143,9 @@ present and present the session failure separately. `kwt pr attach
 also converges on `already_imported`.
 
 Kwt runs each protected PR workspace on a deterministic, workspace-specific
-tmux socket rather than the user's ordinary tmux server. Before invoking that
-server, kwt removes `KWT_GITHUB_TOKEN`, `KWT_FLEET_TOKEN`, and the variable
+tmux socket rather than the shared dedicated `kwt` server or the
+default server. Before invoking that server, kwt removes `KWT_GITHUB_TOKEN`,
+`KWT_FLEET_TOKEN`, and the variable
 named by `fleet.token_env` from the subprocess environment. It installs
 matching session remove-markers before any imported-workspace shell starts.
 Because tmux options are mutable by processes with socket access, filtering
@@ -148,9 +159,9 @@ environments are credential-free. A rejected protected session must be
 removed before retrying.
 
 `kwt list --json` reads the same provenance store before it labels worktrees
-with `tmux_socket_name`. If that store cannot be read or decoded, listing fails
-instead of emitting an imported workspace without its safety-critical socket
-identity.
+with `tmux_socket_name` and `tmux_attach_mode`. If that store cannot be read or
+decoded, listing fails instead of emitting an imported workspace without its
+safety-critical endpoint and attachment policy.
 
 `--project` accepts a repository identity from `kwt projects --json`, a
 registered project name, or its absolute canonical main-repository path.

--- a/docs/workflows/agent-workspaces.md
+++ b/docs/workflows/agent-workspaces.md
@@ -38,6 +38,24 @@ For long-running agent work, keep one branch per worktree, one tmux workspace pe
 branch, and let `kwt status` show which branches are dirty, ahead, behind, or
 quiet.
 
+Kwt keeps workspaces and standalone `kwt tmux` jobs on a dedicated
+tmux server named `kwt`. On POSIX systems, inspect it manually with:
+
+```sh
+env -u TMUX_TMPDIR tmux -L kwt list-sessions
+```
+
+Kwt temporarily adopts a verified matching session on the default
+server during rollout; if both endpoints contain a valid match, the dedicated
+server wins. `kwt tmux list` shows `[kwt]` or `[default]` for this reason.
+Mixed old and new Kwt binaries may still create parallel same-name sessions,
+so cooperating automation should be upgraded together.
+
+Opening a workspace from a client on another tmux server creates a nested
+client after removing the outer `TMUX` and `TMUX_PANE` selectors. Detach to
+return to the outer server. If both clients share the default prefix, send the
+prefix twice to address the inner client.
+
 ## Cross-project steering
 
 The dashboard is project-aware. Use `P` to set the active project perspective

--- a/docs/workflows/directory-workspaces.md
+++ b/docs/workflows/directory-workspaces.md
@@ -55,14 +55,22 @@ the same layout and session without attaching for another client:
 ```sh
 kwt open ~/notes
 kwt open ~/notes --start-session
+kwt open ~/notes --start-session --json
 ```
 
+New directory sessions are created on the dedicated `kwt` tmux server. A
+verified matching session already running on the default server is temporarily
+reused during rollout. The `--start-session --json` result is authoritative
+for the immediately following attachment: `tmux_socket_name` selects `kwt` or
+the adopted default endpoint, and `tmux_attach_mode` is `direct`. A stopped
+workspace reports its intended `kwt` endpoint in inventory.
+
 For inventory clients, `kwt workspace list --json` returns `name`, canonical
-absolute `path`, effective `session_name`, and `session_live` for each entry.
-It returns `[]` when nothing is registered. If a workspace is renamed while a
-matching session is still live, the effective session name remains the live
-name until that session exits; otherwise it is the canonical name kwt will use
-for the next launch.
+absolute `path`, effective `session_name`, `session_live`, `tmux_socket_name`,
+and `tmux_attach_mode` for each entry. It returns `[]` when nothing is
+registered. If a workspace is renamed while a matching session is still live,
+the effective session name remains the live name until that session exits;
+otherwise it is the canonical name kwt will use for the next launch.
 
 ## Scope
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -37,8 +37,7 @@ var (
 	addExpectedRegistration string
 
 	newAddWorkspaceRunner = func(names []string) openWorkspaceRunner {
-		tmuxCommand := tmux.NewTmuxCommandWithStripNames("", names)
-		return tmux.NewWorkspaceRunner(tmuxCommand, names)
+		return newCommandWorkspaceSessions(names, os.Stderr)
 	}
 )
 
@@ -295,7 +294,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 		var expiresAt *time.Time
 		var launchRunner openWorkspaceRunner
-		var launchSession string
+		var launchEndpoint tmux.SessionEndpoint
 		var protectedNames []string
 		if launch {
 			protectedNames = credentials.ProtectedNames(ctx.Config)
@@ -370,7 +369,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				if guard.claim != nil {
 					projects = []models.Project{guard.claim.Registration.Effective}
 				}
-				launchSession, mutationErr = withCurrentWorktreeSession(
+				_, mutationErr = withCurrentWorktreeSession(
 					commandContext,
 					mainPath,
 					worktreePath,
@@ -378,13 +377,15 @@ func runAdd(cmd *cobra.Command, args []string) error {
 					projects,
 					protectedNames,
 					func(sessionName string) error {
-						return launchRunner.EnsureWithGeneration(
+						var establishErr error
+						launchEndpoint, establishErr = launchRunner.EstablishWithGeneration(
 							commandContext,
 							sessionName,
 							worktreePath,
 							worktreeGeneration,
 							layout,
 						)
+						return establishErr
 					},
 				)
 				return mutationErr
@@ -396,7 +397,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 
 		if launch {
-			return launchRunner.Attach(launchSession, os.Getenv("TMUX") != "")
+			return launchRunner.Attach(commandContext, launchEndpoint)
 		}
 		return nil
 	})(cmd, args)

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -437,6 +437,19 @@ func detailInt(details map[string]any, key string) int {
 
 func writeConfigNotes(stderr io.Writer, notes []kwt.Note, interactive, declined bool) {
 	for _, note := range notes {
+		if note.Code == "tmux_lookup_degraded" {
+			_, _ = fmt.Fprintf(stderr, "kwt: tmux lookup degraded: %s\n", note.Message)
+			continue
+		}
+		if note.Code == "tmux_endpoint_degraded" {
+			_, _ = fmt.Fprintf(
+				stderr,
+				"kwt: could not verify tmux endpoint for %s: %s (using the dedicated kwt server)\n",
+				note.Path,
+				note.Message,
+			)
+			continue
+		}
 		if note.Code == "trust_store_unavailable" {
 			_, _ = fmt.Fprintf(
 				stderr,

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -174,6 +174,33 @@ func TestWriteConfigNotesWarnsWhenTrustStoreIsUnavailable(t *testing.T) {
 	assert.Equal(t, "kwt: failed to load trust store /home/trusted_configs.json (continuing empty)\n", stderr.String())
 }
 
+func TestWriteConfigNotesWarnsWhenTmuxEndpointDegrades(t *testing.T) {
+	var stderr bytes.Buffer
+	writeConfigNotes(&stderr, []kwt.Note{{
+		Code:    "tmux_endpoint_degraded",
+		Path:    "/work/widget",
+		Message: "session belongs to a different worktree generation",
+	}}, false, false)
+
+	assert.Equal(t,
+		"kwt: could not verify tmux endpoint for /work/widget: session belongs to a different worktree generation (using the dedicated kwt server)\n",
+		stderr.String(),
+	)
+}
+
+func TestWriteConfigNotesWarnsWhenTmuxLookupDegrades(t *testing.T) {
+	var stderr bytes.Buffer
+	writeConfigNotes(&stderr, []kwt.Note{{
+		Code:    "tmux_lookup_degraded",
+		Message: "default-server adoption lookup degraded",
+	}}, false, false)
+
+	assert.Equal(t,
+		"kwt: tmux lookup degraded: default-server adoption lookup degraded\n",
+		stderr.String(),
+	)
+}
+
 func TestTrustRequirementDecodesHTTPDetailTypes(t *testing.T) {
 	err := service.NewError(service.InteractionRequired, "trust", false, map[string]any{
 		"kind": "repository_config_trust", "path": "/repo/.kwt.toml",
@@ -219,4 +246,19 @@ func TestGuardedRemovalRejectsVersionOneDaemonBeforeMutation(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, service.IsCode(err, service.DaemonIncompatible))
 	assert.False(t, mutated, "an older daemon must be rejected before removal is dispatched")
+}
+
+func TestInventoryRejectsVersionTwoDaemonBeforeRequest(t *testing.T) {
+	observation := kwtdaemon.Observation{
+		State: kwtdaemon.RuntimeReady,
+		Status: kwtdaemon.Status{Capabilities: []string{
+			"worktree.inventory.v2",
+		}},
+		Client: &kwtdaemon.Client{},
+	}
+
+	err := requireInventoryCapability(observation)
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.DaemonIncompatible))
 }

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -248,11 +248,25 @@ func TestGuardedRemovalRejectsVersionOneDaemonBeforeMutation(t *testing.T) {
 	assert.False(t, mutated, "an older daemon must be rejected before removal is dispatched")
 }
 
-func TestInventoryRejectsVersionTwoDaemonBeforeRequest(t *testing.T) {
+func TestInventoryAcceptsVersionTwoDaemon(t *testing.T) {
 	observation := kwtdaemon.Observation{
 		State: kwtdaemon.RuntimeReady,
 		Status: kwtdaemon.Status{Capabilities: []string{
 			"worktree.inventory.v2",
+		}},
+		Client: &kwtdaemon.Client{},
+	}
+
+	err := requireInventoryCapability(observation)
+
+	require.NoError(t, err)
+}
+
+func TestInventoryRejectsVersionOneDaemonBeforeRequest(t *testing.T) {
+	observation := kwtdaemon.Observation{
+		State: kwtdaemon.RuntimeReady,
+		Status: kwtdaemon.Status{Capabilities: []string{
+			"worktree.inventory.v1",
 		}},
 		Client: &kwtdaemon.Client{},
 	}

--- a/internal/cmd/directory_workspace.go
+++ b/internal/cmd/directory_workspace.go
@@ -7,35 +7,31 @@ import (
 )
 
 type directoryWorkspaceRecord struct {
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	SessionName string `json:"session_name"`
-	SessionLive bool   `json:"session_live"`
+	Name           string                `json:"name"`
+	Path           string                `json:"path"`
+	SessionName    string                `json:"session_name"`
+	SessionLive    bool                  `json:"session_live"`
+	TmuxSocketName string                `json:"tmux_socket_name,omitempty"`
+	TmuxAttachMode models.TmuxAttachMode `json:"tmux_attach_mode"`
 }
 
-func directoryWorkspaceRecords(
+func directoryWorkspaceRecordsFromSessions(
 	workspaces []models.Workspace,
-	sessions []string,
+	sessions []tmux.WorkspaceSession,
 ) []directoryWorkspaceRecord {
 	records := make([]directoryWorkspaceRecord, 0, len(workspaces))
-	for _, workspace := range workspaces {
-		sessionName := tmux.DirWorkspaceSessionName(
-			workspace.Name,
-			workspace.Path,
-		)
-		sessionLive := false
-		if live, ok := tmux.MatchDirWorkspaceSession(
-			sessions,
-			workspace.Path,
-		); ok {
-			sessionName = live
-			sessionLive = true
+	for index, workspace := range workspaces {
+		if index >= len(sessions) {
+			break
 		}
+		selected := sessions[index]
 		records = append(records, directoryWorkspaceRecord{
-			Name:        workspace.Name,
-			Path:        workspace.Path,
-			SessionName: sessionName,
-			SessionLive: sessionLive,
+			Name:           workspace.Name,
+			Path:           workspace.Path,
+			SessionName:    selected.Endpoint.SessionName,
+			SessionLive:    selected.Live,
+			TmuxSocketName: selected.Endpoint.SocketName,
+			TmuxAttachMode: models.TmuxAttachDirect,
 		})
 	}
 	return records

--- a/internal/cmd/inventory_subprocess_test.go
+++ b/internal/cmd/inventory_subprocess_test.go
@@ -25,6 +25,7 @@ func runInventoryCommand(
 	args ...string,
 ) ([]byte, []byte, error) {
 	t.Helper()
+	installInventoryTmuxFixture(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	command := exec.CommandContext(ctx, binary, args...)
@@ -38,6 +39,27 @@ func runInventoryCommand(
 		return stdout.Bytes(), stderr.Bytes(), ctx.Err()
 	}
 	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+func installInventoryTmuxFixture(t *testing.T) {
+	t.Helper()
+	if os.Getenv("KWT_TEST_TMUX_FIXTURE_DIR") != "" {
+		return
+	}
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	directory := t.TempDir()
+	name := "tmux"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(directory, name)
+	command := exec.Command("go", "build", "-o", path, "./internal/cmd/testdata/tmuxfixture")
+	command.Dir = root
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	t.Setenv("KWT_TEST_TMUX_FIXTURE_DIR", directory)
+	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func buildDaemonFixture(t *testing.T) string {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -116,6 +116,6 @@ func listedWorktree(entry kwt.Entry) models.Worktree {
 		Path: entry.Path, Branch: entry.Branch, CommitHash: entry.CommitHash,
 		IsMain: entry.IsMain, CreatedAt: entry.CreatedAt, Generation: entry.Generation,
 		Repository: entry.Repository.FullPath, SessionName: entry.SessionName,
-		TmuxSocketName: entry.TmuxSocketName,
+		TmuxSocketName: entry.TmuxSocketName, TmuxAttachMode: entry.TmuxAttachMode,
 	}
 }

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -13,8 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 	kwt "go.kenn.io/kwt"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/pkg/models"
 	"go.kenn.io/kwt/service"
 )
+
+func TestListedWorktreeCopiesEndpointFields(t *testing.T) {
+	got := listedWorktree(kwt.Entry{
+		TmuxSocketName: tmux.KWTServerSocketName,
+		TmuxAttachMode: models.TmuxAttachDirect,
+	})
+
+	assert.Equal(t, tmux.KWTServerSocketName, got.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, got.TmuxAttachMode)
+}
 
 func captureListStdout(t *testing.T, run func() error) (string, error) {
 	t.Helper()
@@ -51,8 +63,10 @@ func TestRunListRequestsCurrentInventoryAndPreservesJSONShape(t *testing.T) {
 		gotRequest = request
 		return kwt.Result{Snapshot: kwt.Snapshot{Entries: []kwt.Entry{{
 			Path: repository, Branch: "main",
-			Repository:  kwt.Repository{FullPath: "github.com/acme/repo"},
-			SessionName: "kwt-workspace-repo-main",
+			Repository:     kwt.Repository{FullPath: "github.com/acme/repo"},
+			SessionName:    "kwt-workspace-repo-main",
+			TmuxSocketName: tmux.KWTServerSocketName,
+			TmuxAttachMode: models.TmuxAttachDirect,
 		}}}}, nil
 	}
 	previousJSON, previousGlobal := listJSON, listGlobal
@@ -75,7 +89,9 @@ func TestRunListRequestsCurrentInventoryAndPreservesJSONShape(t *testing.T) {
       "created_at": "0001-01-01T00:00:00Z",
       "generation": "",
       "repository": "github.com/acme/repo",
-      "session_name": "kwt-workspace-repo-main"
+      "session_name": "kwt-workspace-repo-main",
+      "tmux_socket_name": "kwt",
+      "tmux_attach_mode": "direct"
     }]`, stdout)
 }
 

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -23,6 +24,7 @@ var (
 	openLayout               string
 	openSelectLayout         bool
 	openStartSession         bool
+	openJSON                 bool
 	openExpectedRepository   string
 	openExpectedRegistration string
 	openExpectedGeneration   string
@@ -31,22 +33,14 @@ var (
 	discoverOpenWorktree = discovery.DiscoverWorktree
 
 	newOpenWorkspaceRunner = func(names []string) openWorkspaceRunner {
-		tmuxCommand := tmux.NewTmuxCommandWithStripNames("", names)
-		return tmux.NewWorkspaceRunner(tmuxCommand, names)
+		return newCommandWorkspaceSessions(names, os.Stderr)
 	}
 )
 
 type openWorkspaceRunner interface {
-	Ensure(context.Context, string, string, models.Layout) error
-	EnsureWithGeneration(context.Context, string, string, string, models.Layout) error
-	Attach(string, bool) error
-	EnsureAndAttach(
-		context.Context,
-		string,
-		string,
-		models.Layout,
-		bool,
-	) error
+	Establish(context.Context, string, string, models.Layout) (tmux.SessionEndpoint, error)
+	EstablishWithGeneration(context.Context, string, string, string, models.Layout) (tmux.SessionEndpoint, error)
+	Attach(context.Context, tmux.SessionEndpoint) error
 }
 
 var openCmd = &cobra.Command{
@@ -93,6 +87,7 @@ func init() {
 		false,
 		"ensure an exact workspace exists without attaching",
 	)
+	openCmd.Flags().BoolVar(&openJSON, "json", false, "emit the established tmux endpoint as JSON")
 	openCmd.Flags().StringVar(&openExpectedRepository, "expected-repository", "", "require this registered repository identity before opening")
 	openCmd.Flags().StringVar(&openExpectedRegistration, "expected-registration", "", "require this project registration fingerprint before opening")
 	openCmd.Flags().StringVar(&openExpectedGeneration, "expected-generation", "", "require this exact worktree generation before opening")
@@ -119,8 +114,8 @@ func runOpenWithContext(
 	if err := tmux.ValidateLayouts(ctx.Config.Layouts, ctx.Config.Agents); err != nil {
 		return err
 	}
-	if openStartSession && len(args) != 1 {
-		return fmt.Errorf("--start-session requires an exact workspace path")
+	if err := validateOpenOutputMode(args, openStartSession, openJSON); err != nil {
+		return err
 	}
 	finder := ctx.GetGlobalFinder()
 	selectLayout := func(layouts []models.Layout) (models.Layout, error) {
@@ -142,13 +137,14 @@ func runOpenWithContext(
 					false, nil, nil,
 				)
 			}
-			return openSelectedDirectoryWorkspace(
+			return openSelectedDirectoryWorkspaceWithResult(
 				cmd.Context(),
 				ctx,
 				workspace,
 				selectLayout,
 				openStartSession,
 				config.StdinInteractive(),
+				openResultCallback(cmd),
 			)
 		}
 	}
@@ -177,14 +173,50 @@ func runOpenWithContext(
 			requestedPath,
 		)
 	}
-	return openSelectedWorktree(
+	return openSelectedWorktreeWithResult(
 		cmd.Context(),
 		ctx,
 		entry,
 		selectLayout,
 		openStartSession,
 		config.StdinInteractive(),
+		openResultCallback(cmd),
 	)
+}
+
+type openSessionResult struct {
+	SessionName    string                `json:"session_name"`
+	TmuxSocketName string                `json:"tmux_socket_name,omitempty"`
+	TmuxAttachMode models.TmuxAttachMode `json:"tmux_attach_mode"`
+}
+
+func openSessionResultFromEndpoint(endpoint tmux.SessionEndpoint) openSessionResult {
+	return openSessionResult{
+		SessionName:    endpoint.SessionName,
+		TmuxSocketName: endpoint.SocketName,
+		TmuxAttachMode: models.TmuxAttachDirect,
+	}
+}
+
+func validateOpenOutputMode(args []string, startSession, jsonOutput bool) error {
+	if jsonOutput && !startSession {
+		return fmt.Errorf("--json requires --start-session")
+	}
+	if startSession && len(args) != 1 {
+		return fmt.Errorf("--start-session requires an exact workspace path")
+	}
+	return nil
+}
+
+func openResultCallback(cmd *cobra.Command) func(tmux.SessionEndpoint) error {
+	if !openJSON {
+		return nil
+	}
+	return func(endpoint tmux.SessionEndpoint) error {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(
+			openSessionResultFromEndpoint(endpoint),
+		)
+	}
 }
 
 func resolveExpectedOpenWorktree(
@@ -373,6 +405,26 @@ func openSelectedWorktree(
 	startSession bool,
 	stdinInteractive bool,
 ) error {
+	return openSelectedWorktreeWithResult(
+		commandCtx,
+		ctx,
+		entry,
+		selectLayout,
+		startSession,
+		stdinInteractive,
+		nil,
+	)
+}
+
+func openSelectedWorktreeWithResult(
+	commandCtx context.Context,
+	ctx *CommandContext,
+	entry *discovery.GlobalWorktreeEntry,
+	selectLayout func([]models.Layout) (models.Layout, error),
+	startSession bool,
+	stdinInteractive bool,
+	onEstablished func(tmux.SessionEndpoint) error,
+) error {
 	if err := rejectProtectedWorkspaceOpen(
 		commandCtx,
 		entry.Path,
@@ -430,25 +482,34 @@ func openSelectedWorktree(
 			layout,
 			runner,
 			startSession,
-			os.Getenv("TMUX") != "",
 			protectedNames,
+			onEstablished,
 		)
 	}
-	session, err := runWorktreeSessionEstablishment(
+	var endpoint tmux.SessionEndpoint
+	_, err = runWorktreeSessionEstablishment(
 		commandCtx,
 		entry.Path,
 		entry.Generation,
 		protectedNames,
 		func(session string) error {
-			return runner.EnsureWithGeneration(
+			var establishErr error
+			endpoint, establishErr = runner.EstablishWithGeneration(
 				commandCtx, session, entry.Path, entry.Generation, layout,
 			)
+			return establishErr
 		},
 	)
-	if err != nil || startSession {
+	if err != nil {
 		return err
 	}
-	return runner.Attach(session, os.Getenv("TMUX") != "")
+	if startSession {
+		if onEstablished != nil {
+			return onEstablished(endpoint)
+		}
+		return nil
+	}
+	return runner.Attach(commandCtx, endpoint)
 }
 
 func openExpectedWorktree(
@@ -457,8 +518,8 @@ func openExpectedWorktree(
 	layout models.Layout,
 	runner openWorkspaceRunner,
 	startSession bool,
-	insideTmux bool,
 	protectedNames []string,
+	onEstablished func(tmux.SessionEndpoint) error,
 ) error {
 	mainPath, err := git.New(entry.Path).GetMainRepositoryPath()
 	if err != nil {
@@ -484,6 +545,7 @@ func openExpectedWorktree(
 		return err
 	}
 
+	var endpoint tmux.SessionEndpoint
 	err = guard.run(ctx, func() error {
 		current, discoverErr := discoverOpenWorktree(
 			entry.Path,
@@ -517,13 +579,15 @@ func openExpectedWorktree(
 				if err := acknowledgeRemoteSourcePath(current.Path); err != nil {
 					return err
 				}
-				return runner.EnsureWithGeneration(
+				var establishErr error
+				endpoint, establishErr = runner.EstablishWithGeneration(
 					ctx,
 					openExpectedSession,
 					current.Path,
 					openExpectedGeneration,
 					layout,
 				)
+				return establishErr
 			},
 		)
 		var conditionErr *git.ConditionError
@@ -533,10 +597,16 @@ func openExpectedWorktree(
 		}
 		return generationErr
 	})
-	if err != nil || startSession {
+	if err != nil {
 		return err
 	}
-	return runner.Attach(openExpectedSession, insideTmux)
+	if startSession {
+		if onEstablished != nil {
+			return onEstablished(endpoint)
+		}
+		return nil
+	}
+	return runner.Attach(ctx, endpoint)
 }
 
 func registrationChangedOpenError(cause error) error {
@@ -555,6 +625,26 @@ func openSelectedDirectoryWorkspace(
 	startSession bool,
 	stdinInteractive bool,
 ) error {
+	return openSelectedDirectoryWorkspaceWithResult(
+		commandCtx,
+		ctx,
+		workspace,
+		selectLayout,
+		startSession,
+		stdinInteractive,
+		nil,
+	)
+}
+
+func openSelectedDirectoryWorkspaceWithResult(
+	commandCtx context.Context,
+	ctx *CommandContext,
+	workspace models.Workspace,
+	selectLayout func([]models.Layout) (models.Layout, error),
+	startSession bool,
+	stdinInteractive bool,
+	onEstablished func(tmux.SessionEndpoint) error,
+) error {
 	if err := rejectProtectedWorkspaceOpen(
 		commandCtx,
 		workspace.Path,
@@ -565,11 +655,11 @@ func openSelectedDirectoryWorkspace(
 	if err := acknowledgeRemoteSourcePath(workspace.Path); err != nil {
 		return err
 	}
-	sessions, err := listWorkspaceSessions()
+	sessions, err := resolveDirectorySessions([]models.Workspace{workspace})
 	if err != nil {
 		return fmt.Errorf("failed to list tmux sessions: %w", err)
 	}
-	records := directoryWorkspaceRecords(
+	records := directoryWorkspaceRecordsFromSessions(
 		[]models.Workspace{workspace},
 		sessions,
 	)
@@ -588,21 +678,22 @@ func openSelectedDirectoryWorkspace(
 		return err
 	}
 	runner := newOpenWorkspaceRunner(credentials.ProtectedNames(ctx.Config))
-	if startSession {
-		return runner.Ensure(
-			commandCtx,
-			records[0].SessionName,
-			workspace.Path,
-			layout,
-		)
-	}
-	return runner.EnsureAndAttach(
+	endpoint, err := runner.Establish(
 		commandCtx,
 		records[0].SessionName,
 		workspace.Path,
 		layout,
-		os.Getenv("TMUX") != "",
 	)
+	if err != nil {
+		return err
+	}
+	if startSession {
+		if onEstablished != nil {
+			return onEstablished(endpoint)
+		}
+		return nil
+	}
+	return runner.Attach(commandCtx, endpoint)
 }
 
 func resolveDirectoryWorkspaceLayout(

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -680,7 +680,7 @@ func openSelectedDirectoryWorkspaceWithResult(
 	runner := newOpenWorkspaceRunner(credentials.ProtectedNames(ctx.Config))
 	endpoint, err := runner.Establish(
 		commandCtx,
-		records[0].SessionName,
+		tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
 		workspace.Path,
 		layout,
 	)

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -263,7 +263,7 @@ func TestOpenSelectedDirectoryWorkspaceEnsuresOrAttaches(t *testing.T) {
 	}
 }
 
-func TestOpenSelectedDirectoryWorkspaceUsesRenamedLiveSession(t *testing.T) {
+func TestOpenSelectedDirectoryWorkspaceRequestsCanonicalSession(t *testing.T) {
 	resetWorkspaceCommandDeps(t)
 	workspace := models.Workspace{Name: "renamed", Path: t.TempDir()}
 	liveName := tmux.DirWorkspaceSessionName("old-name", workspace.Path)
@@ -290,7 +290,11 @@ func TestOpenSelectedDirectoryWorkspaceUsesRenamedLiveSession(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.Equal(t, liveName, runner.sessionName)
+	assert.Equal(
+		t,
+		tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+		runner.sessionName,
+	)
 }
 
 func TestOpenAttachesToEndpointReturnedByEstablishment(t *testing.T) {

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -53,27 +55,22 @@ type signalingOpenWorkspaceRunner struct {
 	ensure chan struct{}
 }
 
-func (r *signalingOpenWorkspaceRunner) Ensure(
+func (r *signalingOpenWorkspaceRunner) Establish(
 	context.Context, string, string, models.Layout,
-) error {
+) (tmux.SessionEndpoint, error) {
 	r.ensure <- struct{}{}
-	return nil
+	return tmux.SessionEndpoint{}, nil
 }
 
-func (r *signalingOpenWorkspaceRunner) EnsureWithGeneration(
+func (r *signalingOpenWorkspaceRunner) EstablishWithGeneration(
 	ctx context.Context,
 	sessionName, workingDirectory, _ string,
 	layout models.Layout,
-) error {
-	return r.Ensure(ctx, sessionName, workingDirectory, layout)
+) (tmux.SessionEndpoint, error) {
+	return r.Establish(ctx, sessionName, workingDirectory, layout)
 }
 
-func (r *signalingOpenWorkspaceRunner) Attach(string, bool) error { return nil }
-
-func (r *signalingOpenWorkspaceRunner) EnsureAndAttach(
-	context.Context, string, string, models.Layout, bool,
-) error {
-	r.ensure <- struct{}{}
+func (r *signalingOpenWorkspaceRunner) Attach(context.Context, tmux.SessionEndpoint) error {
 	return nil
 }
 
@@ -84,7 +81,28 @@ type recordingOpenWorkspaceRunner struct {
 	workingDirectory string
 	generation       string
 	layout           models.Layout
-	insideTmux       bool
+	endpoint         tmux.SessionEndpoint
+	attachedEndpoint tmux.SessionEndpoint
+}
+
+func TestOpenSessionResultUsesEstablishedEndpoint(t *testing.T) {
+	for _, endpoint := range []tmux.SessionEndpoint{
+		testCanonicalSessionEndpoint("canonical"),
+		{SessionName: "default-server"},
+	} {
+		got := openSessionResultFromEndpoint(endpoint)
+
+		assert.Equal(t, endpoint.SessionName, got.SessionName)
+		assert.Equal(t, endpoint.SocketName, got.TmuxSocketName)
+		assert.Equal(t, models.TmuxAttachDirect, got.TmuxAttachMode)
+	}
+}
+
+func TestOpenJSONRequiresStartSessionAndExactPath(t *testing.T) {
+	require.Error(t, validateOpenOutputMode(nil, false, true))
+	require.Error(t, validateOpenOutputMode([]string{"workspace"}, false, true))
+	require.Error(t, validateOpenOutputMode(nil, true, true))
+	require.NoError(t, validateOpenOutputMode([]string{"/work/widget"}, true, true))
 }
 
 func markCommandFlagsChanged(t *testing.T, cmd *cobra.Command, names ...string) {
@@ -97,38 +115,37 @@ func markCommandFlagsChanged(t *testing.T, cmd *cobra.Command, names ...string) 
 	}
 }
 
-func (r *recordingOpenWorkspaceRunner) Ensure(
+func (r *recordingOpenWorkspaceRunner) Establish(
 	_ context.Context, sessionName, workingDirectory string, layout models.Layout,
-) error {
+) (tmux.SessionEndpoint, error) {
 	r.ensured = true
 	r.sessionName = sessionName
 	r.workingDirectory = workingDirectory
 	r.layout = layout
-	return nil
+	endpoint := r.endpoint
+	if endpoint.SessionName == "" {
+		endpoint = testCanonicalSessionEndpoint(sessionName)
+	}
+	r.endpoint = endpoint
+	return endpoint, nil
 }
 
-func (r *recordingOpenWorkspaceRunner) EnsureWithGeneration(
+func (r *recordingOpenWorkspaceRunner) EstablishWithGeneration(
 	ctx context.Context,
 	sessionName, workingDirectory, generation string,
 	layout models.Layout,
-) error {
-	err := r.Ensure(ctx, sessionName, workingDirectory, layout)
+) (tmux.SessionEndpoint, error) {
+	endpoint, err := r.Establish(ctx, sessionName, workingDirectory, layout)
 	r.generation = generation
-	return err
+	return endpoint, err
 }
 
-func (r *recordingOpenWorkspaceRunner) EnsureAndAttach(
+func (r *recordingOpenWorkspaceRunner) Attach(
 	_ context.Context,
-	sessionName string,
-	workingDirectory string,
-	layout models.Layout,
-	insideTmux bool,
+	endpoint tmux.SessionEndpoint,
 ) error {
 	r.attached = true
-	r.sessionName = sessionName
-	r.workingDirectory = workingDirectory
-	r.layout = layout
-	r.insideTmux = insideTmux
+	r.attachedEndpoint = endpoint
 	return nil
 }
 
@@ -204,7 +221,9 @@ func TestOpenSelectedDirectoryWorkspaceEnsuresOrAttaches(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetWorkspaceCommandDeps(t)
 			workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
-			listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+			resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+				return testDirectorySessions(workspaces, ""), nil
+			}
 			runner := &recordingOpenWorkspaceRunner{}
 			originalRunner := newOpenWorkspaceRunner
 			originalLayout := openLayout
@@ -238,7 +257,7 @@ func TestOpenSelectedDirectoryWorkspaceEnsuresOrAttaches(t *testing.T) {
 				tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
 				runner.sessionName,
 			)
-			assert.Equal(t, tt.startSession, runner.ensured)
+			assert.True(t, runner.ensured)
 			assert.Equal(t, !tt.startSession, runner.attached)
 		})
 	}
@@ -248,8 +267,8 @@ func TestOpenSelectedDirectoryWorkspaceUsesRenamedLiveSession(t *testing.T) {
 	resetWorkspaceCommandDeps(t)
 	workspace := models.Workspace{Name: "renamed", Path: t.TempDir()}
 	liveName := tmux.DirWorkspaceSessionName("old-name", workspace.Path)
-	listWorkspaceSessions = func() ([]string, error) {
-		return []string{liveName}, nil
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(workspaces, liveName), nil
 	}
 	runner := &recordingOpenWorkspaceRunner{}
 	originalRunner := newOpenWorkspaceRunner
@@ -274,6 +293,80 @@ func TestOpenSelectedDirectoryWorkspaceUsesRenamedLiveSession(t *testing.T) {
 	assert.Equal(t, liveName, runner.sessionName)
 }
 
+func TestOpenAttachesToEndpointReturnedByEstablishment(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(workspaces, ""), nil
+	}
+	want := tmux.SessionEndpoint{
+		SessionName: tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+		SocketName:  tmux.KWTServerSocketName,
+	}
+	runner := &recordingOpenWorkspaceRunner{endpoint: want}
+	originalRunner := newOpenWorkspaceRunner
+	originalLayout := openLayout
+	newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
+	openLayout = tmux.BlankLayoutName
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = originalRunner
+		openLayout = originalLayout
+	})
+
+	err := openSelectedDirectoryWorkspace(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		workspace,
+		nil,
+		false,
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, want, runner.attachedEndpoint)
+}
+
+func TestOpenStartSessionJSONWritesEstablishedEndpointOnly(t *testing.T) {
+	resetWorkspaceCommandDeps(t)
+	workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(workspaces, ""), nil
+	}
+	want := tmux.SessionEndpoint{
+		SessionName: tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+		SocketName:  tmux.KWTServerSocketName,
+	}
+	runner := &recordingOpenWorkspaceRunner{endpoint: want}
+	originalRunner := newOpenWorkspaceRunner
+	originalLayout, originalJSON := openLayout, openJSON
+	newOpenWorkspaceRunner = func([]string) openWorkspaceRunner { return runner }
+	openLayout, openJSON = tmux.BlankLayoutName, true
+	t.Cleanup(func() {
+		newOpenWorkspaceRunner = originalRunner
+		openLayout, openJSON = originalLayout, originalJSON
+	})
+	command := &cobra.Command{}
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+
+	err := openSelectedDirectoryWorkspaceWithResult(
+		context.Background(),
+		&CommandContext{Config: &models.Config{}},
+		workspace,
+		nil,
+		true,
+		false,
+		openResultCallback(command),
+	)
+
+	require.NoError(t, err)
+	assert.False(t, runner.attached)
+	assert.True(t, json.Valid(stdout.Bytes()))
+	var got openSessionResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Equal(t, openSessionResultFromEndpoint(want), got)
+}
+
 func TestOpenSelectedDirectoryWorkspaceUsesDirectoryLayoutDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -292,7 +385,9 @@ func TestOpenSelectedDirectoryWorkspaceUsesDirectoryLayoutDefault(t *testing.T) 
 	)
 	require.NoError(t, err)
 	require.NoError(t, trustStore.Add(resolvedConfigPath, hex.EncodeToString(sum[:])))
-	listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(workspaces, ""), nil
+	}
 	runner := &recordingOpenWorkspaceRunner{}
 	originalRunner := newOpenWorkspaceRunner
 	originalLayout := openLayout
@@ -328,7 +423,9 @@ func TestRunOpenWithContextChoosesRegisteredDirectory(t *testing.T) {
 		t.Run(map[bool]string{false: "attach", true: "start only"}[startSession], func(t *testing.T) {
 			resetWorkspaceCommandDeps(t)
 			workspace := models.Workspace{Name: "notes", Path: t.TempDir()}
-			listWorkspaceSessions = func() ([]string, error) { return nil, nil }
+			resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+				return testDirectorySessions(workspaces, ""), nil
+			}
 			runner := &recordingOpenWorkspaceRunner{}
 			originalRunner := newOpenWorkspaceRunner
 			originalLayout := openLayout
@@ -357,7 +454,7 @@ func TestRunOpenWithContextChoosesRegisteredDirectory(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, workspace.Path, runner.workingDirectory)
-			assert.Equal(t, startSession, runner.ensured)
+			assert.True(t, runner.ensured)
 			assert.Equal(t, !startSession, runner.attached)
 		})
 	}
@@ -743,7 +840,7 @@ func TestOpenSelectedWorktreeUsesBranchObservedInsideLifecycleGuard(t *testing.T
 	), runner.sessionName)
 }
 
-func TestOrdinaryOpenCannotRaceGuardedRemoval(t *testing.T) {
+func TestDirectOpenCannotRaceGuardedRemoval(t *testing.T) {
 	repoPath := newTUITestRepo(t)
 	worktreePath := filepath.Join(t.TempDir(), "open-race")
 	runTUITestGit(t, repoPath, "branch", "open-race")
@@ -806,7 +903,7 @@ func TestOrdinaryOpenCannotRaceGuardedRemoval(t *testing.T) {
 
 	select {
 	case <-runner.ensure:
-		t.Fatal("ordinary open established a session during guarded removal")
+		t.Fatal("direct open established a session during guarded removal")
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(removalGuard.release)
@@ -814,19 +911,9 @@ func TestOrdinaryOpenCannotRaceGuardedRemoval(t *testing.T) {
 	require.Error(t, <-openDone)
 	select {
 	case <-runner.ensure:
-		t.Fatal("ordinary open established a session after its worktree was removed")
+		t.Fatal("direct open established a session after its worktree was removed")
 	default:
 	}
-}
-
-func (r *recordingOpenWorkspaceRunner) Attach(
-	sessionName string,
-	insideTmux bool,
-) error {
-	r.attached = true
-	r.sessionName = sessionName
-	r.insideTmux = insideTmux
-	return nil
 }
 
 func TestExpectedOpenRejectsReplacementBeforeSessionEnsure(t *testing.T) {

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -273,12 +273,17 @@ func runPRImport(cmd *cobra.Command, args []string) error {
 		if importErr != nil {
 			return importErr
 		}
-		result.Workspace.TmuxSocketName = tmux.ProtectedWorkspaceSocketName(
-			result.Workspace.SessionName,
-			result.Workspace.Path,
-		)
 		result.PullRequest.Workspace = &result.Workspace
 		if !prStartSession {
+			return nil
+		}
+		if result.Workspace.TmuxSocketName == "" {
+			result.SessionStartError = pullrequest.NewError(
+				pullrequest.CodeWorkspaceCreation,
+				"imported workspace has no validated protected tmux endpoint",
+				false,
+				nil,
+			)
 			return nil
 		}
 		socketName, startErr := ensurePRWorkspaceSession(
@@ -1115,10 +1120,13 @@ func defaultStartPRWorkspaceSession(
 		return "", err
 	}
 	stripNames := credentials.ProtectedNames(cfg)
-	socketName := tmux.ProtectedWorkspaceSocketName(
-		workspace.SessionName,
-		workspace.Path,
-	)
+	socketName := workspace.TmuxSocketName
+	if socketName == "" {
+		socketName = tmux.ProtectedWorkspaceSocketName(
+			workspace.SessionName,
+			workspace.Path,
+		)
+	}
 	tmuxCommand, _, err := tmux.ResolveProtectedSessionCommand(
 		ctx,
 		socketName,

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -503,9 +503,13 @@ func TestDefaultNewPRServiceRejectsNestedRepositoryIdentity(t *testing.T) {
 func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 	for _, status := range []pullrequest.ImportStatus{pullrequest.ImportCreated, pullrequest.ImportExisting} {
 		t.Run(string(status), func(t *testing.T) {
+			const socketName = "kwt-pr-validated"
 			service := &fakePRService{result: pullrequest.ImportResult{
 				Status: status, Project: pullrequest.Project{Identity: "github.com/acme/widget"},
-				Workspace: pullrequest.Workspace{ID: "ws", Path: "/worktrees/ws", SessionName: "kwt-workspace-ws"},
+				Workspace: pullrequest.Workspace{
+					ID: "ws", Path: "/worktrees/ws", SessionName: "kwt-workspace-ws",
+					TmuxSocketName: socketName, TmuxAttachMode: models.TmuxAttachProtected,
+				},
 			}}
 			withPRCommandDeps(t, testPRConfig(), service)
 			cmd, stdout, _ := prTestCommand()
@@ -517,11 +521,8 @@ func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 			require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
 			assert.Equal(t, status, got.Status)
 			assert.Equal(t, "17", service.gotSelector)
-			socketName := tmux.ProtectedWorkspaceSocketName(
-				got.Workspace.SessionName,
-				got.Workspace.Path,
-			)
 			assert.Equal(t, socketName, got.Workspace.TmuxSocketName)
+			assert.Equal(t, models.TmuxAttachProtected, got.Workspace.TmuxAttachMode)
 			assert.Equal(
 				t,
 				socketName,
@@ -529,6 +530,27 @@ func TestRunPRImportWritesCreatedAndAlreadyImportedResults(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestRunPRImportPreservesUnverifiedWorkspaceEndpoint(t *testing.T) {
+	service := &fakePRService{result: pullrequest.ImportResult{
+		Status: pullrequest.ImportExisting,
+		Workspace: pullrequest.Workspace{
+			ID: "ws", Path: "/worktrees/ws", SessionName: "unrecognized-session",
+			TmuxAttachMode: models.TmuxAttachProtected,
+		},
+	}}
+	withPRCommandDeps(t, testPRConfig(), service)
+	cmd, stdout, _ := prTestCommand()
+
+	err := runPRImport(cmd, []string{"17"})
+
+	require.NoError(t, err)
+	var got pullrequest.ImportResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Empty(t, got.Workspace.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachProtected, got.Workspace.TmuxAttachMode)
+	assert.Empty(t, tryRequireWorkspace(t, got.PullRequest.Workspace).TmuxSocketName)
 }
 
 func TestProtectedPRWorkspaceSessionIgnoresConfiguredLayout(t *testing.T) {
@@ -549,10 +571,13 @@ func TestProtectedPRWorkspaceSessionIgnoresConfiguredLayout(t *testing.T) {
 	assert.Equal(t, tmux.BlankLayout(), layout)
 }
 
-func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
+func TestRunPRImportStartsValidatedWorkspaceSessionOnRequest(t *testing.T) {
+	const socketName = "kwt-pr-validated"
 	workspace := pullrequest.Workspace{
 		ID: "ws", Path: "/worktrees/ws",
-		SessionName: "kwt-workspace-ws",
+		SessionName:    "kwt-workspace-ws",
+		TmuxSocketName: socketName,
+		TmuxAttachMode: models.TmuxAttachProtected,
 	}
 	service := &fakePRService{result: pullrequest.ImportResult{
 		Status:    pullrequest.ImportCreated,
@@ -571,14 +596,7 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 		started = true
 		assert.Equal(t, workspace.Path, got.Path)
 		assert.Equal(t, workspace.SessionName, got.SessionName)
-		assert.Equal(
-			t,
-			tmux.ProtectedWorkspaceSocketName(
-				workspace.SessionName,
-				workspace.Path,
-			),
-			got.TmuxSocketName,
-		)
+		assert.Equal(t, socketName, got.TmuxSocketName)
 		assert.Same(t, cfg, gotConfig)
 		return "kwt-pr-0123456789abcdef", nil
 	}
@@ -594,12 +612,45 @@ func TestRunPRImportStartsCanonicalWorkspaceSessionOnRequest(t *testing.T) {
 	var got pullrequest.ImportResult
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
 	assert.Equal(t, "kwt-pr-0123456789abcdef", got.Workspace.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachProtected, got.Workspace.TmuxAttachMode)
 	importedWorkspace := tryRequireWorkspace(t, got.PullRequest.Workspace)
 	assert.Equal(
 		t,
 		"kwt-pr-0123456789abcdef",
 		importedWorkspace.TmuxSocketName,
 	)
+}
+
+func TestRunPRImportRejectsSessionStartWithoutValidatedEndpoint(t *testing.T) {
+	service := &fakePRService{result: pullrequest.ImportResult{
+		Status: pullrequest.ImportCreated,
+		Workspace: pullrequest.Workspace{
+			ID: "ws", Path: "/worktrees/ws", SessionName: "unrecognized-session",
+			TmuxAttachMode: models.TmuxAttachProtected,
+		},
+	}}
+	withPRCommandDeps(t, testPRConfig(), service)
+	prStartSession = true
+	started := false
+	ensurePRWorkspaceSession = func(
+		context.Context,
+		pullrequest.Workspace,
+		*models.Config,
+	) (string, error) {
+		started = true
+		return "kwt-pr-unverified", nil
+	}
+	cmd, stdout, _ := prTestCommand()
+
+	err := runPRImport(cmd, []string{"17"})
+
+	require.NoError(t, err)
+	assert.False(t, started)
+	var got pullrequest.ImportResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Empty(t, got.Workspace.TmuxSocketName)
+	require.NotNil(t, got.SessionStartError)
+	assert.Equal(t, pullrequest.CodeWorkspaceCreation, got.SessionStartError.Code)
 }
 
 func TestRegisteredPRImportLosesToProjectRemoval(t *testing.T) {
@@ -2938,7 +2989,9 @@ func TestRunPRImportReportsDurableImportWithSessionFailure(t *testing.T) {
 		Status: pullrequest.ImportCreated,
 		Workspace: pullrequest.Workspace{
 			ID: "ws", Path: "/worktrees/ws",
-			SessionName: "kwt-workspace-ws",
+			SessionName:    "kwt-workspace-ws",
+			TmuxSocketName: "kwt-pr-validated",
+			TmuxAttachMode: models.TmuxAttachProtected,
 		},
 	}}
 	withPRCommandDeps(t, testPRConfig(), service)
@@ -2972,7 +3025,9 @@ func TestRunPRImportReportsSessionSafetyFailure(t *testing.T) {
 		Status: pullrequest.ImportExisting,
 		Workspace: pullrequest.Workspace{
 			ID: "ws", Path: "/worktrees/ws",
-			SessionName: "kwt-workspace-ws",
+			SessionName:    "kwt-workspace-ws",
+			TmuxSocketName: "kwt-pr-validated",
+			TmuxAttachMode: models.TmuxAttachProtected,
 		},
 	}}
 	withPRCommandDeps(t, testPRConfig(), service)

--- a/internal/cmd/testdata/tmuxfixture/main.go
+++ b/internal/cmd/testdata/tmuxfixture/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) >= 2 && args[0] == "-L" {
+		args = args[2:]
+	}
+	if len(args) > 0 && args[0] == "list-sessions" {
+		_, _ = fmt.Fprintln(os.Stderr, "no server running on test socket")
+		os.Exit(1)
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "unexpected tmux fixture arguments: %q\n", args)
+	os.Exit(2)
+}

--- a/internal/cmd/tmux_attach.go
+++ b/internal/cmd/tmux_attach.go
@@ -6,13 +6,20 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/finder"
 	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/pkg/models"
 )
 
 var (
-	tmuxAttachInteractive bool
+	tmuxAttachInteractive       bool
+	newTmuxAttachSessionManager = func(
+		config *tmux.SessionConfig,
+		stripNames ...string,
+	) tmux.SessionManagerInterface {
+		return tmux.NewSessionManager(config, stripNames...)
+	}
 )
 
 var tmuxAttachCmd = &cobra.Command{
@@ -48,7 +55,10 @@ func runTmuxAttach(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	sessionManager := tmux.NewSessionManager(nil)
+	sessionManager := newTmuxAttachSessionManager(
+		nil,
+		credentials.ProtectedNames(cfg)...,
+	)
 
 	sessions, err := sessionManager.ListSessions()
 	if err != nil {

--- a/internal/cmd/tmux_attach_test.go
+++ b/internal/cmd/tmux_attach_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/tmux"
+)
+
+type recordingTmuxAttachSessionManager struct {
+	sessions []*tmux.Session
+	attached *tmux.Session
+}
+
+func (*recordingTmuxAttachSessionManager) CreateSession(
+	context.Context,
+	tmux.SessionOptions,
+) (*tmux.Session, error) {
+	return nil, nil
+}
+
+func (m *recordingTmuxAttachSessionManager) ListSessions() ([]*tmux.Session, error) {
+	return m.sessions, nil
+}
+
+func (*recordingTmuxAttachSessionManager) GetSession(string) (*tmux.Session, error) {
+	return nil, nil
+}
+
+func (*recordingTmuxAttachSessionManager) KillSession(string) error { return nil }
+
+func (*recordingTmuxAttachSessionManager) KillSessionDirect(*tmux.Session) error {
+	return nil
+}
+
+func (*recordingTmuxAttachSessionManager) AttachSession(string) error { return nil }
+
+func (m *recordingTmuxAttachSessionManager) AttachSessionDirect(session *tmux.Session) error {
+	m.attached = session
+	return nil
+}
+
+func (*recordingTmuxAttachSessionManager) HasSession(string) bool { return false }
+
+func TestRunTmuxAttachPassesConfiguredProtectedNames(t *testing.T) {
+	initCommandTestConfig(t, t.TempDir())
+	t.Setenv("CUSTOM_FLEET_TOKEN", "secret")
+	viper.Set("fleet.token_env", "CUSTOM_FLEET_TOKEN")
+	manager := &recordingTmuxAttachSessionManager{sessions: []*tmux.Session{{
+		SessionName: "workspace",
+	}}}
+	var protectedNames []string
+	previousManager := newTmuxAttachSessionManager
+	previousInteractive := tmuxAttachInteractive
+	t.Cleanup(func() {
+		newTmuxAttachSessionManager = previousManager
+		tmuxAttachInteractive = previousInteractive
+	})
+	newTmuxAttachSessionManager = func(
+		_ *tmux.SessionConfig,
+		names ...string,
+	) tmux.SessionManagerInterface {
+		protectedNames = append([]string(nil), names...)
+		return manager
+	}
+	tmuxAttachInteractive = false
+
+	err := runTmuxAttach(tmuxAttachCmd, []string{"workspace"})
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"KWT_GITHUB_TOKEN",
+		"KWT_FLEET_TOKEN",
+		"CUSTOM_FLEET_TOKEN",
+	}, protectedNames)
+	assert.Same(t, manager.sessions[0], manager.attached)
+}

--- a/internal/cmd/tmux_diagnostic.go
+++ b/internal/cmd/tmux_diagnostic.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"go.kenn.io/kwt/internal/tmux"
+)
+
+func tmuxDiagnosticReporter(writer io.Writer) func(error) {
+	if writer == nil {
+		writer = os.Stderr
+	}
+	return func(err error) {
+		_, _ = fmt.Fprintf(writer, "warning: %v\n", err)
+	}
+}
+
+func newCommandWorkspaceSessions(
+	stripNames []string,
+	stderr io.Writer,
+) *tmux.WorkspaceSessions {
+	return tmux.NewWorkspaceSessions(tmux.WorkspaceSessionsOptions{
+		StripNames:       stripNames,
+		ReportDiagnostic: tmuxDiagnosticReporter(stderr),
+	})
+}

--- a/internal/cmd/tmux_endpoint_test.go
+++ b/internal/cmd/tmux_endpoint_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/tmux"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+func TestTmuxDiagnosticReporterWritesWarning(t *testing.T) {
+	var output bytes.Buffer
+
+	tmuxDiagnosticReporter(&output)(errors.New("default tmux server unavailable"))
+
+	assert.Equal(t, "warning: default tmux server unavailable\n", output.String())
+}
+
+func TestFormatTmuxSessionLabelDisambiguatesEndpoints(t *testing.T) {
+	assert.Equal(t, "run/test [kwt]", formatTmuxSessionLabel(&tmux.Session{
+		SocketName: tmux.KWTServerSocketName,
+		Context:    "run", Identifier: "test",
+	}))
+	assert.Equal(t, "run/test [default]", formatTmuxSessionLabel(&tmux.Session{
+		Context: "run", Identifier: "test",
+	}))
+}
+
+func TestTmuxSessionRecordSerializesEndpointWithAttachMode(t *testing.T) {
+	started := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	session := &tmux.Session{
+		SessionName: "kwt-run-test-20260102030405",
+		SocketName:  tmux.KWTServerSocketName,
+		ID:          "session-id",
+		Context:     "run",
+		Identifier:  "test",
+		WorkingDir:  "/work/test",
+		Command:     "make test",
+		StartTime:   started,
+		HistorySize: 50000,
+		Metadata:    map[string]string{"created_by": "kwt tmux run"},
+	}
+
+	stdout, err := captureListStdout(t, func() error {
+		return outputSessionsJSON([]*tmux.Session{session})
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{
+		"id":"session-id",
+		"session_name":"kwt-run-test-20260102030405",
+		"context":"run",
+		"identifier":"test",
+		"working_dir":"/work/test",
+		"command":"make test",
+		"start_time":"2026-01-02T03:04:05Z",
+		"history_size":50000,
+		"metadata":{"created_by":"kwt tmux run"},
+		"tmux_socket_name":"kwt",
+		"tmux_attach_mode":"direct"
+	}]`, stdout)
+
+	var records []tmuxSessionRecord
+	require.NoError(t, json.Unmarshal([]byte(stdout), &records))
+	require.Len(t, records, 1)
+	assert.Equal(t, models.TmuxAttachDirect, records[0].TmuxAttachMode)
+}

--- a/internal/cmd/tmux_kill.go
+++ b/internal/cmd/tmux_kill.go
@@ -117,7 +117,7 @@ func selectSessionsToKillWithFinder(sessions []*tmux.Session, cfg *models.Config
 func confirmKillSessions(sessions []*tmux.Session) bool {
 	fmt.Printf("\nThis will terminate %d session(s):\n", len(sessions))
 	for _, session := range sessions {
-		fmt.Printf("  ● %s/%s\n", session.Context, session.Identifier)
+		fmt.Printf("  ● %s\n", formatTmuxSessionLabel(session))
 	}
 
 	fmt.Print("\nAre you sure? (y/N): ")
@@ -132,7 +132,7 @@ func killSessions(sessionManager *tmux.SessionManager, sessions []*tmux.Session)
 	var failedCount int
 
 	for _, session := range sessions {
-		fmt.Printf("Terminating session %s/%s...", session.Context, session.Identifier)
+		fmt.Printf("Terminating session %s...", formatTmuxSessionLabel(session))
 
 		if err := sessionManager.KillSessionDirect(session); err != nil {
 			fmt.Printf(" FAILED: %v\n", err)

--- a/internal/cmd/tmux_list.go
+++ b/internal/cmd/tmux_list.go
@@ -125,13 +125,47 @@ func runTmuxListWatch(sessionManager *tmux.SessionManager, cfg *models.Config) e
 }
 
 func outputSessionsJSON(sessions []*tmux.Session) error {
+	records := make([]tmuxSessionRecord, 0, len(sessions))
+	for _, session := range sessions {
+		records = append(records, tmuxSessionRecordFromSession(session))
+	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(sessions)
+	return encoder.Encode(records)
+}
+
+type tmuxSessionRecord struct {
+	ID             string                `json:"id"`
+	SessionName    string                `json:"session_name"`
+	Context        string                `json:"context"`
+	Identifier     string                `json:"identifier"`
+	WorkingDir     string                `json:"working_dir"`
+	Command        string                `json:"command"`
+	StartTime      time.Time             `json:"start_time"`
+	HistorySize    int                   `json:"history_size"`
+	Metadata       map[string]string     `json:"metadata,omitempty"`
+	TmuxSocketName string                `json:"tmux_socket_name,omitempty"`
+	TmuxAttachMode models.TmuxAttachMode `json:"tmux_attach_mode"`
+}
+
+func tmuxSessionRecordFromSession(session *tmux.Session) tmuxSessionRecord {
+	return tmuxSessionRecord{
+		ID:             session.ID,
+		SessionName:    session.SessionName,
+		Context:        session.Context,
+		Identifier:     session.Identifier,
+		WorkingDir:     session.WorkingDir,
+		Command:        session.Command,
+		StartTime:      session.StartTime,
+		HistorySize:    session.HistorySize,
+		Metadata:       session.Metadata,
+		TmuxSocketName: session.SocketName,
+		TmuxAttachMode: models.TmuxAttachDirect,
+	}
 }
 
 func outputSessionsCSV(sessions []*tmux.Session) error {
-	t := table.New().Headers("context", "identifier", "duration", "command", "working_dir", "session_name")
+	t := table.New().Headers("context", "identifier", "endpoint", "duration", "command", "working_dir", "session_name")
 
 	// Write data
 	for _, session := range sessions {
@@ -139,6 +173,7 @@ func outputSessionsCSV(sessions []*tmux.Session) error {
 		t.Row(
 			session.Context,
 			session.Identifier,
+			tmux.SessionEndpointLabel(session),
 			duration,
 			session.Command,
 			session.WorkingDir,
@@ -158,7 +193,7 @@ func outputSessionsTable(sessions []*tmux.Session, printer *ui.Printer) error {
 	t := table.New().Headers("SESSION", "DURATION", "WORKING_DIR")
 
 	for _, session := range sessions {
-		sessionIdentifier := session.Context + "/" + session.Identifier
+		sessionIdentifier := formatTmuxSessionLabel(session)
 		duration := formatSessionDuration(session.StartTime)
 		workdir := formatWorkingDir(session.WorkingDir, printer)
 
@@ -166,6 +201,15 @@ func outputSessionsTable(sessions []*tmux.Session, printer *ui.Printer) error {
 	}
 
 	return t.Println()
+}
+
+func formatTmuxSessionLabel(session *tmux.Session) string {
+	return fmt.Sprintf(
+		"%s/%s [%s]",
+		session.Context,
+		session.Identifier,
+		tmux.SessionEndpointLabel(session),
+	)
 }
 
 func formatSessionDuration(startTime time.Time) string {

--- a/internal/cmd/tmux_run.go
+++ b/internal/cmd/tmux_run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/tmux"
@@ -22,6 +23,8 @@ var (
 	tmuxRunDetach      bool
 	tmuxRunAutoCleanup bool
 )
+
+var newTmuxRunSessionManager = tmux.NewSessionManager
 
 var tmuxRunCmd = &cobra.Command{
 	Use:   "run [command]",
@@ -93,7 +96,10 @@ func runTmuxRun(cmd *cobra.Command, args []string) error {
 		finalCommand = fmt.Sprintf("(%s); tmux kill-session -t $TMUX_PANE", command)
 	}
 
-	sessionManager := tmux.NewSessionManager(nil)
+	sessionManager := newTmuxRunSessionManager(
+		nil,
+		credentials.ProtectedNames(cfg)...,
+	)
 
 	opts := tmux.SessionOptions{
 		Context:    context,

--- a/internal/cmd/tmux_run_integration_test.go
+++ b/internal/cmd/tmux_run_integration_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/tmux"
+)
+
+func TestTmuxRunAutoCleanupUsesPaneServer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-run-")
+	require.NoError(t, err)
+	manager := tmux.NewSessionManagerWithTempDir(nil, tempDir)
+	kwtServer := tmux.NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux", tmux.KWTServerSocketName, tempDir, nil,
+	)
+	defaultServer := tmux.NewTmuxCommandInTempDirWithStripNames("tmux", tempDir, nil)
+	t.Cleanup(func() {
+		_ = kwtServer.RunCommandContext(context.Background(), "kill-server")
+		_ = defaultServer.RunCommandContext(context.Background(), "kill-server")
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	previousManager := newTmuxRunSessionManager
+	previousDetach := tmuxRunDetach
+	previousCleanup := tmuxRunAutoCleanup
+	previousContext := tmuxRunContext
+	previousIdentifier := tmuxRunIdentifier
+	previousWorktree := tmuxRunWorktree
+	t.Cleanup(func() {
+		newTmuxRunSessionManager = previousManager
+		tmuxRunDetach = previousDetach
+		tmuxRunAutoCleanup = previousCleanup
+		tmuxRunContext = previousContext
+		tmuxRunIdentifier = previousIdentifier
+		tmuxRunWorktree = previousWorktree
+	})
+	var protectedNames []string
+	newTmuxRunSessionManager = func(
+		_ *tmux.SessionConfig,
+		names ...string,
+	) *tmux.SessionManager {
+		protectedNames = append([]string(nil), names...)
+		return manager
+	}
+	tmuxRunDetach = true
+	tmuxRunAutoCleanup = true
+	tmuxRunContext = "integration"
+	tmuxRunIdentifier = "cleanup"
+	tmuxRunWorktree = ""
+	initCommandTestConfig(t, t.TempDir())
+	viper.Set("fleet.token_env", "CUSTOM_FLEET_TOKEN")
+	t.Setenv("CUSTOM_FLEET_TOKEN", "secret")
+
+	command := &cobra.Command{}
+	command.SetContext(context.Background())
+	require.NoError(t, runTmuxRun(command, []string{"sleep 0.5"}))
+	assert.ElementsMatch(t, []string{
+		"KWT_GITHUB_TOKEN",
+		"KWT_FLEET_TOKEN",
+		"CUSTOM_FLEET_TOKEN",
+	}, protectedNames)
+	sessions, err := manager.ListSessions()
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, tmux.KWTServerSocketName, sessions[0].SocketName)
+	require.Eventually(t, func() bool {
+		sessions, listErr := manager.ListSessions()
+		return listErr == nil && len(sessions) == 0
+	}, 3*time.Second, 20*time.Millisecond)
+	defaultSessions, err := defaultServer.ListSessionsContext(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, defaultSessions)
+}

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -34,9 +34,8 @@ import (
 )
 
 type tuiBackend struct {
-	// mu serializes List and MergeFleet: List mutates cfg (launch project and
-	// workspace registration) while MergeFleet's manifest publish reads it,
-	// and the TUI runs the two as concurrent commands.
+	// mu serializes inventory refresh with every operation that reads or
+	// mutates backend configuration and its derived tmux coordinators.
 	mu                        sync.Mutex
 	cfg                       *models.Config
 	workspaceSessions         *tmux.WorkspaceSessions
@@ -246,7 +245,7 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	}
 	renderWorkspaces := result.Snapshot.Workspaces
 	if includeStatuses && result.Freshness == kwt.Fresh {
-		if err := b.applyInventoryConfig(result.Snapshot.Config); err != nil {
+		if err := b.applyInventoryConfigLocked(result.Snapshot.Config); err != nil {
 			return nil, nil, err
 		}
 		launchEntries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.LaunchEntries))
@@ -285,6 +284,12 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 }
 
 func (b *tuiBackend) applyInventoryConfig(effective *models.Config) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.applyInventoryConfigLocked(effective)
+}
+
+func (b *tuiBackend) applyInventoryConfigLocked(effective *models.Config) error {
 	if effective == nil {
 		return service.NewError(
 			service.TransportFailure,
@@ -1172,6 +1177,8 @@ func (b *tuiBackend) CreateWorktree(
 	branch string,
 	source string,
 ) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if row.Entry == nil {
 		return "", fmt.Errorf("no worktree selected")
 	}
@@ -1252,6 +1259,8 @@ func (b *tuiBackend) ListBranches(
 }
 
 func (b *tuiBackend) PreviewWorktree(row dashboard.Row, branch string) (dashboard.Row, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if row.Entry == nil {
 		return dashboard.Row{}, fmt.Errorf("no worktree selected")
 	}
@@ -1291,6 +1300,8 @@ func (b *tuiBackend) worktreeManager(row dashboard.Row) (*worktree.Manager, erro
 }
 
 func (b *tuiBackend) MaterializeWorktree(ctx context.Context, row dashboard.Row) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if row.Fleet == nil {
 		return "", fmt.Errorf("no fleet worktree selected")
 	}
@@ -1581,6 +1592,8 @@ func sameRepositoryIdentity(left string, right string) bool {
 }
 
 func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, force bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if row.Entry == nil {
 		return fmt.Errorf("no worktree selected")
 	}
@@ -1834,6 +1847,8 @@ func cleanComparablePath(path string) string {
 }
 
 func (b *tuiBackend) KillSession(row dashboard.Row) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if row.SessionName == "" {
 		return fmt.Errorf("no live workspace")
 	}
@@ -1845,6 +1860,8 @@ func (b *tuiBackend) OpenInTmux(
 	row dashboard.Row,
 	layoutName string,
 ) (*exec.Cmd, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	endpoint, err := b.establishWorkspaceEndpoint(ctx, row, layoutName, false)
 	if err != nil {
 		return nil, err
@@ -1853,12 +1870,16 @@ func (b *tuiBackend) OpenInTmux(
 }
 
 func (b *tuiBackend) AttachOutsideTmux(row dashboard.Row, layoutName string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.attachWorkspace(context.Background(), row, layoutName, config.StdinInteractive())
 }
 
 // LayoutNames returns the names the TUI layout cycler offers: the reserved
 // blank session first, then the configured presets.
 func (b *tuiBackend) LayoutNames() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	names := make([]string, 0, len(b.cfg.Layouts.Presets)+1)
 	names = append(names, tmux.BlankLayoutName)
 	for _, layout := range b.cfg.Layouts.Presets {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1685,28 +1685,18 @@ func (b *tuiBackend) killProtectedTUIEndpoint(
 	endpoint tmux.SessionEndpoint,
 	request tmux.WorkspaceEndpointRequest,
 ) error {
-	command, state, err := tmux.ResolveProtectedSessionCommand(
+	request.SessionName = endpoint.SessionName
+	err := tmux.KillProtectedWorkspaceSessionsIfMatchingContext(
 		ctx,
 		endpoint.SocketName,
-		endpoint.SessionName,
 		b.protectedNames,
 		os.Getenv("TMUX_TMPDIR"),
+		request,
 	)
-	if err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return nil
-		}
-		return err
-	}
-	switch state {
-	case tmux.ProtectedSessionAbsent:
+	if errors.Is(err, exec.ErrNotFound) {
 		return nil
-	case tmux.ProtectedSessionLive:
-		request.SessionName = endpoint.SessionName
-		return command.KillWorkspaceSessionIfMatchingContext(ctx, request)
-	default:
-		return fmt.Errorf("protected tmux session state is indeterminate")
 	}
+	return err
 }
 
 func (b *tuiBackend) repositoryRootForRow(row dashboard.Row) (string, error) {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -38,7 +38,7 @@ type tuiBackend struct {
 	// and the TUI runs the two as concurrent commands.
 	mu                        sync.Mutex
 	cfg                       *models.Config
-	tmux                      *tmux.TmuxCommand
+	workspaceSessions         *tmux.WorkspaceSessions
 	protectedNames            []string
 	launchDir                 string
 	launchProjectRegistered   bool
@@ -47,11 +47,13 @@ type tuiBackend struct {
 	discoverProjectWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
 	discoverLaunchWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
 	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error)
-	listSessions              func() ([]string, error)
-	ensureWorkspace           func(context.Context, string, string, models.Layout) error
-	ensureWorktree            func(context.Context, string, string, string, models.Layout) error
-	attachSession             func(string, bool) error
-	ensureAndAttach           func(context.Context, string, string, models.Layout, bool) error
+	resolveSessions           func(context.Context, []tmux.WorkspaceEndpointRequest) ([]tmux.WorkspaceSession, error)
+	liveEndpoints             func(context.Context, tmux.WorkspaceEndpointRequest) ([]tmux.SessionEndpoint, error)
+	ensureWorkspace           func(context.Context, string, string, models.Layout) (tmux.SessionEndpoint, error)
+	ensureWorktree            func(context.Context, string, string, string, models.Layout) (tmux.SessionEndpoint, error)
+	attachSession             func(context.Context, tmux.SessionEndpoint) error
+	killEndpoint              func(tmux.SessionEndpoint) error
+	killProtectedEndpoint     func(context.Context, tmux.SessionEndpoint) error
 	registerProject           func(context.Context, models.Project) error
 	registerWorkspace         func(models.Workspace) (models.Workspace, error)
 	unregisterWorkspace       func(name string) error
@@ -65,6 +67,19 @@ type tuiBackend struct {
 	stderr                    io.Writer
 }
 
+type tuiRemovalEndpoint struct {
+	Endpoint  tmux.SessionEndpoint
+	Protected bool
+}
+
+type removedWorktreeCleanupError struct{ err error }
+
+func (e *removedWorktreeCleanupError) Error() string { return e.err.Error() }
+func (e *removedWorktreeCleanupError) Unwrap() error { return e.err }
+func (*removedWorktreeCleanupError) WorktreeRemoved() bool {
+	return true
+}
+
 func newTUIBackend(cfg *models.Config) *tuiBackend {
 	launchDir, _ := os.Getwd()
 	return newTUIBackendWithLaunchDir(cfg, launchDir)
@@ -72,13 +87,12 @@ func newTUIBackend(cfg *models.Config) *tuiBackend {
 
 func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBackend {
 	protectedNames := credentials.ProtectedNames(cfg)
-	tmuxCmd := tmux.NewTmuxCommandWithStripNames("", protectedNames)
-	runner := tmux.NewWorkspaceRunner(tmuxCmd, protectedNames)
+	sessions := newCommandWorkspaceSessions(protectedNames, os.Stderr)
 	backend := &tuiBackend{
-		cfg:            cfg,
-		tmux:           tmuxCmd,
-		protectedNames: protectedNames,
-		launchDir:      launchDir,
+		cfg:               cfg,
+		workspaceSessions: sessions,
+		protectedNames:    protectedNames,
+		launchDir:         launchDir,
 		// Registered projects flow into base-dir discovery so a registered
 		// canonical identity wins over a fork origin (the same precedence
 		// applyProjectIdentityFallback applies to per-project discovery).
@@ -88,20 +102,25 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		discoverProjectWorktrees: discoverLaunchRepoWorktrees,
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
 		collectStatuses:          collectTUIStatuses,
-		listSessions:             tmuxCmd.ListSessions,
-		ensureWorkspace:          runner.Ensure,
-		ensureWorktree:           runner.EnsureWithGeneration,
-		attachSession:            runner.Attach,
-		ensureAndAttach:          runner.EnsureAndAttach,
-		registerProject:          registerProjectWithLifecycle,
-		registerWorkspace:        config.RegisterWorkspace,
-		unregisterWorkspace:      config.UnregisterWorkspace,
-		readFleetState:           readTUIFleetState,
-		acknowledgeRemoteSource:  acknowledgeRemoteSourcePath,
-		removeWorktree:           removeDaemonWorktree,
-		runProjectOperation:      runTUIProjectOperation,
-		now:                      time.Now,
+		resolveSessions: bestEffortDashboardSessionResolver(
+			sessions.ResolveAllBestEffort,
+			tmuxDiagnosticReporter(os.Stderr),
+		),
+		liveEndpoints:           sessions.LiveEndpoints,
+		ensureWorkspace:         sessions.Establish,
+		ensureWorktree:          sessions.EstablishWithGeneration,
+		attachSession:           sessions.Attach,
+		registerProject:         registerProjectWithLifecycle,
+		registerWorkspace:       config.RegisterWorkspace,
+		unregisterWorkspace:     config.UnregisterWorkspace,
+		readFleetState:          readTUIFleetState,
+		acknowledgeRemoteSource: acknowledgeRemoteSourcePath,
+		removeWorktree:          removeDaemonWorktree,
+		runProjectOperation:     runTUIProjectOperation,
+		now:                     time.Now,
 	}
+	backend.killEndpoint = sessions.Kill
+	backend.killProtectedEndpoint = backend.killProtectedTUIEndpoint
 	backend.loadTargetConfig = func(repoRoot string, interactive bool) (*models.Config, error) {
 		return config.LoadForTargetFrom(backend.cfg, repoRoot, interactive)
 	}
@@ -130,14 +149,12 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 		entries           []*discovery.GlobalWorktreeEntry
 		registeredEntries []*discovery.GlobalWorktreeEntry
 		launchEntries     []*discovery.GlobalWorktreeEntry
-		sessions          []string
 		discoveryErr      error
 		registeredErr     error
 		launchErr         error
-		sessionsErr       error
 		startup           sync.WaitGroup
 	)
-	startup.Add(4)
+	startup.Add(3)
 	go func() {
 		defer startup.Done()
 		entries, discoveryErr = b.discoverGlobalWorktrees(
@@ -153,10 +170,6 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 		defer startup.Done()
 		launchEntries, launchErr = b.discoverLaunchWorktrees(b.launchDir)
 	}()
-	go func() {
-		defer startup.Done()
-		sessions, sessionsErr = b.listSessions()
-	}()
 	startup.Wait()
 
 	if discoveryErr != nil {
@@ -171,14 +184,18 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 	if launchErr != nil {
 		return nil, nil, fmt.Errorf("failed to discover launch repository worktrees: %w", launchErr)
 	}
-	if sessionsErr != nil {
-		return nil, nil, sessionsErr
-	}
-
 	entries = mergeTUIEntries(entries, registeredEntries)
 	b.registerLaunchProject(ctx, launchEntries)
 	b.registerLaunchWorkspace(launchEntries)
 	entries = mergeTUIEntries(entries, launchEntries)
+	worktreeSessions, directorySessions, err := b.resolveDashboardSessions(
+		ctx,
+		entries,
+		b.cfg.Workspaces,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	var statusByPath map[string]*models.WorktreeStatus
 	if includeStatuses {
@@ -192,20 +209,15 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 		}
 	}
 
-	liveSessions := make(map[string]bool, len(sessions))
-	for _, session := range sessions {
-		liveSessions[session] = true
-	}
-
 	rows := make([]dashboard.Row, 0, len(entries))
-	for _, entry := range entries {
+	for index, entry := range entries {
 		st := statusByPath[entry.Path]
 		if st == nil {
 			st = unknownStatusForEntry(entry)
 		}
-		rows = append(rows, buildTUIRow(entry, st, liveSessions))
+		rows = append(rows, buildTUIRow(entry, st, worktreeSessions[index]))
 	}
-	rows = append(rows, b.workspaceRows(sessions)...)
+	rows = append(rows, workspaceRows(b.cfg.Workspaces, directorySessions)...)
 	return rows, nil, nil
 }
 
@@ -214,7 +226,8 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 		ctx,
 		kwt.Request{
 			View: kwt.ViewDashboard, LaunchDirectory: b.launchDir,
-			RequireCurrent: includeStatuses,
+			RequireCurrent:          includeStatuses,
+			IncludeProtectedSockets: true,
 		},
 		config.StdinInteractive(),
 		b.stderr,
@@ -225,10 +238,6 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	entries := make([]*discovery.GlobalWorktreeEntry, 0, len(result.Snapshot.Entries))
 	for _, entry := range result.Snapshot.Entries {
 		entries = append(entries, dashboardInventoryEntry(entry))
-	}
-	sessions, err := b.listSessions()
-	if err != nil {
-		return nil, nil, err
 	}
 	renderWorkspaces := result.Snapshot.Workspaces
 	if includeStatuses && result.Freshness == kwt.Fresh {
@@ -250,19 +259,23 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 			return nil, nil, err
 		}
 	}
-	liveSessions := make(map[string]bool, len(sessions))
-	for _, session := range sessions {
-		liveSessions[session] = true
+	worktreeSessions, directorySessions, err := b.resolveDashboardSessions(
+		ctx,
+		entries,
+		renderWorkspaces,
+	)
+	if err != nil {
+		return nil, nil, err
 	}
 	rows := make([]dashboard.Row, 0, len(entries))
-	for _, entry := range entries {
+	for index, entry := range entries {
 		status := statusByPath[entry.Path]
 		if status == nil {
 			status = unknownStatusForEntry(entry)
 		}
-		rows = append(rows, buildTUIRow(entry, status, liveSessions))
+		rows = append(rows, buildTUIRow(entry, status, worktreeSessions[index]))
 	}
-	rows = append(rows, workspaceRows(renderWorkspaces, sessions)...)
+	rows = append(rows, workspaceRows(renderWorkspaces, directorySessions)...)
 	return rows, nil, nil
 }
 
@@ -282,14 +295,28 @@ func (b *tuiBackend) applyInventoryConfig(effective *models.Config) error {
 		*b.cfg = *effective
 	}
 	b.protectedNames = credentials.ProtectedNames(b.cfg)
-	b.tmux = tmux.NewTmuxCommandWithStripNames("", b.protectedNames)
-	b.listSessions = b.tmux.ListSessions
-	runner := tmux.NewWorkspaceRunner(b.tmux, b.protectedNames)
-	b.ensureWorkspace = runner.Ensure
-	b.ensureWorktree = runner.EnsureWithGeneration
-	b.attachSession = runner.Attach
-	b.ensureAndAttach = runner.EnsureAndAttach
+	b.workspaceSessions = tmux.NewWorkspaceSessions(tmux.WorkspaceSessionsOptions{
+		StripNames:       b.protectedNames,
+		ReportDiagnostic: b.reportTmuxDiagnostic,
+	})
+	b.resolveSessions = bestEffortDashboardSessionResolver(
+		b.workspaceSessions.ResolveAllBestEffort,
+		b.reportTmuxDiagnostic,
+	)
+	b.liveEndpoints = b.workspaceSessions.LiveEndpoints
+	b.ensureWorkspace = b.workspaceSessions.Establish
+	b.ensureWorktree = b.workspaceSessions.EstablishWithGeneration
+	b.attachSession = b.workspaceSessions.Attach
+	b.killEndpoint = b.workspaceSessions.Kill
 	return nil
+}
+
+func (b *tuiBackend) reportTmuxDiagnostic(err error) {
+	writer := b.stderr
+	if writer == nil {
+		writer = os.Stderr
+	}
+	tmuxDiagnosticReporter(writer)(err)
 }
 
 func dashboardInventoryEntry(entry kwt.Entry) *discovery.GlobalWorktreeEntry {
@@ -304,6 +331,104 @@ func dashboardInventoryEntry(entry kwt.Entry) *discovery.GlobalWorktreeEntry {
 		RepositoryURL: entry.Repository.URL, RepositoryInfo: info,
 		Path: entry.Path, Branch: entry.Branch, CommitHash: entry.CommitHash,
 		IsMain: entry.IsMain, CreatedAt: entry.CreatedAt, Generation: entry.Generation,
+		TmuxEndpoint: tmux.SessionEndpoint{
+			SessionName: entry.SessionName,
+			SocketName:  entry.TmuxSocketName,
+		},
+		TmuxSessionLive: entry.SessionLive,
+		TmuxResolved:    true,
+		Protected:       entry.TmuxAttachMode == models.TmuxAttachProtected,
+	}
+}
+
+func (b *tuiBackend) resolveDashboardSessions(
+	ctx context.Context,
+	entries []*discovery.GlobalWorktreeEntry,
+	workspaces []models.Workspace,
+) ([]tmux.WorkspaceSession, []tmux.WorkspaceSession, error) {
+	requests := make([]tmux.WorkspaceEndpointRequest, 0, len(entries)+len(workspaces))
+	entryIndexes := make([]int, 0, len(entries))
+	worktreeSessions := make([]tmux.WorkspaceSession, len(entries))
+	for index, entry := range entries {
+		if entry.TmuxResolved {
+			worktreeSessions[index] = tmux.WorkspaceSession{
+				Endpoint: entry.TmuxEndpoint,
+				Live:     entry.TmuxSessionLive,
+			}
+			continue
+		}
+		if entry.Protected {
+			worktreeSessions[index] = tmux.WorkspaceSession{
+				Endpoint: entry.TmuxEndpoint,
+			}
+			continue
+		}
+		sessionName := entry.TmuxEndpoint.SessionName
+		if entry.RepositoryInfo != nil {
+			sessionName = tmux.WorkspaceSessionName(
+				entry.RepositoryInfo,
+				entry.Branch,
+				entry.Path,
+			)
+		}
+		entryIndexes = append(entryIndexes, index)
+		requests = append(requests, tmux.WorkspaceEndpointRequest{
+			SessionName:         sessionName,
+			WorkspacePath:       entry.Path,
+			WorkspaceGeneration: entry.Generation,
+		})
+	}
+	directoryOffset := len(requests)
+	for _, workspace := range workspaces {
+		requests = append(requests, tmux.WorkspaceEndpointRequest{
+			SessionName:   tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+			WorkspacePath: workspace.Path,
+		})
+	}
+	resolved, err := b.resolveSessions(ctx, requests)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(resolved) != len(requests) {
+		return nil, nil, fmt.Errorf(
+			"KWT tmux endpoint resolver returned %d results for %d workspaces",
+			len(resolved),
+			len(requests),
+		)
+	}
+	for offset, index := range entryIndexes {
+		worktreeSessions[index] = resolved[offset]
+	}
+	directorySessions := append(
+		[]tmux.WorkspaceSession(nil),
+		resolved[directoryOffset:]...,
+	)
+	return worktreeSessions, directorySessions, nil
+}
+
+func bestEffortDashboardSessionResolver(
+	resolve func(
+		context.Context,
+		[]tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSessionResolution, error),
+	reportDiagnostic func(error),
+) func(context.Context, []tmux.WorkspaceEndpointRequest) ([]tmux.WorkspaceSession, error) {
+	return func(
+		ctx context.Context,
+		requests []tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSession, error) {
+		resolutions, err := resolve(ctx, requests)
+		if err != nil {
+			return nil, err
+		}
+		sessions := make([]tmux.WorkspaceSession, len(resolutions))
+		for index, resolution := range resolutions {
+			sessions[index] = resolution.Session
+			if resolution.Err != nil && reportDiagnostic != nil {
+				reportDiagnostic(resolution.Err)
+			}
+		}
+		return sessions, nil
 	}
 }
 
@@ -495,23 +620,21 @@ func (b *tuiBackend) registerLaunchProject(
 	b.upsertProject(project)
 }
 
-func (b *tuiBackend) workspaceRows(sessions []string) []dashboard.Row {
-	if b.cfg == nil || len(b.cfg.Workspaces) == 0 {
-		return nil
-	}
-	return workspaceRows(b.cfg.Workspaces, sessions)
-}
-
-func workspaceRows(workspaces []models.Workspace, sessions []string) []dashboard.Row {
+func workspaceRows(workspaces []models.Workspace, sessions []tmux.WorkspaceSession) []dashboard.Row {
 	rows := make([]dashboard.Row, 0, len(workspaces))
-	for _, record := range directoryWorkspaceRecords(workspaces, sessions) {
+	for index, workspace := range workspaces {
+		if index >= len(sessions) {
+			break
+		}
+		session := sessions[index]
 		rows = append(rows, dashboard.Row{
 			Workspace: &dashboard.WorkspaceInfo{
-				Name: record.Name,
-				Path: record.Path,
+				Name: workspace.Name,
+				Path: workspace.Path,
 			},
-			SessionName: record.SessionName,
-			SessionLive: record.SessionLive,
+			SessionName:  session.Endpoint.SessionName,
+			SessionLive:  session.Live,
+			TmuxEndpoint: session.Endpoint,
 		})
 	}
 	return rows
@@ -908,19 +1031,14 @@ func tuiStatusCollectorOptions(baseDir string) status.StatusCollectorOptions {
 func buildTUIRow(
 	entry *discovery.GlobalWorktreeEntry,
 	st *models.WorktreeStatus,
-	liveSessions map[string]bool,
+	session tmux.WorkspaceSession,
 ) dashboard.Row {
-	sessionName := ""
-	sessionLive := false
-	if entry.RepositoryInfo != nil {
-		sessionName = tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path)
-		sessionLive = liveSessions[sessionName]
-	}
 	return dashboard.Row{
-		Entry:       entry,
-		Status:      st,
-		SessionName: sessionName,
-		SessionLive: sessionLive,
+		Entry:        entry,
+		Status:       st,
+		SessionName:  session.Endpoint.SessionName,
+		SessionLive:  session.Live,
+		TmuxEndpoint: session.Endpoint,
 	}
 }
 
@@ -1470,6 +1588,7 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 	if err != nil {
 		return err
 	}
+	endpointRequest := removalEndpointRequest(row)
 	result, removalErr := b.removeWorktree(ctx, kwt.RemovalRequest{
 		RepositoryPath: repoRoot,
 		Path:           row.Entry.Path, ExpectedGeneration: generation,
@@ -1488,15 +1607,97 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 
 	publishTUIFleetBestEffort(ctx, b.cfg)
 
-	if row.SessionLive && row.SessionName != "" {
-		if err := b.tmux.KillSession(row.SessionName); err != nil {
-			if removalErr != nil {
-				return errors.Join(removalErr, err)
-			}
-			return err
+	endpoints, cleanupErr := b.removalEndpoints(
+		ctx,
+		row,
+		endpointRequest,
+	)
+	for _, endpoint := range endpoints {
+		var err error
+		if endpoint.Protected {
+			err = b.killProtectedEndpoint(ctx, endpoint.Endpoint)
+		} else {
+			err = b.killEndpoint(endpoint.Endpoint)
+		}
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf(
+				"stop tmux session %q: %w",
+				endpoint.Endpoint.SessionName,
+				err,
+			))
 		}
 	}
-	return removalErr
+	joinedErr := errors.Join(removalErr, cleanupErr)
+	if joinedErr != nil && result.WorktreeRemoved && !git.WorktreeWasRemoved(joinedErr) {
+		return &removedWorktreeCleanupError{err: joinedErr}
+	}
+	return joinedErr
+}
+
+func removalEndpointRequest(row dashboard.Row) tmux.WorkspaceEndpointRequest {
+	sessionName := strings.TrimSpace(row.SessionName)
+	if sessionName == "" {
+		sessionName = strings.TrimSpace(row.TmuxEndpoint.SessionName)
+	}
+	if sessionName == "" && row.Entry != nil {
+		sessionName = strings.TrimSpace(row.Entry.TmuxEndpoint.SessionName)
+	}
+	return tmux.WorkspaceEndpointRequest{
+		SessionName:         sessionName,
+		WorkspacePath:       row.Entry.Path,
+		WorkspaceGeneration: row.Entry.Generation,
+	}
+}
+
+func (b *tuiBackend) removalEndpoints(
+	ctx context.Context,
+	row dashboard.Row,
+	request tmux.WorkspaceEndpointRequest,
+) ([]tuiRemovalEndpoint, error) {
+	removalEndpoints := make([]tuiRemovalEndpoint, 0, 3)
+	protectedEndpoint := row.TmuxEndpoint
+	if row.Entry.Protected &&
+		strings.TrimSpace(protectedEndpoint.SocketName) != "" &&
+		strings.TrimSpace(protectedEndpoint.SessionName) != "" {
+		removalEndpoints = append(removalEndpoints, tuiRemovalEndpoint{
+			Endpoint:  protectedEndpoint,
+			Protected: true,
+		})
+	}
+	endpoints, err := b.liveEndpoints(ctx, request)
+	if err != nil {
+		return removalEndpoints, fmt.Errorf("inspect workspace tmux sessions: %w", err)
+	}
+	for _, endpoint := range endpoints {
+		removalEndpoints = append(removalEndpoints, tuiRemovalEndpoint{
+			Endpoint: endpoint,
+		})
+	}
+	return removalEndpoints, nil
+}
+
+func (b *tuiBackend) killProtectedTUIEndpoint(
+	ctx context.Context,
+	endpoint tmux.SessionEndpoint,
+) error {
+	command, state, err := tmux.ResolveProtectedSessionCommand(
+		ctx,
+		endpoint.SocketName,
+		endpoint.SessionName,
+		b.protectedNames,
+		os.Getenv("TMUX_TMPDIR"),
+	)
+	if err != nil {
+		return err
+	}
+	switch state {
+	case tmux.ProtectedSessionAbsent:
+		return nil
+	case tmux.ProtectedSessionLive:
+		return command.KillSessionIfPresentContext(ctx, endpoint.SessionName)
+	default:
+		return fmt.Errorf("protected tmux session state is indeterminate")
+	}
 }
 
 func (b *tuiBackend) repositoryRootForRow(row dashboard.Row) (string, error) {
@@ -1634,15 +1835,15 @@ func (b *tuiBackend) KillSession(row dashboard.Row) error {
 	if row.SessionName == "" {
 		return fmt.Errorf("no live workspace")
 	}
-	return b.tmux.KillSession(row.SessionName)
+	return b.killEndpoint(row.TmuxEndpoint)
 }
 
 func (b *tuiBackend) OpenInTmux(ctx context.Context, row dashboard.Row, layoutName string) error {
-	return b.attachWorkspace(ctx, row, layoutName, true, false)
+	return b.attachWorkspace(ctx, row, layoutName, false)
 }
 
 func (b *tuiBackend) AttachOutsideTmux(row dashboard.Row, layoutName string) error {
-	return b.attachWorkspace(context.Background(), row, layoutName, false, config.StdinInteractive())
+	return b.attachWorkspace(context.Background(), row, layoutName, config.StdinInteractive())
 }
 
 // LayoutNames returns the names the TUI layout cycler offers: the reserved
@@ -1660,7 +1861,12 @@ func (b *tuiBackend) InsideTmux() bool {
 	return os.Getenv("TMUX") != ""
 }
 
-func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, layoutName string, insideTmux bool, interactive bool) error {
+func (b *tuiBackend) attachWorkspace(
+	ctx context.Context,
+	row dashboard.Row,
+	layoutName string,
+	interactive bool,
+) error {
 	if row.Entry == nil && row.Workspace == nil {
 		return fmt.Errorf("no worktree selected")
 	}
@@ -1683,25 +1889,30 @@ func (b *tuiBackend) attachWorkspace(ctx context.Context, row dashboard.Row, lay
 		if err != nil {
 			return err
 		}
-		return b.ensureAndAttach(
-			ctx, sessionName, rowPaneRoot(row), layout, insideTmux,
-		)
+		endpoint, err := b.ensureWorkspace(ctx, sessionName, rowPaneRoot(row), layout)
+		if err != nil {
+			return err
+		}
+		return b.attachSession(ctx, endpoint)
 	}
-	sessionName, err := runWorktreeSessionEstablishment(
+	var endpoint tmux.SessionEndpoint
+	_, err = runWorktreeSessionEstablishment(
 		ctx,
 		row.Entry.Path,
 		row.Entry.Generation,
 		b.protectedNames,
 		func(sessionName string) error {
-			return b.ensureWorktree(
+			var establishErr error
+			endpoint, establishErr = b.ensureWorktree(
 				ctx, sessionName, row.Entry.Path, row.Entry.Generation, layout,
 			)
+			return establishErr
 		},
 	)
 	if err != nil {
 		return err
 	}
-	return b.attachSession(sessionName, insideTmux)
+	return b.attachSession(ctx, endpoint)
 }
 
 func rowPaneRoot(row dashboard.Row) string {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -1688,6 +1689,9 @@ func (b *tuiBackend) killProtectedTUIEndpoint(
 		os.Getenv("TMUX_TMPDIR"),
 	)
 	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil
+		}
 		return err
 	}
 	switch state {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -54,7 +54,8 @@ type tuiBackend struct {
 	ensureWorktree            func(context.Context, string, string, string, models.Layout) (tmux.SessionEndpoint, error)
 	attachSession             func(context.Context, tmux.SessionEndpoint) error
 	killEndpoint              func(tmux.SessionEndpoint) error
-	killProtectedEndpoint     func(context.Context, tmux.SessionEndpoint) error
+	cleanupEndpoint           func(context.Context, tmux.SessionEndpoint, tmux.WorkspaceEndpointRequest) error
+	killProtectedEndpoint     func(context.Context, tmux.SessionEndpoint, tmux.WorkspaceEndpointRequest) error
 	registerProject           func(context.Context, models.Project) error
 	registerWorkspace         func(models.Workspace) (models.Workspace, error)
 	unregisterWorkspace       func(name string) error
@@ -121,6 +122,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		now:                     time.Now,
 	}
 	backend.killEndpoint = sessions.Kill
+	backend.cleanupEndpoint = sessions.KillMatching
 	backend.killProtectedEndpoint = backend.killProtectedTUIEndpoint
 	backend.loadTargetConfig = func(repoRoot string, interactive bool) (*models.Config, error) {
 		return config.LoadForTargetFrom(backend.cfg, repoRoot, interactive)
@@ -309,6 +311,7 @@ func (b *tuiBackend) applyInventoryConfig(effective *models.Config) error {
 	b.ensureWorktree = b.workspaceSessions.EstablishWithGeneration
 	b.attachSession = b.workspaceSessions.Attach
 	b.killEndpoint = b.workspaceSessions.Kill
+	b.cleanupEndpoint = b.workspaceSessions.KillMatching
 	return nil
 }
 
@@ -1616,9 +1619,9 @@ func (b *tuiBackend) RemoveWorktree(ctx context.Context, row dashboard.Row, forc
 	for _, endpoint := range endpoints {
 		var err error
 		if endpoint.Protected {
-			err = b.killProtectedEndpoint(ctx, endpoint.Endpoint)
+			err = b.killProtectedEndpoint(ctx, endpoint.Endpoint, endpointRequest)
 		} else {
-			err = b.killEndpoint(endpoint.Endpoint)
+			err = b.cleanupEndpoint(ctx, endpoint.Endpoint, endpointRequest)
 		}
 		if err != nil {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf(
@@ -1680,6 +1683,7 @@ func (b *tuiBackend) removalEndpoints(
 func (b *tuiBackend) killProtectedTUIEndpoint(
 	ctx context.Context,
 	endpoint tmux.SessionEndpoint,
+	request tmux.WorkspaceEndpointRequest,
 ) error {
 	command, state, err := tmux.ResolveProtectedSessionCommand(
 		ctx,
@@ -1698,7 +1702,8 @@ func (b *tuiBackend) killProtectedTUIEndpoint(
 	case tmux.ProtectedSessionAbsent:
 		return nil
 	case tmux.ProtectedSessionLive:
-		return command.KillSessionIfPresentContext(ctx, endpoint.SessionName)
+		request.SessionName = endpoint.SessionName
+		return command.KillWorkspaceSessionIfMatchingContext(ctx, request)
 	default:
 		return fmt.Errorf("protected tmux session state is indeterminate")
 	}

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -53,6 +53,7 @@ type tuiBackend struct {
 	ensureWorkspace           func(context.Context, string, string, models.Layout) (tmux.SessionEndpoint, error)
 	ensureWorktree            func(context.Context, string, string, string, models.Layout) (tmux.SessionEndpoint, error)
 	attachSession             func(context.Context, tmux.SessionEndpoint) error
+	prepareResidentAttach     func(context.Context, tmux.SessionEndpoint) (*exec.Cmd, error)
 	killEndpoint              func(tmux.SessionEndpoint) error
 	cleanupEndpoint           func(context.Context, tmux.SessionEndpoint, tmux.WorkspaceEndpointRequest) error
 	killProtectedEndpoint     func(context.Context, tmux.SessionEndpoint, tmux.WorkspaceEndpointRequest) error
@@ -112,6 +113,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		ensureWorkspace:         sessions.Establish,
 		ensureWorktree:          sessions.EstablishWithGeneration,
 		attachSession:           sessions.Attach,
+		prepareResidentAttach:   sessions.PrepareResidentAttach,
 		registerProject:         registerProjectWithLifecycle,
 		registerWorkspace:       config.RegisterWorkspace,
 		unregisterWorkspace:     config.UnregisterWorkspace,
@@ -310,6 +312,7 @@ func (b *tuiBackend) applyInventoryConfig(effective *models.Config) error {
 	b.ensureWorkspace = b.workspaceSessions.Establish
 	b.ensureWorktree = b.workspaceSessions.EstablishWithGeneration
 	b.attachSession = b.workspaceSessions.Attach
+	b.prepareResidentAttach = b.workspaceSessions.PrepareResidentAttach
 	b.killEndpoint = b.workspaceSessions.Kill
 	b.cleanupEndpoint = b.workspaceSessions.KillMatching
 	return nil
@@ -1837,8 +1840,16 @@ func (b *tuiBackend) KillSession(row dashboard.Row) error {
 	return b.killEndpoint(row.TmuxEndpoint)
 }
 
-func (b *tuiBackend) OpenInTmux(ctx context.Context, row dashboard.Row, layoutName string) error {
-	return b.attachWorkspace(ctx, row, layoutName, false)
+func (b *tuiBackend) OpenInTmux(
+	ctx context.Context,
+	row dashboard.Row,
+	layoutName string,
+) (*exec.Cmd, error) {
+	endpoint, err := b.establishWorkspaceEndpoint(ctx, row, layoutName, false)
+	if err != nil {
+		return nil, err
+	}
+	return b.prepareResidentAttach(ctx, endpoint)
 }
 
 func (b *tuiBackend) AttachOutsideTmux(row dashboard.Row, layoutName string) error {
@@ -1866,33 +1877,46 @@ func (b *tuiBackend) attachWorkspace(
 	layoutName string,
 	interactive bool,
 ) error {
+	endpoint, err := b.establishWorkspaceEndpoint(ctx, row, layoutName, interactive)
+	if err != nil {
+		return err
+	}
+	return b.attachSession(ctx, endpoint)
+}
+
+func (b *tuiBackend) establishWorkspaceEndpoint(
+	ctx context.Context,
+	row dashboard.Row,
+	layoutName string,
+	interactive bool,
+) (tmux.SessionEndpoint, error) {
 	if row.Entry == nil && row.Workspace == nil {
-		return fmt.Errorf("no worktree selected")
+		return tmux.SessionEndpoint{}, fmt.Errorf("no worktree selected")
 	}
 	generation := ""
 	if row.Entry != nil {
 		generation = row.Entry.Generation
 	}
 	if err := rejectProtectedWorkspaceOpen(ctx, rowPaneRoot(row), generation); err != nil {
-		return err
+		return tmux.SessionEndpoint{}, err
 	}
 	if err := b.acknowledgeRemoteSource(rowPaneRoot(row)); err != nil {
-		return err
+		return tmux.SessionEndpoint{}, err
 	}
 	layout, err := b.resolveLayout(row, layoutName, interactive)
 	if err != nil {
-		return err
+		return tmux.SessionEndpoint{}, err
 	}
 	if row.Entry == nil {
 		sessionName, err := b.sessionName(row)
 		if err != nil {
-			return err
+			return tmux.SessionEndpoint{}, err
 		}
 		endpoint, err := b.ensureWorkspace(ctx, sessionName, rowPaneRoot(row), layout)
 		if err != nil {
-			return err
+			return tmux.SessionEndpoint{}, err
 		}
-		return b.attachSession(ctx, endpoint)
+		return endpoint, nil
 	}
 	var endpoint tmux.SessionEndpoint
 	_, err = runWorktreeSessionEstablishment(
@@ -1909,9 +1933,9 @@ func (b *tuiBackend) attachWorkspace(
 		},
 	)
 	if err != nil {
-		return err
+		return tmux.SessionEndpoint{}, err
 	}
-	return b.attachSession(ctx, endpoint)
+	return endpoint, nil
 }
 
 func rowPaneRoot(row dashboard.Row) string {

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -1985,11 +1985,11 @@ func (b *tuiBackend) resolveLayout(row dashboard.Row, layoutName string, interac
 }
 
 func (b *tuiBackend) sessionName(row dashboard.Row) (string, error) {
-	if row.SessionName != "" {
-		return row.SessionName, nil
-	}
 	if row.Workspace != nil {
 		return tmux.DirWorkspaceSessionName(row.Workspace.Name, row.Workspace.Path), nil
+	}
+	if row.SessionName != "" {
+		return row.SessionName, nil
 	}
 	if row.Entry == nil || row.Entry.RepositoryInfo == nil {
 		return "", fmt.Errorf("could not resolve repository info for %s", rowPathForHandoff(row))

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"io"
 	"path/filepath"
 	"testing"
@@ -12,8 +13,30 @@ import (
 	kwt "go.kenn.io/kwt"
 	"go.kenn.io/kwt/internal/config"
 	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+func TestTUIBackendApplyInventoryConfigRewiresCleanupResolver(t *testing.T) {
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing"))
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.liveEndpoints = func(
+		context.Context,
+		tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		return nil, errors.New("stale cleanup resolver")
+	}
+
+	err := backend.applyInventoryConfig(&models.Config{})
+	require.NoError(t, err)
+	endpoints, err := backend.liveEndpoints(
+		context.Background(),
+		tmux.WorkspaceEndpointRequest{SessionName: "workspace", WorkspacePath: "/work"},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, endpoints)
+}
 
 func TestTUIBackendMutationUsesLatestDaemonConfiguration(t *testing.T) {
 	t.Setenv("KWT_HOME", t.TempDir())
@@ -30,7 +53,7 @@ func TestTUIBackendMutationUsesLatestDaemonConfiguration(t *testing.T) {
 	runTUITestGit(t, repository, "remote", "add", "origin", "https://github.com/acme/widget.git")
 	currentBase := filepath.Join(t.TempDir(), "current")
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
 		return map[string]*models.WorktreeStatus{}, nil
 	}
@@ -74,7 +97,7 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 		Workspaces: []models.Workspace{{Name: "live", Path: "/live/workspace"}},
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "/launch")
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	var statusBaseDirectory string
 	backend.collectStatuses = func(_ context.Context, baseDirectory string, _ []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
 		statusBaseDirectory = baseDirectory
@@ -145,13 +168,87 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	require.Len(t, requests, 2)
 	assert.False(t, requests[0].RequireCurrent)
 	assert.True(t, requests[1].RequireCurrent)
+	assert.True(t, requests[0].IncludeProtectedSockets)
+	assert.True(t, requests[1].IncludeProtectedSockets)
+}
+
+func TestTUIBackendDaemonInventoryRetainsProtectedEndpoint(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.resolveSessions = func(
+		_ context.Context,
+		requests []tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSession, error) {
+		assert.Empty(t, requests, "protected workspaces must bypass shared-server resolution")
+		return nil, nil
+	}
+	var request kwt.Request
+	backend.queryInventory = func(
+		_ context.Context,
+		got kwt.Request,
+		_ bool,
+		_ io.Writer,
+	) (kwt.Result, error) {
+		request = got
+		return kwt.Result{Snapshot: kwt.Snapshot{Entries: []kwt.Entry{{
+			Path:           "/work/protected",
+			Branch:         "feature/protected",
+			Repository:     kwt.Repository{FullPath: "github.com/acme/widget", Name: "widget"},
+			SessionName:    "kwt-wt-widget-feature-protected-01234567",
+			TmuxSocketName: "kwt-pr-0123456789abcdef",
+			TmuxAttachMode: models.TmuxAttachProtected,
+		}}}}, nil
+	}
+
+	rows, _, err := backend.ListFast(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, request.IncludeProtectedSockets)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].Entry)
+	assert.True(t, rows[0].Entry.Protected)
+	assert.Equal(t, "kwt-pr-0123456789abcdef", rows[0].TmuxEndpoint.SocketName)
+	assert.Equal(t, "kwt-wt-widget-feature-protected-01234567", rows[0].TmuxEndpoint.SessionName)
+}
+
+func TestTUIBackendDaemonInventoryReusesPublishedDirectSession(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.resolveSessions = func(
+		_ context.Context,
+		requests []tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSession, error) {
+		assert.Empty(t, requests, "daemon worktrees must not be resolved twice")
+		return nil, nil
+	}
+	backend.queryInventory = func(
+		context.Context,
+		kwt.Request,
+		bool,
+		io.Writer,
+	) (kwt.Result, error) {
+		return kwt.Result{Snapshot: kwt.Snapshot{Entries: []kwt.Entry{{
+			Path:           "/work/adopted",
+			Branch:         "feature/adopted",
+			Repository:     kwt.Repository{FullPath: "github.com/acme/widget", Name: "widget"},
+			SessionName:    "kwt-wt-widget-feature-adopted-01234567",
+			SessionLive:    true,
+			TmuxAttachMode: models.TmuxAttachDirect,
+		}}}}, nil
+	}
+
+	rows, _, err := backend.ListFast(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.True(t, rows[0].SessionLive)
+	assert.Empty(t, rows[0].TmuxEndpoint.SocketName)
+	assert.Equal(t, "kwt-wt-widget-feature-adopted-01234567", rows[0].SessionName)
 }
 
 func TestTUIBackendRegistersOnlyCurrentLaunchInventory(t *testing.T) {
 	backend := newTUIBackendWithLaunchDir(&models.Config{
 		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
 	}, "/launch")
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
 		return map[string]*models.WorktreeStatus{}, nil
 	}
@@ -208,7 +305,7 @@ func TestTUIBackendCurrentInventoryIncludesNewLaunchWorkspace(t *testing.T) {
 	backend := newTUIBackendWithLaunchDir(&models.Config{
 		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
 	}, "/launch")
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, error) {
 		return map[string]*models.WorktreeStatus{}, nil
 	}

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2076,6 +2076,62 @@ func TestTUIBackendProtectedCleanupIgnoresMissingTmuxAfterRemoval(t *testing.T) 
 	require.NoError(t, err)
 }
 
+func TestTUIBackendProtectedCleanupTerminatesCanonicalAndLegacySessions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-tui-cleanup-")
+	require.NoError(t, err)
+	t.Setenv("TMUX_TMPDIR", tempDir)
+	socketName := fmt.Sprintf("kwt-pr-cleanup-%d", time.Now().UnixNano())
+	sessionName := "kwt-wt-widget-protected-01234567"
+	generation := "0123456789abcdef0123456789abcdef"
+	canonical := tmux.NewTmuxCommandForSocketWithStripNames(
+		"tmux", socketName, nil,
+	)
+	legacy := tmux.NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux", socketName, tempDir, nil,
+	)
+	t.Cleanup(func() {
+		_ = canonical.RunCommandContext(ctx, "kill-server")
+		_ = legacy.RunCommandContext(ctx, "kill-server")
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+	for _, command := range []*tmux.TmuxCommand{canonical, legacy} {
+		require.NoError(t, command.RunCommandContext(
+			ctx, "new-session", "-d", "-s", sessionName, "sleep", "60",
+		))
+		require.NoError(t, command.SetOptionContext(
+			ctx, sessionName, "@kwt-workspace-generation", generation,
+		))
+		require.NoError(t, command.SetOptionContext(
+			ctx, sessionName, "@kwt-cleanup-"+generation, "1",
+		))
+	}
+
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	err = backend.killProtectedTUIEndpoint(
+		ctx,
+		tmux.SessionEndpoint{
+			SessionName: sessionName,
+			SocketName:  socketName,
+		},
+		tmux.WorkspaceEndpointRequest{
+			SessionName:         sessionName,
+			WorkspaceGeneration: generation,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, canonical.HasSession(sessionName))
+	assert.False(t, legacy.HasSession(sessionName))
+}
+
 func TestTUIBackendRemoveWorktreeSkipsUnresolvedProtectedEndpoint(t *testing.T) {
 	repoPath := newTUITestRepo(t)
 	worktreePath := filepath.Join(t.TempDir(), "unresolved-protected-remove")

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -3977,8 +3977,8 @@ func TestTUIBackendSessionNameAndHandoffPathForWorkspaceRow(t *testing.T) {
 	name, err = backend.sessionName(row)
 
 	require.NoError(t, err)
-	assert.Equal(t, "live-session-name", name,
-		"a non-empty SessionName must win over the workspace branch")
+	assert.Equal(t, tmux.DirWorkspaceSessionName("notes", "/Users/me/notes"), name,
+		"directory workspace establishment must always request the canonical name")
 }
 
 func TestRowPaneRoot(t *testing.T) {
@@ -4329,8 +4329,12 @@ func TestTUIBackendRefusesProtectedPullRequestWorkspace(t *testing.T) {
 // detached session on the user's default tmux server merely because a unit
 // test needs to prove a workspace-only row clears the selection guard.
 func TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner(t *testing.T) {
+	workspacePath := t.TempDir()
 	row := dashboard.Row{
-		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: t.TempDir()},
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: workspacePath},
+		SessionName: tmux.DirWorkspaceSessionName(
+			"old-name", workspacePath,
+		),
 	}
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 	before := defaultTmuxSessions(t)

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -4358,6 +4358,41 @@ func TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner(t *testing.T) {
 		"the stubbed command-layer test must not add default-server tmux sessions")
 }
 
+func TestTUIBackendOpenInTmuxPreparesResidentAttach(t *testing.T) {
+	row := dashboard.Row{
+		Workspace: &dashboard.WorkspaceInfo{Name: "notes", Path: t.TempDir()},
+	}
+	endpoint := testCanonicalSessionEndpoint("workspace")
+	wantProcess := exec.Command("tmux", "attach-session", "-t", endpoint.SessionName)
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.ensureWorkspace = func(
+		context.Context,
+		string,
+		string,
+		models.Layout,
+	) (tmux.SessionEndpoint, error) {
+		return endpoint, nil
+	}
+	backend.attachSession = func(context.Context, tmux.SessionEndpoint) error {
+		t.Fatal("resident attach must not replace the Bubble Tea process")
+		return nil
+	}
+	backend.prepareResidentAttach = func(
+		_ context.Context,
+		got tmux.SessionEndpoint,
+	) (*exec.Cmd, error) {
+		assert.Equal(t, endpoint, got)
+		return wantProcess, nil
+	}
+
+	process, err := backend.OpenInTmux(
+		context.Background(), row, tmux.BlankLayoutName,
+	)
+
+	require.NoError(t, err)
+	assert.Same(t, wantProcess, process)
+}
+
 func defaultTmuxSessions(t *testing.T) []string {
 	t.Helper()
 	if _, err := exec.LookPath("tmux"); err != nil {

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1907,9 +1907,19 @@ func TestTUIBackendRemoveWorktreeKillsEveryMatchingEndpointAfterRemoval(t *testi
 		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
 	}
 	var killed []tmux.SessionEndpoint
-	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+	backend.cleanupEndpoint = func(
+		_ context.Context,
+		endpoint tmux.SessionEndpoint,
+		request tmux.WorkspaceEndpointRequest,
+	) error {
 		assert.True(t, removed, "sessions must remain live until removal succeeds")
+		assert.Equal(t, worktreePath, request.WorkspacePath)
+		assert.Equal(t, generation, request.WorkspaceGeneration)
 		killed = append(killed, endpoint)
+		return nil
+	}
+	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		t.Fatalf("post-removal cleanup used unconditional kill: %+v", endpoint)
 		return nil
 	}
 
@@ -1964,7 +1974,11 @@ func TestTUIBackendRemoveWorktreeSweepsSessionsCreatedDuringRemoval(t *testing.T
 		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
 	}
 	var killed []tmux.SessionEndpoint
-	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+	backend.cleanupEndpoint = func(
+		_ context.Context,
+		endpoint tmux.SessionEndpoint,
+		_ tmux.WorkspaceEndpointRequest,
+	) error {
 		killed = append(killed, endpoint)
 		return nil
 	}
@@ -2015,7 +2029,11 @@ func TestTUIBackendRemoveWorktreeCleansProtectedEndpointWithoutSharedLiveness(t 
 		removed = true
 		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
 	}
-	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+	backend.cleanupEndpoint = func(
+		_ context.Context,
+		endpoint tmux.SessionEndpoint,
+		_ tmux.WorkspaceEndpointRequest,
+	) error {
 		t.Fatalf("protected endpoint routed through ordinary cleanup: %+v", endpoint)
 		return nil
 	}
@@ -2023,8 +2041,11 @@ func TestTUIBackendRemoveWorktreeCleansProtectedEndpointWithoutSharedLiveness(t 
 	backend.killProtectedEndpoint = func(
 		_ context.Context,
 		endpoint tmux.SessionEndpoint,
+		request tmux.WorkspaceEndpointRequest,
 	) error {
 		assert.True(t, removed)
+		assert.Equal(t, worktreePath, request.WorkspacePath)
+		assert.Equal(t, generation, request.WorkspaceGeneration)
 		killed = append(killed, endpoint)
 		return nil
 	}
@@ -2044,6 +2065,11 @@ func TestTUIBackendProtectedCleanupIgnoresMissingTmuxAfterRemoval(t *testing.T) 
 		tmux.SessionEndpoint{
 			SessionName: "kwt-wt-widget-protected-01234567",
 			SocketName:  "kwt-pr-protected-01234567",
+		},
+		tmux.WorkspaceEndpointRequest{
+			SessionName:         "kwt-wt-widget-protected-01234567",
+			WorkspacePath:       "/work/widget",
+			WorkspaceGeneration: "0123456789abcdef0123456789abcdef",
 		},
 	)
 
@@ -2083,13 +2109,18 @@ func TestTUIBackendRemoveWorktreeSkipsUnresolvedProtectedEndpoint(t *testing.T) 
 	) (kwt.RemovalResult, error) {
 		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
 	}
-	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+	backend.cleanupEndpoint = func(
+		_ context.Context,
+		endpoint tmux.SessionEndpoint,
+		_ tmux.WorkspaceEndpointRequest,
+	) error {
 		t.Fatalf("unresolved protected row routed through ordinary cleanup: %+v", endpoint)
 		return nil
 	}
 	backend.killProtectedEndpoint = func(
 		_ context.Context,
 		endpoint tmux.SessionEndpoint,
+		_ tmux.WorkspaceEndpointRequest,
 	) error {
 		t.Fatalf("unresolved protected row routed through protected cleanup: %+v", endpoint)
 		return nil

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -37,6 +37,19 @@ import (
 	"go.kenn.io/kwt/service"
 )
 
+func resolveStoppedWorkspaceSessions(
+	_ context.Context,
+	requests []tmux.WorkspaceEndpointRequest,
+) ([]tmux.WorkspaceSession, error) {
+	sessions := make([]tmux.WorkspaceSession, len(requests))
+	for index, request := range requests {
+		sessions[index] = tmux.WorkspaceSession{
+			Endpoint: testCanonicalSessionEndpoint(request.SessionName),
+		}
+	}
+	return sessions, nil
+}
+
 func TestTUICmdIsolatesFromCwdConfig(t *testing.T) {
 	require.NotNil(t, tuiCmd.PersistentPreRunE,
 		"tui must define its own PersistentPreRunE to bypass root's cwd merge")
@@ -157,7 +170,7 @@ func TestBuildTUIRowSkipsSessionNameWhenRepositoryInfoMissing(t *testing.T) {
 	}
 	status := &models.WorktreeStatus{Path: entry.Path, Branch: entry.Branch}
 
-	row := buildTUIRow(entry, status, map[string]bool{"": true})
+	row := buildTUIRow(entry, status, tmux.WorkspaceSession{})
 
 	assert.Equal(t, entry, row.Entry)
 	assert.Equal(t, status, row.Status)
@@ -173,14 +186,18 @@ func TestBuildTUIRowMarksLiveSessionWhenRepositoryInfoPresent(t *testing.T) {
 	}
 	status := &models.WorktreeStatus{Path: entry.Path, Branch: entry.Branch}
 
-	row := buildTUIRow(entry, status, map[string]bool{
-		"kwt-workspace-github-com-example-kwt-feature-": false,
-	})
+	endpoint := testCanonicalSessionEndpoint(
+		tmux.WorkspaceSessionName(entry.RepositoryInfo, entry.Branch, entry.Path),
+	)
+	row := buildTUIRow(entry, status, tmux.WorkspaceSession{Endpoint: endpoint})
 
 	assert.NotEmpty(t, row.SessionName)
 	assert.False(t, row.SessionLive)
 
-	row = buildTUIRow(entry, status, map[string]bool{row.SessionName: true})
+	row = buildTUIRow(entry, status, tmux.WorkspaceSession{
+		Endpoint: endpoint,
+		Live:     true,
+	})
 	assert.True(t, row.SessionLive)
 }
 
@@ -273,7 +290,7 @@ func TestTUIBackendListAndMergeFleetAreConcurrencySafe(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	// Read cfg.Projects the way the manifest builder does during publish.
 	backend.readFleetState = func(ctx context.Context, cfg *models.Config) (fleet.FleetState, error) {
 		for _, project := range cfg.Projects {
@@ -333,7 +350,7 @@ func TestTUIBackendListIncludesLaunchRepositoryWorktrees(t *testing.T) {
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch, IsCurrent: true},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -371,7 +388,7 @@ func TestTUIBackendListFastSkipsStatusCollection(t *testing.T) {
 		t.Fatal("fast listing must not collect Git status")
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.ListFast(context.Background())
 
@@ -412,7 +429,7 @@ func TestTUIBackendListCollectsStatusForImportedWorktree(t *testing.T) {
 			},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -428,7 +445,7 @@ func TestTUIBackendListFastRunsIndependentDiscoveryConcurrently(t *testing.T) {
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, "/launch")
 	stubTUIProjectRegistration(backend)
-	started := make(chan string, 4)
+	started := make(chan string, 3)
 	release := make(chan struct{})
 	block := func(name string) {
 		started <- name
@@ -446,17 +463,14 @@ func TestTUIBackendListFastRunsIndependentDiscoveryConcurrently(t *testing.T) {
 		block("launch")
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) {
-		block("sessions")
-		return nil, nil
-	}
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	done := make(chan error, 1)
 	go func() {
 		_, _, err := backend.ListFast(context.Background())
 		done <- err
 	}()
 
-	for range 4 {
+	for range 3 {
 		select {
 		case <-started:
 		case <-time.After(2 * time.Second):
@@ -515,7 +529,7 @@ func TestTUIBackendListIncludesRegisteredProjectWorktrees(t *testing.T) {
 			projectEntry.Path: {Path: projectEntry.Path, Branch: projectEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -558,7 +572,7 @@ func TestTUIBackendListPropagatesIncompleteRegisteredProjectInventory(
 	) ([]*discovery.GlobalWorktreeEntry, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.ListFast(context.Background())
 
@@ -695,7 +709,7 @@ func TestTUIBackendMergeFleetIncludesRemoteOnlyFleetRows(t *testing.T) {
 			localEntry.Path: {Path: localEntry.Path, Branch: localEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
 		return fleet.FleetState{Rows: []fleet.FleetRow{
 			{
@@ -771,7 +785,7 @@ func TestTUIBackendMergeFleetDoesNotOfferSyncWithoutRegisteredProject(t *testing
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
 		return fleet.FleetState{Rows: []fleet.FleetRow{{
 			ProjectIdentity: "github.com/example/kwt",
@@ -836,7 +850,7 @@ func TestTUIBackendMergeFleetLocalPresenceComesFromLocalDiscovery(t *testing.T) 
 			localEntry.Path: {Path: localEntry.Path, Branch: localEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
 		return fleet.FleetState{Rows: []fleet.FleetRow{
 			{
@@ -941,7 +955,7 @@ func TestTUIBackendMergeFleetRendersFleetStatusFromLocalObservations(t *testing.
 			localEntry.Path: {Path: localEntry.Path, Branch: localEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
 		return fleet.FleetState{Rows: []fleet.FleetRow{
 			{
@@ -1041,7 +1055,7 @@ func TestTUIBackendMergeFleetMatchesLocalDetachedWorktreeToFleetRow(t *testing.T
 			detachedEntry.Path: {Path: detachedEntry.Path},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
 		return fleet.FleetState{Rows: []fleet.FleetRow{{
 			ProjectIdentity: "github.com/example/kwt",
@@ -1093,7 +1107,7 @@ func TestTUIBackendListIncludesRegisteredProjectWithoutOrigin(t *testing.T) {
 			entries[0].Path: {Path: entries[0].Path, Branch: entries[0].Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -1152,7 +1166,7 @@ func TestTUIBackendListPrefersRegisteredIdentityForGlobalLocalOnlyDuplicate(t *t
 			entries[0].Path: {Path: entries[0].Path, Branch: entries[0].Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -1200,7 +1214,7 @@ func TestTUIBackendListRegistersLaunchRepositoryBestEffort(t *testing.T) {
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -1244,7 +1258,7 @@ func TestTUIBackendRegistersLaunchRepositoryOnceAcrossStagedLoad(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	_, _, err := backend.ListFast(context.Background())
 	require.NoError(t, err)
@@ -1289,7 +1303,7 @@ func TestTUIBackendListAddsLaunchRepositoryToInMemoryProjects(t *testing.T) {
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	rows, _, err := backend.List(context.Background())
 
@@ -1341,7 +1355,7 @@ func TestTUIBackendLaunchRegistrationReusesExistingProjectByPath(t *testing.T) {
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch},
 		}, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 
 	_, _, err := backend.List(context.Background())
 
@@ -1757,8 +1771,14 @@ func TestTUIBackendRemoveWorktreeDelegatesToDaemon(t *testing.T) {
 	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
 	row := dashboard.Row{Entry: &discovery.GlobalWorktreeEntry{
 		Path: worktreePath, Branch: "daemon-tui-remove", Generation: generation,
-	}}
+	}, SessionName: "workspace"}
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.liveEndpoints = func(
+		context.Context,
+		tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		return nil, nil
+	}
 	var request kwt.RemovalRequest
 	backend.removeWorktree = func(
 		_ context.Context,
@@ -1779,10 +1799,302 @@ func TestTUIBackendRemoveWorktreeDelegatesToDaemon(t *testing.T) {
 	assert.DirExists(t, worktreePath, "only the daemon service may perform the mutation")
 }
 
+func TestTUIBackendRemoveWorktreeDoesNotGateMutationOnCleanupInspection(t *testing.T) {
+	t.Setenv("KWT_HOME", t.TempDir())
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "cleanup-inspection-remove")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "cleanup-inspection-remove", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	row := dashboard.Row{
+		Entry: &discovery.GlobalWorktreeEntry{
+			Path: worktreePath, Branch: "cleanup-inspection-remove", Generation: generation,
+		},
+		SessionName: "kwt-wt-widget-cleanup-01234567",
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	removed := false
+	backend.removeWorktree = func(
+		_ context.Context,
+		request kwt.RemovalRequest,
+	) (kwt.RemovalResult, error) {
+		removed = true
+		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
+	}
+	backend.liveEndpoints = func(
+		context.Context,
+		tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		return nil, errors.New("tmux inventory unavailable")
+	}
+
+	err := backend.RemoveWorktree(context.Background(), row, false)
+
+	assert.True(t, removed)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "tmux inventory unavailable")
+	assert.True(t, git.WorktreeWasRemoved(err),
+		"the TUI must refresh after removal even when cleanup inspection fails")
+}
+
+func TestTUIBackendDashboardKeepsRowsWhenOneSessionIsUnsafe(t *testing.T) {
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.resolveSessions = bestEffortDashboardSessionResolver(func(
+		context.Context,
+		[]tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSessionResolution, error) {
+		return []tmux.WorkspaceSessionResolution{
+			{
+				Session: tmux.WorkspaceSession{Endpoint: testCanonicalSessionEndpoint("stale")},
+				Err:     errors.New("session belongs to a different worktree generation"),
+			},
+			{
+				Session: tmux.WorkspaceSession{
+					Endpoint: testCanonicalSessionEndpoint("live"),
+					Live:     true,
+				},
+			},
+		}, nil
+	}, nil)
+	entries := []*discovery.GlobalWorktreeEntry{
+		{Path: "/work/stale", TmuxEndpoint: tmux.SessionEndpoint{SessionName: "stale"}},
+		{Path: "/work/live", TmuxEndpoint: tmux.SessionEndpoint{SessionName: "live"}},
+	}
+
+	sessions, _, err := backend.resolveDashboardSessions(context.Background(), entries, nil)
+
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+	assert.Equal(t, testCanonicalSessionEndpoint("stale"), sessions[0].Endpoint)
+	assert.False(t, sessions[0].Live)
+	assert.Equal(t, testCanonicalSessionEndpoint("live"), sessions[1].Endpoint)
+	assert.True(t, sessions[1].Live)
+}
+
+func TestTUIBackendRemoveWorktreeKillsEveryMatchingEndpointAfterRemoval(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "duplicate-session-remove")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "duplicate-session-remove", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	sessionName := "kwt-wt-widget-duplicate-01234567"
+	row := dashboard.Row{
+		Entry: &discovery.GlobalWorktreeEntry{
+			Path: worktreePath, Branch: "duplicate-session-remove", Generation: generation,
+		},
+		SessionName:  sessionName,
+		SessionLive:  true,
+		TmuxEndpoint: testCanonicalSessionEndpoint(sessionName),
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	removed := false
+	backend.liveEndpoints = func(
+		_ context.Context,
+		request tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		assert.True(t, removed, "cleanup discovery must not gate removal")
+		assert.Equal(t, sessionName, request.SessionName)
+		assert.Equal(t, worktreePath, request.WorkspacePath)
+		assert.Equal(t, generation, request.WorkspaceGeneration)
+		return []tmux.SessionEndpoint{
+			testCanonicalSessionEndpoint(sessionName),
+			{SessionName: sessionName},
+		}, nil
+	}
+	backend.removeWorktree = func(
+		_ context.Context,
+		request kwt.RemovalRequest,
+	) (kwt.RemovalResult, error) {
+		removed = true
+		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
+	}
+	var killed []tmux.SessionEndpoint
+	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		assert.True(t, removed, "sessions must remain live until removal succeeds")
+		killed = append(killed, endpoint)
+		return nil
+	}
+
+	err := backend.RemoveWorktree(context.Background(), row, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, []tmux.SessionEndpoint{
+		testCanonicalSessionEndpoint(sessionName),
+		{SessionName: sessionName},
+	}, killed)
+}
+
+func TestTUIBackendRemoveWorktreeSweepsSessionsCreatedDuringRemoval(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "racing-session-remove")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "racing-session-remove", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	sessionName := "kwt-wt-widget-racing-01234567"
+	lateSessionName := "kwt-wt-widget-previous-89abcdef"
+	row := dashboard.Row{
+		Entry: &discovery.GlobalWorktreeEntry{
+			Path: worktreePath, Branch: "racing-session-remove", Generation: generation,
+		},
+		SessionName:  sessionName,
+		SessionLive:  true,
+		TmuxEndpoint: testCanonicalSessionEndpoint(sessionName),
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	removed := false
+	inspections := 0
+	backend.liveEndpoints = func(
+		_ context.Context,
+		request tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		inspections++
+		assert.Equal(t, sessionName, request.SessionName)
+		assert.Equal(t, worktreePath, request.WorkspacePath)
+		assert.Equal(t, generation, request.WorkspaceGeneration)
+		if !removed {
+			return []tmux.SessionEndpoint{testCanonicalSessionEndpoint(sessionName)}, nil
+		}
+		return []tmux.SessionEndpoint{
+			testCanonicalSessionEndpoint(sessionName),
+			{SessionName: lateSessionName},
+		}, nil
+	}
+	backend.removeWorktree = func(
+		_ context.Context,
+		request kwt.RemovalRequest,
+	) (kwt.RemovalResult, error) {
+		removed = true
+		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
+	}
+	var killed []tmux.SessionEndpoint
+	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		killed = append(killed, endpoint)
+		return nil
+	}
+
+	err := backend.RemoveWorktree(context.Background(), row, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, inspections)
+	assert.Equal(t, []tmux.SessionEndpoint{
+		testCanonicalSessionEndpoint(sessionName),
+		{SessionName: lateSessionName},
+	}, killed)
+}
+
+func TestTUIBackendRemoveWorktreeCleansProtectedEndpointWithoutSharedLiveness(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "protected-session-remove")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "protected-session-remove", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	protectedEndpoint := tmux.SessionEndpoint{
+		SessionName: "kwt-wt-widget-protected-01234567",
+		SocketName:  "kwt-pr-protected-01234567",
+	}
+	row := dashboard.Row{
+		Entry: &discovery.GlobalWorktreeEntry{
+			Path:         worktreePath,
+			Branch:       "protected-session-remove",
+			Generation:   generation,
+			Protected:    true,
+			TmuxEndpoint: protectedEndpoint,
+		},
+		SessionName:  protectedEndpoint.SessionName,
+		SessionLive:  false,
+		TmuxEndpoint: protectedEndpoint,
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.liveEndpoints = func(
+		context.Context,
+		tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		return nil, nil
+	}
+	removed := false
+	backend.removeWorktree = func(
+		_ context.Context,
+		request kwt.RemovalRequest,
+	) (kwt.RemovalResult, error) {
+		removed = true
+		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
+	}
+	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		t.Fatalf("protected endpoint routed through ordinary cleanup: %+v", endpoint)
+		return nil
+	}
+	var killed []tmux.SessionEndpoint
+	backend.killProtectedEndpoint = func(
+		_ context.Context,
+		endpoint tmux.SessionEndpoint,
+	) error {
+		assert.True(t, removed)
+		killed = append(killed, endpoint)
+		return nil
+	}
+
+	err := backend.RemoveWorktree(context.Background(), row, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, []tmux.SessionEndpoint{protectedEndpoint}, killed)
+}
+
+func TestTUIBackendRemoveWorktreeSkipsUnresolvedProtectedEndpoint(t *testing.T) {
+	repoPath := newTUITestRepo(t)
+	worktreePath := filepath.Join(t.TempDir(), "unresolved-protected-remove")
+	runTUITestGit(t, repoPath, "worktree", "add", "-b", "unresolved-protected-remove", worktreePath)
+	generation := tuiTestWorktreeGeneration(t, repoPath, worktreePath)
+	row := dashboard.Row{
+		Entry: &discovery.GlobalWorktreeEntry{
+			Path:       worktreePath,
+			Branch:     "unresolved-protected-remove",
+			Generation: generation,
+			Protected:  true,
+			TmuxEndpoint: tmux.SessionEndpoint{
+				SessionName: "kwt-wt-widget-unverified-01234567",
+			},
+		},
+		SessionName: "kwt-wt-widget-unverified-01234567",
+		TmuxEndpoint: tmux.SessionEndpoint{
+			SessionName: "kwt-wt-widget-unverified-01234567",
+		},
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	backend.liveEndpoints = func(
+		context.Context,
+		tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		return nil, nil
+	}
+	backend.removeWorktree = func(
+		_ context.Context,
+		request kwt.RemovalRequest,
+	) (kwt.RemovalResult, error) {
+		return kwt.RemovalResult{Path: request.Path, WorktreeRemoved: true}, nil
+	}
+	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		t.Fatalf("unresolved protected row routed through ordinary cleanup: %+v", endpoint)
+		return nil
+	}
+	backend.killProtectedEndpoint = func(
+		_ context.Context,
+		endpoint tmux.SessionEndpoint,
+	) error {
+		t.Fatalf("unresolved protected row routed through protected cleanup: %+v", endpoint)
+		return nil
+	}
+
+	err := backend.RemoveWorktree(context.Background(), row, false)
+
+	require.NoError(t, err)
+}
+
 func useInProcessTUIRemoval(t *testing.T, backend *tuiBackend) {
 	t.Helper()
 	home, err := config.CanonicalHome()
 	require.NoError(t, err)
+	backend.liveEndpoints = func(
+		context.Context,
+		tmux.WorkspaceEndpointRequest,
+	) ([]tmux.SessionEndpoint, error) {
+		return nil, nil
+	}
 	backend.removeWorktree = kwt.NewRemovalService(
 		kwt.RemovalServiceOptions{Home: home},
 	).Remove
@@ -3195,7 +3507,7 @@ func TestTUIBackendRemovesLaunchWorktreeOutsideGlobalBase(t *testing.T) {
 	}
 	backend := newTUIBackendWithLaunchDir(cfg, repoPath)
 	useInProcessTUIRemoval(t, backend)
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.registerProject = func(context.Context, models.Project) error { return nil }
 	backend.registerWorkspace = func(
 		workspace models.Workspace,
@@ -3317,7 +3629,7 @@ func TestTUIBackendMergeFleetReturnsHubWarnings(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.readFleetState = func(context.Context, *models.Config) (fleet.FleetState, error) {
 		return fleet.FleetState{Warnings: []fleet.Warning{{
 			Code:    "host_id_collision",
@@ -3353,7 +3665,16 @@ func TestTUIBackendListIncludesWorkspaceRows(t *testing.T) {
 		return nil, nil
 	}
 	liveSession := tmux.DirWorkspaceSessionName("old-name", dir)
-	backend.listSessions = func() ([]string, error) { return []string{liveSession}, nil }
+	backend.resolveSessions = func(
+		_ context.Context,
+		requests []tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSession, error) {
+		require.Len(t, requests, 1)
+		return []tmux.WorkspaceSession{{
+			Endpoint: testCanonicalSessionEndpoint(liveSession),
+			Live:     true,
+		}}, nil
+	}
 
 	rows, _, err := backend.List(context.Background())
 
@@ -3385,7 +3706,7 @@ func TestTUIBackendAutoRegistersNonGitLaunchDir(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	var registered []models.Workspace
 	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
 		registered = append(registered, workspace)
@@ -3417,7 +3738,7 @@ func TestTUIBackendSkipsAutoRegisterWhenAlreadyRegisteredWithCustomName(t *testi
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	called := false
 	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
 		called = true
@@ -3448,7 +3769,7 @@ func TestTUIBackendAutoRegistersLaunchWorkspaceOnlyOnce(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	registrations := 0
 	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
 		registrations++
@@ -3497,7 +3818,7 @@ func TestTUIBackendNeverRegistersWorkspaceForGitLaunchDir(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
 		t.Fatalf("a git launch directory must never be registered as a workspace, got %v", workspace)
 		return workspace, nil
@@ -3526,7 +3847,7 @@ func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
 	) (map[string]*models.WorktreeStatus, error) {
 		return nil, nil
 	}
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.registerWorkspace = func(workspace models.Workspace) (models.Workspace, error) {
 		t.Fatalf("home directory must never be auto-registered, got %v", workspace)
 		return workspace, nil
@@ -3600,10 +3921,86 @@ func TestTUIBackendCarriesConfiguredCredentialName(t *testing.T) {
 func TestTUIBackendAttachWorkspaceGuardRejectsEmptyRow(t *testing.T) {
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 
-	err := backend.attachWorkspace(context.Background(), dashboard.Row{}, "", false, false)
+	err := backend.attachWorkspace(context.Background(), dashboard.Row{}, "", false)
 
 	require.Error(t, err)
 	assert.Equal(t, "no worktree selected", err.Error())
+}
+
+func TestTUIKillSessionUsesEndpointRetainedByRow(t *testing.T) {
+	want := tmux.SessionEndpoint{
+		SessionName: "workspace",
+	}
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+	var killed tmux.SessionEndpoint
+	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		killed = endpoint
+		return nil
+	}
+
+	err := backend.KillSession(dashboard.Row{
+		SessionName:  "workspace",
+		SessionLive:  true,
+		TmuxEndpoint: want,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, want, killed)
+}
+
+func TestDashboardInventoryEntryClassifiesProtectionFromWireMode(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		socketName string
+		attachMode models.TmuxAttachMode
+		protected  bool
+	}{
+		{
+			name:       "protected mode with ordinary-looking socket",
+			socketName: tmux.KWTServerSocketName,
+			attachMode: models.TmuxAttachProtected,
+			protected:  true,
+		},
+		{
+			name:       "direct mode with protected-looking socket",
+			socketName: "kwt-pr-not-authoritative",
+			attachMode: models.TmuxAttachDirect,
+			protected:  false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			entry := dashboardInventoryEntry(kwt.Entry{
+				SessionName:    "workspace",
+				TmuxSocketName: test.socketName,
+				TmuxAttachMode: test.attachMode,
+			})
+
+			assert.Equal(t, test.protected, entry.Protected)
+			assert.Equal(t, test.socketName, entry.TmuxEndpoint.SocketName)
+		})
+	}
+}
+
+func TestDashboardInventoryRowRetainsAdoptedEndpoint(t *testing.T) {
+	entry := kwt.Entry{
+		Path:           "/work/widget",
+		SessionName:    "workspace",
+		TmuxAttachMode: models.TmuxAttachDirect,
+	}
+
+	row := buildTUIRow(
+		dashboardInventoryEntry(entry),
+		&models.WorktreeStatus{},
+		tmux.WorkspaceSession{
+			Endpoint: tmux.SessionEndpoint{
+				SessionName: "workspace",
+			},
+			Live: true,
+		},
+	)
+
+	assert.Empty(t, row.TmuxEndpoint.SocketName)
+	assert.True(t, row.SessionLive)
 }
 
 func TestTUIWorktreeAttachCannotRaceGuardedRemoval(t *testing.T) {
@@ -3654,12 +4051,12 @@ func TestTUIWorktreeAttachCannotRaceGuardedRemoval(t *testing.T) {
 	ensureCalled := make(chan struct{}, 1)
 	attachCalled := make(chan struct{}, 1)
 	backend.ensureWorktree = func(
-		context.Context, string, string, string, models.Layout,
-	) error {
+		_ context.Context, session string, _ string, _ string, _ models.Layout,
+	) (tmux.SessionEndpoint, error) {
 		ensureCalled <- struct{}{}
-		return nil
+		return testCanonicalSessionEndpoint(session), nil
 	}
-	backend.attachSession = func(string, bool) error {
+	backend.attachSession = func(context.Context, tmux.SessionEndpoint) error {
 		attachCalled <- struct{}{}
 		return nil
 	}
@@ -3672,7 +4069,6 @@ func TestTUIWorktreeAttachCannotRaceGuardedRemoval(t *testing.T) {
 				RepositoryInfo: &url.RepositoryInfo{FullPath: repoPath},
 			}},
 			tmux.BlankLayoutName,
-			false,
 			false,
 		)
 	}()
@@ -3712,12 +4108,12 @@ func TestTUIWorktreeAttachUsesBranchObservedInsideLifecycleGuard(t *testing.T) {
 	var attachedSession string
 	backend.ensureWorktree = func(
 		_ context.Context, session string, _, _ string, _ models.Layout,
-	) error {
+	) (tmux.SessionEndpoint, error) {
 		ensuredSession = session
-		return nil
+		return testCanonicalSessionEndpoint(session), nil
 	}
-	backend.attachSession = func(session string, _ bool) error {
-		attachedSession = session
+	backend.attachSession = func(_ context.Context, endpoint tmux.SessionEndpoint) error {
+		attachedSession = endpoint.SessionName
 		return nil
 	}
 	originalBeforeAcquire := beforeProjectGuardAcquire
@@ -3739,7 +4135,6 @@ func TestTUIWorktreeAttachUsesBranchObservedInsideLifecycleGuard(t *testing.T) {
 		}},
 		tmux.BlankLayoutName,
 		false,
-		false,
 	)
 
 	require.NoError(t, err)
@@ -3757,17 +4152,17 @@ func TestTUIBackendAttachAcknowledgesRemoteSourceBeforeWorkspaceLaunch(t *testin
 		return nil
 	}
 	launched := false
-	backend.ensureAndAttach = func(
-		context.Context,
-		string,
-		string,
-		models.Layout,
-		bool,
-	) error {
+	backend.ensureWorkspace = func(
+		_ context.Context,
+		session string,
+		_ string,
+		_ models.Layout,
+	) (tmux.SessionEndpoint, error) {
 		launched = true
 		assert.Equal(t, workspacePath, acknowledged)
-		return nil
+		return testCanonicalSessionEndpoint(session), nil
 	}
+	backend.attachSession = func(context.Context, tmux.SessionEndpoint) error { return nil }
 
 	err := backend.attachWorkspace(
 		context.Background(),
@@ -3776,7 +4171,6 @@ func TestTUIBackendAttachAcknowledgesRemoteSourceBeforeWorkspaceLaunch(t *testin
 			Path: workspacePath,
 		}},
 		tmux.BlankLayoutName,
-		false,
 		false,
 	)
 
@@ -3801,15 +4195,14 @@ func TestTUIBackendRefusesProtectedPullRequestWorkspace(t *testing.T) {
 	))
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 	called := false
-	backend.ensureAndAttach = func(
+	backend.ensureWorkspace = func(
 		context.Context,
 		string,
 		string,
 		models.Layout,
-		bool,
-	) error {
+	) (tmux.SessionEndpoint, error) {
 		called = true
-		return nil
+		return tmux.SessionEndpoint{}, nil
 	}
 
 	err := backend.attachWorkspace(
@@ -3821,7 +4214,6 @@ func TestTUIBackendRefusesProtectedPullRequestWorkspace(t *testing.T) {
 			},
 		},
 		tmux.BlankLayoutName,
-		false,
 		false,
 	)
 
@@ -3843,25 +4235,23 @@ func TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner(t *testing.T) {
 
 	var gotSession, gotRoot string
 	var gotLayout models.Layout
-	var gotInsideTmux bool
-	backend.ensureAndAttach = func(
-		ctx context.Context,
+	backend.ensureWorkspace = func(
+		_ context.Context,
 		session, root string,
 		layout models.Layout,
-		insideTmux bool,
-	) error {
+	) (tmux.SessionEndpoint, error) {
 		gotSession, gotRoot = session, root
-		gotLayout, gotInsideTmux = layout, insideTmux
-		return nil
+		gotLayout = layout
+		return testCanonicalSessionEndpoint(session), nil
 	}
+	backend.attachSession = func(context.Context, tmux.SessionEndpoint) error { return nil }
 
-	err := backend.attachWorkspace(context.Background(), row, tmux.BlankLayoutName, false, false)
+	err := backend.attachWorkspace(context.Background(), row, tmux.BlankLayoutName, false)
 
 	require.NoError(t, err)
 	assert.Equal(t, tmux.DirWorkspaceSessionName("notes", row.Workspace.Path), gotSession)
 	assert.Equal(t, row.Workspace.Path, gotRoot)
 	assert.Equal(t, tmux.BlankLayout(), gotLayout)
-	assert.False(t, gotInsideTmux)
 	assert.Equal(t, before, defaultTmuxSessions(t),
 		"the stubbed command-layer test must not add default-server tmux sessions")
 }
@@ -4015,7 +4405,7 @@ func TestTUIBackendSerializesUnregisterWithFullLoad(t *testing.T) {
 	backend.discoverGlobalWorktrees = noEntries
 	backend.discoverProjectWorktrees = noEntries
 	backend.discoverLaunchWorktrees = noEntries
-	backend.listSessions = func() ([]string, error) { return nil, nil }
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	backend.unregisterWorkspace = func(string) error { return nil }
 
 	collecting := make(chan struct{})

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -50,6 +50,14 @@ func resolveStoppedWorkspaceSessions(
 	return sessions, nil
 }
 
+func requireTUIBackendStateLocked(t *testing.T, backend *tuiBackend) {
+	t.Helper()
+	if backend.mu.TryLock() {
+		backend.mu.Unlock()
+		t.Fatal("TUI backend operation read mutable state without holding its mutex")
+	}
+}
+
 func TestTUICmdIsolatesFromCwdConfig(t *testing.T) {
 	require.NotNil(t, tuiCmd.PersistentPreRunE,
 		"tui must define its own PersistentPreRunE to bypass root's cwd merge")
@@ -1784,6 +1792,7 @@ func TestTUIBackendRemoveWorktreeDelegatesToDaemon(t *testing.T) {
 		_ context.Context,
 		input kwt.RemovalRequest,
 	) (kwt.RemovalResult, error) {
+		requireTUIBackendStateLocked(t, backend)
 		request = input
 		return kwt.RemovalResult{
 			Path: input.Path, Branch: "daemon-tui-remove", WorktreeRemoved: true,
@@ -4036,6 +4045,7 @@ func TestTUIKillSessionUsesEndpointRetainedByRow(t *testing.T) {
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 	var killed tmux.SessionEndpoint
 	backend.killEndpoint = func(endpoint tmux.SessionEndpoint) error {
+		requireTUIBackendStateLocked(t, backend)
 		killed = endpoint
 		return nil
 	}
@@ -4346,13 +4356,14 @@ func TestTUIBackendAttachWorkspacePassesWorkspaceRowToRunner(t *testing.T) {
 		session, root string,
 		layout models.Layout,
 	) (tmux.SessionEndpoint, error) {
+		requireTUIBackendStateLocked(t, backend)
 		gotSession, gotRoot = session, root
 		gotLayout = layout
 		return testCanonicalSessionEndpoint(session), nil
 	}
 	backend.attachSession = func(context.Context, tmux.SessionEndpoint) error { return nil }
 
-	err := backend.attachWorkspace(context.Background(), row, tmux.BlankLayoutName, false)
+	err := backend.AttachOutsideTmux(row, tmux.BlankLayoutName)
 
 	require.NoError(t, err)
 	assert.Equal(t, tmux.DirWorkspaceSessionName("notes", row.Workspace.Path), gotSession)

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2035,6 +2035,21 @@ func TestTUIBackendRemoveWorktreeCleansProtectedEndpointWithoutSharedLiveness(t 
 	assert.Equal(t, []tmux.SessionEndpoint{protectedEndpoint}, killed)
 }
 
+func TestTUIBackendProtectedCleanupIgnoresMissingTmuxAfterRemoval(t *testing.T) {
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing"))
+	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
+
+	err := backend.killProtectedTUIEndpoint(
+		context.Background(),
+		tmux.SessionEndpoint{
+			SessionName: "kwt-wt-widget-protected-01234567",
+			SocketName:  "kwt-pr-protected-01234567",
+		},
+	)
+
+	require.NoError(t, err)
+}
+
 func TestTUIBackendRemoveWorktreeSkipsUnresolvedProtectedEndpoint(t *testing.T) {
 	repoPath := newTUITestRepo(t)
 	worktreePath := filepath.Join(t.TempDir(), "unresolved-protected-remove")

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,13 +18,27 @@ var (
 	workspaceAddName string
 	workspaceJSON    bool
 
-	registerWorkspace     = config.RegisterWorkspace
-	unregisterWorkspace   = config.UnregisterWorkspace
-	loadWorkspaceConfig   = config.Load
-	listWorkspaceSessions = func() ([]string, error) {
-		return tmux.NewTmuxCommand("").ListSessions()
-	}
+	registerWorkspace        = config.RegisterWorkspace
+	unregisterWorkspace      = config.UnregisterWorkspace
+	loadWorkspaceConfig      = config.Load
+	resolveDirectorySessions = resolveRegisteredDirectorySessions
 )
+
+func resolveRegisteredDirectorySessions(
+	workspaces []models.Workspace,
+) ([]tmux.WorkspaceSession, error) {
+	requests := make([]tmux.WorkspaceEndpointRequest, len(workspaces))
+	for index, workspace := range workspaces {
+		requests[index] = tmux.WorkspaceEndpointRequest{
+			SessionName:   tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+			WorkspacePath: workspace.Path,
+		}
+	}
+	return newCommandWorkspaceSessions(nil, os.Stderr).ResolveAll(
+		context.Background(),
+		requests,
+	)
+}
 
 var workspaceCmd = &cobra.Command{
 	Use:   "workspace",
@@ -96,11 +111,11 @@ func runWorkspaceList(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no workspaces registered")
 		return nil
 	}
-	sessions, err := listWorkspaceSessions()
+	sessions, err := resolveDirectorySessions(cfg.Workspaces)
 	if err != nil {
 		return fmt.Errorf("failed to list tmux sessions: %w", err)
 	}
-	records := directoryWorkspaceRecords(cfg.Workspaces, sessions)
+	records := directoryWorkspaceRecordsFromSessions(cfg.Workspaces, sessions)
 	if workspaceJSON {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(records)
 	}
@@ -131,13 +146,25 @@ func runWorkspaceRemove(cmd *cobra.Command, args []string) error {
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unregistered workspace %s\n", name)
 	if livePath != "" {
-		sessions, err := listWorkspaceSessions()
+		sessions, err := resolveDirectorySessions(
+			[]models.Workspace{{Name: name, Path: livePath}},
+		)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not check for a live session: %v\n", err)
-		} else if session, ok := tmux.MatchDirWorkspaceSession(sessions, livePath); ok {
+		} else if records := directoryWorkspaceRecordsFromSessions(
+			[]models.Workspace{{Name: name, Path: livePath}},
+			sessions,
+		); len(records) == 1 && records[0].SessionLive {
+			record := records[0]
+			killCommand := tmux.KillCommandHint(tmux.SessionEndpoint{
+				SessionName: record.SessionName,
+				SocketName:  record.TmuxSocketName,
+			})
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-				"its tmux session %s is still running; kill it with: tmux kill-session -t %s\n",
-				session, session)
+				"its tmux session %s is still running; kill it with: %s\n",
+				record.SessionName,
+				killCommand,
+			)
 		}
 	}
 	return nil

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -26,12 +26,12 @@ func resetWorkspaceCommandDeps(t *testing.T) {
 	origRegister := registerWorkspace
 	origUnregister := unregisterWorkspace
 	origLoad := loadWorkspaceConfig
-	origSessions := listWorkspaceSessions
+	origSessions := resolveDirectorySessions
 	t.Cleanup(func() {
 		registerWorkspace = origRegister
 		unregisterWorkspace = origUnregister
 		loadWorkspaceConfig = origLoad
-		listWorkspaceSessions = origSessions
+		resolveDirectorySessions = origSessions
 	})
 }
 
@@ -84,8 +84,11 @@ func TestWorkspaceListShowsLiveState(t *testing.T) {
 			{Name: "scratch", Path: "/Users/me/scratch"},
 		}}, nil
 	}
-	listWorkspaceSessions = func() ([]string, error) {
-		return []string{tmuxDirSessionNameForTest("notes", "/Users/me/notes")}, nil
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(
+			workspaces,
+			tmuxDirSessionNameForTest("notes", "/Users/me/notes"),
+		), nil
 	}
 
 	cmd, stdout, _ := fleetTestCommand()
@@ -111,8 +114,8 @@ func TestWorkspaceListJSONReportsCanonicalAndEffectiveSessions(t *testing.T) {
 		return &models.Config{Workspaces: workspaces}, nil
 	}
 	oldLiveName := tmux.DirWorkspaceSessionName("old-name", workspaces[0].Path)
-	listWorkspaceSessions = func() ([]string, error) {
-		return []string{oldLiveName}, nil
+	resolveDirectorySessions = func(got []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(got, oldLiveName), nil
 	}
 
 	cmd, stdout, _ := fleetTestCommand()
@@ -122,20 +125,63 @@ func TestWorkspaceListJSONReportsCanonicalAndEffectiveSessions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
 	require.Len(t, got, 2)
 	assert.Equal(t, directoryWorkspaceRecord{
-		Name:        "renamed",
-		Path:        "/Users/me/notes",
-		SessionName: oldLiveName,
-		SessionLive: true,
+		Name:           "renamed",
+		Path:           "/Users/me/notes",
+		SessionName:    oldLiveName,
+		SessionLive:    true,
+		TmuxSocketName: tmux.KWTServerSocketName,
+		TmuxAttachMode: models.TmuxAttachDirect,
 	}, got[0])
 	assert.Equal(t, directoryWorkspaceRecord{
-		Name: "scratch",
-		Path: "/Users/me/scratch",
+		Name: "scratch", Path: "/Users/me/scratch",
 		SessionName: tmux.DirWorkspaceSessionName(
 			"scratch",
 			"/Users/me/scratch",
 		),
-		SessionLive: false,
+		SessionLive:    false,
+		TmuxSocketName: tmux.KWTServerSocketName,
+		TmuxAttachMode: models.TmuxAttachDirect,
 	}, got[1])
+}
+
+func TestDirectoryWorkspaceRecordsRetainResolvedLiveEndpoint(t *testing.T) {
+	workspace := models.Workspace{Name: "renamed", Path: "/Users/me/notes"}
+	liveName := tmux.DirWorkspaceSessionName("old-name", workspace.Path)
+
+	records := directoryWorkspaceRecordsFromSessions(
+		[]models.Workspace{workspace},
+		[]tmux.WorkspaceSession{{
+			Endpoint: tmux.SessionEndpoint{
+				SessionName: liveName,
+			},
+			Live: true,
+		}},
+	)
+
+	require.Len(t, records, 1)
+	assert.Equal(t, liveName, records[0].SessionName)
+	assert.True(t, records[0].SessionLive)
+	assert.Empty(t, records[0].TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, records[0].TmuxAttachMode)
+}
+
+func TestDirectoryWorkspaceRecordsUseResolvedStoppedSession(t *testing.T) {
+	workspace := models.Workspace{Name: "notes", Path: "/Users/me/notes"}
+	liveName := tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path)
+
+	records := directoryWorkspaceRecordsFromSessions(
+		[]models.Workspace{workspace},
+		[]tmux.WorkspaceSession{{
+			Endpoint: tmux.SessionEndpoint{
+				SessionName: liveName,
+				SocketName:  tmux.KWTServerSocketName,
+			},
+		}},
+	)
+
+	require.Len(t, records, 1)
+	assert.False(t, records[0].SessionLive)
+	assert.Equal(t, tmux.KWTServerSocketName, records[0].TmuxSocketName)
 }
 
 func TestWorkspaceListJSONEmptyRegistryEmitsArray(t *testing.T) {
@@ -177,8 +223,11 @@ func TestWorkspaceRemoveReportsLiveSession(t *testing.T) {
 	loadWorkspaceConfig = func() (*models.Config, error) {
 		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
 	}
-	listWorkspaceSessions = func() ([]string, error) {
-		return []string{tmuxDirSessionNameForTest("notes", "/Users/me/notes")}, nil
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(
+			workspaces,
+			tmuxDirSessionNameForTest("notes", "/Users/me/notes"),
+		), nil
 	}
 	unregisterWorkspace = func(name string) error {
 		assert.Equal(t, "notes", name)
@@ -190,12 +239,12 @@ func TestWorkspaceRemoveReportsLiveSession(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "still running")
+	assert.Contains(t, stdout.String(), "tmux -L kwt kill-session")
 }
 
 func TestWorkspaceRemovePropagatesUnknownNameError(t *testing.T) {
 	resetWorkspaceCommandDeps(t)
 	loadWorkspaceConfig = func() (*models.Config, error) { return &models.Config{}, nil }
-	listWorkspaceSessions = func() ([]string, error) { return nil, nil }
 	unregisterWorkspace = func(name string) error {
 		return errors.New(`no workspace named "nope"; no workspaces registered`)
 	}
@@ -212,8 +261,11 @@ func TestWorkspaceRemoveReportsLiveSessionCaseInsensitive(t *testing.T) {
 	loadWorkspaceConfig = func() (*models.Config, error) {
 		return &models.Config{Workspaces: []models.Workspace{{Name: "Notes", Path: "/Users/me/notes"}}}, nil
 	}
-	listWorkspaceSessions = func() ([]string, error) {
-		return []string{tmuxDirSessionNameForTest("Notes", "/Users/me/notes")}, nil
+	resolveDirectorySessions = func(workspaces []models.Workspace) ([]tmux.WorkspaceSession, error) {
+		return testDirectorySessions(
+			workspaces,
+			tmuxDirSessionNameForTest("Notes", "/Users/me/notes"),
+		), nil
 	}
 	unregisterWorkspace = func(name string) error {
 		assert.Equal(t, "notes", name)
@@ -229,6 +281,30 @@ func TestWorkspaceRemoveReportsLiveSessionCaseInsensitive(t *testing.T) {
 
 func tmuxDirSessionNameForTest(name, path string) string {
 	return tmux.DirWorkspaceSessionName(name, path)
+}
+
+func testCanonicalSessionEndpoint(name string) tmux.SessionEndpoint {
+	return tmux.SessionEndpoint{
+		SessionName: name,
+		SocketName:  tmux.KWTServerSocketName,
+	}
+}
+
+func testDirectorySessions(
+	workspaces []models.Workspace,
+	liveName string,
+) []tmux.WorkspaceSession {
+	sessions := make([]tmux.WorkspaceSession, len(workspaces))
+	for index, workspace := range workspaces {
+		sessions[index] = tmux.WorkspaceSession{Endpoint: testCanonicalSessionEndpoint(
+			tmux.DirWorkspaceSessionName(workspace.Name, workspace.Path),
+		)}
+	}
+	if liveName != "" && len(sessions) > 0 {
+		sessions[0].Endpoint.SessionName = liveName
+		sessions[0].Live = true
+	}
+	return sessions
 }
 
 // TestWorkspaceCmdIsolatesFromCwdConfig guards the config-isolation invariant:
@@ -249,7 +325,7 @@ func TestWorkspaceListPropagatesSessionError(t *testing.T) {
 	loadWorkspaceConfig = func() (*models.Config, error) {
 		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
 	}
-	listWorkspaceSessions = func() ([]string, error) {
+	resolveDirectorySessions = func([]models.Workspace) ([]tmux.WorkspaceSession, error) {
 		return nil, errors.New("tmux: no such file or directory")
 	}
 
@@ -265,7 +341,7 @@ func TestWorkspaceRemoveWarnsOnSessionCheckError(t *testing.T) {
 	loadWorkspaceConfig = func() (*models.Config, error) {
 		return &models.Config{Workspaces: []models.Workspace{{Name: "notes", Path: "/Users/me/notes"}}}, nil
 	}
-	listWorkspaceSessions = func() ([]string, error) {
+	resolveDirectorySessions = func([]models.Workspace) ([]tmux.WorkspaceSession, error) {
 		return nil, errors.New("tmux: no such file or directory")
 	}
 	unregisterWorkspace = func(name string) error {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -170,7 +170,41 @@ func (c *Client) inventory(ctx context.Context, request kwt.Request) (kwt.Result
 		request,
 		&result,
 	)
-	return result, err
+	if err != nil {
+		return result, err
+	}
+	if err := validateInventoryAttachModes(result); err != nil {
+		return kwt.Result{}, service.NewError(
+			service.DaemonIncompatible,
+			"the running kwt daemon returned an unsupported tmux attachment mode",
+			false,
+			nil,
+			err,
+		)
+	}
+	return result, nil
+}
+
+func validateInventoryAttachModes(result kwt.Result) error {
+	groups := [][]kwt.Entry{
+		result.Snapshot.Entries,
+		result.Snapshot.LaunchEntries,
+	}
+	for _, entries := range groups {
+		for index, entry := range entries {
+			switch entry.TmuxAttachMode {
+			case models.TmuxAttachDirect, models.TmuxAttachProtected:
+				continue
+			default:
+				return fmt.Errorf(
+					"inventory entry %d has tmux attachment mode %q",
+					index,
+					entry.TmuxAttachMode,
+				)
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Client) ApproveConfig(ctx context.Context, approval kwt.ConfigApproval) error {

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	kitdaemon "go.kenn.io/kit/daemon"
 	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/pkg/models"
 	"go.kenn.io/kwt/service"
 )
 
@@ -239,6 +240,66 @@ func TestClientAllowsInventoryResponseLargerThanControlPlaneLimit(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, result.Notes, 1)
 	assert.Equal(t, largePath, result.Notes[0].Path)
+}
+
+func TestClientRejectsUnknownInventoryAttachModes(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		result kwt.Result
+	}{
+		{
+			name: "missing entry mode",
+			result: kwt.Result{Snapshot: kwt.Snapshot{Entries: []kwt.Entry{{
+				Path: "/work/widget",
+			}}}},
+		},
+		{
+			name: "unknown entry mode",
+			result: kwt.Result{Snapshot: kwt.Snapshot{Entries: []kwt.Entry{{
+				Path: "/work/widget", TmuxAttachMode: "sideways",
+			}}}},
+		},
+		{
+			name: "unknown launch entry mode",
+			result: kwt.Result{Snapshot: kwt.Snapshot{LaunchEntries: []kwt.Entry{{
+				Path: "/work/widget", TmuxAttachMode: "sideways",
+			}}}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				require.NoError(t, json.NewEncoder(w).Encode(test.result))
+			}))
+			defer server.Close()
+			client := clientForUnverifiedServer(t, server, "secret")
+
+			_, err := client.Inventory(context.Background(), kwt.Request{View: kwt.ViewDashboard})
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.DaemonIncompatible), err)
+		})
+	}
+}
+
+func TestClientAcceptsKnownInventoryAttachModes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(kwt.Result{
+			Snapshot: kwt.Snapshot{Entries: []kwt.Entry{
+				{Path: "/work/direct", TmuxAttachMode: models.TmuxAttachDirect},
+				{Path: "/work/protected", TmuxAttachMode: models.TmuxAttachProtected},
+			}, LaunchEntries: []kwt.Entry{{
+				Path: "/work/launch", TmuxAttachMode: models.TmuxAttachDirect,
+			}}},
+		}))
+	}))
+	defer server.Close()
+	client := clientForUnverifiedServer(t, server, "secret")
+
+	result, err := client.Inventory(context.Background(), kwt.Request{View: kwt.ViewDashboard})
+
+	require.NoError(t, err)
+	require.Len(t, result.Snapshot.Entries, 2)
+	require.Len(t, result.Snapshot.LaunchEntries, 1)
 }
 
 func TestClientReportsEndpointSpecificResponseLimit(t *testing.T) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -188,7 +188,8 @@ func TestNewRuntimeRecordAdvertisesFirstDomainContracts(t *testing.T) {
 	require.NoError(t, err)
 
 	capabilities := strings.Split(record.Metadata[metadataCapabilities], ",")
-	assert.Contains(t, capabilities, "worktree.inventory.v1")
+	assert.Contains(t, capabilities, "worktree.inventory.v3")
+	assert.NotContains(t, capabilities, "worktree.inventory.v2")
 	assert.Contains(t, capabilities, "project.removal.v1")
 	assert.Contains(t, capabilities, "worktree.removal.v1")
 	assert.Contains(t, capabilities, "worktree.removal.v2")

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -179,7 +179,7 @@ func setMismatchedRuntimeIdentity(t *testing.T, record *kitdaemon.RuntimeRecord)
 	)
 }
 
-func TestNewRuntimeRecordAdvertisesFirstDomainContracts(t *testing.T) {
+func TestNewRuntimeRecordAdvertisesCurrentDomainContracts(t *testing.T) {
 	record, _, err := NewRuntimeRecord(
 		t.TempDir(),
 		Build{Version: "development"},
@@ -188,8 +188,8 @@ func TestNewRuntimeRecordAdvertisesFirstDomainContracts(t *testing.T) {
 	require.NoError(t, err)
 
 	capabilities := strings.Split(record.Metadata[metadataCapabilities], ",")
-	assert.Contains(t, capabilities, "worktree.inventory.v3")
-	assert.NotContains(t, capabilities, "worktree.inventory.v2")
+	assert.Contains(t, capabilities, "worktree.inventory.v2")
+	assert.NotContains(t, capabilities, "worktree.inventory.v1")
 	assert.Contains(t, capabilities, "project.removal.v1")
 	assert.Contains(t, capabilities, "worktree.removal.v1")
 	assert.Contains(t, capabilities, "worktree.removal.v2")

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -13,7 +13,7 @@ const (
 	CapabilityStatus          = "daemon.status"
 	CapabilityShutdown        = "daemon.shutdown"
 	CapabilityProjectRemoval  = "project.removal.v1"
-	CapabilityInventory       = "worktree.inventory.v1"
+	CapabilityInventory       = "worktree.inventory.v3"
 	CapabilityRemoval         = "worktree.removal.v1"
 	CapabilityGuardedRemoval  = "worktree.removal.v2"
 	CapabilityOperationStream = "operation.stream.v1"

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -13,7 +13,7 @@ const (
 	CapabilityStatus          = "daemon.status"
 	CapabilityShutdown        = "daemon.shutdown"
 	CapabilityProjectRemoval  = "project.removal.v1"
-	CapabilityInventory       = "worktree.inventory.v3"
+	CapabilityInventory       = "worktree.inventory.v2"
 	CapabilityRemoval         = "worktree.removal.v1"
 	CapabilityGuardedRemoval  = "worktree.removal.v2"
 	CapabilityOperationStream = "operation.stream.v1"

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -21,14 +21,20 @@ import (
 
 // GlobalWorktreeEntry represents a discovered worktree.
 type GlobalWorktreeEntry struct {
-	RepositoryURL  string              // Full repository URL
-	RepositoryInfo *url.RepositoryInfo // Parsed repository information
-	Branch         string
-	Path           string
-	CommitHash     string
-	IsMain         bool
-	CreatedAt      time.Time // Worktree directory modification time
-	Generation     string    // Durable worktree registration identity
+	RepositoryURL   string              // Full repository URL
+	RepositoryInfo  *url.RepositoryInfo // Parsed repository information
+	Branch          string
+	Path            string
+	CommitHash      string
+	IsMain          bool
+	CreatedAt       time.Time // Worktree directory modification time
+	Generation      string    // Durable worktree registration identity
+	TmuxEndpoint    tmux.SessionEndpoint
+	TmuxSessionLive bool // Liveness from the same observation as TmuxEndpoint.
+	TmuxResolved    bool // Inventory supplied endpoint and liveness; do not probe again.
+	// Protected is derived from the inventory attachment policy. Socket names
+	// are addresses and must not be used to infer workspace protection.
+	Protected bool
 }
 
 type worktreeCandidate struct {

--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -244,6 +244,7 @@ func layoutItemLabel(l models.Layout) string {
 func (f *Finder) generateSessionPreview(session *tmux.Session, maxLines int) string {
 	preview := []string{
 		fmt.Sprintf("Session: %s", session.SessionName),
+		fmt.Sprintf("Endpoint: %s", tmux.SessionEndpointLabel(session)),
 		fmt.Sprintf("Context: %s", session.Context),
 		fmt.Sprintf("Identifier: %s", session.Identifier),
 		fmt.Sprintf("Command: %s", session.Command),
@@ -402,6 +403,12 @@ func (f *Finder) buildSessionFinderOptions(sessions []*tmux.Session) []fuzzyfind
 func (f *Finder) formatSessionForDisplay(sessions []*tmux.Session) func(int) string {
 	return func(i int) string {
 		session := sessions[i]
-		return fmt.Sprintf("%s/%s - %s", session.Context, session.Identifier, session.Command)
+		return fmt.Sprintf(
+			"%s/%s [%s] - %s",
+			session.Context,
+			session.Identifier,
+			tmux.SessionEndpointLabel(session),
+			session.Command,
+		)
 	}
 }

--- a/internal/finder/finder_test.go
+++ b/internal/finder/finder_test.go
@@ -331,6 +331,7 @@ func TestGenerateSessionPreview(t *testing.T) {
 
 	expectedContent := []string{
 		"Session: test-session",
+		"Endpoint: default",
 		"Context: test-context",
 		"Identifier: test-id",
 		"Command: vim test.go",
@@ -594,6 +595,7 @@ func TestBuildSessionFinderOptions_WithoutPreview(t *testing.T) {
 func TestFormatSessionForDisplay(t *testing.T) {
 	sessions := []*tmux.Session{
 		{
+			SocketName: tmux.KWTServerSocketName,
 			Context:    "project1",
 			Identifier: "session1",
 			Command:    "vim main.go",
@@ -609,13 +611,13 @@ func TestFormatSessionForDisplay(t *testing.T) {
 	formatter := finder.formatSessionForDisplay(sessions)
 
 	result0 := formatter(0)
-	expected0 := "project1/session1 - vim main.go"
+	expected0 := "project1/session1 [kwt] - vim main.go"
 	if result0 != expected0 {
 		t.Errorf("formatSessionForDisplay(0) = %s, expected %s", result0, expected0)
 	}
 
 	result1 := formatter(1)
-	expected1 := "project2/session2 - make test"
+	expected1 := "project2/session2 [default] - make test"
 	if result1 != expected1 {
 		t.Errorf("formatSessionForDisplay(1) = %s, expected %s", result1, expected1)
 	}

--- a/internal/lifecycle/cache.go
+++ b/internal/lifecycle/cache.go
@@ -14,7 +14,7 @@ import (
 	"go.kenn.io/kit/safefileio"
 )
 
-const cacheVersion = 1
+const cacheVersion = 3
 
 type Cache interface {
 	Current() (Result, bool)
@@ -39,7 +39,7 @@ func NewFileCache(home string) (*FileCache, *Diagnostic, error) {
 	if err := safefileio.EnsurePrivateDir(dir); err != nil {
 		return nil, nil, fmt.Errorf("secure inventory cache directory: %w", err)
 	}
-	cache := &FileCache{path: filepath.Join(dir, "inventory-v1.json")}
+	cache := &FileCache{path: filepath.Join(dir, "inventory-v3.json")}
 	file, err := safefileio.OpenCurrentUserFile(cache.path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/lifecycle/cache.go
+++ b/internal/lifecycle/cache.go
@@ -14,7 +14,7 @@ import (
 	"go.kenn.io/kit/safefileio"
 )
 
-const cacheVersion = 3
+const cacheVersion = 2
 
 type Cache interface {
 	Current() (Result, bool)
@@ -39,7 +39,7 @@ func NewFileCache(home string) (*FileCache, *Diagnostic, error) {
 	if err := safefileio.EnsurePrivateDir(dir); err != nil {
 		return nil, nil, fmt.Errorf("secure inventory cache directory: %w", err)
 	}
-	cache := &FileCache{path: filepath.Join(dir, "inventory-v3.json")}
+	cache := &FileCache{path: filepath.Join(dir, "inventory-v2.json")}
 	file, err := safefileio.OpenCurrentUserFile(cache.path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/lifecycle/cache_test.go
+++ b/internal/lifecycle/cache_test.go
@@ -37,23 +37,23 @@ func TestFileCacheRoundTripsSnapshot(t *testing.T) {
 	assert.Equal(t, want.Snapshot, got.Snapshot)
 }
 
-func TestFileCacheUsesThirdInventoryFormat(t *testing.T) {
+func TestFileCacheUsesSecondInventoryFormat(t *testing.T) {
 	home := t.TempDir()
 	cache, diagnostic, err := NewFileCache(home)
 	require.NoError(t, err)
 	assert.Nil(t, diagnostic)
 	require.NoError(t, cache.Store(Result{ObservedAt: time.Unix(7, 0).UTC()}))
 
-	_, err = os.Stat(filepath.Join(home, "cache", "inventory-v3.json"))
+	_, err = os.Stat(filepath.Join(home, "cache", "inventory-v2.json"))
 	require.NoError(t, err)
 }
 
-func TestFileCacheIgnoresSecondInventoryFormat(t *testing.T) {
+func TestFileCacheIgnoresFirstInventoryFormat(t *testing.T) {
 	home := t.TempDir()
 	dir := filepath.Join(home, "cache")
 	require.NoError(t, os.Mkdir(dir, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v2.json"), []byte(`{
-		"version": 2,
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v1.json"), []byte(`{
+		"version": 1,
 		"observed_at": "1970-01-01T00:00:07Z",
 		"snapshot": {"entries": [{"path": "/repo", "branch": "main"}]}
 	}`), 0o600))
@@ -69,7 +69,7 @@ func TestFileCacheWrongVersionIsDisposable(t *testing.T) {
 	home := t.TempDir()
 	dir := filepath.Join(home, "cache")
 	require.NoError(t, os.Mkdir(dir, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v3.json"), []byte(`{"version":99}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v2.json"), []byte(`{"version":99}`), 0o600))
 
 	cache, diagnostic, err := NewFileCache(home)
 	require.NoError(t, err)

--- a/internal/lifecycle/cache_test.go
+++ b/internal/lifecycle/cache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 func TestFileCacheRoundTripsSnapshot(t *testing.T) {
@@ -16,8 +17,12 @@ func TestFileCacheRoundTripsSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, diagnostic)
 	want := Result{ObservedAt: time.Unix(7, 0).UTC(), Snapshot: Snapshot{
-		Entries:       []Entry{{Path: "/repo", Branch: "main"}},
-		LaunchEntries: []Entry{{Path: "/repo", Branch: "main"}},
+		Entries: []Entry{{
+			Path: "/repo", Branch: "main", TmuxAttachMode: models.TmuxAttachDirect,
+		}},
+		LaunchEntries: []Entry{{
+			Path: "/repo", Branch: "main", TmuxAttachMode: models.TmuxAttachDirect,
+		}},
 	}}
 	require.NoError(t, cache.Store(want))
 	want.Snapshot.Entries[0].Branch = "updated"
@@ -32,22 +37,39 @@ func TestFileCacheRoundTripsSnapshot(t *testing.T) {
 	assert.Equal(t, want.Snapshot, got.Snapshot)
 }
 
-func TestFileCacheUsesFirstInventoryFormat(t *testing.T) {
+func TestFileCacheUsesThirdInventoryFormat(t *testing.T) {
 	home := t.TempDir()
 	cache, diagnostic, err := NewFileCache(home)
 	require.NoError(t, err)
 	assert.Nil(t, diagnostic)
 	require.NoError(t, cache.Store(Result{ObservedAt: time.Unix(7, 0).UTC()}))
 
-	_, err = os.Stat(filepath.Join(home, "cache", "inventory-v1.json"))
+	_, err = os.Stat(filepath.Join(home, "cache", "inventory-v3.json"))
 	require.NoError(t, err)
+}
+
+func TestFileCacheIgnoresSecondInventoryFormat(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "cache")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v2.json"), []byte(`{
+		"version": 2,
+		"observed_at": "1970-01-01T00:00:07Z",
+		"snapshot": {"entries": [{"path": "/repo", "branch": "main"}]}
+	}`), 0o600))
+
+	cache, diagnostic, err := NewFileCache(home)
+	require.NoError(t, err)
+	assert.Nil(t, diagnostic)
+	_, ok := cache.Current()
+	assert.False(t, ok)
 }
 
 func TestFileCacheWrongVersionIsDisposable(t *testing.T) {
 	home := t.TempDir()
 	dir := filepath.Join(home, "cache")
 	require.NoError(t, os.Mkdir(dir, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v1.json"), []byte(`{"version":99}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inventory-v3.json"), []byte(`{"version":99}`), 0o600))
 
 	cache, diagnostic, err := NewFileCache(home)
 	require.NoError(t, err)

--- a/internal/lifecycle/inventory.go
+++ b/internal/lifecycle/inventory.go
@@ -181,20 +181,23 @@ type Repository struct {
 }
 
 type Entry struct {
-	Path           string     `json:"path"`
-	Branch         string     `json:"branch"`
-	CommitHash     string     `json:"commit_hash"`
-	IsMain         bool       `json:"is_main"`
-	CreatedAt      time.Time  `json:"created_at"`
-	Generation     string     `json:"generation"`
-	Repository     Repository `json:"repository"`
-	SessionName    string     `json:"session_name"`
-	TmuxSocketName string     `json:"tmux_socket_name,omitempty"`
+	Path           string                `json:"path"`
+	Branch         string                `json:"branch"`
+	CommitHash     string                `json:"commit_hash"`
+	IsMain         bool                  `json:"is_main"`
+	CreatedAt      time.Time             `json:"created_at"`
+	Generation     string                `json:"generation"`
+	Repository     Repository            `json:"repository"`
+	SessionName    string                `json:"session_name"`
+	SessionLive    bool                  `json:"session_live"`
+	TmuxSocketName string                `json:"tmux_socket_name,omitempty"`
+	TmuxAttachMode models.TmuxAttachMode `json:"tmux_attach_mode"`
 }
 
 type Note struct {
-	Code string `json:"code"`
-	Path string `json:"path"`
+	Code    string `json:"code"`
+	Path    string `json:"path"`
+	Message string `json:"message,omitempty"`
 }
 
 type Diagnostic struct {

--- a/internal/lifecycle/removal.go
+++ b/internal/lifecycle/removal.go
@@ -181,6 +181,12 @@ func (s *removalService) Remove(
 			return reg.RemoveIfMatchAfter(request.Path, record, func() error {
 				if request.Session != nil {
 					sessionCondition := *request.Session
+					// compat(kag1): default-server adoption
+					if sessionCondition.SocketDirectory == "" {
+						sessionCondition.SocketDirectory = removalSocketDirectory(
+							request.Expansion,
+						)
+					}
 					sessionCondition.WorkspacePath = request.Path
 					sessionCondition.WorkspaceGeneration = request.ExpectedGeneration
 					sessionCondition.ProtectedSocketTopology = protectedTarget != nil

--- a/internal/lifecycle/removal_session.go
+++ b/internal/lifecycle/removal_session.go
@@ -102,8 +102,15 @@ func validateCurrentRemovalSessionTarget(
 	if err != nil {
 		return err
 	}
+	// compat(kag1): default-server adoption
+	expectedSocketDirectory := removalSocketDirectory(expansion)
+	if condition.SocketDirectory != expectedSocketDirectory {
+		return changedRemovalSessionTarget()
+	}
 	if protected == nil {
-		if condition.SessionName != expectedSession {
+		// compat(kag1): default-server adoption
+		if condition.SessionName != expectedSession ||
+			(condition.SocketName != "" && condition.SocketName != tmux.KWTServerSocketName) {
 			return changedRemovalSessionTarget()
 		}
 		return nil
@@ -111,15 +118,16 @@ func validateCurrentRemovalSessionTarget(
 	if protected.branch != branch {
 		return changedRemovalSessionTarget()
 	}
-	legacySocketDirectory := expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")]
-	validSocketDirectory := condition.SocketDirectory == "" ||
-		(legacySocketDirectory != "" && condition.SocketDirectory == legacySocketDirectory)
 	if condition.SessionName != protected.session ||
-		condition.SocketName != protected.socketName ||
-		!validSocketDirectory {
+		condition.SocketName != protected.socketName {
 		return changedRemovalSessionTarget()
 	}
 	return nil
+}
+
+// compat(kag1): default-server adoption
+func removalSocketDirectory(expansion ExpansionContext) string {
+	return expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")]
 }
 
 func changedRemovalSessionTarget() error {

--- a/internal/lifecycle/removal_test.go
+++ b/internal/lifecycle/removal_test.go
@@ -142,13 +142,14 @@ func TestRemovalServiceTerminatesConfirmedSessionBeforeRemovingWorktree(t *testi
 		SessionID:   "$7",
 		CreatedAt:   "1720000000",
 	}
+	expansion := testExpansion(t)
 
 	result, err := NewRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
 		Path:           worktreePath, ExpectedGeneration: generation,
-		Expansion: testExpansion(t),
+		Expansion: expansion,
 		Session:   &condition,
 	})
 
@@ -157,6 +158,7 @@ func TestRemovalServiceTerminatesConfirmedSessionBeforeRemovingWorktree(t *testi
 	assert.True(t, guard.terminated)
 	assert.True(t, guard.pathLive, "session guard must run before checkout removal")
 	expectedCondition := condition
+	expectedCondition.SocketDirectory = removalSocketDirectory(expansion)
 	expectedCondition.WorkspacePath = worktreePath
 	expectedCondition.WorkspaceGeneration = generation
 	expectedCondition.ProtectedNames = credentials.ProtectedNames(nil)
@@ -389,7 +391,7 @@ func TestRemovalServiceRejectsStaleSessionSocket(t *testing.T) {
 	assert.DirExists(t, worktreePath)
 }
 
-func TestRemovalServiceAcceptsOrdinarySessionOnExplicitSocketEndpoint(t *testing.T) {
+func TestRemovalServiceAcceptsDirectSessionOnCanonicalSocketEndpoint(t *testing.T) {
 	repositoryPath, worktreePath := removalRepository(t, "custom-endpoint")
 	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
 	require.NoError(t, err)
@@ -398,10 +400,12 @@ func TestRemovalServiceAcceptsOrdinarySessionOnExplicitSocketEndpoint(t *testing
 	guard := &recordingRemovalSessionGuard{}
 	condition := RemovalSessionCondition{
 		SessionName:     removalSessionName(t, worktreePath, "custom-endpoint"),
-		SocketName:      "team-server",
+		SocketName:      tmux.KWTServerSocketName,
 		SocketDirectory: "/srv/tmux",
 		Absent:          true,
 	}
+	expansion := testExpansion(t)
+	expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")] = "/srv/tmux"
 
 	result, err := NewRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
@@ -409,7 +413,7 @@ func TestRemovalServiceAcceptsOrdinarySessionOnExplicitSocketEndpoint(t *testing
 		RepositoryPath:     repositoryPath,
 		Path:               worktreePath,
 		ExpectedGeneration: generation,
-		Expansion:          testExpansion(t),
+		Expansion:          expansion,
 		Session:            &condition,
 	})
 
@@ -422,6 +426,97 @@ func TestRemovalServiceAcceptsOrdinarySessionOnExplicitSocketEndpoint(t *testing
 	assert.Equal(t, expectedCondition, guard.condition)
 	assert.False(t, guard.condition.ProtectedSocketTopology)
 	assert.True(t, result.WorktreeRemoved)
+}
+
+func TestRemovalServiceRejectsDirectSessionSocketDirectoryOutsideRequest(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "wrong-socket-directory")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	home := t.TempDir()
+	registerRemovalRepository(t, home, repositoryPath)
+	guard := &recordingRemovalSessionGuard{}
+	expansion := testExpansion(t)
+	expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")] = "/srv/expected-tmux"
+
+	result, err := NewRemovalService(RemovalServiceOptions{
+		Home: home, SessionGuard: guard,
+	}).Remove(context.Background(), RemovalRequest{
+		RepositoryPath:     repositoryPath,
+		Path:               worktreePath,
+		ExpectedGeneration: generation,
+		Expansion:          expansion,
+		Session: &RemovalSessionCondition{
+			SessionName:     removalSessionName(t, worktreePath, "wrong-socket-directory"),
+			SocketName:      tmux.KWTServerSocketName,
+			SocketDirectory: "/srv/unrelated-tmux",
+			Absent:          true,
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.Conflict))
+	assert.False(t, guard.quiesced)
+	assert.False(t, result.WorktreeRemoved)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemovalServiceUsesRequestSocketDirectoryWhenConditionOmitsIt(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "implicit-socket-directory")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	home := t.TempDir()
+	registerRemovalRepository(t, home, repositoryPath)
+	guard := &recordingRemovalSessionGuard{}
+	expansion := testExpansion(t)
+	expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")] = "/srv/request-tmux"
+
+	result, err := NewRemovalService(RemovalServiceOptions{
+		Home: home, SessionGuard: guard,
+	}).Remove(context.Background(), RemovalRequest{
+		RepositoryPath:     repositoryPath,
+		Path:               worktreePath,
+		ExpectedGeneration: generation,
+		Expansion:          expansion,
+		Session: &RemovalSessionCondition{
+			SessionName: removalSessionName(t, worktreePath, "implicit-socket-directory"),
+			SocketName:  tmux.KWTServerSocketName,
+			Absent:      true,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, guard.quiesced)
+	assert.Equal(t, "/srv/request-tmux", guard.condition.SocketDirectory)
+	assert.True(t, result.WorktreeRemoved)
+}
+
+func TestRemovalServiceRejectsDirectSessionOnArbitraryNamedSocket(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "arbitrary-endpoint")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	home := t.TempDir()
+	registerRemovalRepository(t, home, repositoryPath)
+	guard := &recordingRemovalSessionGuard{}
+
+	result, err := NewRemovalService(RemovalServiceOptions{
+		Home: home, SessionGuard: guard,
+	}).Remove(context.Background(), RemovalRequest{
+		RepositoryPath:     repositoryPath,
+		Path:               worktreePath,
+		ExpectedGeneration: generation,
+		Expansion:          testExpansion(t),
+		Session: &RemovalSessionCondition{
+			SessionName: removalSessionName(t, worktreePath, "arbitrary-endpoint"),
+			SocketName:  "team-server",
+			Absent:      true,
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.Conflict))
+	assert.False(t, guard.quiesced)
+	assert.False(t, result.WorktreeRemoved)
+	assert.DirExists(t, worktreePath)
 }
 
 func TestRemovalServiceCarriesDurableGenerationAfterWorktreeMove(t *testing.T) {
@@ -596,7 +691,7 @@ func TestRemovalServicePreservesConfirmedSessionWhenDirtyWorktreeCannotBeRemoved
 }
 
 func TestRemovalServicePreservesNativeDirtyErrorWithoutSessionGuard(t *testing.T) {
-	repositoryPath, worktreePath := removalRepository(t, "ordinary-dirty")
+	repositoryPath, worktreePath := removalRepository(t, "direct-dirty")
 	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -95,7 +95,11 @@ func (s *InventoryService) Query(ctx context.Context, request Request) (Result, 
 		result.ObservedAt = s.now()
 		result.RefreshError = nil
 		if request.View == ViewDashboard {
-			result.RefreshError = s.publishDashboard(generation, result)
+			result.RefreshError = s.publishDashboard(
+				generation,
+				request.IncludeProtectedSockets,
+				result,
+			)
 		}
 		return cloneResult(result), nil
 	})
@@ -110,14 +114,18 @@ func (s *InventoryService) Query(ctx context.Context, request Request) (Result, 
 	}
 }
 
-func (s *InventoryService) publishDashboard(generation uint64, result Result) *Diagnostic {
+func (s *InventoryService) publishDashboard(
+	generation uint64,
+	includesProtectedSockets bool,
+	result Result,
+) *Diagnostic {
 	s.publishMu.Lock()
 	defer s.publishMu.Unlock()
 	if !s.isLatestDashboard(generation) {
 		return nil
 	}
 	var diagnostic *Diagnostic
-	if s.cache != nil {
+	if s.cache != nil && includesProtectedSockets {
 		if err := s.cache.Store(result); err != nil {
 			diagnostic = &Diagnostic{At: s.now(), Message: boundedDiagnostic(err)}
 		}

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -241,7 +241,9 @@ func TestServiceFreshDashboardSurvivesCacheWriteFailure(t *testing.T) {
 		Now:    func() time.Time { return time.Unix(10, 0) },
 	})
 
-	result, err := service.Query(context.Background(), Request{View: ViewDashboard, RequireCurrent: true})
+	result, err := service.Query(context.Background(), Request{
+		View: ViewDashboard, RequireCurrent: true, IncludeProtectedSockets: true,
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, Fresh, result.Freshness)
@@ -249,6 +251,35 @@ func TestServiceFreshDashboardSurvivesCacheWriteFailure(t *testing.T) {
 	assert.Equal(t, "/new", result.Snapshot.Entries[0].Path)
 	require.NotNil(t, result.RefreshError)
 	assert.Contains(t, result.RefreshError.Message, cacheErr.Error())
+}
+
+func TestServiceDoesNotCacheDashboardWithoutProtectedSockets(t *testing.T) {
+	var calls atomic.Int32
+	source := sourceFunc(func(_ context.Context, request Request) (Result, error) {
+		calls.Add(1)
+		entry := Entry{Path: "/unenriched", TmuxAttachMode: models.TmuxAttachDirect}
+		if request.IncludeProtectedSockets {
+			entry = Entry{Path: "/enriched", TmuxAttachMode: models.TmuxAttachProtected}
+		}
+		return Result{Snapshot: Snapshot{Entries: []Entry{entry}}}, nil
+	})
+	cache := &testCache{}
+	service := NewInventoryService(InventoryServiceOptions{Source: source, Cache: cache})
+
+	_, err := service.Query(context.Background(), Request{
+		View: ViewDashboard, RequireCurrent: true,
+	})
+	require.NoError(t, err)
+	_, ok := cache.Current()
+	assert.False(t, ok)
+
+	result, err := service.Query(context.Background(), Request{
+		View: ViewDashboard, IncludeProtectedSockets: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Snapshot.Entries, 1)
+	assert.Equal(t, "/enriched", result.Snapshot.Entries[0].Path)
+	assert.Equal(t, int32(2), calls.Load())
 }
 
 func TestServiceResultsDoNotShareEffectiveConfig(t *testing.T) {
@@ -265,7 +296,7 @@ func TestServiceResultsDoNotShareEffectiveConfig(t *testing.T) {
 	})
 
 	result, err := service.Query(context.Background(), Request{
-		View: ViewDashboard, RequireCurrent: true,
+		View: ViewDashboard, RequireCurrent: true, IncludeProtectedSockets: true,
 	})
 	require.NoError(t, err)
 	result.Snapshot.Config.Worktree.BaseDir = "/mutated"
@@ -302,6 +333,7 @@ func TestServiceNewestDashboardRefreshOwnsSharedCache(t *testing.T) {
 	go func() {
 		_, err := service.Query(context.Background(), Request{
 			View: ViewDashboard, LaunchDirectory: "/old", RequireCurrent: true,
+			IncludeProtectedSockets: true,
 		})
 		oldDone <- err
 	}()
@@ -309,6 +341,7 @@ func TestServiceNewestDashboardRefreshOwnsSharedCache(t *testing.T) {
 	go func() {
 		_, err := service.Query(context.Background(), Request{
 			View: ViewDashboard, LaunchDirectory: "/new", RequireCurrent: true,
+			IncludeProtectedSockets: true,
 		})
 		newDone <- err
 	}()

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -126,7 +126,11 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 	}
 	result.Notes = append(result.Notes, notes...)
 	if request.IncludeProtectedSockets {
-		if err := s.annotateProtectedSockets(ctx, result.Snapshot.Entries); err != nil {
+		if err := s.annotateProtectedSockets(
+			ctx,
+			result.Snapshot.Entries,
+			result.Snapshot.LaunchEntries,
+		); err != nil {
 			return Result{}, inventorySourceFailure("failed to read pull-request provenance", err)
 		}
 	}
@@ -583,7 +587,10 @@ func publicNotes(notes []config.ConfigNote) []Note {
 	return result
 }
 
-func (s *currentSource) annotateProtectedSockets(ctx context.Context, entries []Entry) error {
+func (s *currentSource) annotateProtectedSockets(
+	ctx context.Context,
+	entryGroups ...[]Entry,
+) error {
 	records := make(map[string]pullrequest.Provenance)
 	err := pullrequest.NewFileStore(filepath.Join(s.home, "pull-requests.json")).View(
 		ctx,
@@ -597,6 +604,13 @@ func (s *currentSource) annotateProtectedSockets(ctx context.Context, entries []
 	if err != nil {
 		return fmt.Errorf("failed to read pull-request provenance: %w", err)
 	}
+	for _, entries := range entryGroups {
+		annotateProtectedEntries(records, entries)
+	}
+	return nil
+}
+
+func annotateProtectedEntries(records map[string]pullrequest.Provenance, entries []Entry) {
 	for index := range entries {
 		for _, record := range records {
 			workspace := record.Workspace
@@ -645,5 +659,4 @@ func (s *currentSource) annotateProtectedSockets(ctx context.Context, entries []
 			break
 		}
 	}
-	return nil
 }

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -206,6 +206,7 @@ func (s *currentSource) annotateWorkspaceEndpoints(
 	apply := func(group []Entry, offset int) {
 		for index := range group {
 			resolution := resolutions[offset+index]
+			group[index].SessionName = resolution.Session.Endpoint.SessionName
 			group[index].SessionLive = resolution.Session.Live
 			group[index].TmuxSocketName = resolution.Session.Endpoint.SocketName
 			group[index].TmuxAttachMode = models.TmuxAttachDirect

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -30,15 +30,39 @@ type repositoryScanResult struct {
 }
 
 type SourceOptions struct {
-	Home string
+	Home                     string
+	resolveWorkspaceSessions func(
+		context.Context,
+		tmux.WorkspaceSessionsOptions,
+		[]tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSessionResolution, error)
 }
 
 type currentSource struct {
-	home string
+	home                     string
+	workspaceSessions        *tmux.WorkspaceSessionsOptions
+	resolveWorkspaceSessions func(
+		context.Context,
+		tmux.WorkspaceSessionsOptions,
+		[]tmux.WorkspaceEndpointRequest,
+	) ([]tmux.WorkspaceSessionResolution, error)
 }
 
 func NewSource(options SourceOptions) Source {
-	return &currentSource{home: options.Home}
+	resolveWorkspaceSessions := options.resolveWorkspaceSessions
+	if resolveWorkspaceSessions == nil {
+		resolveWorkspaceSessions = func(
+			ctx context.Context,
+			options tmux.WorkspaceSessionsOptions,
+			requests []tmux.WorkspaceEndpointRequest,
+		) ([]tmux.WorkspaceSessionResolution, error) {
+			return tmux.NewWorkspaceSessions(options).ResolveAllBestEffort(ctx, requests)
+		}
+	}
+	return &currentSource{
+		home:                     options.Home,
+		resolveWorkspaceSessions: resolveWorkspaceSessions,
+	}
 }
 
 func (s *currentSource) Load(ctx context.Context, request Request) (result Result, err error) {
@@ -90,12 +114,109 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 			return Result{}, inventorySourceFailure("load dashboard inventory", err)
 		}
 	}
+	notes, err := s.annotateWorkspaceEndpoints(
+		ctx,
+		expansion,
+		protectedNames,
+		result.Snapshot.Entries,
+		result.Snapshot.LaunchEntries,
+	)
+	if err != nil {
+		return Result{}, inventorySourceFailure("inspect KWT tmux endpoints", err)
+	}
+	result.Notes = append(result.Notes, notes...)
 	if request.IncludeProtectedSockets {
 		if err := s.annotateProtectedSockets(ctx, result.Snapshot.Entries); err != nil {
 			return Result{}, inventorySourceFailure("failed to read pull-request provenance", err)
 		}
 	}
 	return result, nil
+}
+
+func (s *currentSource) annotateWorkspaceEndpoints(
+	ctx context.Context,
+	expansion ExpansionContext,
+	stripNames []string,
+	entries []Entry,
+	launchEntries []Entry,
+) ([]Note, error) {
+	total := len(entries) + len(launchEntries)
+	if total == 0 {
+		return nil, nil
+	}
+	requests := make([]tmux.WorkspaceEndpointRequest, 0, total)
+	for _, group := range [][]Entry{entries, launchEntries} {
+		for _, entry := range group {
+			requests = append(requests, tmux.WorkspaceEndpointRequest{
+				SessionName:         entry.SessionName,
+				WorkspacePath:       entry.Path,
+				WorkspaceGeneration: entry.Generation,
+			})
+		}
+	}
+
+	options := tmux.WorkspaceSessionsOptions{
+		StripNames:              stripNames,
+		DefaultServerTempDir:    expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")],
+		DefaultServerTempDirSet: true,
+	}
+	if s.workspaceSessions != nil {
+		options = *s.workspaceSessions
+	}
+	var resolverDiagnostics []error
+	existingReportDiagnostic := options.ReportDiagnostic
+	options.ReportDiagnostic = func(err error) {
+		resolverDiagnostics = append(resolverDiagnostics, err)
+		if existingReportDiagnostic != nil {
+			existingReportDiagnostic(err)
+		}
+	}
+	resolve := s.resolveWorkspaceSessions
+	if resolve == nil {
+		resolve = func(
+			ctx context.Context,
+			options tmux.WorkspaceSessionsOptions,
+			requests []tmux.WorkspaceEndpointRequest,
+		) ([]tmux.WorkspaceSessionResolution, error) {
+			return tmux.NewWorkspaceSessions(options).ResolveAllBestEffort(ctx, requests)
+		}
+	}
+	resolutions, err := resolve(ctx, options, requests)
+	if err != nil {
+		return nil, err
+	}
+	if len(resolutions) != total {
+		return nil, fmt.Errorf(
+			"KWT tmux endpoint resolver returned %d results for %d workspaces",
+			len(resolutions),
+			total,
+		)
+	}
+	notes := make([]Note, 0, len(resolverDiagnostics))
+	for _, diagnostic := range resolverDiagnostics {
+		notes = append(notes, Note{
+			Code:    "tmux_lookup_degraded",
+			Message: boundedDiagnostic(diagnostic),
+		})
+	}
+	apply := func(group []Entry, offset int) {
+		for index := range group {
+			resolution := resolutions[offset+index]
+			group[index].SessionLive = resolution.Session.Live
+			group[index].TmuxSocketName = resolution.Session.Endpoint.SocketName
+			group[index].TmuxAttachMode = models.TmuxAttachDirect
+			if resolution.Err != nil {
+				notes = append(notes, Note{
+					Code:    "tmux_endpoint_degraded",
+					Path:    group[index].Path,
+					Message: boundedDiagnostic(resolution.Err),
+				})
+			}
+		}
+	}
+	apply(entries, 0)
+	apply(launchEntries, len(entries))
+	return notes, nil
 }
 
 func inventorySourceFailure(message string, err error) error {
@@ -496,6 +617,11 @@ func (s *currentSource) annotateProtectedSockets(ctx context.Context, entries []
 			if workspace.Generation != "" && workspace.Generation != entries[index].Generation {
 				continue
 			}
+			entries[index].TmuxSocketName = ""
+			entries[index].TmuxAttachMode = models.TmuxAttachProtected
+			// Shared-server liveness was observed for a different endpoint. Protected
+			// liveness is not part of inventory's provenance-only annotation.
+			entries[index].SessionLive = false
 			verifiedSession := false
 			for _, identity := range pullrequest.ProvenanceRepositoryIdentities(record) {
 				info, ok := repositoryurl.CanonicalRepositoryInfo(identity)
@@ -509,11 +635,13 @@ func (s *currentSource) annotateProtectedSockets(ctx context.Context, entries []
 					break
 				}
 			}
-			if !verifiedSession {
-				continue
+			if verifiedSession {
+				entries[index].SessionName = workspace.SessionName
+				entries[index].TmuxSocketName = tmux.ProtectedWorkspaceSocketName(
+					workspace.SessionName,
+					workspace.Path,
+				)
 			}
-			entries[index].SessionName = workspace.SessionName
-			entries[index].TmuxSocketName = tmux.ProtectedWorkspaceSocketName(workspace.SessionName, workspace.Path)
 			break
 		}
 	}

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -125,14 +125,13 @@ func (s *currentSource) Load(ctx context.Context, request Request) (result Resul
 		return Result{}, inventorySourceFailure("inspect KWT tmux endpoints", err)
 	}
 	result.Notes = append(result.Notes, notes...)
-	if request.IncludeProtectedSockets {
-		if err := s.annotateProtectedSockets(
-			ctx,
-			result.Snapshot.Entries,
-			result.Snapshot.LaunchEntries,
-		); err != nil {
-			return Result{}, inventorySourceFailure("failed to read pull-request provenance", err)
-		}
+	if err := s.annotateProtectedSockets(
+		ctx,
+		request.IncludeProtectedSockets,
+		result.Snapshot.Entries,
+		result.Snapshot.LaunchEntries,
+	); err != nil {
+		return Result{}, inventorySourceFailure("failed to read pull-request provenance", err)
 	}
 	return result, nil
 }
@@ -590,6 +589,7 @@ func publicNotes(notes []config.ConfigNote) []Note {
 
 func (s *currentSource) annotateProtectedSockets(
 	ctx context.Context,
+	includeSocketName bool,
 	entryGroups ...[]Entry,
 ) error {
 	records := make(map[string]pullrequest.Provenance)
@@ -606,12 +606,16 @@ func (s *currentSource) annotateProtectedSockets(
 		return fmt.Errorf("failed to read pull-request provenance: %w", err)
 	}
 	for _, entries := range entryGroups {
-		annotateProtectedEntries(records, entries)
+		annotateProtectedEntries(records, entries, includeSocketName)
 	}
 	return nil
 }
 
-func annotateProtectedEntries(records map[string]pullrequest.Provenance, entries []Entry) {
+func annotateProtectedEntries(
+	records map[string]pullrequest.Provenance,
+	entries []Entry,
+	includeSocketName bool,
+) {
 	for index := range entries {
 		for _, record := range records {
 			workspace := record.Workspace
@@ -652,10 +656,12 @@ func annotateProtectedEntries(records map[string]pullrequest.Provenance, entries
 			}
 			if verifiedSession {
 				entries[index].SessionName = workspace.SessionName
-				entries[index].TmuxSocketName = tmux.ProtectedWorkspaceSocketName(
-					workspace.SessionName,
-					workspace.Path,
-				)
+				if includeSocketName {
+					entries[index].TmuxSocketName = tmux.ProtectedWorkspaceSocketName(
+						workspace.SessionName,
+						workspace.Path,
+					)
+				}
 			}
 			break
 		}

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -353,7 +353,7 @@ func TestSourceRepositoryInventoryIgnoresInheritedGitRouting(t *testing.T) {
 	assert.Equal(t, canonicalTarget, result.Snapshot.Entries[0].Path)
 }
 
-func TestSourceReadsProvenanceOnlyWhenRequested(t *testing.T) {
+func TestSourceRequiresValidProvenanceForProtectedClassification(t *testing.T) {
 	home := t.TempDir()
 	baseDirectory := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
@@ -365,7 +365,7 @@ func TestSourceReadsProvenanceOnlyWhenRequested(t *testing.T) {
 	_, err := source.Load(context.Background(), Request{
 		View: ViewDashboard, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
 	})
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "failed to read pull-request provenance")
 
 	_, err = source.Load(context.Background(), Request{
 		View: ViewDashboard, Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
@@ -427,7 +427,7 @@ func TestAnnotateProtectedSocketsPreservesVerifiedPersistedEndpoint(t *testing.T
 			}}
 
 			err := (&currentSource{home: home}).annotateProtectedSockets(
-				context.Background(), entries,
+				context.Background(), true, entries,
 			)
 
 			require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestAnnotateProtectedSocketsPreservesVerifiedPersistedEndpoint(t *testing.T
 	}
 }
 
-func TestSourceDashboardLaunchEntryRetainsProtectedEndpoint(t *testing.T) {
+func TestSourceDashboardLaunchEntryRetainsProtectedPolicy(t *testing.T) {
 	home := t.TempDir()
 	baseDirectory := t.TempDir()
 	repository := filepath.Join(baseDirectory, "widget")
@@ -484,28 +484,46 @@ func TestSourceDashboardLaunchEntryRetainsProtectedEndpoint(t *testing.T) {
 		},
 	}
 
-	result, err := source.Load(context.Background(), Request{
-		View: ViewDashboard, LaunchDirectory: repository,
-		IncludeProtectedSockets: true,
-		Expansion:               testExpansion(t),
-		UntrustedConfig:         IgnoreUntrustedConfig,
-	})
-
-	require.NoError(t, err)
-	require.NotEmpty(t, result.Snapshot.Entries)
-	require.NotEmpty(t, result.Snapshot.LaunchEntries)
 	wantSocket := tmux.ProtectedWorkspaceSocketName(sessionName, repository)
-	for _, group := range [][]Entry{result.Snapshot.Entries, result.Snapshot.LaunchEntries} {
-		var matched *Entry
-		for index := range group {
-			if group[index].Path == repository {
-				matched = &group[index]
-				break
+	for _, test := range []struct {
+		name                    string
+		includeProtectedSockets bool
+		wantSocket              string
+	}{
+		{name: "mode only"},
+		{
+			name:                    "mode and socket",
+			includeProtectedSockets: true,
+			wantSocket:              wantSocket,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := source.Load(context.Background(), Request{
+				View: ViewDashboard, LaunchDirectory: repository,
+				IncludeProtectedSockets: test.includeProtectedSockets,
+				Expansion:               testExpansion(t),
+				UntrustedConfig:         IgnoreUntrustedConfig,
+			})
+
+			require.NoError(t, err)
+			require.NotEmpty(t, result.Snapshot.Entries)
+			require.NotEmpty(t, result.Snapshot.LaunchEntries)
+			for _, group := range [][]Entry{
+				result.Snapshot.Entries,
+				result.Snapshot.LaunchEntries,
+			} {
+				var matched *Entry
+				for index := range group {
+					if group[index].Path == repository {
+						matched = &group[index]
+						break
+					}
+				}
+				require.NotNil(t, matched)
+				assert.Equal(t, models.TmuxAttachProtected, matched.TmuxAttachMode)
+				assert.Equal(t, test.wantSocket, matched.TmuxSocketName)
 			}
-		}
-		require.NotNil(t, matched)
-		assert.Equal(t, models.TmuxAttachProtected, matched.TmuxAttachMode)
-		assert.Equal(t, wantSocket, matched.TmuxSocketName)
+		})
 	}
 }
 

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -423,6 +423,7 @@ func TestAnnotateProtectedSocketsPreservesVerifiedPersistedEndpoint(t *testing.T
 				Path: path, Branch: branch, Generation: generation,
 				Repository:  Repository{FullPath: "github.com/acme/widget"},
 				SessionName: derived,
+				SessionLive: true,
 			}}
 
 			err := (&currentSource{home: home}).annotateProtectedSockets(
@@ -432,8 +433,172 @@ func TestAnnotateProtectedSocketsPreservesVerifiedPersistedEndpoint(t *testing.T
 			require.NoError(t, err)
 			assert.Equal(t, test.wantName, entries[0].SessionName)
 			assert.Equal(t, test.wantSocket, entries[0].TmuxSocketName)
+			assert.Equal(t, models.TmuxAttachProtected, entries[0].TmuxAttachMode)
+			assert.False(t, entries[0].SessionLive,
+				"shared-server liveness must not be retained for a protected endpoint")
 		})
 	}
+}
+
+func TestAnnotateWorkspaceEndpointsUsesCanonicalStateWhenTmuxIsUnavailable(t *testing.T) {
+	options := tmux.WorkspaceSessionsOptions{Command: "kwt-test-missing-tmux-binary"}
+	source := &currentSource{
+		workspaceSessions: &options,
+	}
+	entries := []Entry{{
+		Path: "/work/widget", SessionName: "kwt-wt-widget-main-01234567",
+	}}
+
+	_, err := source.annotateWorkspaceEndpoints(
+		context.Background(), testExpansion(t), nil, entries, nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, tmux.KWTServerSocketName, entries[0].TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, entries[0].TmuxAttachMode)
+}
+
+func TestAnnotateWorkspaceEndpointsPublishesCanonicalAndAdoptedState(t *testing.T) {
+	source := &currentSource{
+		resolveWorkspaceSessions: func(
+			_ context.Context,
+			_ tmux.WorkspaceSessionsOptions,
+			requests []tmux.WorkspaceEndpointRequest,
+		) ([]tmux.WorkspaceSessionResolution, error) {
+			require.Len(t, requests, 2)
+			return []tmux.WorkspaceSessionResolution{
+				{Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
+					SessionName: requests[0].SessionName,
+					SocketName:  tmux.KWTServerSocketName,
+				}}},
+				{
+					Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
+						SessionName: requests[1].SessionName,
+					},
+						Live: true,
+					},
+				},
+			}, nil
+		},
+	}
+	entries := []Entry{
+		{Path: "/work/one", SessionName: "one"},
+		{Path: "/work/two", SessionName: "two"},
+	}
+
+	_, err := source.annotateWorkspaceEndpoints(
+		context.Background(), testExpansion(t), nil, entries, nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, tmux.KWTServerSocketName, entries[0].TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, entries[0].TmuxAttachMode)
+	assert.Empty(t, entries[1].TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, entries[1].TmuxAttachMode)
+	assert.True(t, entries[1].SessionLive)
+}
+
+func TestAnnotateWorkspaceEndpointsDegradesOnlyUnsafeEntry(t *testing.T) {
+	source := &currentSource{
+		resolveWorkspaceSessions: func(
+			_ context.Context,
+			_ tmux.WorkspaceSessionsOptions,
+			requests []tmux.WorkspaceEndpointRequest,
+		) ([]tmux.WorkspaceSessionResolution, error) {
+			require.Len(t, requests, 2)
+			return []tmux.WorkspaceSessionResolution{
+				{
+					Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
+						SessionName: requests[0].SessionName,
+						SocketName:  tmux.KWTServerSocketName,
+					}},
+					Err: &tmux.SessionSafetyError{Reason: "stale generation"},
+				},
+				{Session: tmux.WorkspaceSession{
+					Endpoint: tmux.SessionEndpoint{SessionName: requests[1].SessionName},
+					Live:     true,
+				}},
+			}, nil
+		},
+	}
+	entries := []Entry{
+		{Path: "/work/one", SessionName: "one"},
+		{Path: "/work/two", SessionName: "two"},
+	}
+
+	notes, err := source.annotateWorkspaceEndpoints(
+		context.Background(), testExpansion(t), nil, entries, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, notes, 1)
+	assert.Equal(t, "tmux_endpoint_degraded", notes[0].Code)
+	assert.Equal(t, "/work/one", notes[0].Path)
+	assert.Contains(t, notes[0].Message, "stale generation")
+	assert.Equal(t, tmux.KWTServerSocketName, entries[0].TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, entries[0].TmuxAttachMode)
+	assert.Empty(t, entries[1].TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachDirect, entries[1].TmuxAttachMode)
+}
+
+func TestAnnotateWorkspaceEndpointsPublishesResolverDiagnostic(t *testing.T) {
+	source := &currentSource{
+		resolveWorkspaceSessions: func(
+			_ context.Context,
+			options tmux.WorkspaceSessionsOptions,
+			requests []tmux.WorkspaceEndpointRequest,
+		) ([]tmux.WorkspaceSessionResolution, error) {
+			require.NotNil(t, options.ReportDiagnostic)
+			options.ReportDiagnostic(errors.New("default tmux server unavailable"))
+			return []tmux.WorkspaceSessionResolution{{
+				Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
+					SessionName: requests[0].SessionName,
+					SocketName:  tmux.KWTServerSocketName,
+				}},
+			}}, nil
+		},
+	}
+	entries := []Entry{{Path: "/work/widget", SessionName: "workspace"}}
+
+	notes, err := source.annotateWorkspaceEndpoints(
+		context.Background(), testExpansion(t), nil, entries, nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, notes, 1)
+	assert.Equal(t, "tmux_lookup_degraded", notes[0].Code)
+	assert.Empty(t, notes[0].Path)
+	assert.Contains(t, notes[0].Message, "default tmux server unavailable")
+}
+
+func TestAnnotateWorkspaceEndpointsTreatsRequestTempDirAsExplicitlyUnset(t *testing.T) {
+	expansion := testExpansion(t)
+	delete(expansion.Environment, normalizedEnvironmentName("TMUX_TMPDIR"))
+	var captured tmux.WorkspaceSessionsOptions
+	source := &currentSource{
+		resolveWorkspaceSessions: func(
+			_ context.Context,
+			options tmux.WorkspaceSessionsOptions,
+			requests []tmux.WorkspaceEndpointRequest,
+		) ([]tmux.WorkspaceSessionResolution, error) {
+			captured = options
+			return []tmux.WorkspaceSessionResolution{{
+				Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
+					SessionName: requests[0].SessionName,
+					SocketName:  tmux.KWTServerSocketName,
+				}},
+			}}, nil
+		},
+	}
+	entries := []Entry{{Path: "/work/widget", SessionName: "workspace"}}
+
+	_, err := source.annotateWorkspaceEndpoints(
+		context.Background(), expansion, nil, entries, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, captured.DefaultServerTempDirSet)
+	assert.Empty(t, captured.DefaultServerTempDir)
 }
 
 func TestSourceSeparatesLaunchInventoryFromDashboardEntries(t *testing.T) {

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -440,6 +440,75 @@ func TestAnnotateProtectedSocketsPreservesVerifiedPersistedEndpoint(t *testing.T
 	}
 }
 
+func TestSourceDashboardLaunchEntryRetainsProtectedEndpoint(t *testing.T) {
+	home := t.TempDir()
+	baseDirectory := t.TempDir()
+	repository := filepath.Join(baseDirectory, "widget")
+	for _, args := range [][]string{
+		{"init", "-b", "main", repository},
+		{"-C", repository, "-c", "user.name=Test", "-c", "user.email=test@example.com",
+			"commit", "--allow-empty", "-m", "initial"},
+		{"-C", repository, "remote", "add", "origin", "https://github.com/acme/widget.git"},
+	} {
+		command := exec.Command("git", args...)
+		require.NoError(t, command.Run())
+	}
+	var err error
+	baseDirectory, err = filepath.EvalSymlinks(baseDirectory)
+	require.NoError(t, err)
+	repository, err = filepath.EvalSymlinks(repository)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(
+		"[worktree]\nbasedir = '"+baseDirectory+"'\n"+
+			"[[projects]]\nrepository = 'github.com/acme/widget'\nname = 'widget'\npath = '"+
+			repository+"'\n",
+	), 0o600))
+	sessionName := "kwt-wt-widget-main-" + template.ShortHash(repository)
+	require.NoError(t, pullrequest.NewFileStore(
+		filepath.Join(home, "pull-requests.json"),
+	).Update(context.Background(), func(records map[string]pullrequest.Provenance) error {
+		records["github:github.com/acme/widget#1"] = pullrequest.Provenance{
+			Repository: "github.com/acme/widget",
+			Project:    pullrequest.Project{Identity: "github.com/acme/widget"},
+			Workspace: pullrequest.Workspace{
+				Repository: "github.com/acme/widget",
+				Path:       repository, Branch: "main", SessionName: sessionName,
+			},
+		}
+		return nil
+	}))
+	source := &currentSource{
+		home: home,
+		workspaceSessions: &tmux.WorkspaceSessionsOptions{
+			Command: "kwt-test-missing-tmux-binary",
+		},
+	}
+
+	result, err := source.Load(context.Background(), Request{
+		View: ViewDashboard, LaunchDirectory: repository,
+		IncludeProtectedSockets: true,
+		Expansion:               testExpansion(t),
+		UntrustedConfig:         IgnoreUntrustedConfig,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Snapshot.Entries)
+	require.NotEmpty(t, result.Snapshot.LaunchEntries)
+	wantSocket := tmux.ProtectedWorkspaceSocketName(sessionName, repository)
+	for _, group := range [][]Entry{result.Snapshot.Entries, result.Snapshot.LaunchEntries} {
+		var matched *Entry
+		for index := range group {
+			if group[index].Path == repository {
+				matched = &group[index]
+				break
+			}
+		}
+		require.NotNil(t, matched)
+		assert.Equal(t, models.TmuxAttachProtected, matched.TmuxAttachMode)
+		assert.Equal(t, wantSocket, matched.TmuxSocketName)
+	}
+}
+
 func TestAnnotateWorkspaceEndpointsUsesCanonicalStateWhenTmuxIsUnavailable(t *testing.T) {
 	options := tmux.WorkspaceSessionsOptions{Command: "kwt-test-missing-tmux-binary"}
 	source := &currentSource{

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -537,12 +537,12 @@ func TestAnnotateWorkspaceEndpointsPublishesCanonicalAndAdoptedState(t *testing.
 			require.Len(t, requests, 2)
 			return []tmux.WorkspaceSessionResolution{
 				{Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
-					SessionName: requests[0].SessionName,
+					SessionName: "canonical-renamed",
 					SocketName:  tmux.KWTServerSocketName,
 				}}},
 				{
 					Session: tmux.WorkspaceSession{Endpoint: tmux.SessionEndpoint{
-						SessionName: requests[1].SessionName,
+						SessionName: "adopted-renamed",
 					},
 						Live: true,
 					},
@@ -560,8 +560,10 @@ func TestAnnotateWorkspaceEndpointsPublishesCanonicalAndAdoptedState(t *testing.
 	)
 
 	require.NoError(t, err)
+	assert.Equal(t, "canonical-renamed", entries[0].SessionName)
 	assert.Equal(t, tmux.KWTServerSocketName, entries[0].TmuxSocketName)
 	assert.Equal(t, models.TmuxAttachDirect, entries[0].TmuxAttachMode)
+	assert.Equal(t, "adopted-renamed", entries[1].SessionName)
 	assert.Empty(t, entries[1].TmuxSocketName)
 	assert.Equal(t, models.TmuxAttachDirect, entries[1].TmuxAttachMode)
 	assert.True(t, entries[1].SessionLive)

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -13,6 +13,7 @@ import (
 	"go.kenn.io/kwt/internal/tmux"
 	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 type Provider interface {
@@ -223,6 +224,10 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 			}
 			return AsError(createErr, CodeWorkspaceCreation, "failed to create pull-request workspace")
 		}
+		workspace = protectedWorkspaceEndpoint(
+			workspace,
+			[]string{pr.Repository.Identity, project.Identity},
+		)
 		created = &workspace
 
 		newRecord := Provenance{
@@ -306,25 +311,41 @@ func matchingProvenanceWorkspace(byPath map[string]Workspace, record Provenance)
 			workspace.Generation != record.Workspace.Generation) {
 		return Workspace{}, false
 	}
-	for _, identity := range ProvenanceRepositoryIdentities(record) {
+	identities := ProvenanceRepositoryIdentities(record)
+	protected := protectedWorkspaceEndpoint(workspace, nil)
+	candidate := workspace
+	candidate.Path = record.Workspace.Path
+	candidate.SessionName = record.Workspace.SessionName
+	candidate = protectedWorkspaceEndpoint(candidate, identities)
+	if candidate.TmuxSocketName != "" {
+		return candidate, true
+	}
+	return protected, true
+}
+
+func protectedWorkspaceEndpoint(
+	workspace Workspace,
+	repositoryIdentities []string,
+) Workspace {
+	workspace.TmuxSocketName = ""
+	workspace.TmuxAttachMode = models.TmuxAttachProtected
+	for _, identity := range repositoryIdentities {
 		info, valid := repositoryurl.CanonicalRepositoryInfo(identity)
 		if !valid || !tmux.MatchesWorkspaceSessionName(
-			record.Workspace.SessionName,
+			workspace.SessionName,
 			info,
-			record.Workspace.Branch,
-			record.Workspace.Path,
+			workspace.Branch,
+			workspace.Path,
 		) {
 			continue
 		}
-		workspace.Path = record.Workspace.Path
-		workspace.SessionName = record.Workspace.SessionName
 		workspace.TmuxSocketName = tmux.ProtectedWorkspaceSocketName(
-			record.Workspace.SessionName,
-			record.Workspace.Path,
+			workspace.SessionName,
+			workspace.Path,
 		)
 		break
 	}
-	return workspace, true
+	return workspace
 }
 
 func (s *Service) provenanceSourceMatches(record Provenance, pr PullRequest) bool {

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -712,6 +712,23 @@ func TestImportPreservesLegacyProtectedWorkspaceEndpoint(t *testing.T) {
 	assert.Zero(t, backend.createCalls)
 }
 
+func TestProtectedWorkspaceEndpointAcceptsPreNormalizationDollarSigns(t *testing.T) {
+	identity := testProject().Identity
+	info, ok := urlutil.CanonicalRepositoryInfo(identity)
+	require.True(t, ok)
+	workspace := Workspace{
+		Branch: "pr-41-feature$widgets",
+		Path:   "/worktrees/widget/pr-41-feature-widgets",
+	}
+	workspace.SessionName = "kwt-wt-" + info.Repository + "-" + workspace.Branch + "-" +
+		template.ShortHash(workspace.Path)
+
+	got := protectedWorkspaceEndpoint(workspace, []string{identity})
+
+	assert.NotEmpty(t, got.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachProtected, got.TmuxAttachMode)
+}
+
 func TestMatchingProvenanceWorkspaceProtectsUnrecognizedSessionName(t *testing.T) {
 	live := Workspace{
 		Path: "/worktrees/widget/pr-41", Branch: "pr-41",

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -18,6 +18,8 @@ import (
 	"go.kenn.io/kwt/internal/template"
 	"go.kenn.io/kwt/internal/tmux"
 	urlutil "go.kenn.io/kwt/internal/url"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/pkg/models"
 )
 
 func testProject() Project {
@@ -325,7 +327,9 @@ func TestListMarksExistingImport(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.True(t, got[0].Imported)
-	assert.Equal(t, &workspace, got[0].Workspace)
+	want := workspace
+	want.TmuxAttachMode = models.TmuxAttachProtected
+	assert.Equal(t, &want, got[0].Workspace)
 }
 
 func TestImportPersistsWorkspaceGenerationInProvenance(t *testing.T) {
@@ -485,7 +489,9 @@ func TestListRecognizesLegacyCasedProvenance(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.True(t, got[0].Imported)
-	assert.Equal(t, &workspace, got[0].Workspace)
+	want := workspace
+	want.TmuxAttachMode = models.TmuxAttachProtected
+	assert.Equal(t, &want, got[0].Workspace)
 }
 
 func TestListRecognizesTransferredRepositoryProvenance(t *testing.T) {
@@ -525,7 +531,9 @@ func TestListRecognizesTransferredRepositoryProvenance(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.True(t, got[0].Imported)
-	assert.Equal(t, &workspace, got[0].Workspace)
+	want := workspace
+	want.TmuxAttachMode = models.TmuxAttachProtected
+	assert.Equal(t, &want, got[0].Workspace)
 }
 
 func TestImportSameRepositoryUsesMatchingRemoteAndCanonicalName(t *testing.T) {
@@ -688,6 +696,7 @@ func TestImportPreservesLegacyProtectedWorkspaceEndpoint(t *testing.T) {
 	assert.Equal(t, recordedPath, listed[0].Workspace.Path)
 	assert.Equal(t, legacyName, listed[0].Workspace.SessionName)
 	assert.Equal(t, legacySocket, listed[0].Workspace.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachProtected, listed[0].Workspace.TmuxAttachMode)
 
 	result, err := service.Import(context.Background(), testProject(), pr.ID)
 	require.NoError(t, err)
@@ -695,10 +704,36 @@ func TestImportPreservesLegacyProtectedWorkspaceEndpoint(t *testing.T) {
 	assert.Equal(t, recordedPath, result.Workspace.Path)
 	assert.Equal(t, legacyName, result.Workspace.SessionName)
 	assert.Equal(t, legacySocket, result.Workspace.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachProtected, result.Workspace.TmuxAttachMode)
 	assert.Equal(t, recordedPath, store.records[pr.ID].Workspace.Path)
 	assert.Equal(t, legacyName, store.records[pr.ID].Workspace.SessionName)
 	assert.Equal(t, legacySocket, store.records[pr.ID].Workspace.TmuxSocketName)
+	assert.Equal(t, models.TmuxAttachProtected, store.records[pr.ID].Workspace.TmuxAttachMode)
 	assert.Zero(t, backend.createCalls)
+}
+
+func TestMatchingProvenanceWorkspaceProtectsUnrecognizedSessionName(t *testing.T) {
+	live := Workspace{
+		Path: "/worktrees/widget/pr-41", Branch: "pr-41",
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	record := Provenance{
+		Repository: "github.com/acme/widget",
+		Project:    testProject(),
+		Workspace: Workspace{
+			Path: live.Path, Branch: live.Branch, Generation: live.Generation,
+			SessionName: "unrecognized-session",
+		},
+	}
+
+	got, ok := matchingProvenanceWorkspace(
+		map[string]Workspace{utils.CanonicalPath(live.Path): live},
+		record,
+	)
+
+	require.True(t, ok)
+	assert.Equal(t, models.TmuxAttachProtected, got.TmuxAttachMode)
+	assert.Empty(t, got.TmuxSocketName)
 }
 
 func TestImportDoesNotReturnExistingWorkspaceWhenBranchDiffers(t *testing.T) {
@@ -880,7 +915,9 @@ func TestImportMigratesTransferredRepositoryProvenance(t *testing.T) {
 	}, migrated.RepositoryAliases)
 	assert.Equal(t, testProject().Identity, migrated.Project.Identity)
 	assert.Equal(t, pr.Source.Repository.Identity, migrated.SourceRepo)
-	assert.Equal(t, workspace, migrated.Workspace)
+	wantWorkspace := workspace
+	wantWorkspace.TmuxAttachMode = models.TmuxAttachProtected
+	assert.Equal(t, wantWorkspace, migrated.Workspace)
 }
 
 func TestImportMigratesConsecutiveRepositoryTransfers(t *testing.T) {

--- a/internal/pullrequest/types.go
+++ b/internal/pullrequest/types.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"go.kenn.io/kwt/pkg/models"
 )
 
 type ErrorCode string
@@ -96,14 +98,17 @@ type PullRequest struct {
 }
 
 type Workspace struct {
-	ID             string `json:"id"`
-	Repository     string `json:"repository"`
-	Branch         string `json:"branch"`
-	Path           string `json:"path"`
-	Generation     string `json:"generation,omitempty"`
-	State          string `json:"state"`
-	SessionName    string `json:"session_name"`
-	TmuxSocketName string `json:"tmux_socket_name,omitempty"`
+	ID          string `json:"id"`
+	Repository  string `json:"repository"`
+	Branch      string `json:"branch"`
+	Path        string `json:"path"`
+	Generation  string `json:"generation,omitempty"`
+	State       string `json:"state"`
+	SessionName string `json:"session_name"`
+	// TmuxSocketName is empty when protection is known but repository identity
+	// is insufficient to publish an attachable endpoint.
+	TmuxSocketName string                `json:"tmux_socket_name,omitempty"`
+	TmuxAttachMode models.TmuxAttachMode `json:"tmux_attach_mode"`
 	partialCleanup *workspacePartialCleanup
 	// preserveOnImportError means Kit could not prove that cleanup was safe.
 	// Other post-creation failures retain rollback metadata and are cleaned up.

--- a/internal/tmux/bootstrap.go
+++ b/internal/tmux/bootstrap.go
@@ -315,6 +315,15 @@ func BuildSessionBootstrapCommand(session string, stripNames []string) []string 
 const workspacePathOption = "@kwt-workspace-path"
 const workspaceIdentityOption = "@kwt-workspace-id"
 const workspaceGenerationOption = "@kwt-workspace-generation"
+const workspaceCleanupOptionPrefix = "@kwt-cleanup-"
+
+// workspaceCleanupOption encodes the verified identity in an option name.
+// tmux 2.1 can test that option atomically with if-shell -F, but cannot compare
+// two format values. This keeps marker validation and termination in one
+// server command without raising KWT's tmux version floor.
+func workspaceCleanupOption(identity string) string {
+	return workspaceCleanupOptionPrefix + identity
+}
 
 func workspacePathIdentity(worktreeDir string) string {
 	digest := sha256.Sum256([]byte(utils.PathKey(worktreeDir)))
@@ -329,20 +338,27 @@ func buildWorkspaceSessionBootstrapCommand(
 	session, worktreeDir, generation string,
 	stripNames []string,
 ) []string {
+	workspaceIdentity := workspacePathIdentity(worktreeDir)
 	cmd := BuildSessionBootstrapCommand(session, stripNames)
 	cmd = append(
 		cmd,
 		";", "set-option", "-t", session, workspacePathOption, worktreeDir,
 		";", "set-option", "-t", session, workspaceIdentityOption,
-		workspacePathIdentity(worktreeDir),
+		workspaceIdentity,
 	)
+	cleanupIdentity := workspaceIdentity
 	if generation != "" {
 		cmd = append(
 			cmd,
 			";", "set-option", "-t", session, workspaceGenerationOption, generation,
 		)
+		cleanupIdentity = generation
 	}
-	return cmd
+	return append(
+		cmd,
+		";", "set-option", "-t", session,
+		workspaceCleanupOption(cleanupIdentity), "1",
+	)
 }
 
 // buildProtectedSessionBootstrapCommand records the workspace identity in the

--- a/internal/tmux/bootstrap_test.go
+++ b/internal/tmux/bootstrap_test.go
@@ -368,6 +368,7 @@ func TestBuildWorkspaceSessionBootstrapCommandRecordsPathIdentity(t *testing.T) 
 		workspacePathIdentity("/worktrees/topic"),
 		workspaceGenerationOption,
 		generation,
+		"@kwt-cleanup-" + generation,
 	} {
 		if !slices.Contains(got, want) {
 			t.Errorf("buildWorkspaceSessionBootstrapCommand() = %v, missing %q", got, want)

--- a/internal/tmux/cleanup.go
+++ b/internal/tmux/cleanup.go
@@ -1,0 +1,134 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type sessionCleanupIdentity struct {
+	SessionID           string
+	WorkspaceIdentity   string
+	WorkspaceGeneration string
+	Absent              bool
+}
+
+type workspaceCleanupCommand interface {
+	workspaceSessionCleanupIdentityContext(
+		context.Context,
+		string,
+	) (sessionCleanupIdentity, error)
+	KillSessionIfPresentContext(context.Context, string) error
+}
+
+func killWorkspaceSessionIfMatching(
+	ctx context.Context,
+	command workspaceCleanupCommand,
+	request WorkspaceEndpointRequest,
+) error {
+	identity, err := command.workspaceSessionCleanupIdentityContext(
+		ctx,
+		request.SessionName,
+	)
+	if err != nil {
+		return err
+	}
+	if identity.Absent {
+		return nil
+	}
+	if !validRemovalSessionID(identity.SessionID) {
+		return &SessionSafetyError{Reason: fmt.Sprintf(
+			"tmux session %q has malformed cleanup identity",
+			request.SessionName,
+		)}
+	}
+	if request.WorkspaceGeneration != "" {
+		if !validLowerHex(identity.WorkspaceGeneration, 32) {
+			return &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q has malformed worktree generation markers",
+				request.SessionName,
+			)}
+		}
+		if identity.WorkspaceGeneration != request.WorkspaceGeneration {
+			return &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q belongs to a different worktree generation",
+				request.SessionName,
+			)}
+		}
+	} else {
+		if !validLowerHex(identity.WorkspaceIdentity, 64) {
+			return &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q has malformed workspace identity markers",
+				request.SessionName,
+			)}
+		}
+		if identity.WorkspaceIdentity != workspacePathIdentity(request.WorkspacePath) {
+			return &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q belongs to a different workspace identity",
+				request.SessionName,
+			)}
+		}
+	}
+	return command.KillSessionIfPresentContext(ctx, identity.SessionID)
+}
+
+// KillWorkspaceSessionIfMatchingContext terminates a cleanup target only when
+// its KWT identity markers still match the removed workspace.
+func (t *TmuxCommand) KillWorkspaceSessionIfMatchingContext(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+) error {
+	return killWorkspaceSessionIfMatching(ctx, t, request)
+}
+
+func (t *TmuxCommand) workspaceSessionCleanupIdentityContext(
+	ctx context.Context,
+	session string,
+) (sessionCleanupIdentity, error) {
+	output, stderr, err := t.runCommandOutputContextWithStderr(
+		ctx,
+		"display-message",
+		"-p",
+		"-t",
+		session,
+		"#{session_id}\t#{@kwt-workspace-id}\t#{@kwt-workspace-generation}",
+	)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		err = errors.Join(ctxErr, err)
+	}
+	return classifySessionCleanupIdentity(output, stderr, err)
+}
+
+func classifySessionCleanupIdentity(
+	output string,
+	stderr string,
+	err error,
+) (sessionCleanupIdentity, error) {
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return sessionCleanupIdentity{}, err
+		}
+		var exited exitCoder
+		if errors.As(err, &exited) && exited.ExitCode() == 1 &&
+			isExplicitlyAbsentTmuxDiagnostic(stderr) {
+			return sessionCleanupIdentity{Absent: true}, nil
+		}
+		return sessionCleanupIdentity{}, fmt.Errorf(
+			"inspect tmux cleanup identity: %w, stderr: %s",
+			err,
+			strings.TrimSpace(stderr),
+		)
+	}
+	fields := strings.Split(strings.TrimSuffix(output, "\n"), "\t")
+	if len(fields) != 3 {
+		return sessionCleanupIdentity{}, fmt.Errorf(
+			"inspect tmux cleanup identity: malformed response",
+		)
+	}
+	return sessionCleanupIdentity{
+		SessionID:           strings.TrimSuffix(fields[0], "\r"),
+		WorkspaceIdentity:   strings.TrimSuffix(fields[1], "\r"),
+		WorkspaceGeneration: strings.TrimSuffix(fields[2], "\r"),
+	}, nil
+}

--- a/internal/tmux/cleanup.go
+++ b/internal/tmux/cleanup.go
@@ -92,7 +92,7 @@ func (t *TmuxCommand) workspaceSessionCleanupIdentityContext(
 		"-p",
 		"-t",
 		session,
-		"#{session_id}\t#{@kwt-workspace-id}\t#{@kwt-workspace-generation}",
+		"#{session_id}|#{@kwt-workspace-id}|#{@kwt-workspace-generation}",
 	)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		err = errors.Join(ctxErr, err)
@@ -120,7 +120,7 @@ func classifySessionCleanupIdentity(
 			strings.TrimSpace(stderr),
 		)
 	}
-	fields := strings.Split(strings.TrimSuffix(output, "\n"), "\t")
+	fields := strings.Split(strings.TrimSuffix(output, "\n"), "|")
 	if len(fields) != 3 {
 		return sessionCleanupIdentity{}, fmt.Errorf(
 			"inspect tmux cleanup identity: malformed response",

--- a/internal/tmux/cleanup.go
+++ b/internal/tmux/cleanup.go
@@ -141,6 +141,69 @@ func (t *TmuxCommand) KillWorkspaceSessionIfMatchingContext(
 	return killWorkspaceSessionIfMatching(ctx, t, request)
 }
 
+// KillProtectedWorkspaceSessionsIfMatchingContext terminates every verified
+// protected session at the canonical socket and the explicit socket directory
+// used by earlier KWT versions. Each endpoint is checked independently so a
+// live canonical session cannot hide a matching prior-location session.
+func KillProtectedWorkspaceSessionsIfMatchingContext(
+	ctx context.Context,
+	socketName string,
+	protectedNames []string,
+	legacyTempDir string,
+	request WorkspaceEndpointRequest,
+) error {
+	type protectedCleanupTarget struct {
+		location string
+		command  *TmuxCommand
+	}
+	targets := []protectedCleanupTarget{{
+		location: "canonical",
+		command:  newProtectedSessionProbeCommand(socketName, protectedNames),
+	}}
+	if legacyTempDir != "" {
+		// compat(kag1): protected sessions created with inherited TMUX_TMPDIR
+		targets = append(targets, protectedCleanupTarget{
+			location: "legacy",
+			command: NewTmuxCommandForSocketInTempDirWithStripNames(
+				"", socketName, legacyTempDir, protectedNames,
+			),
+		})
+	}
+
+	var cleanupErr error
+	for _, target := range targets {
+		state, err := probeProtectedSessionCommand(
+			ctx,
+			target.command,
+			request.SessionName,
+		)
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf(
+				"inspect %s protected tmux endpoint: %w",
+				target.location,
+				err,
+			))
+			continue
+		}
+		switch state {
+		case ProtectedSessionAbsent:
+			continue
+		case ProtectedSessionLive:
+			err = target.command.KillWorkspaceSessionIfMatchingContext(ctx, request)
+		default:
+			err = fmt.Errorf("protected tmux session state is indeterminate")
+		}
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf(
+				"clean up %s protected tmux endpoint: %w",
+				target.location,
+				err,
+			))
+		}
+	}
+	return cleanupErr
+}
+
 func (t *TmuxCommand) killWorkspaceSessionWithOptionContext(
 	ctx context.Context,
 	session string,

--- a/internal/tmux/cleanup.go
+++ b/internal/tmux/cleanup.go
@@ -7,19 +7,22 @@ import (
 	"strings"
 )
 
-type sessionCleanupIdentity struct {
-	SessionID           string
-	WorkspaceIdentity   string
-	WorkspaceGeneration string
-	Absent              bool
-}
+type workspaceCleanupResult uint8
+
+const (
+	workspaceCleanupTerminated workspaceCleanupResult = iota
+	workspaceCleanupAbsent
+	workspaceCleanupMismatch
+)
+
+const workspaceCleanupMismatchOutput = "kwt-cleanup-marker-mismatch"
 
 type workspaceCleanupCommand interface {
-	workspaceSessionCleanupIdentityContext(
+	killWorkspaceSessionWithOptionContext(
 		context.Context,
 		string,
-	) (sessionCleanupIdentity, error)
-	KillSessionIfPresentContext(context.Context, string) error
+		string,
+	) (workspaceCleanupResult, error)
 }
 
 func killWorkspaceSessionIfMatching(
@@ -27,54 +30,40 @@ func killWorkspaceSessionIfMatching(
 	command workspaceCleanupCommand,
 	request WorkspaceEndpointRequest,
 ) error {
-	identity, err := command.workspaceSessionCleanupIdentityContext(
-		ctx,
-		request.SessionName,
-	)
-	if err != nil {
-		return err
-	}
-	if identity.Absent {
-		return nil
-	}
-	if !validRemovalSessionID(identity.SessionID) {
-		return &SessionSafetyError{Reason: fmt.Sprintf(
-			"tmux session %q has malformed cleanup identity",
-			request.SessionName,
-		)}
-	}
-	if request.WorkspaceGeneration != "" {
-		if !validLowerHex(identity.WorkspaceGeneration, 32) {
+	cleanupIdentity := request.WorkspaceGeneration
+	mismatchReason := "belongs to a different worktree generation"
+	if cleanupIdentity != "" {
+		if !validLowerHex(cleanupIdentity, 32) {
 			return &SessionSafetyError{Reason: fmt.Sprintf(
 				"tmux session %q has malformed worktree generation markers",
 				request.SessionName,
 			)}
 		}
-		if identity.WorkspaceGeneration != request.WorkspaceGeneration {
-			return &SessionSafetyError{Reason: fmt.Sprintf(
-				"tmux session %q belongs to a different worktree generation",
-				request.SessionName,
-			)}
-		}
 	} else {
-		if !validLowerHex(identity.WorkspaceIdentity, 64) {
-			return &SessionSafetyError{Reason: fmt.Sprintf(
-				"tmux session %q has malformed workspace identity markers",
-				request.SessionName,
-			)}
-		}
-		if identity.WorkspaceIdentity != workspacePathIdentity(request.WorkspacePath) {
-			return &SessionSafetyError{Reason: fmt.Sprintf(
-				"tmux session %q belongs to a different workspace identity",
-				request.SessionName,
-			)}
-		}
+		cleanupIdentity = workspacePathIdentity(request.WorkspacePath)
+		mismatchReason = "belongs to a different workspace identity"
 	}
-	return command.KillSessionIfPresentContext(ctx, identity.SessionID)
+
+	result, err := command.killWorkspaceSessionWithOptionContext(
+		ctx,
+		request.SessionName,
+		workspaceCleanupOption(cleanupIdentity),
+	)
+	if err != nil {
+		return err
+	}
+	if result == workspaceCleanupMismatch {
+		return &SessionSafetyError{Reason: fmt.Sprintf(
+			"tmux session %q %s",
+			request.SessionName,
+			mismatchReason,
+		)}
+	}
+	return nil
 }
 
 // KillWorkspaceSessionIfMatchingContext terminates a cleanup target only when
-// its KWT identity markers still match the removed workspace.
+// its KWT identity marker still matches the removed workspace.
 func (t *TmuxCommand) KillWorkspaceSessionIfMatchingContext(
 	ctx context.Context,
 	request WorkspaceEndpointRequest,
@@ -82,53 +71,61 @@ func (t *TmuxCommand) KillWorkspaceSessionIfMatchingContext(
 	return killWorkspaceSessionIfMatching(ctx, t, request)
 }
 
-func (t *TmuxCommand) workspaceSessionCleanupIdentityContext(
+func (t *TmuxCommand) killWorkspaceSessionWithOptionContext(
 	ctx context.Context,
 	session string,
-) (sessionCleanupIdentity, error) {
+	cleanupOption string,
+) (workspaceCleanupResult, error) {
+	// if-shell -F evaluates the marker and queues the selected branch inside
+	// one server request. A server restart cannot redirect the kill to a new
+	// server that reused the original session ID.
+	condition := "#{?" + cleanupOption + ",1,0}"
+	killCommand := "kill-session -t " + quoteTmuxCommandArgument("="+session)
 	output, stderr, err := t.runCommandOutputContextWithStderr(
 		ctx,
-		"display-message",
-		"-p",
+		"if-shell",
+		"-F",
 		"-t",
 		session,
-		"#{session_id}|#{@kwt-workspace-id}|#{@kwt-workspace-generation}",
+		condition,
+		killCommand,
+		"display-message -p "+workspaceCleanupMismatchOutput,
 	)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		err = errors.Join(ctxErr, err)
 	}
-	return classifySessionCleanupIdentity(output, stderr, err)
-}
-
-func classifySessionCleanupIdentity(
-	output string,
-	stderr string,
-	err error,
-) (sessionCleanupIdentity, error) {
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return sessionCleanupIdentity{}, err
+			return workspaceCleanupMismatch, err
 		}
 		var exited exitCoder
 		if errors.As(err, &exited) && exited.ExitCode() == 1 &&
 			isExplicitlyAbsentTmuxDiagnostic(stderr) {
-			return sessionCleanupIdentity{Absent: true}, nil
+			return workspaceCleanupAbsent, nil
 		}
-		return sessionCleanupIdentity{}, fmt.Errorf(
-			"inspect tmux cleanup identity: %w, stderr: %s",
+		return workspaceCleanupMismatch, fmt.Errorf(
+			"inspect and terminate tmux cleanup target: %w, stderr: %s",
 			err,
 			strings.TrimSpace(stderr),
 		)
 	}
-	fields := strings.Split(strings.TrimSuffix(output, "\n"), "|")
-	if len(fields) != 3 {
-		return sessionCleanupIdentity{}, fmt.Errorf(
-			"inspect tmux cleanup identity: malformed response",
+	switch strings.TrimSpace(output) {
+	case "":
+		return workspaceCleanupTerminated, nil
+	case workspaceCleanupMismatchOutput:
+		return workspaceCleanupMismatch, nil
+	default:
+		return workspaceCleanupMismatch, fmt.Errorf(
+			"inspect and terminate tmux cleanup target: malformed response",
 		)
 	}
-	return sessionCleanupIdentity{
-		SessionID:           strings.TrimSuffix(fields[0], "\r"),
-		WorkspaceIdentity:   strings.TrimSuffix(fields[1], "\r"),
-		WorkspaceGeneration: strings.TrimSuffix(fields[2], "\r"),
-	}, nil
+}
+
+func quoteTmuxCommandArgument(value string) string {
+	value = strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`$`, `\$`,
+	).Replace(value)
+	return `"` + value + `"`
 }

--- a/internal/tmux/cleanup.go
+++ b/internal/tmux/cleanup.go
@@ -17,9 +17,27 @@ const (
 
 const workspaceCleanupMismatchOutput = "kwt-cleanup-marker-mismatch"
 
+type workspaceCleanupIdentity struct {
+	SessionID           string
+	WorkspaceIdentity   string
+	WorkspaceGeneration string
+	Absent              bool
+}
+
 type workspaceCleanupCommand interface {
 	killWorkspaceSessionWithOptionContext(
 		context.Context,
+		string,
+		string,
+	) (workspaceCleanupResult, error)
+	workspaceSessionCleanupIdentityContext(
+		context.Context,
+		string,
+	) (workspaceCleanupIdentity, error)
+	killWorkspaceSessionWithObservedIdentityContext(
+		context.Context,
+		string,
+		string,
 		string,
 		string,
 	) (workspaceCleanupResult, error)
@@ -30,36 +48,88 @@ func killWorkspaceSessionIfMatching(
 	command workspaceCleanupCommand,
 	request WorkspaceEndpointRequest,
 ) error {
-	cleanupIdentity := request.WorkspaceGeneration
+	expectedIdentity := request.WorkspaceGeneration
+	markerOption := workspaceGenerationOption
 	mismatchReason := "belongs to a different worktree generation"
-	if cleanupIdentity != "" {
-		if !validLowerHex(cleanupIdentity, 32) {
-			return &SessionSafetyError{Reason: fmt.Sprintf(
-				"tmux session %q has malformed worktree generation markers",
+	malformedReason := "has malformed worktree generation markers"
+	identityLength := 32
+	if expectedIdentity != "" {
+		if !validLowerHex(expectedIdentity, identityLength) {
+			return workspaceCleanupSafetyError(
 				request.SessionName,
-			)}
+				malformedReason,
+			)
 		}
 	} else {
-		cleanupIdentity = workspacePathIdentity(request.WorkspacePath)
+		expectedIdentity = workspacePathIdentity(request.WorkspacePath)
+		markerOption = workspaceIdentityOption
 		mismatchReason = "belongs to a different workspace identity"
+		malformedReason = "has malformed workspace identity markers"
+		identityLength = 64
 	}
 
 	result, err := command.killWorkspaceSessionWithOptionContext(
 		ctx,
 		request.SessionName,
-		workspaceCleanupOption(cleanupIdentity),
+		workspaceCleanupOption(expectedIdentity),
+	)
+	if err != nil {
+		return err
+	}
+	if result != workspaceCleanupMismatch {
+		return nil
+	}
+
+	// compat(kag1): sessions created before atomic cleanup markers
+	identity, err := command.workspaceSessionCleanupIdentityContext(
+		ctx,
+		request.SessionName,
+	)
+	if err != nil {
+		return err
+	}
+	if identity.Absent {
+		return nil
+	}
+	if !validRemovalSessionID(identity.SessionID) {
+		return workspaceCleanupSafetyError(
+			request.SessionName,
+			"has malformed cleanup identity",
+		)
+	}
+	observedIdentity := identity.WorkspaceGeneration
+	if markerOption == workspaceIdentityOption {
+		observedIdentity = identity.WorkspaceIdentity
+	}
+	if !validLowerHex(observedIdentity, identityLength) {
+		return workspaceCleanupSafetyError(request.SessionName, malformedReason)
+	}
+	if observedIdentity != expectedIdentity {
+		return workspaceCleanupSafetyError(request.SessionName, mismatchReason)
+	}
+
+	result, err = command.killWorkspaceSessionWithObservedIdentityContext(
+		ctx,
+		request.SessionName,
+		identity.SessionID,
+		markerOption,
+		expectedIdentity,
 	)
 	if err != nil {
 		return err
 	}
 	if result == workspaceCleanupMismatch {
-		return &SessionSafetyError{Reason: fmt.Sprintf(
-			"tmux session %q %s",
-			request.SessionName,
-			mismatchReason,
-		)}
+		return workspaceCleanupSafetyError(request.SessionName, mismatchReason)
 	}
 	return nil
+}
+
+func workspaceCleanupSafetyError(session, reason string) error {
+	return &SessionSafetyError{Reason: fmt.Sprintf(
+		"tmux session %q %s",
+		session,
+		reason,
+	)}
 }
 
 // KillWorkspaceSessionIfMatchingContext terminates a cleanup target only when
@@ -91,6 +161,92 @@ func (t *TmuxCommand) killWorkspaceSessionWithOptionContext(
 		killCommand,
 		"display-message -p "+workspaceCleanupMismatchOutput,
 	)
+	return classifyWorkspaceCleanupResult(ctx, output, stderr, err)
+}
+
+// compat(kag1): sessions created before atomic cleanup markers
+func (t *TmuxCommand) workspaceSessionCleanupIdentityContext(
+	ctx context.Context,
+	session string,
+) (workspaceCleanupIdentity, error) {
+	output, stderr, err := t.runCommandOutputContextWithStderr(
+		ctx,
+		"display-message",
+		"-p",
+		"-t",
+		session,
+		"#{session_id}|#{@kwt-workspace-id}|#{@kwt-workspace-generation}",
+	)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		err = errors.Join(ctxErr, err)
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return workspaceCleanupIdentity{}, err
+		}
+		var exited exitCoder
+		if errors.As(err, &exited) && exited.ExitCode() == 1 &&
+			isExplicitlyAbsentTmuxDiagnostic(stderr) {
+			return workspaceCleanupIdentity{Absent: true}, nil
+		}
+		return workspaceCleanupIdentity{}, fmt.Errorf(
+			"inspect tmux cleanup identity: %w, stderr: %s",
+			err,
+			strings.TrimSpace(stderr),
+		)
+	}
+	fields := strings.Split(strings.TrimSuffix(output, "\n"), "|")
+	if len(fields) != 3 {
+		return workspaceCleanupIdentity{}, fmt.Errorf(
+			"inspect tmux cleanup identity: malformed response",
+		)
+	}
+	return workspaceCleanupIdentity{
+		SessionID:           strings.TrimSuffix(fields[0], "\r"),
+		WorkspaceIdentity:   strings.TrimSuffix(fields[1], "\r"),
+		WorkspaceGeneration: strings.TrimSuffix(fields[2], "\r"),
+	}, nil
+}
+
+// compat(kag1): sessions created before atomic cleanup markers
+func (t *TmuxCommand) killWorkspaceSessionWithObservedIdentityContext(
+	ctx context.Context,
+	session string,
+	sessionID string,
+	markerOption string,
+	expectedIdentity string,
+) (workspaceCleanupResult, error) {
+	showMarkerArgs := append(
+		[]string{t.command},
+		t.socketArgs([]string{
+			"show-options", "-v", "-t", sessionID, markerOption,
+		})...,
+	)
+	quotedShowMarkerArgs := make([]string, len(showMarkerArgs))
+	for index, argument := range showMarkerArgs {
+		quotedShowMarkerArgs[index] = quotePOSIXShellArgument(argument)
+	}
+	condition := "test \"$(" + strings.Join(quotedShowMarkerArgs, " ") +
+		" 2>/dev/null)\" = " + quotePOSIXShellArgument(expectedIdentity)
+	killCommand := "kill-session -t " + quoteTmuxCommandArgument(sessionID)
+	output, stderr, err := t.runCommandOutputContextWithStderr(
+		ctx,
+		"if-shell",
+		"-t",
+		session,
+		condition,
+		killCommand,
+		"display-message -p "+workspaceCleanupMismatchOutput,
+	)
+	return classifyWorkspaceCleanupResult(ctx, output, stderr, err)
+}
+
+func classifyWorkspaceCleanupResult(
+	ctx context.Context,
+	output string,
+	stderr string,
+	err error,
+) (workspaceCleanupResult, error) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		err = errors.Join(ctxErr, err)
 	}
@@ -128,4 +284,8 @@ func quoteTmuxCommandArgument(value string) string {
 		`$`, `\$`,
 	).Replace(value)
 	return `"` + value + `"`
+}
+
+func quotePOSIXShellArgument(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }

--- a/internal/tmux/cleanup_integration_test.go
+++ b/internal/tmux/cleanup_integration_test.go
@@ -30,7 +30,7 @@ func TestTmuxCommandAtomicallyTerminatesMatchingWorkspace(t *testing.T) {
 		require.NoError(t, os.RemoveAll(tempDir))
 	})
 
-	session := `kwt-wt-topic;'$HOME"-01234567`
+	session := `kwt-wt-topic;'"-01234567`
 	require.NoError(t, command.NewSessionWithCommandContext(
 		ctx, session, tempDir, "sleep 60",
 	))

--- a/internal/tmux/cleanup_integration_test.go
+++ b/internal/tmux/cleanup_integration_test.go
@@ -52,3 +52,45 @@ func TestTmuxCommandAtomicallyTerminatesMatchingWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, command.HasSession(session))
 }
+
+func TestTmuxCommandTerminatesVerifiedPreCleanupMarkerWorkspace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-cleanup-")
+	require.NoError(t, err)
+	command := NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux", KWTServerSocketName, tempDir, nil,
+	)
+	t.Cleanup(func() {
+		_ = command.RunCommandContext(ctx, "kill-server")
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	session := "kwt-wt-legacy-main-01234567"
+	require.NoError(t, command.NewSessionWithCommandContext(
+		ctx, session, tempDir, "sleep 60",
+	))
+	require.NoError(t, command.SetOptionContext(
+		ctx,
+		session,
+		workspaceGenerationOption,
+		resolverTestGeneration,
+	))
+
+	err = command.KillWorkspaceSessionIfMatchingContext(
+		ctx,
+		WorkspaceEndpointRequest{
+			SessionName:         session,
+			WorkspaceGeneration: resolverTestGeneration,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, command.HasSession(session))
+}

--- a/internal/tmux/cleanup_integration_test.go
+++ b/internal/tmux/cleanup_integration_test.go
@@ -1,0 +1,54 @@
+package tmux
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTmuxCommandAtomicallyTerminatesMatchingWorkspace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-cleanup-")
+	require.NoError(t, err)
+	command := NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux", KWTServerSocketName, tempDir, nil,
+	)
+	t.Cleanup(func() {
+		_ = command.RunCommandContext(ctx, "kill-server")
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	session := `kwt-wt-topic;'$HOME"-01234567`
+	require.NoError(t, command.NewSessionWithCommandContext(
+		ctx, session, tempDir, "sleep 60",
+	))
+	require.NoError(t, command.SetOptionContext(
+		ctx,
+		session,
+		workspaceCleanupOption(resolverTestGeneration),
+		"1",
+	))
+
+	err = command.KillWorkspaceSessionIfMatchingContext(
+		ctx,
+		WorkspaceEndpointRequest{
+			SessionName:         session,
+			WorkspaceGeneration: resolverTestGeneration,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, command.HasSession(session))
+}

--- a/internal/tmux/cleanup_test.go
+++ b/internal/tmux/cleanup_test.go
@@ -2,7 +2,6 @@ package tmux
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,24 +9,22 @@ import (
 )
 
 type fakeWorkspaceCleanupCommand struct {
-	identity   sessionCleanupIdentity
-	observeErr error
-	killed     []string
+	result  workspaceCleanupResult
+	err     error
+	calls   int
+	session string
+	option  string
 }
 
-func (f *fakeWorkspaceCleanupCommand) workspaceSessionCleanupIdentityContext(
-	context.Context,
-	string,
-) (sessionCleanupIdentity, error) {
-	return f.identity, f.observeErr
-}
-
-func (f *fakeWorkspaceCleanupCommand) KillSessionIfPresentContext(
+func (f *fakeWorkspaceCleanupCommand) killWorkspaceSessionWithOptionContext(
 	_ context.Context,
-	target string,
-) error {
-	f.killed = append(f.killed, target)
-	return nil
+	session string,
+	option string,
+) (workspaceCleanupResult, error) {
+	f.calls++
+	f.session = session
+	f.option = option
+	return f.result, f.err
 }
 
 func TestKillWorkspaceSessionIfMatching(t *testing.T) {
@@ -38,56 +35,59 @@ func TestKillWorkspaceSessionIfMatching(t *testing.T) {
 	}
 	tests := []struct {
 		name       string
-		identity   sessionCleanupIdentity
-		observeErr error
+		result     workspaceCleanupResult
+		invokeErr  error
 		request    WorkspaceEndpointRequest
-		wantKilled []string
+		wantOption string
+		wantCalls  int
 		wantError  string
 	}{
 		{
-			name: "observed generation",
-			identity: sessionCleanupIdentity{
-				SessionID: "$7", WorkspaceGeneration: resolverTestGeneration,
-			},
-			request: worktreeRequest, wantKilled: []string{"$7"},
+			name: "matching generation", result: workspaceCleanupTerminated,
+			request:    worktreeRequest,
+			wantOption: workspaceCleanupOption(resolverTestGeneration),
+			wantCalls:  1,
 		},
 		{
-			name: "replacement generation",
-			identity: sessionCleanupIdentity{
-				SessionID: "$8", WorkspaceGeneration: "fedcba9876543210fedcba9876543210",
-			},
-			request: worktreeRequest, wantError: "different worktree generation",
+			name: "replacement generation", result: workspaceCleanupMismatch,
+			request:    worktreeRequest,
+			wantOption: workspaceCleanupOption(resolverTestGeneration),
+			wantCalls:  1, wantError: "different worktree generation",
 		},
 		{
-			name: "malformed generation",
-			identity: sessionCleanupIdentity{
-				SessionID: "$8", WorkspaceGeneration: "not-a-generation",
+			name: "malformed requested generation",
+			request: WorkspaceEndpointRequest{
+				SessionName:         "kwt-wt-widget-main-01234567",
+				WorkspaceGeneration: "not-a-generation",
 			},
-			request: worktreeRequest, wantError: "malformed worktree generation",
+			wantError: "malformed worktree generation",
 		},
 		{
-			name: "different directory workspace",
-			identity: sessionCleanupIdentity{
-				SessionID: "$9", WorkspaceIdentity: workspacePathIdentity("/work/replacement"),
-			},
+			name: "different directory workspace", result: workspaceCleanupMismatch,
 			request: WorkspaceEndpointRequest{
 				SessionName: "kwt-workspace-widget", WorkspacePath: "/work/widget",
 			},
-			wantError: "different workspace identity",
+			wantOption: workspaceCleanupOption(workspacePathIdentity("/work/widget")),
+			wantCalls:  1, wantError: "different workspace identity",
 		},
 		{
-			name: "already absent", identity: sessionCleanupIdentity{Absent: true},
-			request: worktreeRequest,
+			name: "already absent", result: workspaceCleanupAbsent,
+			request:    worktreeRequest,
+			wantOption: workspaceCleanupOption(resolverTestGeneration),
+			wantCalls:  1,
 		},
 		{
-			name: "observation failure", observeErr: context.Canceled,
-			request: worktreeRequest, wantError: context.Canceled.Error(),
+			name: "invocation failure", invokeErr: context.Canceled,
+			request:    worktreeRequest,
+			wantOption: workspaceCleanupOption(resolverTestGeneration),
+			wantCalls:  1, wantError: context.Canceled.Error(),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			command := &fakeWorkspaceCleanupCommand{
-				identity: test.identity, observeErr: test.observeErr,
+				result: test.result,
+				err:    test.invokeErr,
 			}
 
 			err := killWorkspaceSessionIfMatching(
@@ -100,42 +100,19 @@ func TestKillWorkspaceSessionIfMatching(t *testing.T) {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, test.wantError)
 			}
-			assert.Equal(t, test.wantKilled, command.killed)
+			assert.Equal(t, test.wantCalls, command.calls)
+			assert.Equal(t, test.wantOption, command.option)
+			if test.wantCalls != 0 {
+				assert.Equal(t, test.request.SessionName, command.session)
+			}
 		})
 	}
 }
 
-func TestClassifySessionCleanupIdentityReadsPortableTuple(t *testing.T) {
-	workspaceIdentity := strings.Repeat("a", 64)
-
-	identity, err := classifySessionCleanupIdentity(
-		"$7|"+workspaceIdentity+"|"+resolverTestGeneration+"\n",
-		"",
-		nil,
+func TestQuoteTmuxCommandArgument(t *testing.T) {
+	assert.Equal(
+		t,
+		`"=kwt-wt-topic;'\$HOME\""`,
+		quoteTmuxCommandArgument(`=kwt-wt-topic;'$HOME"`),
 	)
-
-	require.NoError(t, err)
-	assert.Equal(t, sessionCleanupIdentity{
-		SessionID:           "$7",
-		WorkspaceIdentity:   workspaceIdentity,
-		WorkspaceGeneration: resolverTestGeneration,
-	}, identity)
-}
-
-func TestClassifySessionCleanupIdentityTreatsExplicitAbsenceAsComplete(t *testing.T) {
-	identity, err := classifySessionCleanupIdentity(
-		"",
-		"can't find session: workspace\n",
-		fakeProbeExitError(1),
-	)
-
-	require.NoError(t, err)
-	assert.True(t, identity.Absent)
-}
-
-func TestClassifySessionCleanupIdentityRejectsMalformedTuple(t *testing.T) {
-	_, err := classifySessionCleanupIdentity("$7|only-two-fields\n", "", nil)
-
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "malformed response")
 }

--- a/internal/tmux/cleanup_test.go
+++ b/internal/tmux/cleanup_test.go
@@ -1,0 +1,141 @@
+package tmux
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeWorkspaceCleanupCommand struct {
+	identity   sessionCleanupIdentity
+	observeErr error
+	killed     []string
+}
+
+func (f *fakeWorkspaceCleanupCommand) workspaceSessionCleanupIdentityContext(
+	context.Context,
+	string,
+) (sessionCleanupIdentity, error) {
+	return f.identity, f.observeErr
+}
+
+func (f *fakeWorkspaceCleanupCommand) KillSessionIfPresentContext(
+	_ context.Context,
+	target string,
+) error {
+	f.killed = append(f.killed, target)
+	return nil
+}
+
+func TestKillWorkspaceSessionIfMatching(t *testing.T) {
+	worktreeRequest := WorkspaceEndpointRequest{
+		SessionName:         "kwt-wt-widget-main-01234567",
+		WorkspacePath:       "/work/widget",
+		WorkspaceGeneration: resolverTestGeneration,
+	}
+	tests := []struct {
+		name       string
+		identity   sessionCleanupIdentity
+		observeErr error
+		request    WorkspaceEndpointRequest
+		wantKilled []string
+		wantError  string
+	}{
+		{
+			name: "observed generation",
+			identity: sessionCleanupIdentity{
+				SessionID: "$7", WorkspaceGeneration: resolverTestGeneration,
+			},
+			request: worktreeRequest, wantKilled: []string{"$7"},
+		},
+		{
+			name: "replacement generation",
+			identity: sessionCleanupIdentity{
+				SessionID: "$8", WorkspaceGeneration: "fedcba9876543210fedcba9876543210",
+			},
+			request: worktreeRequest, wantError: "different worktree generation",
+		},
+		{
+			name: "malformed generation",
+			identity: sessionCleanupIdentity{
+				SessionID: "$8", WorkspaceGeneration: "not-a-generation",
+			},
+			request: worktreeRequest, wantError: "malformed worktree generation",
+		},
+		{
+			name: "different directory workspace",
+			identity: sessionCleanupIdentity{
+				SessionID: "$9", WorkspaceIdentity: workspacePathIdentity("/work/replacement"),
+			},
+			request: WorkspaceEndpointRequest{
+				SessionName: "kwt-workspace-widget", WorkspacePath: "/work/widget",
+			},
+			wantError: "different workspace identity",
+		},
+		{
+			name: "already absent", identity: sessionCleanupIdentity{Absent: true},
+			request: worktreeRequest,
+		},
+		{
+			name: "observation failure", observeErr: context.Canceled,
+			request: worktreeRequest, wantError: context.Canceled.Error(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := &fakeWorkspaceCleanupCommand{
+				identity: test.identity, observeErr: test.observeErr,
+			}
+
+			err := killWorkspaceSessionIfMatching(
+				context.Background(), command, test.request,
+			)
+
+			if test.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, test.wantError)
+			}
+			assert.Equal(t, test.wantKilled, command.killed)
+		})
+	}
+}
+
+func TestClassifySessionCleanupIdentityReadsOneObservedTuple(t *testing.T) {
+	workspaceIdentity := strings.Repeat("a", 64)
+
+	identity, err := classifySessionCleanupIdentity(
+		"$7\t"+workspaceIdentity+"\t"+resolverTestGeneration+"\n",
+		"",
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, sessionCleanupIdentity{
+		SessionID:           "$7",
+		WorkspaceIdentity:   workspaceIdentity,
+		WorkspaceGeneration: resolverTestGeneration,
+	}, identity)
+}
+
+func TestClassifySessionCleanupIdentityTreatsExplicitAbsenceAsComplete(t *testing.T) {
+	identity, err := classifySessionCleanupIdentity(
+		"",
+		"can't find session: workspace\n",
+		fakeProbeExitError(1),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, identity.Absent)
+}
+
+func TestClassifySessionCleanupIdentityRejectsMalformedTuple(t *testing.T) {
+	_, err := classifySessionCleanupIdentity("$7\tonly-two-fields\n", "", nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "malformed response")
+}

--- a/internal/tmux/cleanup_test.go
+++ b/internal/tmux/cleanup_test.go
@@ -105,11 +105,11 @@ func TestKillWorkspaceSessionIfMatching(t *testing.T) {
 	}
 }
 
-func TestClassifySessionCleanupIdentityReadsOneObservedTuple(t *testing.T) {
+func TestClassifySessionCleanupIdentityReadsPortableTuple(t *testing.T) {
 	workspaceIdentity := strings.Repeat("a", 64)
 
 	identity, err := classifySessionCleanupIdentity(
-		"$7\t"+workspaceIdentity+"\t"+resolverTestGeneration+"\n",
+		"$7|"+workspaceIdentity+"|"+resolverTestGeneration+"\n",
 		"",
 		nil,
 	)
@@ -134,7 +134,7 @@ func TestClassifySessionCleanupIdentityTreatsExplicitAbsenceAsComplete(t *testin
 }
 
 func TestClassifySessionCleanupIdentityRejectsMalformedTuple(t *testing.T) {
-	_, err := classifySessionCleanupIdentity("$7\tonly-two-fields\n", "", nil)
+	_, err := classifySessionCleanupIdentity("$7|only-two-fields\n", "", nil)
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "malformed response")

--- a/internal/tmux/cleanup_test.go
+++ b/internal/tmux/cleanup_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,11 +10,18 @@ import (
 )
 
 type fakeWorkspaceCleanupCommand struct {
-	result  workspaceCleanupResult
-	err     error
-	calls   int
-	session string
-	option  string
+	result          workspaceCleanupResult
+	err             error
+	identity        workspaceCleanupIdentity
+	identityErr     error
+	compatResult    workspaceCleanupResult
+	compatErr       error
+	calls           []string
+	session         string
+	option          string
+	compatSessionID string
+	compatMarker    string
+	compatExpected  string
 }
 
 func (f *fakeWorkspaceCleanupCommand) killWorkspaceSessionWithOptionContext(
@@ -21,10 +29,34 @@ func (f *fakeWorkspaceCleanupCommand) killWorkspaceSessionWithOptionContext(
 	session string,
 	option string,
 ) (workspaceCleanupResult, error) {
-	f.calls++
+	f.calls = append(f.calls, "atomic")
 	f.session = session
 	f.option = option
 	return f.result, f.err
+}
+
+func (f *fakeWorkspaceCleanupCommand) workspaceSessionCleanupIdentityContext(
+	_ context.Context,
+	session string,
+) (workspaceCleanupIdentity, error) {
+	f.calls = append(f.calls, "inspect")
+	f.session = session
+	return f.identity, f.identityErr
+}
+
+func (f *fakeWorkspaceCleanupCommand) killWorkspaceSessionWithObservedIdentityContext(
+	_ context.Context,
+	session string,
+	sessionID string,
+	markerOption string,
+	expectedIdentity string,
+) (workspaceCleanupResult, error) {
+	f.calls = append(f.calls, "compat")
+	f.session = session
+	f.compatSessionID = sessionID
+	f.compatMarker = markerOption
+	f.compatExpected = expectedIdentity
+	return f.compatResult, f.compatErr
 }
 
 func TestKillWorkspaceSessionIfMatching(t *testing.T) {
@@ -34,25 +66,54 @@ func TestKillWorkspaceSessionIfMatching(t *testing.T) {
 		WorkspaceGeneration: resolverTestGeneration,
 	}
 	tests := []struct {
-		name       string
-		result     workspaceCleanupResult
-		invokeErr  error
-		request    WorkspaceEndpointRequest
-		wantOption string
-		wantCalls  int
-		wantError  string
+		name         string
+		result       workspaceCleanupResult
+		invokeErr    error
+		identity     workspaceCleanupIdentity
+		compatResult workspaceCleanupResult
+		compatErr    error
+		request      WorkspaceEndpointRequest
+		wantOption   string
+		wantCalls    []string
+		wantError    string
 	}{
 		{
 			name: "matching generation", result: workspaceCleanupTerminated,
 			request:    worktreeRequest,
 			wantOption: workspaceCleanupOption(resolverTestGeneration),
-			wantCalls:  1,
+			wantCalls:  []string{"atomic"},
 		},
 		{
 			name: "replacement generation", result: workspaceCleanupMismatch,
+			identity: workspaceCleanupIdentity{
+				SessionID:           "$8",
+				WorkspaceGeneration: "fedcba9876543210fedcba9876543210",
+			},
 			request:    worktreeRequest,
 			wantOption: workspaceCleanupOption(resolverTestGeneration),
-			wantCalls:  1, wantError: "different worktree generation",
+			wantCalls:  []string{"atomic", "inspect"},
+			wantError:  "different worktree generation",
+		},
+		{
+			name: "pre-cleanup-marker generation", result: workspaceCleanupMismatch,
+			identity: workspaceCleanupIdentity{
+				SessionID: "$7", WorkspaceGeneration: resolverTestGeneration,
+			},
+			compatResult: workspaceCleanupTerminated,
+			request:      worktreeRequest,
+			wantOption:   workspaceCleanupOption(resolverTestGeneration),
+			wantCalls:    []string{"atomic", "inspect", "compat"},
+		},
+		{
+			name: "pre-cleanup-marker replacement race", result: workspaceCleanupMismatch,
+			identity: workspaceCleanupIdentity{
+				SessionID: "$7", WorkspaceGeneration: resolverTestGeneration,
+			},
+			compatResult: workspaceCleanupMismatch,
+			request:      worktreeRequest,
+			wantOption:   workspaceCleanupOption(resolverTestGeneration),
+			wantCalls:    []string{"atomic", "inspect", "compat"},
+			wantError:    "different worktree generation",
 		},
 		{
 			name: "malformed requested generation",
@@ -67,27 +128,35 @@ func TestKillWorkspaceSessionIfMatching(t *testing.T) {
 			request: WorkspaceEndpointRequest{
 				SessionName: "kwt-workspace-widget", WorkspacePath: "/work/widget",
 			},
+			identity: workspaceCleanupIdentity{
+				SessionID:         "$9",
+				WorkspaceIdentity: workspacePathIdentity("/work/replacement"),
+			},
 			wantOption: workspaceCleanupOption(workspacePathIdentity("/work/widget")),
-			wantCalls:  1, wantError: "different workspace identity",
+			wantCalls:  []string{"atomic", "inspect"},
+			wantError:  "different workspace identity",
 		},
 		{
 			name: "already absent", result: workspaceCleanupAbsent,
 			request:    worktreeRequest,
 			wantOption: workspaceCleanupOption(resolverTestGeneration),
-			wantCalls:  1,
+			wantCalls:  []string{"atomic"},
 		},
 		{
 			name: "invocation failure", invokeErr: context.Canceled,
 			request:    worktreeRequest,
 			wantOption: workspaceCleanupOption(resolverTestGeneration),
-			wantCalls:  1, wantError: context.Canceled.Error(),
+			wantCalls:  []string{"atomic"}, wantError: context.Canceled.Error(),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			command := &fakeWorkspaceCleanupCommand{
-				result: test.result,
-				err:    test.invokeErr,
+				result:       test.result,
+				err:          test.invokeErr,
+				identity:     test.identity,
+				compatResult: test.compatResult,
+				compatErr:    test.compatErr,
 			}
 
 			err := killWorkspaceSessionIfMatching(
@@ -102,8 +171,11 @@ func TestKillWorkspaceSessionIfMatching(t *testing.T) {
 			}
 			assert.Equal(t, test.wantCalls, command.calls)
 			assert.Equal(t, test.wantOption, command.option)
-			if test.wantCalls != 0 {
+			if len(test.wantCalls) != 0 {
 				assert.Equal(t, test.request.SessionName, command.session)
+			}
+			if slices.Contains(test.wantCalls, "compat") {
+				assert.Equal(t, test.identity.SessionID, command.compatSessionID)
 			}
 		})
 	}

--- a/internal/tmux/endpoint.go
+++ b/internal/tmux/endpoint.go
@@ -35,12 +35,12 @@ func KillCommandHint(endpoint SessionEndpoint) string {
 		return fmt.Sprintf(
 			"env -u TMUX_TMPDIR tmux -L %s kill-session -t %s",
 			endpoint.SocketName,
-			endpoint.SessionName,
+			exactSessionTarget(endpoint.SessionName),
 		)
 	}
 	return fmt.Sprintf(
 		"env -u TMUX -u TMUX_PANE tmux kill-session -t %s",
-		endpoint.SessionName,
+		exactSessionTarget(endpoint.SessionName),
 	)
 }
 

--- a/internal/tmux/endpoint.go
+++ b/internal/tmux/endpoint.go
@@ -1,0 +1,127 @@
+package tmux
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KWTServerSocketName is the fixed named socket shared by KWT workspaces and
+// long-running KWT sessions.
+const KWTServerSocketName = "kwt"
+
+// SessionEndpoint is the durable tmux address for one session.
+type SessionEndpoint struct {
+	SessionName string
+	SocketName  string
+}
+
+// WorkspaceSession pairs a durable endpoint with its observed liveness.
+type WorkspaceSession struct {
+	Endpoint SessionEndpoint
+	Live     bool
+}
+
+func canonicalEndpoint(session string) SessionEndpoint {
+	return SessionEndpoint{
+		SessionName: session,
+		SocketName:  KWTServerSocketName,
+	}
+}
+
+// KillCommandHint formats a manual command for the durable endpoint address.
+// It does not infer attachment policy from the socket name.
+func KillCommandHint(endpoint SessionEndpoint) string {
+	if endpoint.SocketName != "" {
+		return fmt.Sprintf(
+			"env -u TMUX_TMPDIR tmux -L %s kill-session -t %s",
+			endpoint.SocketName,
+			endpoint.SessionName,
+		)
+	}
+	return fmt.Sprintf(
+		"env -u TMUX -u TMUX_PANE tmux kill-session -t %s",
+		endpoint.SessionName,
+	)
+}
+
+// WorkspaceSessionsOptions configures workspace session coordination. The
+// explicit directories are dependency seams for daemon request context and
+// isolated real-tmux tests.
+type WorkspaceSessionsOptions struct {
+	Command              string
+	StripNames           []string
+	KWTServerTempDir     string
+	DefaultServerTempDir string
+	// DefaultServerTempDirSet makes an empty directory override ambient
+	// TMUX_TMPDIR instead of inheriting it.
+	DefaultServerTempDirSet bool
+	ReportDiagnostic        func(error)
+}
+
+type serverCommands struct {
+	command                 string
+	kwtServerTempDir        string
+	defaultServerTempDir    string
+	defaultServerTempDirSet bool
+	stripNames              []string
+}
+
+func newServerCommands(options WorkspaceSessionsOptions) serverCommands {
+	defaultServerTempDir := strings.TrimSpace(options.DefaultServerTempDir)
+	return serverCommands{
+		command:                 options.Command,
+		kwtServerTempDir:        strings.TrimSpace(options.KWTServerTempDir),
+		defaultServerTempDir:    defaultServerTempDir,
+		defaultServerTempDirSet: options.DefaultServerTempDirSet || defaultServerTempDir != "",
+		stripNames:              append([]string(nil), options.StripNames...),
+	}
+}
+
+func (f serverCommands) kwtServer() *TmuxCommand {
+	if f.kwtServerTempDir != "" {
+		return NewTmuxCommandForSocketInTempDirWithStripNames(
+			f.command,
+			KWTServerSocketName,
+			f.kwtServerTempDir,
+			f.stripNames,
+		)
+	}
+	return NewTmuxCommandForSocketWithStripNames(
+		f.command,
+		KWTServerSocketName,
+		f.stripNames,
+	)
+}
+
+// compat(kag1): default-server adoption
+func (f serverCommands) defaultServer() *TmuxCommand {
+	var command *TmuxCommand
+	if f.defaultServerTempDir != "" {
+		command = NewTmuxCommandInTempDirWithStripNames(
+			f.command,
+			f.defaultServerTempDir,
+			f.stripNames,
+		)
+	} else {
+		command = NewTmuxCommandWithStripNames(f.command, f.stripNames)
+		command.clearSocketTempDir = f.defaultServerTempDirSet
+	}
+	command.stripParentTmux = true
+	return command
+}
+
+func (f serverCommands) commandForEndpoint(
+	endpoint SessionEndpoint,
+) (*TmuxCommand, error) {
+	switch endpoint.SocketName {
+	case KWTServerSocketName:
+		return f.kwtServer(), nil
+	case "":
+		return f.defaultServer(), nil
+	default:
+		return nil, fmt.Errorf(
+			"socket %q is not an ordinary KWT tmux server",
+			endpoint.SocketName,
+		)
+	}
+}

--- a/internal/tmux/endpoint_test.go
+++ b/internal/tmux/endpoint_test.go
@@ -1,0 +1,182 @@
+package tmux
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionEndpointContainsOnlyDurableAddressFields(t *testing.T) {
+	typeOfEndpoint := reflect.TypeOf(SessionEndpoint{})
+	got := make([]string, 0, typeOfEndpoint.NumField())
+	for index := 0; index < typeOfEndpoint.NumField(); index++ {
+		got = append(got, typeOfEndpoint.Field(index).Name)
+	}
+
+	assert.Equal(t, []string{"SessionName", "SocketName"}, got)
+	for index := 0; index < typeOfEndpoint.NumField(); index++ {
+		assert.Empty(t, typeOfEndpoint.Field(index).Tag.Get("json"))
+	}
+}
+
+func TestSessionDeclaresAddressFieldsWithoutEmbeddingEndpoint(t *testing.T) {
+	typeOfSession := reflect.TypeOf(Session{})
+	_, embedded := typeOfSession.FieldByName("SessionEndpoint")
+	assert.False(t, embedded)
+
+	for _, name := range []string{"SessionName", "SocketName"} {
+		field, found := typeOfSession.FieldByName(name)
+		require.True(t, found)
+		assert.Len(t, field.Index, 1)
+	}
+}
+
+func TestCanonicalEndpointUsesKWTServer(t *testing.T) {
+	endpoint := canonicalEndpoint("kwt-wt-widget-main-01234567")
+
+	assert.Equal(t, "kwt-wt-widget-main-01234567", endpoint.SessionName)
+	assert.Equal(t, "kwt", endpoint.SocketName)
+}
+
+func TestKillCommandHintUsesEndpointAddress(t *testing.T) {
+	assert.Equal(t,
+		"env -u TMUX_TMPDIR tmux -L kwt kill-session -t workspace",
+		KillCommandHint(SessionEndpoint{SessionName: "workspace", SocketName: KWTServerSocketName}),
+	)
+	assert.Equal(t,
+		"env -u TMUX -u TMUX_PANE tmux kill-session -t workspace",
+		KillCommandHint(SessionEndpoint{SessionName: "workspace"}),
+	)
+}
+
+func TestServerCommandsSeparateKWTAndDefaultEnvironmentPolicy(t *testing.T) {
+	t.Setenv("TMUX_TMPDIR", "/ambient/tmux")
+	t.Setenv("TMUX", "/tmp/custom,42,0")
+	t.Setenv("TMUX_PANE", "%7")
+	t.Setenv("GHOSTHUB_AUTH", "secret")
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command: "tmux", StripNames: []string{"GHOSTHUB_AUTH"},
+	})
+
+	kwtServer := servers.kwtServer().newCmd(
+		context.Background(),
+		[]string{"list-sessions"},
+	)
+	defaultServer := servers.defaultServer().newCmd(
+		context.Background(),
+		[]string{"list-sessions"},
+	)
+
+	assert.Equal(
+		t,
+		[]string{"tmux", "-L", KWTServerSocketName, "list-sessions"},
+		kwtServer.Args,
+	)
+	assert.False(t, slices.Contains(kwtServer.Env, "TMUX_TMPDIR=/ambient/tmux"))
+	assert.True(t, slices.Contains(defaultServer.Env, "TMUX_TMPDIR=/ambient/tmux"))
+	assert.False(t, slices.Contains(defaultServer.Env, "TMUX=/tmp/custom,42,0"))
+	assert.False(t, slices.Contains(defaultServer.Env, "TMUX_PANE=%7"))
+	for _, command := range []*execCommandView{
+		{env: kwtServer.Env},
+		{env: defaultServer.Env},
+	} {
+		for _, entry := range command.env {
+			assert.False(t, hasEnvName(entry, "GHOSTHUB_AUTH"))
+		}
+	}
+}
+
+func TestServerCommandsExplicitlyUnsetDefaultTempDir(t *testing.T) {
+	t.Setenv("TMUX_TMPDIR", "/ambient/tmux")
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command:                 "tmux",
+		DefaultServerTempDirSet: true,
+	})
+
+	command := servers.defaultServer().newCmd(
+		context.Background(),
+		[]string{"list-sessions"},
+	)
+
+	assert.False(t, slices.Contains(command.Env, "TMUX_TMPDIR=/ambient/tmux"))
+}
+
+func TestDefaultServerSwitchClientPreservesCurrentClientIdentity(t *testing.T) {
+	t.Setenv("TMUX_TMPDIR", "/ambient/tmux")
+	t.Setenv("TMUX", "/ambient/tmux/tmux-501/default,42,0")
+	t.Setenv("TMUX_PANE", "%7")
+	servers := newServerCommands(WorkspaceSessionsOptions{Command: "tmux"})
+
+	command := servers.defaultServer().switchClientCmd("workspace")
+
+	assert.True(t, slices.Contains(
+		command.Env,
+		"TMUX=/ambient/tmux/tmux-501/default,42,0",
+	))
+	assert.True(t, slices.Contains(command.Env, "TMUX_PANE=%7"))
+	assert.True(t, slices.Contains(command.Env, "TMUX_TMPDIR=/ambient/tmux"))
+}
+
+func TestDefaultServerProbeStripsParentIdentityWithoutExtraNames(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/custom,42,0")
+	t.Setenv("TMUX_PANE", "%7")
+
+	command := newServerCommands(WorkspaceSessionsOptions{Command: "tmux"}).defaultServer().newCmd(
+		context.Background(),
+		[]string{"list-sessions"},
+	)
+
+	assert.False(t, slices.Contains(command.Env, "TMUX=/tmp/custom,42,0"))
+	assert.False(t, slices.Contains(command.Env, "TMUX_PANE=%7"))
+}
+
+// execCommandView keeps the environment assertion above focused without
+// teaching the test about exec.Cmd fields beyond the environment slice.
+type execCommandView struct {
+	env []string
+}
+
+func TestDefaultServerTempDirDoesNotMoveKWTServerSocket(t *testing.T) {
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command: "tmux", DefaultServerTempDir: "/host/login/tmux",
+	})
+
+	assert.Empty(t, servers.kwtServer().socketTempDir)
+	assert.Equal(t, "/host/login/tmux", servers.defaultServer().socketTempDir)
+}
+
+func TestServerCommandsTempDirsIsolateBothEndpoints(t *testing.T) {
+	tempDir := t.TempDir()
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command: "tmux", KWTServerTempDir: tempDir, DefaultServerTempDir: tempDir,
+	})
+
+	assert.Equal(t, KWTServerSocketName, servers.kwtServer().socketName)
+	assert.Equal(t, tempDir, servers.kwtServer().socketTempDir)
+	assert.Empty(t, servers.defaultServer().socketName)
+	assert.Equal(t, tempDir, servers.defaultServer().socketTempDir)
+}
+
+func TestServerCommandsSelectOnlyOrdinaryServers(t *testing.T) {
+	servers := newServerCommands(WorkspaceSessionsOptions{Command: "tmux"})
+
+	kwtServer, err := servers.commandForEndpoint(canonicalEndpoint("workspace"))
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, kwtServer.socketName)
+
+	defaultServer, err := servers.commandForEndpoint(SessionEndpoint{
+		SessionName: "workspace",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, defaultServer.socketName)
+
+	_, err = servers.commandForEndpoint(SessionEndpoint{
+		SessionName: "workspace",
+		SocketName:  "kwt-pr-protected",
+	})
+	require.ErrorContains(t, err, "not an ordinary KWT tmux server")
+}

--- a/internal/tmux/endpoint_test.go
+++ b/internal/tmux/endpoint_test.go
@@ -44,11 +44,11 @@ func TestCanonicalEndpointUsesKWTServer(t *testing.T) {
 
 func TestKillCommandHintUsesEndpointAddress(t *testing.T) {
 	assert.Equal(t,
-		"env -u TMUX_TMPDIR tmux -L kwt kill-session -t workspace",
+		"env -u TMUX_TMPDIR tmux -L kwt kill-session -t =workspace",
 		KillCommandHint(SessionEndpoint{SessionName: "workspace", SocketName: KWTServerSocketName}),
 	)
 	assert.Equal(t,
-		"env -u TMUX -u TMUX_PANE tmux kill-session -t workspace",
+		"env -u TMUX -u TMUX_PANE tmux kill-session -t =workspace",
 		KillCommandHint(SessionEndpoint{SessionName: "workspace"}),
 	)
 }

--- a/internal/tmux/kill_test.go
+++ b/internal/tmux/kill_test.go
@@ -1,0 +1,62 @@
+package tmux
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKillSessionIfPresentTreatsOnlyExplicitAbsenceAsSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is unavailable on Windows")
+	}
+	fixture := filepath.Join(t.TempDir(), "tmux-fixture")
+	require.NoError(t, os.WriteFile(fixture, []byte(`#!/bin/sh
+printf '%s\n' "$KWT_TEST_TMUX_STDERR" >&2
+exit "$KWT_TEST_TMUX_EXIT"
+`), 0o700))
+
+	tests := []struct {
+		name      string
+		stderr    string
+		exit      string
+		wantError bool
+	}{
+		{name: "no server", stderr: "no server running on test socket", exit: "1"},
+		{name: "missing socket", stderr: "error connecting to /tmp/tmux/socket (No such file or directory)", exit: "1"},
+		{name: "missing session", stderr: "can't find session: workspace", exit: "1"},
+		{name: "permission failure", stderr: "error connecting to /tmp/tmux/socket (Permission denied)", exit: "1", wantError: true},
+		{name: "unexpected failure", stderr: "server rejected request", exit: "2", wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("KWT_TEST_TMUX_STDERR", test.stderr)
+			t.Setenv("KWT_TEST_TMUX_EXIT", test.exit)
+			command := NewTmuxCommand(fixture)
+
+			err := command.KillSessionIfPresentContext(
+				context.Background(),
+				"workspace",
+			)
+
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKillSessionIfPresentPreservesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := NewTmuxCommand("tmux").KillSessionIfPresentContext(ctx, "workspace")
+
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/tmux/kill_test.go
+++ b/internal/tmux/kill_test.go
@@ -3,12 +3,48 @@ package tmux
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestKillSessionIfPresentDoesNotPrefixMatchReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-kill-")
+	require.NoError(t, err)
+	command := NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux", KWTServerSocketName, tempDir, nil,
+	)
+	t.Cleanup(func() {
+		_ = command.RunCommandContext(ctx, "kill-server")
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	require.NoError(t, command.RunCommandContext(
+		ctx, "new-session", "-d", "-s", "workspace", "sleep", "60",
+	))
+	require.NoError(t, command.RunCommandContext(
+		ctx, "new-session", "-d", "-s", "workspace-build", "sleep", "60",
+	))
+	require.NoError(t, command.KillSessionContext(ctx, "workspace"))
+
+	err = command.KillSessionContext(ctx, "workspace")
+	require.Error(t, err)
+	require.True(t, command.HasSession("workspace-build"))
+
+	require.NoError(t, command.KillSessionIfPresentContext(ctx, "workspace"))
+	require.True(t, command.HasSession("workspace-build"))
+}
 
 func TestKillSessionIfPresentTreatsOnlyExplicitAbsenceAsSuccess(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -29,6 +65,7 @@ exit "$KWT_TEST_TMUX_EXIT"
 		{name: "no server", stderr: "no server running on test socket", exit: "1"},
 		{name: "missing socket", stderr: "error connecting to /tmp/tmux/socket (No such file or directory)", exit: "1"},
 		{name: "missing session", stderr: "can't find session: workspace", exit: "1"},
+		{name: "tmux 2.1 missing session", stderr: "can't find session workspace", exit: "1"},
 		{name: "permission failure", stderr: "error connecting to /tmp/tmux/socket (Permission denied)", exit: "1", wantError: true},
 		{name: "unexpected failure", stderr: "server rejected request", exit: "2", wantError: true},
 	}

--- a/internal/tmux/kill_test.go
+++ b/internal/tmux/kill_test.go
@@ -40,6 +40,7 @@ func TestKillSessionIfPresentDoesNotPrefixMatchReplacement(t *testing.T) {
 
 	err = command.KillSessionContext(ctx, "workspace")
 	require.Error(t, err)
+	require.False(t, command.HasSession("workspace"))
 	require.True(t, command.HasSession("workspace-build"))
 
 	require.NoError(t, command.KillSessionIfPresentContext(ctx, "workspace"))

--- a/internal/tmux/layout.go
+++ b/internal/tmux/layout.go
@@ -79,6 +79,19 @@ func BuildFirstPaneRespawnCommand(paneID, worktreeDir, shell string) []string {
 	return []string{"respawn-pane", "-k", "-c", worktreeDir, "-t", paneID, shell, "-l"}
 }
 
+// buildFirstPaneCommandRespawnCommand replaces the inert first-pane
+// placeholder with a caller-supplied command after the session bootstrap has
+// installed its environment removal markers. command remains one argv value
+// so tmux preserves new-session's command-string semantics and runs it through
+// the configured default shell.
+func buildFirstPaneCommandRespawnCommand(
+	paneID, worktreeDir, command string,
+) []string {
+	return []string{
+		"respawn-pane", "-k", "-c", worktreeDir, "-t", paneID, command,
+	}
+}
+
 // BuildRemainingPaneSequence returns the tmux invocations that create the
 // panes after the first (one split-window per extra pane) and arrange them
 // (select-layout, emitted only for multi-pane layouts). Each split-window

--- a/internal/tmux/manager.go
+++ b/internal/tmux/manager.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,45 +19,140 @@ var (
 )
 
 type SessionManager struct {
-	config  *SessionConfig
-	tmuxCmd TmuxInterface
+	config        *SessionConfig
+	kwtServer     sessionManagerCommand
+	defaultServer sessionManagerCommand
+	// stripNames also drive session removal markers; filtering the tmux
+	// client alone cannot mask values retained by an existing server.
+	stripNames      []string
+	attachEndpoint  func(context.Context, SessionEndpoint, workspaceAttachCommand, string) error
+	tmuxEnvironment func() string
 }
 
-func NewSessionManager(config *SessionConfig) *SessionManager {
+type sessionManagerCommand interface {
+	sessionEnvironmentReader
+	RunCommandContext(ctx context.Context, args ...string) error
+	RunCommandOutputContext(ctx context.Context, args ...string) (string, error)
+	SetOptionContext(context.Context, string, string, any) error
+	ListSessionsDetailed() ([]*SessionInfo, error)
+	KillSession(string) error
+	HasSession(string) bool
+	AttachSession(string) error
+	SwitchClient(string) error
+	AttachSessionNested(context.Context, string) error
+	ServerPIDContext(context.Context) (string, error)
+}
+
+func NewSessionManager(
+	config *SessionConfig,
+	stripNames ...string,
+) *SessionManager {
 	if config == nil {
 		config = DefaultSessionConfig()
 	}
 
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command: config.TmuxCommand, StripNames: stripNames,
+	})
+	return newSessionManagerWithCommands(
+		config,
+		servers.kwtServer(),
+		servers.defaultServer(),
+		stripNames...,
+	)
+}
+
+// NewSessionManagerWithTempDir constructs a manager whose KWT and default
+// tmux servers are rooted in tempDir. It is intended for isolated integration
+// tests that exercise both server endpoints.
+func NewSessionManagerWithTempDir(
+	config *SessionConfig,
+	tempDir string,
+	stripNames ...string,
+) *SessionManager {
+	if config == nil {
+		config = DefaultSessionConfig()
+	}
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command:              config.TmuxCommand,
+		KWTServerTempDir:     tempDir,
+		DefaultServerTempDir: tempDir,
+		StripNames:           stripNames,
+	})
+	return newSessionManagerWithCommands(
+		config,
+		servers.kwtServer(),
+		servers.defaultServer(),
+		stripNames...,
+	)
+}
+
+func newSessionManagerWithCommands(
+	config *SessionConfig,
+	kwtServer sessionManagerCommand,
+	defaultServer sessionManagerCommand,
+	stripNames ...string,
+) *SessionManager {
 	return &SessionManager{
-		config:  config,
-		tmuxCmd: NewTmuxCommand(config.TmuxCommand),
+		config: config, kwtServer: kwtServer, defaultServer: defaultServer,
+		stripNames:      cleanNames(stripNames),
+		attachEndpoint:  attachWorkspaceEndpoint,
+		tmuxEnvironment: func() string { return os.Getenv("TMUX") },
 	}
 }
 
 func (sm *SessionManager) CreateSession(ctx context.Context, opts SessionOptions) (*Session, error) {
 	sessionName := fmt.Sprintf("kwt-%s-%s-%s", opts.Context, opts.Identifier, time.Now().Format("20060102150405"))
 
-	// Create session with or without command
-	if opts.Command != "" {
-		// Create session with command - when command finishes, session will automatically terminate
-		if err := sm.tmuxCmd.NewSessionWithCommandContext(ctx, sessionName, opts.WorkingDir, opts.Command); err != nil {
-			return nil, fmt.Errorf("failed to create tmux session with command: %w", err)
-		}
-	} else {
-		// Create session without command (traditional behavior)
-		if err := sm.tmuxCmd.NewSessionContext(ctx, sessionName, opts.WorkingDir); err != nil {
-			return nil, fmt.Errorf("failed to create tmux session: %w", err)
-		}
+	stripNames, err := deriveSessionStripNames(
+		ctx, sm.kwtServer, sessionName, false, sm.stripNames,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot inspect tmux bootstrap environment: %w", err)
 	}
 
-	if err := sm.tmuxCmd.SetOptionContext(ctx, sessionName, "history-limit", sm.config.HistoryLimit); err != nil {
-		_ = sm.tmuxCmd.KillSession(sessionName)
-		return nil, fmt.Errorf("failed to set history limit: %w", err)
+	createCmd := BuildSessionCreateCommand(sessionName, opts.WorkingDir)
+	firstPaneOut, err := sm.kwtServer.RunCommandOutputContext(ctx, createCmd...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tmux session: %w", wrapTmuxErr(createCmd, err))
+	}
+	firstPane := strings.TrimSpace(firstPaneOut)
+	if firstPane == "" {
+		return nil, sm.abortCreate(
+			sessionName,
+			createCmd,
+			fmt.Errorf("tmux returned an empty first-pane ID"),
+		)
+	}
+
+	bootstrapCmd := BuildSessionBootstrapCommand(sessionName, stripNames)
+	if err := sm.kwtServer.RunCommandContext(ctx, bootstrapCmd...); err != nil {
+		return nil, sm.abortCreate(sessionName, bootstrapCmd, err)
+	}
+	if err := sm.kwtServer.SetOptionContext(
+		ctx, sessionName, "history-limit", sm.config.HistoryLimit,
+	); err != nil {
+		return nil, sm.abortCreate(
+			sessionName,
+			[]string{"set-option", "-t", sessionName, "history-limit"},
+			err,
+		)
+	}
+
+	respawnCmd, err := sm.sessionRespawnCommand(
+		ctx, sessionName, firstPane, opts.WorkingDir, opts.Command,
+	)
+	if err != nil {
+		return nil, sm.abortCreate(sessionName, nil, err)
+	}
+	if err := sm.kwtServer.RunCommandContext(ctx, respawnCmd...); err != nil {
+		return nil, sm.abortCreate(sessionName, respawnCmd, err)
 	}
 
 	session := &Session{
-		ID:          utils.GenerateID(),
 		SessionName: sessionName,
+		SocketName:  KWTServerSocketName,
+		ID:          utils.GenerateID(),
 		Context:     opts.Context,
 		Identifier:  opts.Identifier,
 		WorkingDir:  opts.WorkingDir,
@@ -69,12 +165,84 @@ func (sm *SessionManager) CreateSession(ctx context.Context, opts SessionOptions
 	return session, nil
 }
 
+func (sm *SessionManager) sessionRespawnCommand(
+	ctx context.Context,
+	sessionName string,
+	firstPane string,
+	workingDir string,
+	command string,
+) ([]string, error) {
+	if command != "" {
+		return buildFirstPaneCommandRespawnCommand(
+			firstPane, workingDir, command,
+		), nil
+	}
+
+	defaultShellCmd := []string{
+		"show-options", "-v", "-t", sessionName, "default-shell",
+	}
+	defaultShellOut, err := sm.kwtServer.RunCommandOutputContext(
+		ctx, defaultShellCmd...,
+	)
+	if err != nil {
+		return nil, wrapTmuxErr(defaultShellCmd, err)
+	}
+	defaultShell := strings.TrimSpace(defaultShellOut)
+	if defaultShell == "" {
+		defaultShellCmd = []string{"show-options", "-gv", "default-shell"}
+		defaultShellOut, err = sm.kwtServer.RunCommandOutputContext(
+			ctx, defaultShellCmd...,
+		)
+		if err != nil {
+			return nil, wrapTmuxErr(defaultShellCmd, err)
+		}
+		defaultShell = strings.TrimSpace(defaultShellOut)
+	}
+	if defaultShell == "" {
+		return nil, fmt.Errorf("tmux returned an empty default-shell")
+	}
+	return BuildFirstPaneRespawnCommand(
+		firstPane, workingDir, defaultShell,
+	), nil
+}
+
+func (sm *SessionManager) abortCreate(
+	sessionName string,
+	args []string,
+	err error,
+) error {
+	if len(args) > 0 {
+		err = wrapTmuxErr(args, err)
+	}
+	if killErr := sm.kwtServer.KillSession(sessionName); killErr != nil {
+		return fmt.Errorf(
+			"%w (also failed to kill partial session: %v)", err, killErr,
+		)
+	}
+	return err
+}
+
 func (sm *SessionManager) ListSessions() ([]*Session, error) {
-	tmuxSessions, err := sm.tmuxCmd.ListSessionsDetailed()
+	kwtServer, err := sm.listEndpoint(sm.kwtServer, KWTServerSocketName)
 	if err != nil {
 		return nil, err
 	}
+	// compat(kag1): default-server adoption
+	defaultServer, err := sm.listEndpoint(sm.defaultServer, "")
+	if err != nil {
+		return nil, fmt.Errorf("list default-server tmux sessions: %w", err)
+	}
+	return append(kwtServer, defaultServer...), nil
+}
 
+func (sm *SessionManager) listEndpoint(
+	command sessionManagerCommand,
+	socketName string,
+) ([]*Session, error) {
+	tmuxSessions, err := command.ListSessionsDetailed()
+	if err != nil {
+		return nil, err
+	}
 	var sessions []*Session
 	for _, tmuxSession := range tmuxSessions {
 		// Only show kwt-managed sessions
@@ -82,7 +250,7 @@ func (sm *SessionManager) ListSessions() ([]*Session, error) {
 			continue
 		}
 
-		session := sm.parseSessionFromTmux(tmuxSession)
+		session := sm.parseSessionFromEndpoint(tmuxSession, socketName)
 		if session != nil {
 			sessions = append(sessions, session)
 		}
@@ -92,6 +260,13 @@ func (sm *SessionManager) ListSessions() ([]*Session, error) {
 }
 
 func (sm *SessionManager) parseSessionFromTmux(info *SessionInfo) *Session {
+	return sm.parseSessionFromEndpoint(info, KWTServerSocketName)
+}
+
+func (sm *SessionManager) parseSessionFromEndpoint(
+	info *SessionInfo,
+	socketName string,
+) *Session {
 	// Parse the timestamped run format before the broad eight-hex workspace
 	// suffix, because the last eight decimal timestamp digits are also hex.
 	if matches := legacySessionRe.FindStringSubmatch(info.Name); len(matches) == 4 {
@@ -104,8 +279,9 @@ func (sm *SessionManager) parseSessionFromTmux(info *SessionInfo) *Session {
 			command = "Shell session (original command completed)"
 		}
 		return &Session{
-			ID:          utils.GenerateShortID(),
 			SessionName: info.Name,
+			SocketName:  socketName,
+			ID:          utils.GenerateShortID(),
 			Context:     matches[1],
 			Identifier:  matches[2],
 			WorkingDir:  info.WorkingDir,
@@ -124,8 +300,9 @@ func (sm *SessionManager) parseSessionFromTmux(info *SessionInfo) *Session {
 	}
 	if len(workspaceMatch) == 3 {
 		return &Session{
-			ID:          utils.GenerateShortID(),
 			SessionName: info.Name,
+			SocketName:  socketName,
+			ID:          utils.GenerateShortID(),
 			Context:     "workspace",
 			Identifier:  workspaceMatch[1],
 			WorkingDir:  info.WorkingDir,
@@ -177,8 +354,12 @@ func (sm *SessionManager) KillSession(id string) error {
 }
 
 func (sm *SessionManager) KillSessionDirect(session *Session) error {
-	if sm.tmuxCmd.HasSession(session.SessionName) {
-		if err := sm.tmuxCmd.KillSession(session.SessionName); err != nil {
+	command, err := sm.commandForSession(session)
+	if err != nil {
+		return err
+	}
+	if command.HasSession(session.SessionName) {
+		if err := command.KillSession(session.SessionName); err != nil {
 			return fmt.Errorf("failed to kill tmux session: %w", err)
 		}
 	}
@@ -196,14 +377,47 @@ func (sm *SessionManager) AttachSession(id string) error {
 }
 
 func (sm *SessionManager) AttachSessionDirect(session *Session) error {
-	if !sm.tmuxCmd.HasSession(session.SessionName) {
+	command, err := sm.commandForSession(session)
+	if err != nil {
+		return err
+	}
+	if !command.HasSession(session.SessionName) {
 		return fmt.Errorf("tmux session %s no longer exists", session.SessionName)
 	}
-
-	return sm.tmuxCmd.AttachSession(session.SessionName)
+	return sm.attachEndpoint(
+		context.Background(),
+		sessionEndpoint(session),
+		command,
+		sm.tmuxEnvironment(),
+	)
 }
 
 // HasSession checks if a session exists
 func (sm *SessionManager) HasSession(sessionName string) bool {
-	return sm.tmuxCmd.HasSession(sessionName)
+	// compat(kag1): default-server adoption
+	return sm.kwtServer.HasSession(sessionName) || sm.defaultServer.HasSession(sessionName)
+}
+
+func (sm *SessionManager) commandForSession(
+	session *Session,
+) (sessionManagerCommand, error) {
+	if session == nil {
+		return nil, fmt.Errorf("tmux session is required")
+	}
+	switch session.SocketName {
+	case KWTServerSocketName:
+		return sm.kwtServer, nil
+	case "":
+		// compat(kag1): default-server adoption
+		return sm.defaultServer, nil
+	default:
+		return nil, fmt.Errorf("socket %q is not a KWT workspace endpoint", session.SocketName)
+	}
+}
+
+func sessionEndpoint(session *Session) SessionEndpoint {
+	return SessionEndpoint{
+		SessionName: session.SessionName,
+		SocketName:  session.SocketName,
+	}
 }

--- a/internal/tmux/manager.go
+++ b/internal/tmux/manager.go
@@ -102,13 +102,13 @@ func newSessionManagerWithCommands(
 }
 
 func (sm *SessionManager) CreateSession(ctx context.Context, opts SessionOptions) (*Session, error) {
-	if opts.Context == "wt" || opts.Context == "workspace" {
+	sessionName := fmt.Sprintf("kwt-%s-%s-%s", opts.Context, opts.Identifier, time.Now().Format("20060102150405"))
+	if isKWTSessionName(sessionName) {
 		return nil, fmt.Errorf(
 			"tmux context %q is reserved for workspace sessions",
 			opts.Context,
 		)
 	}
-	sessionName := fmt.Sprintf("kwt-%s-%s-%s", opts.Context, opts.Identifier, time.Now().Format("20060102150405"))
 
 	stripNames, err := deriveSessionStripNames(
 		ctx, sm.kwtServer, sessionName, false, sm.stripNames,

--- a/internal/tmux/manager.go
+++ b/internal/tmux/manager.go
@@ -102,6 +102,12 @@ func newSessionManagerWithCommands(
 }
 
 func (sm *SessionManager) CreateSession(ctx context.Context, opts SessionOptions) (*Session, error) {
+	if opts.Context == "wt" || opts.Context == "workspace" {
+		return nil, fmt.Errorf(
+			"tmux context %q is reserved for workspace sessions",
+			opts.Context,
+		)
+	}
 	sessionName := fmt.Sprintf("kwt-%s-%s-%s", opts.Context, opts.Identifier, time.Now().Format("20060102150405"))
 
 	stripNames, err := deriveSessionStripNames(

--- a/internal/tmux/manager.go
+++ b/internal/tmux/manager.go
@@ -102,7 +102,12 @@ func newSessionManagerWithCommands(
 }
 
 func (sm *SessionManager) CreateSession(ctx context.Context, opts SessionOptions) (*Session, error) {
-	sessionName := fmt.Sprintf("kwt-%s-%s-%s", opts.Context, opts.Identifier, time.Now().Format("20060102150405"))
+	sessionName := sanitizeTmuxName(fmt.Sprintf(
+		"kwt-%s-%s-%s",
+		opts.Context,
+		opts.Identifier,
+		time.Now().Format("20060102150405"),
+	))
 	if isKWTSessionName(sessionName) {
 		return nil, fmt.Errorf(
 			"tmux context %q is reserved for workspace sessions",

--- a/internal/tmux/manager_integration_test.go
+++ b/internal/tmux/manager_integration_test.go
@@ -1,0 +1,79 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionManagerMasksConfiguredCredentialRetainedByExistingServer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	const tokenName = "KWT_RETAINED_TOKEN_TEST"
+	const tokenValue = "must-not-reach-session"
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-manager-")
+	require.NoError(t, err)
+	server := NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux", KWTServerSocketName, tempDir, nil,
+	)
+	t.Cleanup(func() {
+		_ = server.RunCommandContext(context.Background(), "kill-server")
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	require.NoError(t, server.NewSessionWithCommandContext(
+		context.Background(), "keeper", tempDir, "sleep 60",
+	))
+	require.NoError(t, server.RunCommandContext(
+		context.Background(),
+		"set-environment", "-g", tokenName, tokenValue,
+	))
+
+	manager := NewSessionManagerWithTempDir(nil, tempDir, tokenName)
+	probeCommand := fmt.Sprintf(
+		"if env | grep -q '^%s='; then printf 'credential-leaked\\n'; "+
+			"else printf 'credential-clean\\n'; fi; sleep 60",
+		tokenName,
+	)
+	session, err := manager.CreateSession(context.Background(), SessionOptions{
+		Context:    "run",
+		Identifier: "retained-token",
+		WorkingDir: tempDir,
+		Command:    probeCommand,
+	})
+	require.NoError(t, err)
+	marker, err := server.RunCommandOutputContext(
+		context.Background(),
+		"show-environment", "-t", session.SessionName, tokenName,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "-"+tokenName+"\n", marker)
+
+	var paneEnvironment string
+	require.Eventually(t, func() bool {
+		paneEnvironment, err = server.RunCommandOutputContext(
+			context.Background(),
+			"capture-pane", "-p", "-S", "-", "-t", session.SessionName,
+		)
+		return err == nil && (strings.Contains(paneEnvironment, "credential-clean") ||
+			strings.Contains(paneEnvironment, "credential-leaked"))
+	}, 3*time.Second, 20*time.Millisecond)
+	assert.False(
+		t,
+		strings.Contains(paneEnvironment, "credential-leaked"),
+		"session pane inherited configured credential from server-global environment",
+	)
+}

--- a/internal/tmux/manager_test.go
+++ b/internal/tmux/manager_test.go
@@ -1,12 +1,227 @@
 package tmux
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type recordingSessionManagerCommand struct {
+	detailed  []*SessionInfo
+	listErr   error
+	has       bool
+	serverPID string
+	calls     []string
+}
+
+func (r *recordingSessionManagerCommand) SetOptionContext(
+	_ context.Context, sessionName, option string, value any,
+) error {
+	r.calls = append(r.calls, fmt.Sprintf("set-option:%s:%s:%v", sessionName, option, value))
+	return nil
+}
+
+func (r *recordingSessionManagerCommand) RunCommandContext(
+	_ context.Context,
+	args ...string,
+) error {
+	r.calls = append(r.calls, "run-command:"+strings.Join(args, " "))
+	return nil
+}
+
+func (r *recordingSessionManagerCommand) RunCommandOutputContext(
+	_ context.Context,
+	args ...string,
+) (string, error) {
+	r.calls = append(r.calls, "run-command-output:"+strings.Join(args, " "))
+	if len(args) > 0 && args[0] == "new-session" {
+		r.has = true
+		return "%1\n", nil
+	}
+	if len(args) > 0 && args[0] == "show-options" {
+		return "/bin/sh\n", nil
+	}
+	return "", nil
+}
+
+func (r *recordingSessionManagerCommand) GlobalEnvironmentContext(
+	context.Context,
+) (string, error) {
+	r.calls = append(r.calls, "global-environment")
+	return "", nil
+}
+
+func (r *recordingSessionManagerCommand) SessionEnvironmentContext(
+	context.Context,
+	string,
+) (string, error) {
+	r.calls = append(r.calls, "session-environment")
+	return "", nil
+}
+
+func (r *recordingSessionManagerCommand) ListSessionsDetailed() ([]*SessionInfo, error) {
+	r.calls = append(r.calls, "list-sessions")
+	return r.detailed, r.listErr
+}
+
+func (r *recordingSessionManagerCommand) KillSession(sessionName string) error {
+	r.calls = append(r.calls, "kill-session:"+sessionName)
+	return nil
+}
+
+func (r *recordingSessionManagerCommand) HasSession(sessionName string) bool {
+	r.calls = append(r.calls, "has-session:"+sessionName)
+	return r.has
+}
+
+func (r *recordingSessionManagerCommand) AttachSession(sessionName string) error {
+	r.calls = append(r.calls, "attach-session:"+sessionName)
+	return nil
+}
+
+func (r *recordingSessionManagerCommand) SwitchClient(sessionName string) error {
+	r.calls = append(r.calls, "switch-client:"+sessionName)
+	return nil
+}
+
+func (r *recordingSessionManagerCommand) AttachSessionNested(
+	_ context.Context, sessionName string,
+) error {
+	r.calls = append(r.calls, "nested-attach:"+sessionName)
+	return nil
+}
+
+func (r *recordingSessionManagerCommand) ServerPIDContext(context.Context) (string, error) {
+	r.calls = append(r.calls, "server-pid")
+	return r.serverPID, nil
+}
+
+func TestSessionManagerCreatesOnlyOnKWTServer(t *testing.T) {
+	kwtServer := &recordingSessionManagerCommand{}
+	defaultServer := &recordingSessionManagerCommand{}
+	manager := newSessionManagerWithCommands(DefaultSessionConfig(), kwtServer, defaultServer)
+
+	session, err := manager.CreateSession(context.Background(), SessionOptions{
+		Context: "run", Identifier: "test", WorkingDir: "/work",
+	})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, kwtServer.calls)
+	assert.Empty(t, defaultServer.calls)
+	assert.Equal(t, KWTServerSocketName, session.SocketName)
+}
+
+func TestSessionManagerUnionsKWTAndDefaultServerEndpoints(t *testing.T) {
+	kwtServer := &recordingSessionManagerCommand{detailed: []*SessionInfo{{
+		Name: "kwt-run-kwt-20260101120000",
+	}}}
+	defaultServer := &recordingSessionManagerCommand{detailed: []*SessionInfo{{
+		Name: "kwt-run-default-20260101120000",
+	}}}
+	manager := newSessionManagerWithCommands(DefaultSessionConfig(), kwtServer, defaultServer)
+
+	sessions, err := manager.ListSessions()
+
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+	assert.Equal(t, KWTServerSocketName, sessions[0].SocketName)
+	assert.Empty(t, sessions[1].SocketName)
+}
+
+func TestSessionManagerKeepsEqualNamesFromBothEndpoints(t *testing.T) {
+	info := &SessionInfo{Name: "kwt-run-same-20260101120000"}
+	manager := newSessionManagerWithCommands(
+		DefaultSessionConfig(),
+		&recordingSessionManagerCommand{detailed: []*SessionInfo{info}},
+		&recordingSessionManagerCommand{detailed: []*SessionInfo{info}},
+	)
+
+	sessions, err := manager.ListSessions()
+
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+	assert.NotEqual(t, sessions[0].SocketName, sessions[1].SocketName)
+}
+
+func TestSessionManagerFailsWhenDefaultServerInventoryIsIncomplete(t *testing.T) {
+	manager := newSessionManagerWithCommands(
+		DefaultSessionConfig(),
+		&recordingSessionManagerCommand{},
+		&recordingSessionManagerCommand{listErr: errors.New("permission denied")},
+	)
+
+	_, err := manager.ListSessions()
+
+	require.ErrorContains(t, err, "permission denied")
+}
+
+func TestSessionManagerAttachAndKillUseSelectedEndpoint(t *testing.T) {
+	kwtServer := &recordingSessionManagerCommand{has: true}
+	defaultServer := &recordingSessionManagerCommand{has: true}
+	manager := newSessionManagerWithCommands(DefaultSessionConfig(), kwtServer, defaultServer)
+	manager.tmuxEnvironment = func() string { return "" }
+	adoptedSession := &Session{
+		SessionName: "adopted",
+	}
+
+	require.NoError(t, manager.AttachSessionDirect(adoptedSession))
+	require.NoError(t, manager.KillSessionDirect(adoptedSession))
+	assert.Contains(t, defaultServer.calls, "attach-session:adopted")
+	assert.Contains(t, defaultServer.calls, "kill-session:adopted")
+	assert.Empty(t, kwtServer.calls)
+}
+
+func TestSessionManagerStripsConfiguredCredentialFromEveryAttachPath(t *testing.T) {
+	t.Setenv("CUSTOM_FLEET_TOKEN", "secret")
+	manager := NewSessionManager(nil, "CUSTOM_FLEET_TOKEN")
+
+	for endpoint, rawCommand := range map[string]sessionManagerCommand{
+		"kwt":     manager.kwtServer,
+		"default": manager.defaultServer,
+	} {
+		command, ok := rawCommand.(*TmuxCommand)
+		require.True(t, ok)
+		commands := map[string]*exec.Cmd{
+			"direct": command.attachSessionCmd("workspace"),
+			"nested": command.attachSessionNestedCmd(context.Background(), "workspace"),
+			"switch": command.switchClientCmd("workspace"),
+		}
+		for path, attach := range commands {
+			for _, entry := range attach.Env {
+				assert.Falsef(
+					t,
+					hasEnvName(entry, "CUSTOM_FLEET_TOKEN"),
+					"%s %s attach leaked configured credential: %v",
+					endpoint,
+					path,
+					attach.Env,
+				)
+			}
+		}
+	}
+}
+
+func TestSessionManagerNestsAttachmentAcrossServers(t *testing.T) {
+	canonical := &recordingSessionManagerCommand{has: true, serverPID: "43"}
+	manager := newSessionManagerWithCommands(
+		DefaultSessionConfig(), canonical, &recordingSessionManagerCommand{},
+	)
+	manager.tmuxEnvironment = func() string { return "/tmp/default,42,0" }
+
+	err := manager.AttachSessionDirect(&Session{
+		SessionName: "canonical", SocketName: KWTServerSocketName,
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, canonical.calls, "nested-attach:canonical")
+}
 
 func TestParseWorkspaceSession(t *testing.T) {
 	sm := NewSessionManager(nil)

--- a/internal/tmux/manager_test.go
+++ b/internal/tmux/manager_test.go
@@ -118,6 +118,21 @@ func TestSessionManagerCreatesOnlyOnKWTServer(t *testing.T) {
 	assert.Equal(t, KWTServerSocketName, session.SocketName)
 }
 
+func TestSessionManagerNormalizesDollarSignsInGeneratedSessionName(t *testing.T) {
+	kwtServer := &recordingSessionManagerCommand{}
+	manager := newSessionManagerWithCommands(
+		DefaultSessionConfig(), kwtServer, &recordingSessionManagerCommand{},
+	)
+
+	session, err := manager.CreateSession(context.Background(), SessionOptions{
+		Context: "run$local", Identifier: "build$target", WorkingDir: "/work",
+	})
+
+	require.NoError(t, err)
+	assert.NotContains(t, session.SessionName, "$")
+	assert.Contains(t, session.SessionName, "kwt-run-local-build-target-")
+}
+
 func TestSessionManagerRejectsWorkspaceNamespaceContexts(t *testing.T) {
 	for _, sessionContext := range []string{
 		"wt",

--- a/internal/tmux/manager_test.go
+++ b/internal/tmux/manager_test.go
@@ -118,6 +118,24 @@ func TestSessionManagerCreatesOnlyOnKWTServer(t *testing.T) {
 	assert.Equal(t, KWTServerSocketName, session.SocketName)
 }
 
+func TestSessionManagerRejectsWorkspaceNamespaceContexts(t *testing.T) {
+	for _, sessionContext := range []string{"wt", "workspace"} {
+		t.Run(sessionContext, func(t *testing.T) {
+			kwtServer := &recordingSessionManagerCommand{}
+			manager := newSessionManagerWithCommands(
+				DefaultSessionConfig(), kwtServer, &recordingSessionManagerCommand{},
+			)
+
+			_, err := manager.CreateSession(context.Background(), SessionOptions{
+				Context: sessionContext, Identifier: "standalone", WorkingDir: "/work",
+			})
+
+			require.ErrorContains(t, err, "reserved for workspace sessions")
+			assert.Empty(t, kwtServer.calls)
+		})
+	}
+}
+
 func TestSessionManagerUnionsKWTAndDefaultServerEndpoints(t *testing.T) {
 	kwtServer := &recordingSessionManagerCommand{detailed: []*SessionInfo{{
 		Name: "kwt-run-kwt-20260101120000",

--- a/internal/tmux/manager_test.go
+++ b/internal/tmux/manager_test.go
@@ -119,7 +119,12 @@ func TestSessionManagerCreatesOnlyOnKWTServer(t *testing.T) {
 }
 
 func TestSessionManagerRejectsWorkspaceNamespaceContexts(t *testing.T) {
-	for _, sessionContext := range []string{"wt", "workspace"} {
+	for _, sessionContext := range []string{
+		"wt",
+		"wt-build",
+		"workspace",
+		"workspace-review",
+	} {
 		t.Run(sessionContext, func(t *testing.T) {
 			kwtServer := &recordingSessionManagerCommand{}
 			manager := newSessionManagerWithCommands(

--- a/internal/tmux/probe.go
+++ b/internal/tmux/probe.go
@@ -116,7 +116,8 @@ func classifyProtectedSessionProbe(
 func isExplicitlyAbsentTmuxDiagnostic(stderr string) bool {
 	diagnostic := strings.TrimSpace(stderr)
 	if strings.HasPrefix(diagnostic, "no server running on ") ||
-		strings.HasPrefix(diagnostic, "can't find session: ") {
+		strings.HasPrefix(diagnostic, "can't find session: ") ||
+		strings.HasPrefix(diagnostic, "can't find session ") {
 		return true
 	}
 	return strings.HasPrefix(diagnostic, "error connecting to ") &&

--- a/internal/tmux/probe.go
+++ b/internal/tmux/probe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -92,9 +91,6 @@ func classifyProtectedSessionProbe(
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return ProtectedSessionIndeterminate, err
-		}
-		if errors.Is(err, exec.ErrNotFound) {
-			return ProtectedSessionAbsent, nil
 		}
 		var exited exitCoder
 		if errors.As(err, &exited) && exited.ExitCode() == 1 &&

--- a/internal/tmux/probe.go
+++ b/internal/tmux/probe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 )
 
@@ -91,6 +92,9 @@ func classifyProtectedSessionProbe(
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return ProtectedSessionIndeterminate, err
+		}
+		if errors.Is(err, exec.ErrNotFound) {
+			return ProtectedSessionAbsent, nil
 		}
 		var exited exitCoder
 		if errors.As(err, &exited) && exited.ExitCode() == 1 &&

--- a/internal/tmux/probe_test.go
+++ b/internal/tmux/probe_test.go
@@ -3,6 +3,8 @@ package tmux
 import (
 	"context"
 	"errors"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +15,21 @@ type fakeProbeExitError int
 
 func (e fakeProbeExitError) Error() string { return "tmux exited" }
 func (e fakeProbeExitError) ExitCode() int { return int(e) }
+
+func TestProbeProtectedSessionTreatsMissingTmuxAsAbsent(t *testing.T) {
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing"))
+
+	state, err := ProbeProtectedSession(
+		context.Background(),
+		"kwt-pr-0123456789abcdef",
+		"kwt-wt-widget-main-01234567",
+		nil,
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, ProtectedSessionAbsent, state)
+}
 
 func TestClassifyProtectedSessionProbe(t *testing.T) {
 	tests := []struct {
@@ -51,7 +68,7 @@ func TestClassifyProtectedSessionProbePreservesCancellation(t *testing.T) {
 		"expected",
 		"",
 		"no server running on /tmp/tmux/socket\n",
-		errors.Join(context.Canceled, fakeProbeExitError(1)),
+		errors.Join(context.Canceled, exec.ErrNotFound),
 	)
 
 	assert.Equal(t, ProtectedSessionIndeterminate, state)

--- a/internal/tmux/probe_test.go
+++ b/internal/tmux/probe_test.go
@@ -16,7 +16,7 @@ type fakeProbeExitError int
 func (e fakeProbeExitError) Error() string { return "tmux exited" }
 func (e fakeProbeExitError) ExitCode() int { return int(e) }
 
-func TestProbeProtectedSessionTreatsMissingTmuxAsAbsent(t *testing.T) {
+func TestProbeProtectedSessionTreatsMissingTmuxAsIndeterminate(t *testing.T) {
 	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing"))
 
 	state, err := ProbeProtectedSession(
@@ -27,8 +27,8 @@ func TestProbeProtectedSessionTreatsMissingTmuxAsAbsent(t *testing.T) {
 		"",
 	)
 
-	require.NoError(t, err)
-	assert.Equal(t, ProtectedSessionAbsent, state)
+	assert.ErrorIs(t, err, exec.ErrNotFound)
+	assert.Equal(t, ProtectedSessionIndeterminate, state)
 }
 
 func TestClassifyProtectedSessionProbe(t *testing.T) {

--- a/internal/tmux/probe_test.go
+++ b/internal/tmux/probe_test.go
@@ -44,6 +44,7 @@ func TestClassifyProtectedSessionProbe(t *testing.T) {
 		{name: "no server", stderr: "no server running on /tmp/tmux/socket\n", err: fakeProbeExitError(1), want: ProtectedSessionAbsent},
 		{name: "missing socket", stderr: "error connecting to /tmp/tmux/socket (No such file or directory)\n", err: fakeProbeExitError(1), want: ProtectedSessionAbsent},
 		{name: "missing session", stderr: "can't find session: expected\n", err: fakeProbeExitError(1), want: ProtectedSessionAbsent},
+		{name: "tmux 2.1 missing session", stderr: "can't find session expected\n", err: fakeProbeExitError(1), want: ProtectedSessionAbsent},
 		{name: "permission failure", stderr: "error connecting to /tmp/tmux/socket (Permission denied)\n", err: fakeProbeExitError(1), want: ProtectedSessionIndeterminate, wantErr: true},
 		{name: "unexpected session", output: "other\n", want: ProtectedSessionIndeterminate, wantErr: true},
 		{name: "multiple sessions", output: "expected\nother\n", want: ProtectedSessionIndeterminate, wantErr: true},

--- a/internal/tmux/removal.go
+++ b/internal/tmux/removal.go
@@ -54,9 +54,11 @@ type RemovalSessionLease interface {
 	Resume() error
 }
 
-// RemovalSessionGuard validates that one exact tmux session remains absent.
-// Live-session removal is rejected because tmux has no atomic primitive that
-// can both freeze a shared server's topology and hand control back to KWT.
+// RemovalSessionGuard validates that one exact tmux session remains absent on
+// both the KWT and default-server endpoints, or on its protected endpoint and
+// both shared endpoints. Live-session removal is rejected because tmux has no
+// atomic primitive that can both freeze a shared server's topology and hand
+// control back to KWT.
 type RemovalSessionGuard interface {
 	Quiesce(context.Context, RemovalSessionCondition) (RemovalSessionLease, error)
 }
@@ -65,13 +67,14 @@ type removalSessionGuard struct {
 	command          string
 	inspect          func(context.Context, *TmuxCommand) (string, string, error)
 	inspectProtected func(context.Context, *TmuxCommand, string) (ProtectedSessionState, error)
+	serverCommands   func(RemovalSessionCondition) serverCommands
 }
 
 var removalSocketSelectors = []string{"TMUX", "TMUX_TMPDIR"}
 
-// NewRemovalSessionGuard targets the canonical default tmux server unless the
-// request carries an explicit socket endpoint. Ambient tmux selectors are
-// never removal authority.
+// NewRemovalSessionGuard probes both the KWT server and the temporary
+// default-server adoption endpoint. Protected topology is derived by the
+// lifecycle layer; ambient tmux selectors are never removal authority.
 func NewRemovalSessionGuard(command string) RemovalSessionGuard {
 	return &removalSessionGuard{
 		command:          command,
@@ -165,26 +168,55 @@ func (g *removalSessionGuard) Quiesce(
 		}
 	}
 	if condition.ProtectedSocketTopology {
-		ordinaryCondition := condition
-		ordinaryCondition.SocketDirectory = ""
-		ordinaryCondition.SocketName = ""
-		ordinaryCondition.ProtectedSocketTopology = false
-		if err := g.validateOrdinaryAbsence(ctx, ordinaryCondition); err != nil {
+		sharedCondition := condition
+		sharedCondition.SocketName = ""
+		sharedCondition.ProtectedSocketTopology = false
+		if err := g.validateSharedServerAbsence(ctx, sharedCondition); err != nil {
 			return nil, err
 		}
 		return g.quiesceProtected(ctx, condition)
 	}
-	if err := g.validateOrdinaryAbsence(ctx, condition); err != nil {
+	if err := g.validateSharedServerAbsence(ctx, condition); err != nil {
 		return nil, err
 	}
 	return noRemovalSessionLease{}, nil
 }
 
-func (g *removalSessionGuard) validateOrdinaryAbsence(
+func (g *removalSessionGuard) validateSharedServerAbsence(
 	ctx context.Context,
 	condition RemovalSessionCondition,
 ) error {
-	command := newRemovalTmuxCommand(g.command, condition)
+	servers := g.removalServerCommands(condition)
+	commands := []*TmuxCommand{servers.kwtServer()}
+	// compat(kag1): default-server adoption
+	commands = append(commands, servers.defaultServer())
+	for _, command := range commands {
+		if err := g.validateSharedEndpointAbsence(ctx, condition, command); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *removalSessionGuard) removalServerCommands(
+	condition RemovalSessionCondition,
+) serverCommands {
+	if g.serverCommands != nil {
+		return g.serverCommands(condition)
+	}
+	return newServerCommands(WorkspaceSessionsOptions{
+		Command:                 g.command,
+		DefaultServerTempDir:    condition.SocketDirectory,
+		DefaultServerTempDirSet: true,
+		StripNames:              removalStripNames(condition),
+	})
+}
+
+func (g *removalSessionGuard) validateSharedEndpointAbsence(
+	ctx context.Context,
+	condition RemovalSessionCondition,
+	command *TmuxCommand,
+) error {
 	inspect := g.inspect
 	if inspect == nil {
 		inspect = inspectRemovalSessions
@@ -335,26 +367,6 @@ type noRemovalSessionLease struct{}
 
 func (noRemovalSessionLease) Terminate(context.Context) error { return nil }
 func (noRemovalSessionLease) Resume() error                   { return nil }
-
-func newRemovalTmuxCommand(command string, condition RemovalSessionCondition) *TmuxCommand {
-	stripNames := removalStripNames(condition)
-	if condition.SocketName != "" {
-		if condition.SocketDirectory != "" {
-			return NewTmuxCommandForSocketInTempDirWithStripNames(
-				command,
-				condition.SocketName,
-				condition.SocketDirectory,
-				stripNames,
-			)
-		}
-		return NewTmuxCommandForSocketWithStripNames(
-			command, condition.SocketName, stripNames,
-		)
-	}
-	tmuxCommand := NewTmuxCommandWithStripNames(command, stripNames)
-	tmuxCommand.socketTempDir = condition.SocketDirectory
-	return tmuxCommand
-}
 
 func removalStripNames(condition RemovalSessionCondition) []string {
 	names := make([]string, 0, len(removalSocketSelectors)+len(condition.ProtectedNames))

--- a/internal/tmux/removal_integration_test.go
+++ b/internal/tmux/removal_integration_test.go
@@ -21,7 +21,7 @@ func TestRemovalSessionGuardRejectsLiveSessionWithoutChangingIt(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux is not installed")
 	}
-	tempDir := t.TempDir()
+	tempDir := shortRemovalTmuxTempDir(t)
 	outputPath := filepath.Join(tempDir, "activity")
 	scriptPath := filepath.Join(tempDir, "activity.sh")
 	require.NoError(t, os.WriteFile(scriptPath, []byte(
@@ -66,11 +66,13 @@ func TestRemovalSessionGuardAcceptsMissingNamedSocketWhenAbsenceWasConfirmed(t *
 		t.Skip("tmux is not installed")
 	}
 
-	guard := NewRemovalSessionGuard("tmux")
+	tempDir := shortRemovalTmuxTempDir(t)
+	guard := isolatedRemovalSessionGuard(tempDir)
 	err := quiesceAndTerminateForTest(guard, RemovalSessionCondition{
-		SessionName: "kwt-missing-protected-session",
-		Absent:      true,
-		SocketName:  "kwt-missing-protected-socket",
+		SessionName:             "kwt-missing-protected-session",
+		Absent:                  true,
+		SocketName:              "kwt-missing-protected-socket",
+		ProtectedSocketTopology: true,
 	})
 
 	require.NoError(t, err)
@@ -84,7 +86,7 @@ func TestRemovalSessionGuardRejectsDelimiterBearingWorkspaceMarker(t *testing.T)
 		t.Skip("tmux is not installed")
 	}
 
-	tempDir := t.TempDir()
+	tempDir := shortRemovalTmuxTempDir(t)
 	command := NewTmuxCommandInTempDir("tmux", tempDir)
 	const session = "kwt-removal-marker-test"
 	require.NoError(t, command.RunCommandContext(
@@ -100,7 +102,7 @@ func TestRemovalSessionGuardRejectsDelimiterBearingWorkspaceMarker(t *testing.T)
 		"attacker|"+strings.Repeat("a", 64),
 	))
 
-	lease, err := NewRemovalSessionGuard("tmux").Quiesce(
+	lease, err := isolatedRemovalSessionGuard(tempDir).Quiesce(
 		context.Background(),
 		RemovalSessionCondition{
 			SessionName:         "different-session",
@@ -114,6 +116,30 @@ func TestRemovalSessionGuardRejectsDelimiterBearingWorkspaceMarker(t *testing.T)
 	assert.Nil(t, lease)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "malformed session inventory")
+}
+
+func isolatedRemovalSessionGuard(tempDir string) RemovalSessionGuard {
+	return &removalSessionGuard{
+		command:          "tmux",
+		inspect:          inspectRemovalSessions,
+		inspectProtected: probeProtectedSessionCommand,
+		serverCommands: func(condition RemovalSessionCondition) serverCommands {
+			return newServerCommands(WorkspaceSessionsOptions{
+				Command:              "tmux",
+				KWTServerTempDir:     tempDir,
+				DefaultServerTempDir: tempDir,
+				StripNames:           removalStripNames(condition),
+			})
+		},
+	}
+}
+
+func shortRemovalTmuxTempDir(t *testing.T) string {
+	t.Helper()
+	directory, err := os.MkdirTemp("/tmp", "kwt-rm-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(directory)) })
+	return directory
 }
 
 func quiesceAndTerminateForTest(

--- a/internal/tmux/removal_test.go
+++ b/internal/tmux/removal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -91,15 +92,15 @@ func TestRemovalSessionInspectionFailsClosedWhenListedSessionDisappears(t *testi
 	assert.Contains(t, err.Error(), "inspect tmux sessions")
 }
 
-func TestOrdinaryNamedSocketRemovalUsesSharedServerScan(t *testing.T) {
-	var inspected *TmuxCommand
+func TestSharedServerNamedSocketRemovalUsesSharedServerScan(t *testing.T) {
+	var inspected []*TmuxCommand
 	guard := &removalSessionGuard{
 		command: "tmux",
 		inspect: func(
 			_ context.Context,
 			command *TmuxCommand,
 		) (string, string, error) {
-			inspected = command
+			inspected = append(inspected, command)
 			return removalInventoryOutput(removalSessionRow{
 				SessionName: "another-session",
 			}), "", nil
@@ -115,16 +116,94 @@ func TestOrdinaryNamedSocketRemovalUsesSharedServerScan(t *testing.T) {
 
 	lease, err := guard.Quiesce(context.Background(), RemovalSessionCondition{
 		SessionName:     "expected",
-		SocketName:      "team-server",
+		SocketName:      KWTServerSocketName,
 		SocketDirectory: "/srv/tmux",
 		Absent:          true,
 	})
 
 	require.NoError(t, err)
 	require.NotNil(t, lease)
-	require.NotNil(t, inspected)
-	assert.Equal(t, "team-server", inspected.socketName)
-	assert.Equal(t, "/srv/tmux", inspected.socketTempDir)
+	require.Len(t, inspected, 2)
+	assert.Equal(t, KWTServerSocketName, inspected[0].socketName)
+	assert.Empty(t, inspected[0].socketTempDir)
+	assert.Empty(t, inspected[1].socketName)
+	assert.Equal(t, "/srv/tmux", inspected[1].socketTempDir)
+}
+
+func TestSharedServerRemovalProbesKWTThenDefaultServerEndpoints(t *testing.T) {
+	var sockets []string
+	guard := &removalSessionGuard{
+		command: "tmux",
+		inspect: func(
+			_ context.Context,
+			command *TmuxCommand,
+		) (string, string, error) {
+			sockets = append(sockets, command.socketName)
+			return "", "no server running on test socket", errors.New("tmux exited")
+		},
+	}
+
+	lease, err := guard.Quiesce(context.Background(), RemovalSessionCondition{
+		SessionName: "workspace", SocketName: KWTServerSocketName, Absent: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, []string{KWTServerSocketName, ""}, sockets)
+}
+
+func TestSharedServerRemovalDoesNotInheritAmbientDefaultTempDir(t *testing.T) {
+	t.Setenv("TMUX_TMPDIR", "/ambient/tmux")
+	var defaultEnvironment []string
+	guard := &removalSessionGuard{
+		command: "tmux",
+		inspect: func(
+			_ context.Context,
+			command *TmuxCommand,
+		) (string, string, error) {
+			if command.socketName == "" {
+				defaultEnvironment = command.newCmd(
+					context.Background(),
+					[]string{"list-sessions"},
+				).Env
+			}
+			return "", "no server running on test socket", errors.New("tmux exited")
+		},
+	}
+
+	lease, err := guard.Quiesce(context.Background(), RemovalSessionCondition{
+		SessionName: "workspace", SocketName: KWTServerSocketName, Absent: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.False(t, slices.Contains(defaultEnvironment, "TMUX_TMPDIR=/ambient/tmux"))
+}
+
+func TestSharedServerRemovalRejectsLiveDefaultServerSessionAfterKWTAbsence(t *testing.T) {
+	guard := &removalSessionGuard{
+		command: "tmux",
+		inspect: func(
+			_ context.Context,
+			command *TmuxCommand,
+		) (string, string, error) {
+			if command.socketName == KWTServerSocketName {
+				return "", "no server running on test socket", errors.New("tmux exited")
+			}
+			return removalInventoryOutput(removalSessionRow{
+				SessionName: "workspace",
+			}), "", nil
+		},
+	}
+
+	lease, err := guard.Quiesce(context.Background(), RemovalSessionCondition{
+		SessionName: "workspace", SocketName: KWTServerSocketName, Absent: true,
+	})
+
+	assert.Nil(t, lease)
+	var conditionErr *RemovalSessionConditionError
+	require.ErrorAs(t, err, &conditionErr)
+	assert.Contains(t, conditionErr.Reason, "started after confirmation")
 }
 
 func TestRemovalFailsClosedOnMalformedWorkspaceInventory(t *testing.T) {
@@ -289,9 +368,9 @@ func TestRemovalRejectsGenerationMarkedSessionAfterWorktreeMove(t *testing.T) {
 	assert.Contains(t, conditionErr.Reason, "worktree")
 }
 
-func TestProtectedRemovalRejectsOrdinaryGenerationMarkedSessionAfterWorktreeMove(t *testing.T) {
+func TestProtectedRemovalRejectsSharedServerGenerationMarkedSessionAfterWorktreeMove(t *testing.T) {
 	const generation = "0123456789abcdef0123456789abcdef"
-	ordinaryInspections := 0
+	sharedServerInspections := 0
 	protectedInspections := 0
 	guard := &removalSessionGuard{
 		command: "tmux",
@@ -299,8 +378,8 @@ func TestProtectedRemovalRejectsOrdinaryGenerationMarkedSessionAfterWorktreeMove
 			_ context.Context,
 			command *TmuxCommand,
 		) (string, string, error) {
-			ordinaryInspections++
-			assert.Empty(t, command.socketName)
+			sharedServerInspections++
+			assert.Equal(t, KWTServerSocketName, command.socketName)
 			return removalInventoryOutput(removalSessionRow{
 				SessionName:         "kwt-wt-repo-topic-oldhash",
 				WorkspaceIdentity:   strings.Repeat("a", 64),
@@ -329,8 +408,8 @@ func TestProtectedRemovalRejectsOrdinaryGenerationMarkedSessionAfterWorktreeMove
 	assert.Nil(t, lease)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "worktree remains live")
-	assert.Equal(t, 1, ordinaryInspections)
-	assert.Zero(t, protectedInspections, "ordinary ownership must fail before protected probing")
+	assert.Equal(t, 1, sharedServerInspections)
+	assert.Zero(t, protectedInspections, "sharedServer ownership must fail before protected probing")
 }
 
 func TestRemovalFailsClosedOnUnmarkedKWTSessionAfterWorktreeMove(t *testing.T) {
@@ -434,7 +513,7 @@ func TestProtectedRemovalFailsClosedOnUnexpectedCanonicalTopology(t *testing.T) 
 	var inspected []*TmuxCommand
 	guard := &removalSessionGuard{
 		command: "tmux",
-		inspect: absentOrdinaryRemovalInspection,
+		inspect: absentSharedServerRemovalInspection,
 		inspectProtected: func(
 			_ context.Context,
 			command *TmuxCommand,
@@ -455,7 +534,7 @@ func TestProtectedRemovalFailsClosedOnUnexpectedCanonicalTopology(t *testing.T) 
 
 	assert.Nil(t, lease)
 	require.Error(t, err)
-	require.Len(t, inspected, 1, "indeterminate canonical topology must not fall through to legacy")
+	require.Len(t, inspected, 1, "indeterminate current topology must not fall through to the prior directory")
 	assert.Equal(t, "kwt-pr-protected", inspected[0].socketName)
 	assert.Empty(t, inspected[0].socketTempDir)
 }
@@ -465,7 +544,7 @@ func TestProtectedRemovalCommandsStripRequestProtectedNames(t *testing.T) {
 	inspections := 0
 	guard := &removalSessionGuard{
 		command: "tmux",
-		inspect: absentOrdinaryRemovalInspection,
+		inspect: absentSharedServerRemovalInspection,
 		inspectProtected: func(
 			_ context.Context,
 			command *TmuxCommand,
@@ -493,14 +572,14 @@ func TestProtectedRemovalCommandsStripRequestProtectedNames(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, lease)
-	assert.Equal(t, 2, inspections, "canonical and legacy endpoints must both be sanitized")
+	assert.Equal(t, 2, inspections, "current and prior endpoints must both be sanitized")
 }
 
-func TestProtectedRemovalChecksCanonicalBeforeLegacyEndpoint(t *testing.T) {
+func TestProtectedRemovalChecksCurrentBeforePriorSocketDirectory(t *testing.T) {
 	var inspected []*TmuxCommand
 	guard := &removalSessionGuard{
 		command: "tmux",
-		inspect: absentOrdinaryRemovalInspection,
+		inspect: absentSharedServerRemovalInspection,
 		inspectProtected: func(
 			_ context.Context,
 			command *TmuxCommand,
@@ -529,7 +608,42 @@ func TestProtectedRemovalChecksCanonicalBeforeLegacyEndpoint(t *testing.T) {
 	assert.Equal(t, "/tmp/legacy-tmux", inspected[1].socketTempDir)
 }
 
-func absentOrdinaryRemovalInspection(
+func TestProtectedRemovalPreservesPriorSharedServerSocketDirectory(t *testing.T) {
+	var sharedServer []*TmuxCommand
+	guard := &removalSessionGuard{
+		command: "tmux",
+		inspect: func(
+			_ context.Context,
+			command *TmuxCommand,
+		) (string, string, error) {
+			sharedServer = append(sharedServer, command)
+			return "", "no server running on /tmp/tmux/default", errors.New("tmux exited")
+		},
+		inspectProtected: func(
+			context.Context,
+			*TmuxCommand,
+			string,
+		) (ProtectedSessionState, error) {
+			return ProtectedSessionAbsent, nil
+		},
+	}
+
+	lease, err := guard.Quiesce(context.Background(), RemovalSessionCondition{
+		SessionName:             "expected",
+		SocketName:              "kwt-pr-protected",
+		SocketDirectory:         "/tmp/legacy-tmux",
+		Absent:                  true,
+		ProtectedSocketTopology: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Len(t, sharedServer, 2)
+	assert.Empty(t, sharedServer[0].socketTempDir)
+	assert.Equal(t, "/tmp/legacy-tmux", sharedServer[1].socketTempDir)
+}
+
+func absentSharedServerRemovalInspection(
 	context.Context,
 	*TmuxCommand,
 ) (string, string, error) {

--- a/internal/tmux/resolver.go
+++ b/internal/tmux/resolver.go
@@ -344,6 +344,14 @@ func workspaceSessionCandidate(
 	if IsKWTDirectoryWorkspaceSessionName(request.SessionName) {
 		return MatchDirWorkspaceSession(names, request.WorkspacePath)
 	}
+	// compat(kag1): pre-dollar tmux session names. The path hash survives
+	// sanitization changes; marker inspection still proves the candidate's
+	// identity and generation before it can be used.
+	for _, name := range names {
+		if MatchesLegacyWorkspaceSessionPath(name, request.WorkspacePath) {
+			return name, true
+		}
+	}
 	return "", false
 }
 

--- a/internal/tmux/resolver.go
+++ b/internal/tmux/resolver.go
@@ -1,0 +1,504 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type endpointCommand interface {
+	ListSessionsContext(context.Context) ([]string, error)
+	SessionUserOptionContext(context.Context, string, string) (string, error)
+	ServerPIDContext(context.Context) (string, error)
+}
+
+// WorkspaceEndpointRequest is the identity required to resolve an existing
+// workspace session. Directory workspaces omit the generation.
+type WorkspaceEndpointRequest struct {
+	SessionName         string
+	WorkspacePath       string
+	WorkspaceGeneration string
+}
+
+// WorkspaceSessionResolution is one inventory-oriented endpoint result.
+// Err describes why the intended endpoint had to be returned instead of a
+// verified live session; callers must not use this best-effort result to
+// establish or attach a session without resolving it again.
+type WorkspaceSessionResolution struct {
+	Session WorkspaceSession
+	Err     error
+}
+
+type resolvedWorkspaceSession struct {
+	WorkspaceSession
+	adopted bool
+}
+
+func newResolvedWorkspaceSession(
+	sessionName string,
+	live bool,
+	adopted bool,
+) resolvedWorkspaceSession {
+	socketName := KWTServerSocketName
+	if adopted {
+		socketName = ""
+	}
+	return resolvedWorkspaceSession{
+		WorkspaceSession: WorkspaceSession{
+			Endpoint: SessionEndpoint{
+				SessionName: sessionName,
+				SocketName:  socketName,
+			},
+			Live: live,
+		},
+		adopted: adopted,
+	}
+}
+
+// endpointResolver chooses the KWT server or a verified live default-server
+// session. It never migrates or modifies sessions.
+type endpointResolver struct {
+	canonical        endpointCommand
+	defaultServer    endpointCommand
+	reportDiagnostic func(error)
+}
+
+func newEndpointResolver(
+	canonical endpointCommand,
+	defaultServer endpointCommand,
+	reportDiagnostic func(error),
+) *endpointResolver {
+	if reportDiagnostic == nil {
+		reportDiagnostic = func(error) {}
+	}
+	return &endpointResolver{
+		canonical:        canonical,
+		defaultServer:    defaultServer,
+		reportDiagnostic: reportDiagnostic,
+	}
+}
+
+func (r *endpointResolver) resolve(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+) (resolvedWorkspaceSession, error) {
+	intended := newResolvedWorkspaceSession(request.SessionName, false, false)
+	canonicalNames, err := r.canonical.ListSessionsContext(ctx)
+	if err != nil {
+		return resolvedWorkspaceSession{}, fmt.Errorf(
+			"inspect canonical tmux endpoint: %w",
+			err,
+		)
+	}
+	if candidate, ok := workspaceSessionCandidate(canonicalNames, request); ok {
+		candidateRequest := request
+		candidateRequest.SessionName = candidate
+		matches, inspectErr := inspectWorkspaceCandidate(
+			ctx,
+			r.canonical,
+			candidateRequest,
+			true,
+		)
+		if inspectErr != nil {
+			return resolvedWorkspaceSession{}, inspectErr
+		}
+		if matches {
+			return newResolvedWorkspaceSession(candidate, true, false), nil
+		}
+	}
+
+	// compat(kag1): default-server adoption
+	defaultNames, err := r.defaultServer.ListSessionsContext(ctx)
+	if err != nil {
+		r.reportDiagnostic(fmt.Errorf("default-server adoption lookup degraded: %w", err))
+		return intended, nil
+	}
+	adopted, found, err := r.adoptDefaultServerSession(ctx, request, defaultNames)
+	if err != nil {
+		return resolvedWorkspaceSession{}, err
+	}
+	if found {
+		return adopted, nil
+	}
+	return intended, nil
+}
+
+// liveEndpoints returns every verified live endpoint for cleanup operations.
+// Unlike attachment resolution, it does not stop after finding the preferred
+// canonical endpoint.
+func (r *endpointResolver) liveEndpoints(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+) ([]SessionEndpoint, error) {
+	canonicalNames, err := r.canonical.ListSessionsContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("inspect canonical tmux endpoint: %w", err)
+	}
+	// compat(kag1): default-server adoption
+	defaultNames, err := r.defaultServer.ListSessionsContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("inspect default tmux endpoint: %w", err)
+	}
+
+	endpoints := make([]SessionEndpoint, 0, 2)
+	for _, candidate := range workspaceCleanupCandidates(canonicalNames, request) {
+		candidateRequest := request
+		candidateRequest.SessionName = candidate
+		matches, inspectErr := inspectWorkspaceCleanupCandidate(
+			ctx,
+			r.canonical,
+			candidateRequest,
+			candidate == request.SessionName,
+		)
+		if inspectErr != nil {
+			return nil, inspectErr
+		}
+		if matches {
+			endpoints = append(endpoints, canonicalEndpoint(candidate))
+		}
+	}
+	// compat(kag1): default-server adoption
+	for _, candidate := range workspaceCleanupCandidates(defaultNames, request) {
+		candidateRequest := request
+		candidateRequest.SessionName = candidate
+		matches, inspectErr := inspectWorkspaceCleanupCandidate(
+			ctx,
+			r.defaultServer,
+			candidateRequest,
+			false,
+		)
+		if inspectErr != nil {
+			return nil, fmt.Errorf(
+				"inspect adopted default-server workspace: %w",
+				inspectErr,
+			)
+		}
+		if matches {
+			endpoints = append(endpoints, SessionEndpoint{SessionName: candidate})
+		}
+	}
+	return endpoints, nil
+}
+
+// resolveAll resolves an inventory snapshot while enumerating each server at
+// most once. Exact candidates still receive the same marker checks as resolve.
+func (r *endpointResolver) resolveAll(
+	ctx context.Context,
+	requests []WorkspaceEndpointRequest,
+) ([]resolvedWorkspaceSession, error) {
+	results, err := r.resolveAllBestEffort(ctx, requests)
+	if err != nil {
+		return nil, err
+	}
+	resolved := make([]resolvedWorkspaceSession, len(results))
+	for index := range results {
+		if results[index].Err != nil {
+			return nil, results[index].Err
+		}
+		resolved[index] = resolvedWorkspaceSession{
+			WorkspaceSession: results[index].Session,
+		}
+	}
+	return resolved, nil
+}
+
+// resolveAllBestEffort preserves one result per inventory request. Marker
+// inspection failures degrade only that request to its intended canonical
+// endpoint; failure to enumerate the canonical server remains a batch error.
+func (r *endpointResolver) resolveAllBestEffort(
+	ctx context.Context,
+	requests []WorkspaceEndpointRequest,
+) ([]WorkspaceSessionResolution, error) {
+	if len(requests) == 0 {
+		return []WorkspaceSessionResolution{}, nil
+	}
+	canonicalNames, err := r.canonical.ListSessionsContext(ctx)
+	if cancellationErr := resolutionCancellation(ctx, err); cancellationErr != nil {
+		return nil, cancellationErr
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect canonical tmux endpoint: %w", err)
+	}
+	// compat(kag1): default-server adoption
+	defaultNames, defaultErr := r.defaultServer.ListSessionsContext(ctx)
+	if cancellationErr := resolutionCancellation(ctx, defaultErr); cancellationErr != nil {
+		return nil, cancellationErr
+	}
+	if defaultErr != nil {
+		r.reportDiagnostic(fmt.Errorf("default-server adoption lookup degraded: %w", defaultErr))
+		defaultNames = nil
+	}
+
+	results := make([]WorkspaceSessionResolution, 0, len(requests))
+	for _, request := range requests {
+		endpoint, resolveErr := r.resolveFromInventory(
+			ctx,
+			request,
+			canonicalNames,
+			defaultNames,
+			defaultErr == nil,
+		)
+		if resolveErr != nil {
+			if cancellationErr := resolutionCancellation(ctx, resolveErr); cancellationErr != nil {
+				return nil, cancellationErr
+			}
+			results = append(results, WorkspaceSessionResolution{
+				Session: newResolvedWorkspaceSession(
+					request.SessionName, false, false,
+				).WorkspaceSession,
+				Err: resolveErr,
+			})
+			continue
+		}
+		results = append(results, WorkspaceSessionResolution{
+			Session: endpoint.WorkspaceSession,
+		})
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func resolutionCancellation(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return nil
+}
+
+func (r *endpointResolver) resolveFromInventory(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+	canonicalNames []string,
+	defaultNames []string,
+	defaultAvailable bool,
+) (resolvedWorkspaceSession, error) {
+	intended := newResolvedWorkspaceSession(request.SessionName, false, false)
+	if candidate, ok := workspaceSessionCandidate(canonicalNames, request); ok {
+		candidateRequest := request
+		candidateRequest.SessionName = candidate
+		matches, err := inspectWorkspaceCandidate(ctx, r.canonical, candidateRequest, true)
+		if err != nil {
+			return resolvedWorkspaceSession{}, err
+		}
+		if matches {
+			return newResolvedWorkspaceSession(candidate, true, false), nil
+		}
+	}
+	if !defaultAvailable {
+		return intended, nil
+	}
+	adopted, found, err := r.adoptDefaultServerSession(ctx, request, defaultNames)
+	if err != nil {
+		return resolvedWorkspaceSession{}, err
+	}
+	if found {
+		return adopted, nil
+	}
+	return intended, nil
+}
+
+// compat(kag1): default-server adoption
+func (r *endpointResolver) adoptDefaultServerSession(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+	names []string,
+) (resolvedWorkspaceSession, bool, error) {
+	candidate, ok := workspaceSessionCandidate(names, request)
+	if !ok {
+		return resolvedWorkspaceSession{}, false, nil
+	}
+	candidateRequest := request
+	candidateRequest.SessionName = candidate
+	matches, err := inspectWorkspaceCandidate(
+		ctx,
+		r.defaultServer,
+		candidateRequest,
+		false,
+	)
+	if err != nil {
+		return resolvedWorkspaceSession{}, false, fmt.Errorf(
+			"inspect adopted default-server workspace: %w",
+			err,
+		)
+	}
+	if !matches {
+		return resolvedWorkspaceSession{}, false, nil
+	}
+	return newResolvedWorkspaceSession(candidate, true, true), true, nil
+}
+
+func workspaceSessionCandidate(
+	names []string,
+	request WorkspaceEndpointRequest,
+) (string, bool) {
+	if containsExactSession(names, request.SessionName) {
+		return request.SessionName, true
+	}
+	if IsKWTDirectoryWorkspaceSessionName(request.SessionName) {
+		return MatchDirWorkspaceSession(names, request.WorkspacePath)
+	}
+	return "", false
+}
+
+func workspaceCleanupCandidates(
+	names []string,
+	request WorkspaceEndpointRequest,
+) []string {
+	directoryWorkspace := request.WorkspaceGeneration == "" &&
+		IsKWTDirectoryWorkspaceSessionName(request.SessionName)
+	candidates := make([]string, 0, len(names))
+	for _, name := range names {
+		if directoryWorkspace {
+			if IsKWTDirectoryWorkspaceSessionName(name) {
+				candidates = append(candidates, name)
+			}
+			continue
+		}
+		if IsKWTWorktreeSessionName(name) {
+			candidates = append(candidates, name)
+		}
+	}
+	return candidates
+}
+
+func containsExactSession(names []string, expected string) bool {
+	for _, name := range names {
+		if name == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func inspectWorkspaceCandidate(
+	ctx context.Context,
+	command endpointCommand,
+	request WorkspaceEndpointRequest,
+	canonical bool,
+) (bool, error) {
+	identity, err := command.SessionUserOptionContext(
+		ctx,
+		request.SessionName,
+		workspaceIdentityOption,
+	)
+	if err != nil {
+		return false, fmt.Errorf("read workspace identity marker: %w", err)
+	}
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		if canonical {
+			return false, &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q lacks workspace identity markers; remove it before reopening the workspace",
+				request.SessionName,
+			)}
+		}
+		return false, nil
+	}
+	if !validLowerHex(identity, 64) {
+		if canonical {
+			return false, &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q has malformed workspace identity markers",
+				request.SessionName,
+			)}
+		}
+		return false, errors.New("malformed workspace identity marker")
+	}
+	if identity != workspacePathIdentity(request.WorkspacePath) {
+		if canonical {
+			return false, &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q belongs to a different workspace identity",
+				request.SessionName,
+			)}
+		}
+		return false, nil
+	}
+	if request.WorkspaceGeneration == "" {
+		return true, nil
+	}
+	return inspectWorkspaceGenerationCandidate(ctx, command, request, canonical)
+}
+
+func inspectWorkspaceCleanupCandidate(
+	ctx context.Context,
+	command endpointCommand,
+	request WorkspaceEndpointRequest,
+	canonical bool,
+) (bool, error) {
+	if request.WorkspaceGeneration != "" {
+		return inspectWorkspaceGenerationCandidate(ctx, command, request, canonical)
+	}
+	return inspectWorkspaceCandidate(ctx, command, request, canonical)
+}
+
+func inspectWorkspaceGenerationCandidate(
+	ctx context.Context,
+	command endpointCommand,
+	request WorkspaceEndpointRequest,
+	canonical bool,
+) (bool, error) {
+	generation, err := command.SessionUserOptionContext(
+		ctx,
+		request.SessionName,
+		workspaceGenerationOption,
+	)
+	if err != nil {
+		return false, fmt.Errorf("read workspace generation marker: %w", err)
+	}
+	generation = strings.TrimSpace(generation)
+	if generation == "" {
+		if canonical {
+			return false, &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q lacks worktree identity markers; remove it before reopening the worktree",
+				request.SessionName,
+			)}
+		}
+		return false, nil
+	}
+	if !validLowerHex(generation, 32) {
+		if canonical {
+			return false, &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q has malformed worktree generation markers",
+				request.SessionName,
+			)}
+		}
+		return false, errors.New("malformed workspace generation marker")
+	}
+	if generation != request.WorkspaceGeneration {
+		if canonical {
+			return false, &SessionSafetyError{Reason: fmt.Sprintf(
+				"tmux session %q belongs to a different worktree generation",
+				request.SessionName,
+			)}
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func parseTMUXServerPID(value string) (uint64, error) {
+	lastComma := strings.LastIndexByte(value, ',')
+	if lastComma <= 0 || lastComma == len(value)-1 {
+		return 0, errors.New("TMUX must contain socket, server PID, and pane index")
+	}
+	remaining := value[:lastComma]
+	secondComma := strings.LastIndexByte(remaining, ',')
+	if secondComma <= 0 || secondComma == len(remaining)-1 {
+		return 0, errors.New("TMUX must contain socket, server PID, and pane index")
+	}
+	return parseCanonicalPID(remaining[secondComma+1:])
+}
+
+func parseCanonicalPID(value string) (uint64, error) {
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil || strconv.FormatUint(parsed, 10) != value {
+		return 0, fmt.Errorf("invalid numeric PID %q", value)
+	}
+	return parsed, nil
+}

--- a/internal/tmux/resolver_test.go
+++ b/internal/tmux/resolver_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/template"
 )
 
 const resolverTestGeneration = "0123456789abcdef0123456789abcdef"
@@ -113,6 +114,46 @@ func TestResolverPrefersMatchingCanonicalWhenBothEndpointsAreLive(t *testing.T) 
 	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
 	assert.True(t, got.Live)
 	assert.Empty(t, defaultServer.calls, "canonical state must win before defaultServer inspection")
+}
+
+func TestResolverAdoptsPreNormalizationDollarSignSessionName(t *testing.T) {
+	request := resolverTestRequest()
+	suffix := "-" + template.ShortHash(request.WorkspacePath)
+	request.SessionName = "kwt-wt-widget-tools-main-home" + suffix
+	legacyName := "kwt-wt-widget$tools-main$home" + suffix
+
+	for _, test := range []struct {
+		name       string
+		canonical  []string
+		adopted    []string
+		wantSocket string
+	}{
+		{
+			name:       "canonical server",
+			canonical:  []string{legacyName},
+			wantSocket: KWTServerSocketName,
+		},
+		{
+			name:    "default server",
+			adopted: []string{legacyName},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			canonical, defaultServer := newResolverTestCommands(
+				request.WorkspacePath, request.SessionName,
+			)
+			canonical.sessions = test.canonical
+			defaultServer.sessions = test.adopted
+			resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+			got, err := resolver.resolve(context.Background(), request)
+
+			require.NoError(t, err)
+			assert.True(t, got.Live)
+			assert.Equal(t, legacyName, got.Endpoint.SessionName)
+			assert.Equal(t, test.wantSocket, got.Endpoint.SocketName)
+		})
+	}
 }
 
 func TestResolverReturnsEveryMatchingLiveEndpoint(t *testing.T) {

--- a/internal/tmux/resolver_test.go
+++ b/internal/tmux/resolver_test.go
@@ -1,0 +1,566 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const resolverTestGeneration = "0123456789abcdef0123456789abcdef"
+
+type fakeEndpointCommand struct {
+	sessions           []string
+	listErr            error
+	options            map[string]string
+	optionsBySession   map[string]map[string]string
+	optionErrors       map[string]error
+	serverPID          string
+	serverPIDErr       error
+	requireEnumeration bool
+	listed             bool
+	calls              []string
+}
+
+func (f *fakeEndpointCommand) ListSessionsContext(context.Context) ([]string, error) {
+	f.calls = append(f.calls, "list-sessions")
+	f.listed = true
+	return append([]string(nil), f.sessions...), f.listErr
+}
+
+func (f *fakeEndpointCommand) SessionUserOptionContext(
+	_ context.Context,
+	session string,
+	option string,
+) (string, error) {
+	if f.requireEnumeration && !f.listed {
+		panic("session marker inspected before list-sessions")
+	}
+	f.calls = append(f.calls, option)
+	if err := f.optionErrors[option]; err != nil {
+		return "", err
+	}
+	if options := f.optionsBySession[session]; options != nil {
+		return options[option], nil
+	}
+	return f.options[option], nil
+}
+
+func (f *fakeEndpointCommand) ServerPIDContext(context.Context) (string, error) {
+	f.calls = append(f.calls, "display-message -p #{pid}")
+	return f.serverPID, f.serverPIDErr
+}
+
+func (f *fakeEndpointCommand) AttachSession(session string) error {
+	f.calls = append(f.calls, "attach-session "+session)
+	return nil
+}
+
+func (f *fakeEndpointCommand) SwitchClient(session string) error {
+	f.calls = append(f.calls, "switch-client "+session)
+	return nil
+}
+
+func (f *fakeEndpointCommand) AttachSessionNested(_ context.Context, session string) error {
+	f.calls = append(f.calls, "nested-attach "+session)
+	return nil
+}
+
+func newResolverTestCommands(path, session string) (*fakeEndpointCommand, *fakeEndpointCommand) {
+	matching := map[string]string{
+		workspaceIdentityOption:   workspacePathIdentity(path),
+		workspaceGenerationOption: resolverTestGeneration,
+	}
+	return &fakeEndpointCommand{
+			options:      cloneStringMap(matching),
+			optionErrors: make(map[string]error),
+		}, &fakeEndpointCommand{
+			options:            cloneStringMap(matching),
+			optionErrors:       make(map[string]error),
+			requireEnumeration: true,
+		}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func resolverTestRequest() WorkspaceEndpointRequest {
+	return WorkspaceEndpointRequest{
+		SessionName:         "kwt-wt-widget-main-01234567",
+		WorkspacePath:       "/work/widget",
+		WorkspaceGeneration: resolverTestGeneration,
+	}
+}
+
+func TestResolverPrefersMatchingCanonicalWhenBothEndpointsAreLive(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	canonical.sessions = []string{request.SessionName}
+	defaultServer.sessions = []string{request.SessionName}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
+	assert.True(t, got.Live)
+	assert.Empty(t, defaultServer.calls, "canonical state must win before defaultServer inspection")
+}
+
+func TestResolverReturnsEveryMatchingLiveEndpoint(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	canonical.sessions = []string{request.SessionName}
+	defaultServer.sessions = []string{request.SessionName}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.liveEndpoints(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, []SessionEndpoint{
+		{SessionName: request.SessionName, SocketName: KWTServerSocketName},
+		{SessionName: request.SessionName},
+	}, got)
+	assert.Equal(t, []string{
+		"list-sessions",
+		workspaceGenerationOption,
+	}, canonical.calls)
+	assert.Equal(t, []string{
+		"list-sessions",
+		workspaceGenerationOption,
+	}, defaultServer.calls)
+}
+
+func TestResolverReturnsRenamedLiveEndpointsByWorkspaceMarkers(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	canonicalRenamed := "kwt-wt-widget-renamed-aaaaaaaa"
+	defaultRenamed := "kwt-wt-widget-previous-bbbbbbbb"
+	unrelated := "kwt-wt-other-main-cccccccc"
+	matching := map[string]string{
+		workspaceIdentityOption:   workspacePathIdentity(request.WorkspacePath),
+		workspaceGenerationOption: request.WorkspaceGeneration,
+	}
+	canonical.sessions = []string{unrelated, canonicalRenamed}
+	canonical.optionsBySession = map[string]map[string]string{
+		unrelated: {
+			workspaceIdentityOption:   workspacePathIdentity("/work/other"),
+			workspaceGenerationOption: "fedcba9876543210fedcba9876543210",
+		},
+		canonicalRenamed: cloneStringMap(matching),
+	}
+	defaultServer.sessions = []string{defaultRenamed}
+	defaultServer.optionsBySession = map[string]map[string]string{
+		defaultRenamed: cloneStringMap(matching),
+	}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.liveEndpoints(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, []SessionEndpoint{
+		{SessionName: canonicalRenamed, SocketName: KWTServerSocketName},
+		{SessionName: defaultRenamed},
+	}, got)
+}
+
+func TestResolverReturnsMovedWorktreeEndpointByGeneration(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	oldSessionName := "kwt-wt-widget-old-path-aaaaaaaa"
+	canonical.sessions = []string{oldSessionName}
+	canonical.optionsBySession = map[string]map[string]string{
+		oldSessionName: {
+			workspaceIdentityOption:   workspacePathIdentity("/work/widget-before-move"),
+			workspaceGenerationOption: request.WorkspaceGeneration,
+		},
+	}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.liveEndpoints(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, []SessionEndpoint{
+		{SessionName: oldSessionName, SocketName: KWTServerSocketName},
+	}, got)
+}
+
+func TestResolverTreatsGeneratedLegacyDirPrefixAsWorktree(t *testing.T) {
+	request := resolverTestRequest()
+	request.SessionName = "kwt-workspace-dir-owner-widget-topic-01234567"
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	canonicalSession := "kwt-wt-widget-topic-89abcdef"
+	canonical.sessions = []string{canonicalSession}
+	canonical.optionsBySession = map[string]map[string]string{
+		canonicalSession: {
+			workspaceIdentityOption:   workspacePathIdentity(request.WorkspacePath),
+			workspaceGenerationOption: request.WorkspaceGeneration,
+		},
+	}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.liveEndpoints(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, []SessionEndpoint{
+		{SessionName: canonicalSession, SocketName: KWTServerSocketName},
+	}, got)
+}
+
+func TestResolverReusesMatchingEnumeratedDefaultServerSession(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.sessions = []string{request.SessionName}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Empty(t, got.Endpoint.SocketName)
+	assert.True(t, got.Live)
+	assert.Equal(t, []string{
+		"list-sessions",
+		workspaceIdentityOption,
+		workspaceGenerationOption,
+	}, defaultServer.calls)
+}
+
+func TestResolverIgnoresMismatchedDefaultServerMarkers(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.sessions = []string{request.SessionName}
+	defaultServer.options[workspaceIdentityOption] = workspacePathIdentity("/work/other")
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
+	assert.False(t, got.Live)
+}
+
+func TestResolverIgnoresUnmarkedDefaultServerCandidate(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.sessions = []string{request.SessionName}
+	defaultServer.options[workspaceIdentityOption] = ""
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
+	assert.False(t, got.Live)
+}
+
+func TestResolverRejectsMismatchedCanonicalMarkers(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	canonical.sessions = []string{request.SessionName}
+	canonical.options[workspaceGenerationOption] = "fedcba9876543210fedcba9876543210"
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	_, err := resolver.resolve(context.Background(), request)
+
+	var safety *SessionSafetyError
+	require.ErrorAs(t, err, &safety)
+	assert.Contains(t, safety.Reason, "different worktree generation")
+}
+
+func TestResolverFailsClosedWhenEnumeratedDefaultServerCandidateCannotBeRead(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.sessions = []string{request.SessionName}
+	defaultServer.optionErrors[workspaceIdentityOption] = errors.New("permission denied")
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	_, err := resolver.resolve(context.Background(), request)
+
+	require.ErrorContains(t, err, "inspect adopted default-server workspace")
+	require.ErrorContains(t, err, "permission denied")
+}
+
+func TestResolverFailsOpenWhenDefaultServerEnumerationFailsBeforeDiscovery(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.listErr = errors.New("default server wedged")
+	var diagnostics []error
+	resolver := newEndpointResolver(canonical, defaultServer, func(err error) {
+		diagnostics = append(diagnostics, err)
+	})
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
+	assert.False(t, got.Live)
+	require.Len(t, diagnostics, 1)
+	assert.ErrorContains(t, diagnostics[0], "default-server adoption lookup degraded")
+	assert.Equal(t, []string{"list-sessions"}, defaultServer.calls)
+}
+
+func TestResolverRejectsMalformedDefaultServerMarkerAfterDiscovery(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.sessions = []string{request.SessionName}
+	defaultServer.options[workspaceIdentityOption] = "not-a-workspace-identity"
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	_, err := resolver.resolve(context.Background(), request)
+
+	require.ErrorContains(t, err, "malformed workspace identity marker")
+}
+
+func TestResolverDirectoryWorkspaceRequiresOnlyPathIdentity(t *testing.T) {
+	request := resolverTestRequest()
+	request.WorkspaceGeneration = ""
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	defaultServer.sessions = []string{request.SessionName}
+	delete(defaultServer.options, workspaceGenerationOption)
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Empty(t, got.Endpoint.SocketName)
+	assert.Equal(t, []string{"list-sessions", workspaceIdentityOption}, defaultServer.calls)
+}
+
+func TestResolverFindsRenamedDirectoryWorkspaceByVerifiedPath(t *testing.T) {
+	path := "/work/notes"
+	request := WorkspaceEndpointRequest{
+		SessionName:   DirWorkspaceSessionName("renamed", path),
+		WorkspacePath: path,
+	}
+	canonical, defaultServer := newResolverTestCommands(path, request.SessionName)
+	previousName := DirWorkspaceSessionName("previous", path)
+	canonical.sessions = []string{previousName}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolve(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.True(t, got.Live)
+	assert.Equal(t, previousName, got.Endpoint.SessionName)
+	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
+}
+
+func TestResolverBatchEnumeratesEachEndpointOnce(t *testing.T) {
+	canonical := &fakeEndpointCommand{
+		options: make(map[string]string), optionErrors: make(map[string]error),
+	}
+	defaultServer := &fakeEndpointCommand{
+		options: make(map[string]string), optionErrors: make(map[string]error),
+	}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolveAll(context.Background(), []WorkspaceEndpointRequest{
+		{SessionName: "one", WorkspacePath: "/work/one"},
+		{SessionName: "two", WorkspacePath: "/work/two"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, KWTServerSocketName, got[0].Endpoint.SocketName)
+	assert.Equal(t, KWTServerSocketName, got[1].Endpoint.SocketName)
+	assert.Equal(t, []string{"list-sessions"}, canonical.calls)
+	assert.Equal(t, []string{"list-sessions"}, defaultServer.calls)
+}
+
+func TestResolverBatchKeepsResolvingAfterWorkspaceSafetyError(t *testing.T) {
+	first := WorkspaceEndpointRequest{
+		SessionName:         "kwt-wt-widget-main-01234567",
+		WorkspacePath:       "/work/widget",
+		WorkspaceGeneration: resolverTestGeneration,
+	}
+	second := WorkspaceEndpointRequest{
+		SessionName:         "kwt-wt-gadget-main-89abcdef",
+		WorkspacePath:       "/work/gadget",
+		WorkspaceGeneration: resolverTestGeneration,
+	}
+	canonical, defaultServer := newResolverTestCommands(first.WorkspacePath, first.SessionName)
+	canonical.sessions = []string{first.SessionName, second.SessionName}
+	canonical.optionsBySession = map[string]map[string]string{
+		first.SessionName: {
+			workspaceIdentityOption:   workspacePathIdentity(first.WorkspacePath),
+			workspaceGenerationOption: "fedcba9876543210fedcba9876543210",
+		},
+		second.SessionName: {
+			workspaceIdentityOption:   workspacePathIdentity(second.WorkspacePath),
+			workspaceGenerationOption: second.WorkspaceGeneration,
+		},
+	}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolveAllBestEffort(
+		context.Background(),
+		[]WorkspaceEndpointRequest{first, second},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	var safetyErr *SessionSafetyError
+	require.ErrorAs(t, got[0].Err, &safetyErr)
+	assert.Equal(t, canonicalEndpoint(first.SessionName), got[0].Session.Endpoint)
+	assert.False(t, got[0].Session.Live)
+	require.NoError(t, got[1].Err)
+	assert.Equal(t, canonicalEndpoint(second.SessionName), got[1].Session.Endpoint)
+	assert.True(t, got[1].Session.Live)
+	assert.Equal(t, 1, countCall(canonical.calls, "list-sessions"))
+	assert.Equal(t, 1, countCall(defaultServer.calls, "list-sessions"))
+}
+
+func TestResolverBestEffortPreservesCancellation(t *testing.T) {
+	request := resolverTestRequest()
+	tests := []struct {
+		name      string
+		configure func(*fakeEndpointCommand, *fakeEndpointCommand)
+	}{
+		{
+			name: "default server enumeration",
+			configure: func(_ *fakeEndpointCommand, defaultServer *fakeEndpointCommand) {
+				defaultServer.listErr = context.Canceled
+			},
+		},
+		{
+			name: "canonical marker inspection",
+			configure: func(canonical *fakeEndpointCommand, _ *fakeEndpointCommand) {
+				canonical.sessions = []string{request.SessionName}
+				canonical.optionErrors[workspaceGenerationOption] = context.DeadlineExceeded
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			canonical, defaultServer := newResolverTestCommands(
+				request.WorkspacePath, request.SessionName,
+			)
+			test.configure(canonical, defaultServer)
+			resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+			_, err := resolver.resolveAllBestEffort(
+				context.Background(), []WorkspaceEndpointRequest{request},
+			)
+
+			require.Error(t, err)
+			assert.True(t,
+				errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
+			)
+		})
+	}
+}
+
+func TestResolverBestEffortChecksCanceledContextBeforeReturning(t *testing.T) {
+	request := resolverTestRequest()
+	canonical, defaultServer := newResolverTestCommands(request.WorkspacePath, request.SessionName)
+	ctx, cancel := context.WithCancel(context.Background())
+	defaultServer.listErr = errors.New("default server unavailable")
+	resolver := newEndpointResolver(canonical, defaultServer, func(error) { cancel() })
+
+	_, err := resolver.resolveAllBestEffort(ctx, []WorkspaceEndpointRequest{request})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func countCall(calls []string, expected string) int {
+	count := 0
+	for _, call := range calls {
+		if call == expected {
+			count++
+		}
+	}
+	return count
+}
+
+func TestParseTMUXServerPIDUsesRightmostFields(t *testing.T) {
+	pid, err := parseTMUXServerPID("/tmp/a,b/default,42,0")
+
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), pid)
+}
+
+func TestParseTMUXServerPIDRejectsMalformedValues(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"/tmp/default,42",
+		"/tmp/default,nope,0",
+		"/tmp/default,042,0",
+		",42,0",
+		"/tmp/default,42,",
+	} {
+		t.Run(fmt.Sprintf("value_%q", value), func(t *testing.T) {
+			_, err := parseTMUXServerPID(value)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestAttachWorkspaceEndpointSwitchesOnMatchingServerPID(t *testing.T) {
+	canonical := &fakeEndpointCommand{serverPID: "42"}
+
+	err := attachWorkspaceEndpoint(
+		context.Background(),
+		canonicalEndpoint("workspace"),
+		canonical,
+		"/tmp/default,42,0",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"display-message -p #{pid}",
+		"switch-client workspace",
+	}, canonical.calls)
+}
+
+func TestAttachWorkspaceEndpointNestsAcrossServers(t *testing.T) {
+	canonical := &fakeEndpointCommand{serverPID: "43"}
+
+	err := attachWorkspaceEndpoint(
+		context.Background(),
+		canonicalEndpoint("workspace"),
+		canonical,
+		"/tmp/default,42,0",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"display-message -p #{pid}",
+		"nested-attach workspace",
+	}, canonical.calls)
+}
+
+func TestAttachWorkspaceEndpointOutsideTmuxDoesNotProbeServer(t *testing.T) {
+	canonical := &fakeEndpointCommand{serverPIDErr: errors.New("must not run")}
+
+	err := attachWorkspaceEndpoint(
+		context.Background(),
+		canonicalEndpoint("workspace"),
+		canonical,
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"attach-session workspace"}, canonical.calls)
+}
+
+func TestAttachWorkspaceEndpointRejectsNonNumericServerPIDWithoutVersionProbe(t *testing.T) {
+	canonical := &fakeEndpointCommand{serverPID: "#{pid}"}
+
+	err := attachWorkspaceEndpoint(
+		context.Background(),
+		canonicalEndpoint("workspace"),
+		canonical,
+		"/tmp/default,42,0",
+	)
+
+	require.ErrorContains(t, err, "tmux 2.1")
+	assert.Equal(t, []string{"display-message -p #{pid}"}, canonical.calls)
+}

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,9 +12,15 @@ import (
 	"go.kenn.io/kwt/pkg/models"
 )
 
+type sessionEnvironmentReader interface {
+	GlobalEnvironmentContext(context.Context) (string, error)
+	SessionEnvironmentContext(context.Context, string) (string, error)
+}
+
 // workspaceTmux is the minimal tmux surface the workspace runner needs.
 // *TmuxCommand satisfies it; tests use a mock.
 type workspaceTmux interface {
+	sessionEnvironmentReader
 	HasSessionContext(context.Context, string) (bool, error)
 	RunCommandContext(ctx context.Context, args ...string) error
 	RunCommandOutputContext(ctx context.Context, args ...string) (string, error)
@@ -21,8 +28,6 @@ type workspaceTmux interface {
 	AttachSession(session string) error
 	AttachSessionWithoutEnvironment(context.Context, string) error
 	KillSessionContext(context.Context, string) error
-	GlobalEnvironmentContext(context.Context) (string, error)
-	SessionEnvironmentContext(context.Context, string) (string, error)
 	sessionOptionContext(context.Context, string, string) (string, error)
 	sessionUserOption(context.Context, string, string) (string, error)
 	globalOptionContext(context.Context, string) (string, error)
@@ -60,6 +65,8 @@ type WorkspaceRunner struct {
 }
 
 const partialSessionCleanupTimeout = 2 * time.Second
+
+var errWorkspaceSessionAbsent = errors.New("tmux workspace session is no longer running")
 
 // NewProtectedWorkspaceRunner requires credential-clean tmux state and a
 // matching kwt workspace marker before it reuses an existing session.
@@ -122,7 +129,7 @@ func (r *WorkspaceRunner) EnsureAndAttach(
 }
 
 // Attach presents an already-established workspace session. Callers that
-// guard Ensure with a lifecycle lock can release that lock before the ordinary
+// guard Ensure with a lifecycle lock can release that lock before the direct
 // tmux client occupies the foreground.
 func (r *WorkspaceRunner) Attach(session string, insideTmux bool) error {
 	return r.attach(session, insideTmux)
@@ -130,7 +137,7 @@ func (r *WorkspaceRunner) Attach(session string, insideTmux bool) error {
 
 // Ensure creates or repairs the workspace session without attaching a client.
 // Automation callers can use this to establish kwt's canonical layout and
-// bootstrap before handing presentation to another ordinary tmux client.
+// bootstrap before handing presentation to another direct tmux client.
 func (r *WorkspaceRunner) Ensure(
 	ctx context.Context, session, worktreeDir string, layout models.Layout,
 ) error {
@@ -145,6 +152,51 @@ func (r *WorkspaceRunner) EnsureWithGeneration(
 	layout models.Layout,
 ) error {
 	return r.ensure(ctx, session, worktreeDir, generation, layout)
+}
+
+// RepairExisting repairs a verified adopted directory session without ever
+// creating a replacement on the default server.
+func (r *WorkspaceRunner) RepairExisting(
+	ctx context.Context,
+	session, worktreeDir string,
+	_ models.Layout,
+) error {
+	return r.repairExisting(ctx, session, worktreeDir, "")
+}
+
+// RepairExistingWithGeneration repairs a verified adopted worktree session
+// without ever creating a replacement on the default server.
+func (r *WorkspaceRunner) RepairExistingWithGeneration(
+	ctx context.Context,
+	session, worktreeDir, generation string,
+	_ models.Layout,
+) error {
+	return r.repairExisting(ctx, session, worktreeDir, generation)
+}
+
+func (r *WorkspaceRunner) repairExisting(
+	ctx context.Context,
+	session, worktreeDir, generation string,
+) error {
+	if err := ValidateStartDirectory(worktreeDir); err != nil {
+		return err
+	}
+	exists, err := r.tmux.HasSessionContext(ctx, session)
+	if err != nil {
+		return fmt.Errorf("cannot inspect tmux session: %w", err)
+	}
+	if !exists {
+		return errWorkspaceSessionAbsent
+	}
+	if err := r.validateExistingWorkspaceIdentity(ctx, session, worktreeDir); err != nil {
+		return err
+	}
+	if generation != "" {
+		if err := r.validateExistingWorktreeGeneration(ctx, session, generation); err != nil {
+			return err
+		}
+	}
+	return r.repairBootstrap(ctx, session, worktreeDir, generation)
 }
 
 func (r *WorkspaceRunner) ensure(
@@ -195,6 +247,17 @@ func (r *WorkspaceRunner) validateExistingWorktreeIdentity(
 	worktreeDir string,
 	generation string,
 ) error {
+	if err := r.validateExistingWorkspaceIdentity(ctx, session, worktreeDir); err != nil {
+		return err
+	}
+	return r.validateExistingWorktreeGeneration(ctx, session, generation)
+}
+
+func (r *WorkspaceRunner) validateExistingWorkspaceIdentity(
+	ctx context.Context,
+	session string,
+	worktreeDir string,
+) error {
 	workspaceIdentity, err := r.tmux.sessionUserOption(
 		ctx,
 		session,
@@ -216,6 +279,14 @@ func (r *WorkspaceRunner) validateExistingWorktreeIdentity(
 			session,
 		)}
 	}
+	return nil
+}
+
+func (r *WorkspaceRunner) validateExistingWorktreeGeneration(
+	ctx context.Context,
+	session string,
+	generation string,
+) error {
 	existingGeneration, err := r.tmux.sessionUserOption(
 		ctx,
 		session,
@@ -402,27 +473,39 @@ func (r *WorkspaceRunner) sessionStripNames(
 	session string,
 	sessionExists bool,
 ) ([]string, error) {
+	return deriveSessionStripNames(
+		ctx, r.tmux, session, sessionExists, r.extraStripNames,
+	)
+}
+
+func deriveSessionStripNames(
+	ctx context.Context,
+	environment sessionEnvironmentReader,
+	session string,
+	sessionExists bool,
+	extraStripNames []string,
+) ([]string, error) {
 	launcherEnv := os.Environ()
 	launcher := append(
 		StripEnvNames(launcherEnv),
-		matchingProtectedEnvironmentNames(launcherEnv, r.extraStripNames)...,
+		matchingProtectedEnvironmentNames(launcherEnv, extraStripNames)...,
 	)
 	var serverDerived, sessionDerived []string
-	if output, err := r.tmux.GlobalEnvironmentContext(ctx); err == nil {
+	if output, err := environment.GlobalEnvironmentContext(ctx); err == nil {
 		serverNames := ParseServerEnvNames(output)
 		serverDerived = append(
 			CanonicalStripNames(serverNames),
-			matchingProtectedNames(serverNames, r.extraStripNames)...,
+			matchingProtectedNames(serverNames, extraStripNames)...,
 		)
 	} else if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
 	if sessionExists {
-		if output, err := r.tmux.SessionEnvironmentContext(ctx, session); err == nil {
+		if output, err := environment.SessionEnvironmentContext(ctx, session); err == nil {
 			sessionNames := ParseServerEnvNames(output)
 			sessionDerived = append(
 				CanonicalStripNames(sessionNames),
-				matchingProtectedNames(sessionNames, r.extraStripNames)...,
+				matchingProtectedNames(sessionNames, extraStripNames)...,
 			)
 		} else if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
@@ -430,7 +513,7 @@ func (r *WorkspaceRunner) sessionStripNames(
 	}
 	return MergeStripNames(
 		CanonicalStripExactNames(),
-		r.extraStripNames,
+		extraStripNames,
 		launcher,
 		serverDerived,
 		sessionDerived,

--- a/internal/tmux/runner.go
+++ b/internal/tmux/runner.go
@@ -154,8 +154,8 @@ func (r *WorkspaceRunner) EnsureWithGeneration(
 	return r.ensure(ctx, session, worktreeDir, generation, layout)
 }
 
-// RepairExisting repairs a verified adopted directory session without ever
-// creating a replacement on the default server.
+// RepairExisting repairs a verified directory session without creating a
+// replacement if the observed session exits concurrently.
 func (r *WorkspaceRunner) RepairExisting(
 	ctx context.Context,
 	session, worktreeDir string,
@@ -164,8 +164,8 @@ func (r *WorkspaceRunner) RepairExisting(
 	return r.repairExisting(ctx, session, worktreeDir, "")
 }
 
-// RepairExistingWithGeneration repairs a verified adopted worktree session
-// without ever creating a replacement on the default server.
+// RepairExistingWithGeneration repairs a verified worktree session without
+// creating a replacement if the observed session exits concurrently.
 func (r *WorkspaceRunner) RepairExistingWithGeneration(
 	ctx context.Context,
 	session, worktreeDir, generation string,

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -111,11 +111,13 @@ func IsKWTWorktreeSessionName(name string) bool {
 	return isKWTSessionName(name)
 }
 
-// sanitizeTmuxName replaces characters tmux disallows in a session name
-// ('.' and ':') plus path separators and whitespace with '-'.
+// sanitizeTmuxName replaces characters that are disallowed or not preserved
+// consistently in tmux session names, plus path separators and whitespace,
+// with '-'. tmux 3.4 rewrites '$' during new-session, which makes later
+// commands unable to target the requested spelling.
 func sanitizeTmuxName(s string) string {
 	return strings.NewReplacer(
-		".", "-", ":", "-", "/", "-", " ", "-", "\t", "-",
+		".", "-", ":", "-", "$", "-", "/", "-", " ", "-", "\t", "-",
 	).Replace(s)
 }
 

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -61,9 +61,7 @@ func DefaultSessionConfig() *SessionConfig {
 // (unlike info+branch: two detached-HEAD worktrees of the same repo both report
 // branch "HEAD" and would otherwise collide on the same session name).
 func WorkspaceSessionName(info *url.RepositoryInfo, branch, worktreePath string) string {
-	hash := template.ShortHash(worktreePath)
-	raw := fmt.Sprintf("kwt-wt-%s-%s-%s", info.Repository, branch, hash)
-	return sanitizeTmuxName(raw)
+	return sanitizeTmuxName(workspaceSessionNameRaw(info, branch, worktreePath))
 }
 
 // MatchesWorkspaceSessionName verifies the deterministic session identities
@@ -73,18 +71,39 @@ func MatchesWorkspaceSessionName(
 	info *url.RepositoryInfo,
 	branch, worktreePath string,
 ) bool {
-	return name == WorkspaceSessionName(info, branch, worktreePath) ||
-		name == previousWorkspaceSessionName(info, branch, worktreePath)
+	currentRaw := workspaceSessionNameRaw(info, branch, worktreePath)
+	previousRaw := previousWorkspaceSessionNameRaw(info, branch, worktreePath)
+	return name == sanitizeTmuxName(currentRaw) ||
+		name == sanitizeTmuxName(previousRaw) ||
+		// compat(kag1): pre-dollar tmux session names
+		name == sanitizeTmuxNameBeforeDollarNormalization(currentRaw) ||
+		name == sanitizeTmuxNameBeforeDollarNormalization(previousRaw)
+}
+
+func workspaceSessionNameRaw(
+	info *url.RepositoryInfo,
+	branch, worktreePath string,
+) string {
+	hash := template.ShortHash(worktreePath)
+	return fmt.Sprintf("kwt-wt-%s-%s-%s", info.Repository, branch, hash)
 }
 
 func previousWorkspaceSessionName(
 	info *url.RepositoryInfo,
 	branch, worktreePath string,
 ) string {
+	return sanitizeTmuxName(previousWorkspaceSessionNameRaw(
+		info, branch, worktreePath,
+	))
+}
+
+func previousWorkspaceSessionNameRaw(
+	info *url.RepositoryInfo,
+	branch, worktreePath string,
+) string {
 	hash := template.ShortHash(worktreePath)
-	raw := fmt.Sprintf("kwt-workspace-%s-%s-%s-%s-%s",
+	return fmt.Sprintf("kwt-workspace-%s-%s-%s-%s-%s",
 		info.Host, info.Owner, info.Repository, branch, hash)
-	return sanitizeTmuxName(raw)
 }
 
 // MatchesLegacyWorkspaceSessionPath recognizes pre-marker KWT sessions by
@@ -118,6 +137,13 @@ func IsKWTWorktreeSessionName(name string) bool {
 func sanitizeTmuxName(s string) string {
 	return strings.NewReplacer(
 		".", "-", ":", "-", "$", "-", "/", "-", " ", "-", "\t", "-",
+	).Replace(s)
+}
+
+// compat(kag1): pre-dollar tmux session names
+func sanitizeTmuxNameBeforeDollarNormalization(s string) string {
+	return strings.NewReplacer(
+		".", "-", ":", "-", "/", "-", " ", "-", "\t", "-",
 	).Replace(s)
 }
 

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -88,15 +88,6 @@ func workspaceSessionNameRaw(
 	return fmt.Sprintf("kwt-wt-%s-%s-%s", info.Repository, branch, hash)
 }
 
-func previousWorkspaceSessionName(
-	info *url.RepositoryInfo,
-	branch, worktreePath string,
-) string {
-	return sanitizeTmuxName(previousWorkspaceSessionNameRaw(
-		info, branch, worktreePath,
-	))
-}
-
 func previousWorkspaceSessionNameRaw(
 	info *url.RepositoryInfo,
 	branch, worktreePath string,

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -9,16 +9,19 @@ import (
 	"go.kenn.io/kwt/internal/url"
 )
 
+// Session is KWT's internal observation of one managed tmux session. Wire
+// commands map it to their own response types rather than serializing it.
 type Session struct {
-	ID          string            `json:"id"`
-	SessionName string            `json:"session_name"`
-	Context     string            `json:"context"`
-	Identifier  string            `json:"identifier"`
-	WorkingDir  string            `json:"working_dir"`
-	Command     string            `json:"command"`
-	StartTime   time.Time         `json:"start_time"`
-	HistorySize int               `json:"history_size"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	SessionName string
+	SocketName  string
+	ID          string
+	Context     string
+	Identifier  string
+	WorkingDir  string
+	Command     string
+	StartTime   time.Time
+	HistorySize int
+	Metadata    map[string]string
 }
 
 type SessionOptions struct {
@@ -33,6 +36,15 @@ type SessionConfig struct {
 	Enabled      bool   `toml:"enabled" json:"enabled"`
 	TmuxCommand  string `toml:"tmux_command" json:"tmux_command"`
 	HistoryLimit int    `toml:"history_limit" json:"history_limit"`
+}
+
+// SessionEndpointLabel returns the human-readable server identity for a KWT
+// tmux session.
+func SessionEndpointLabel(session *Session) string {
+	if session == nil || session.SocketName == "" {
+		return "default"
+	}
+	return session.SocketName
 }
 
 func DefaultSessionConfig() *SessionConfig {
@@ -108,6 +120,12 @@ func sanitizeTmuxName(s string) string {
 }
 
 const dirWorkspaceSessionPrefix = "kwt-workspace-dir-"
+
+// IsKWTDirectoryWorkspaceSessionName reports whether name is in the managed
+// directory-workspace namespace.
+func IsKWTDirectoryWorkspaceSessionName(name string) bool {
+	return strings.HasPrefix(name, dirWorkspaceSessionPrefix)
+}
 
 // DirWorkspaceSessionName returns a stable, tmux-safe session name for a
 // directory workspace: kwt-workspace-dir-{name}-{hash}. The hash is computed

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/internal/template"
 	"go.kenn.io/kwt/internal/url"
 )
 
@@ -123,6 +124,28 @@ func TestMatchesWorkspaceSessionName(t *testing.T) {
 	))
 	assert.False(t, MatchesWorkspaceSessionName(
 		"kwt-wt-kwt-feature-foo-9cc4e551", info, branch, "/another/path",
+	))
+}
+
+func TestMatchesWorkspaceSessionNameAcceptsPreNormalizationDollarSigns(t *testing.T) {
+	info := &url.RepositoryInfo{
+		Host: "github.com", Owner: "acme", Repository: "kwt$tools",
+	}
+	branch := "feature/$HOME"
+	path := "/worktrees/kwt-tools"
+	suffix := "-" + template.ShortHash(path)
+
+	assert.True(t, MatchesWorkspaceSessionName(
+		"kwt-wt-kwt$tools-feature-$HOME"+suffix,
+		info,
+		branch,
+		path,
+	))
+	assert.True(t, MatchesWorkspaceSessionName(
+		"kwt-workspace-github-com-acme-kwt$tools-feature-$HOME"+suffix,
+		info,
+		branch,
+		path,
 	))
 }
 

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -80,6 +80,16 @@ func TestWorkspaceSessionName(t *testing.T) {
 	assert.NotEqual(t, detached1, detached2)
 }
 
+func TestGeneratedWorkspaceSessionNamesNormalizeDollarSigns(t *testing.T) {
+	info := &url.RepositoryInfo{Repository: "kwt$tools"}
+
+	worktree := WorkspaceSessionName(info, "feature/$HOME", "/worktrees/kwt$tools")
+	directory := DirWorkspaceSessionName("notes$archive", "/workspaces/notes$archive")
+
+	assert.NotContains(t, worktree, "$")
+	assert.NotContains(t, directory, "$")
+}
+
 func TestWorkspaceSessionNameDoesNotOverlapDirectoryWorkspaceNamespace(t *testing.T) {
 	info := &url.RepositoryInfo{Repository: "workspace"}
 	path := "/worktrees/notes"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -36,11 +37,13 @@ type SessionManagerInterface interface {
 }
 
 type TmuxCommand struct {
-	command         string
-	socketName      string
-	socketTempDir   string
-	extraStripNames map[string]bool
-	attachProcess   attachProcessFunc
+	command            string
+	socketName         string
+	socketTempDir      string
+	clearSocketTempDir bool
+	extraStripNames    map[string]bool
+	stripParentTmux    bool
+	attachProcess      attachProcessFunc
 }
 
 type attachProcessFunc func(*exec.Cmd) error
@@ -60,7 +63,7 @@ func NewTmuxCommandWithStripNames(
 
 // NewTmuxCommandForSocketWithStripNames targets a named tmux socket for every
 // invocation. A named socket gives protected workspaces a server boundary
-// separate from the user's ordinary tmux server.
+// separate from the user's default tmux server.
 func NewTmuxCommandForSocketWithStripNames(
 	command string,
 	socketName string,
@@ -102,7 +105,16 @@ func NewTmuxCommandForSocketInTempDirWithStripNames(
 // NewTmuxCommandInTempDir targets the default socket beneath an explicit
 // TMUX_TMPDIR, ignoring any ambient socket selection inherited by the daemon.
 func NewTmuxCommandInTempDir(command, tempDir string) *TmuxCommand {
-	tmuxCommand := NewTmuxCommand(command)
+	return NewTmuxCommandInTempDirWithStripNames(command, tempDir, nil)
+}
+
+// NewTmuxCommandInTempDirWithStripNames targets the default socket beneath an
+// explicit TMUX_TMPDIR and removes caller-owned credential names.
+func NewTmuxCommandInTempDirWithStripNames(
+	command, tempDir string,
+	names []string,
+) *TmuxCommand {
+	tmuxCommand := NewTmuxCommandWithStripNames(command, names)
 	tmuxCommand.socketTempDir = strings.TrimSpace(tempDir)
 	return tmuxCommand
 }
@@ -145,13 +157,28 @@ func (t *TmuxCommand) SetOptionContext(ctx context.Context, sessionName, option 
 }
 
 func (t *TmuxCommand) ListSessions() ([]string, error) {
+	return t.ListSessionsContext(context.Background())
+}
+
+// ListSessionsContext returns exact session names on this command's endpoint.
+// An explicitly missing tmux server is an empty inventory.
+func (t *TmuxCommand) ListSessionsContext(ctx context.Context) ([]string, error) {
 	args := []string{"list-sessions", "-F", "#{session_name}"}
-	output, err := t.runCommandOutput(args...)
+	output, stderr, err := t.runCommandOutputContextWithStderr(ctx, args...)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, errors.Join(ctxErr, err)
+	}
 	if err != nil {
-		if strings.Contains(err.Error(), "no server running") {
+		var exited exitCoder
+		if errors.As(err, &exited) && exited.ExitCode() == 1 &&
+			isExplicitlyAbsentTmuxDiagnostic(stderr) {
 			return []string{}, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf(
+			"tmux list-sessions failed: %w, stderr: %s",
+			err,
+			strings.TrimSpace(stderr),
+		)
 	}
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")
@@ -164,15 +191,54 @@ func (t *TmuxCommand) ListSessions() ([]string, error) {
 	return sessions, nil
 }
 
+// SessionUserOptionContext reads one session-local user option without
+// exposing the command implementation to endpoint resolvers.
+func (t *TmuxCommand) SessionUserOptionContext(
+	ctx context.Context,
+	session string,
+	option string,
+) (string, error) {
+	return t.sessionUserOption(ctx, session, option)
+}
+
+// SessionWorkspaceIdentityContext reads the marker binding a session to its
+// workspace path.
+func (t *TmuxCommand) SessionWorkspaceIdentityContext(
+	ctx context.Context,
+	session string,
+) (string, error) {
+	return t.sessionUserOption(ctx, session, workspaceIdentityOption)
+}
+
+// ServerPIDContext returns the tmux server PID format for this endpoint.
+func (t *TmuxCommand) ServerPIDContext(ctx context.Context) (string, error) {
+	output, err := t.RunCommandOutputContext(
+		ctx,
+		"display-message",
+		"-p",
+		"#{pid}",
+	)
+	return strings.TrimSpace(output), err
+}
+
 func (t *TmuxCommand) ListSessionsDetailed() ([]*SessionInfo, error) {
 	format := "#{session_name}:#{session_created}:#{session_activity}:#{session_attached}:#{pane_current_command}:#{pane_current_path}"
 	args := []string{"list-sessions", "-F", format}
-	output, err := t.runCommandOutput(args...)
+	output, stderr, err := t.runCommandOutputContextWithStderr(
+		context.Background(),
+		args...,
+	)
 	if err != nil {
-		if strings.Contains(err.Error(), "no server running") {
+		var exited exitCoder
+		if errors.As(err, &exited) && exited.ExitCode() == 1 &&
+			isExplicitlyAbsentTmuxDiagnostic(stderr) {
 			return []*SessionInfo{}, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf(
+			"tmux list-sessions failed: %w, stderr: %s",
+			err,
+			strings.TrimSpace(stderr),
+		)
 	}
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")
@@ -221,6 +287,36 @@ func (t *TmuxCommand) KillSessionContext(
 	return t.RunCommandContext(ctx, "kill-session", "-t", sessionName)
 }
 
+// KillSessionIfPresentContext terminates a cleanup target while treating a
+// session or server that exited concurrently as an already-complete cleanup.
+func (t *TmuxCommand) KillSessionIfPresentContext(
+	ctx context.Context,
+	sessionName string,
+) error {
+	_, stderr, err := t.runCommandOutputContextWithStderr(
+		ctx,
+		"kill-session",
+		"-t",
+		sessionName,
+	)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return errors.Join(ctxErr, err)
+	}
+	if err == nil {
+		return nil
+	}
+	var exited exitCoder
+	if errors.As(err, &exited) && exited.ExitCode() == 1 &&
+		isExplicitlyAbsentTmuxDiagnostic(stderr) {
+		return nil
+	}
+	return fmt.Errorf(
+		"tmux kill-session failed: %w, stderr: %s",
+		err,
+		strings.TrimSpace(stderr),
+	)
+}
+
 func (t *TmuxCommand) AttachSession(sessionName string) error {
 	return t.runAttachProcess(
 		context.Background(),
@@ -236,6 +332,16 @@ func (t *TmuxCommand) AttachSessionWithoutEnvironment(
 		ctx,
 		t.attachSessionWithoutEnvironmentCmd(ctx, sessionName),
 	)
+}
+
+// AttachSessionNested attaches to a workspace on a different tmux
+// server. It removes the parent client's identity so tmux permits nesting,
+// while retaining normal environment synchronization for the target session.
+func (t *TmuxCommand) AttachSessionNested(
+	ctx context.Context,
+	sessionName string,
+) error {
+	return t.runAttachProcess(ctx, t.attachSessionNestedCmd(ctx, sessionName))
 }
 
 func (t *TmuxCommand) runAttachProcess(
@@ -262,6 +368,17 @@ func (t *TmuxCommand) attachSessionWithoutEnvironmentCmd(
 	// This command targets the protected workspace's isolated socket. A
 	// parent TMUX value tells tmux it is already inside a client on another
 	// server, which makes tmux reject the cross-server attachment as nested.
+	cmd.Env = filteredEnviron(cmd.Env, func(name string) bool {
+		return name == "TMUX" || name == "TMUX_PANE"
+	})
+	return cmd
+}
+
+func (t *TmuxCommand) attachSessionNestedCmd(
+	ctx context.Context,
+	sessionName string,
+) *exec.Cmd {
+	cmd := t.newAttachCmd(ctx, []string{"attach-session", "-t", sessionName})
 	cmd.Env = filteredEnviron(cmd.Env, func(name string) bool {
 		return name == "TMUX" || name == "TMUX_PANE"
 	})
@@ -323,7 +440,15 @@ func (t *TmuxCommand) SwitchClient(target string) error {
 // switchClientCmd builds the switch-client invocation through the
 // attach-class exec seam; split out so tests can pin the sanitizer choice.
 func (t *TmuxCommand) switchClientCmd(target string) *exec.Cmd {
-	return t.newAttachCmd(context.Background(), []string{"switch-client", "-t", target})
+	cmd := exec.CommandContext(
+		context.Background(),
+		t.command,
+		t.socketArgs([]string{"switch-client", "-t", target})...,
+	)
+	cmd.Env = t.socketEnvironmentPreservingClient(
+		AttachSanitizedEnviron(os.Environ()),
+	)
+	return cmd
 }
 
 func (t *TmuxCommand) runCommand(args ...string) error {
@@ -336,19 +461,6 @@ func (t *TmuxCommand) runCommand(args ...string) error {
 		return fmt.Errorf("tmux command failed: %w, stderr: %s", err, stderr.String())
 	}
 	return nil
-}
-
-func (t *TmuxCommand) runCommandOutput(args ...string) (string, error) {
-	cmd := t.newCmd(context.Background(), args)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("tmux command failed: %w, stderr: %s", err, stderr.String())
-	}
-	return stdout.String(), nil
 }
 
 func (t *TmuxCommand) RunCommandContext(ctx context.Context, args ...string) error {
@@ -514,18 +626,38 @@ func (t *TmuxCommand) socketArgs(args []string) []string {
 }
 
 func (t *TmuxCommand) stripExtraNames(env []string) []string {
-	if len(t.extraStripNames) == 0 && t.socketName == "" && t.socketTempDir == "" {
+	if len(t.extraStripNames) == 0 && t.socketName == "" &&
+		t.socketTempDir == "" && !t.clearSocketTempDir && !t.stripParentTmux {
 		return env
 	}
 	return filteredEnviron(env, func(name string) bool {
-		if (t.socketName != "" || t.socketTempDir != "") && strings.EqualFold(name, "TMUX_TMPDIR") {
+		if (t.socketName != "" || t.socketTempDir != "" || t.clearSocketTempDir) &&
+			strings.EqualFold(name, "TMUX_TMPDIR") {
 			return true
 		}
-		if t.socketTempDir != "" && strings.EqualFold(name, "TMUX") {
+		if (t.socketTempDir != "" || t.stripParentTmux) &&
+			(strings.EqualFold(name, "TMUX") || strings.EqualFold(name, "TMUX_PANE")) {
 			return true
 		}
 		return t.extraStripNames[strings.ToLower(name)]
 	})
+}
+
+func (t *TmuxCommand) socketEnvironmentPreservingClient(env []string) []string {
+	env = filteredEnviron(env, func(name string) bool {
+		if (t.socketName != "" || t.socketTempDir != "" || t.clearSocketTempDir) &&
+			strings.EqualFold(name, "TMUX_TMPDIR") {
+			return true
+		}
+		if strings.EqualFold(name, "TMUX") || strings.EqualFold(name, "TMUX_PANE") {
+			return false
+		}
+		return t.extraStripNames[strings.ToLower(name)]
+	})
+	if t.socketTempDir != "" {
+		env = append(env, "TMUX_TMPDIR="+t.socketTempDir)
+	}
+	return env
 }
 
 func (t *TmuxCommand) socketEnvironment(env []string) []string {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -344,6 +344,15 @@ func (t *TmuxCommand) AttachSessionNested(
 	return t.runAttachProcess(ctx, t.attachSessionNestedCmd(ctx, sessionName))
 }
 
+// AttachSessionNestedCommand builds a cross-server attach process for a
+// terminal owner such as Bubble Tea to run through its managed process API.
+func (t *TmuxCommand) AttachSessionNestedCommand(
+	ctx context.Context,
+	sessionName string,
+) *exec.Cmd {
+	return t.attachSessionNestedCmd(ctx, sessionName)
+}
+
 func (t *TmuxCommand) runAttachProcess(
 	ctx context.Context,
 	cmd *exec.Cmd,

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -284,7 +284,9 @@ func (t *TmuxCommand) KillSessionContext(
 	ctx context.Context,
 	sessionName string,
 ) error {
-	return t.RunCommandContext(ctx, "kill-session", "-t", sessionName)
+	return t.RunCommandContext(
+		ctx, "kill-session", "-t", exactSessionTarget(sessionName),
+	)
 }
 
 // KillSessionIfPresentContext terminates a cleanup target while treating a
@@ -297,7 +299,7 @@ func (t *TmuxCommand) KillSessionIfPresentContext(
 		ctx,
 		"kill-session",
 		"-t",
-		sessionName,
+		exactSessionTarget(sessionName),
 	)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return errors.Join(ctxErr, err)
@@ -315,6 +317,10 @@ func (t *TmuxCommand) KillSessionIfPresentContext(
 		err,
 		strings.TrimSpace(stderr),
 	)
+}
+
+func exactSessionTarget(sessionName string) string {
+	return "=" + sessionName
 }
 
 func (t *TmuxCommand) AttachSession(sessionName string) error {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -378,7 +378,7 @@ func (t *TmuxCommand) attachSessionWithoutEnvironmentCmd(
 ) *exec.Cmd {
 	cmd := t.newAttachCmd(
 		ctx,
-		[]string{"attach-session", "-E", "-t", sessionName},
+		[]string{"attach-session", "-E", "-t", exactSessionTarget(sessionName)},
 	)
 	// This command targets the protected workspace's isolated socket. A
 	// parent TMUX value tells tmux it is already inside a client on another
@@ -393,7 +393,10 @@ func (t *TmuxCommand) attachSessionNestedCmd(
 	ctx context.Context,
 	sessionName string,
 ) *exec.Cmd {
-	cmd := t.newAttachCmd(ctx, []string{"attach-session", "-t", sessionName})
+	cmd := t.newAttachCmd(
+		ctx,
+		[]string{"attach-session", "-t", exactSessionTarget(sessionName)},
+	)
 	cmd.Env = filteredEnviron(cmd.Env, func(name string) bool {
 		return name == "TMUX" || name == "TMUX_PANE"
 	})
@@ -404,7 +407,10 @@ func (t *TmuxCommand) attachSessionNestedCmd(
 // attach-class exec seam; split out so tests can pin that the attach path
 // uses the full-strip sanitizer without needing a tty to run it.
 func (t *TmuxCommand) attachSessionCmd(sessionName string) *exec.Cmd {
-	return t.newAttachCmd(context.Background(), []string{"attach-session", "-t", sessionName})
+	return t.newAttachCmd(
+		context.Background(),
+		[]string{"attach-session", "-t", exactSessionTarget(sessionName)},
+	)
 }
 
 func (t *TmuxCommand) HasSession(sessionName string) bool {
@@ -420,7 +426,7 @@ func (t *TmuxCommand) HasSessionContext(
 		ctx,
 		"has-session",
 		"-t",
-		sessionName,
+		exactSessionTarget(sessionName),
 	)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return false, ctxErr
@@ -458,7 +464,9 @@ func (t *TmuxCommand) switchClientCmd(target string) *exec.Cmd {
 	cmd := exec.CommandContext(
 		context.Background(),
 		t.command,
-		t.socketArgs([]string{"switch-client", "-t", target})...,
+		t.socketArgs([]string{
+			"switch-client", "-t", exactSessionTarget(target),
+		})...,
 	)
 	cmd.Env = t.socketEnvironmentPreservingClient(
 		AttachSanitizedEnviron(os.Environ()),

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -9,6 +9,26 @@ import (
 	"testing"
 )
 
+func newRemovalTmuxCommand(command string, condition RemovalSessionCondition) *TmuxCommand {
+	stripNames := removalStripNames(condition)
+	if condition.SocketName != "" {
+		if condition.SocketDirectory != "" {
+			return NewTmuxCommandForSocketInTempDirWithStripNames(
+				command,
+				condition.SocketName,
+				condition.SocketDirectory,
+				stripNames,
+			)
+		}
+		return NewTmuxCommandForSocketWithStripNames(
+			command, condition.SocketName, stripNames,
+		)
+	}
+	tmuxCommand := NewTmuxCommandWithStripNames(command, stripNames)
+	tmuxCommand.socketTempDir = condition.SocketDirectory
+	return tmuxCommand
+}
+
 // TestNewCmdSanitizesEnvironment pins the exec seam every TmuxCommand method
 // funnels through (newCmd): the *exec.Cmd it builds carries a sanitized copy
 // of the process environment, not the raw os.Environ(), so a tmux server
@@ -364,6 +384,39 @@ func TestProtectedAttachStripsParentTmuxIdentity(t *testing.T) {
 	}
 }
 
+func TestDirectNestedAttachStripsParentIdentityWithoutProtectedFlag(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+	t.Setenv("TMUX_PANE", "%7")
+	t.Setenv("UNRELATED_VAR", "keep-me")
+
+	tc := NewTmuxCommandForSocketWithStripNames(
+		"tmux",
+		KWTServerSocketName,
+		nil,
+	)
+	cmd := tc.attachSessionNestedCmd(context.Background(), "workspace")
+
+	want := []string{
+		"tmux", "-L", KWTServerSocketName,
+		"attach-session", "-t", "workspace",
+	}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("direct nested attach args = %v, want %v", cmd.Args, want)
+	}
+	foundUnrelated := false
+	for _, entry := range cmd.Env {
+		if hasEnvName(entry, "TMUX") || hasEnvName(entry, "TMUX_PANE") {
+			t.Fatalf("direct nested attach leaked parent identity: %v", cmd.Env)
+		}
+		if hasEnvName(entry, "UNRELATED_VAR") {
+			foundUnrelated = true
+		}
+	}
+	if !foundUnrelated {
+		t.Fatalf("direct nested attach dropped unrelated environment: %v", cmd.Env)
+	}
+}
+
 func TestNamedSocketCommandsIgnoreAmbientTmuxTempDirectory(t *testing.T) {
 	t.Setenv("TMUX_TMPDIR", "/tmp/caller-specific-tmux")
 
@@ -427,7 +480,7 @@ func TestExternalAttachReplacesCurrentProcess(t *testing.T) {
 		wantGone []string
 	}{
 		{
-			name: "ordinary",
+			name: "direct",
 			attach: func(tc *TmuxCommand) error {
 				return tc.AttachSession("workspace")
 			},

--- a/internal/tmux/tmux_env_test.go
+++ b/internal/tmux/tmux_env_test.go
@@ -319,8 +319,8 @@ func TestAttachPathsUseFullStripSanitizer(t *testing.T) {
 		"switch-client":  tc.switchClientCmd("x").Env,
 	}
 	for name, args := range cmds {
-		wantArgs := []string{"tmux", name, "-t", "x"}
-		if len(args) != len(wantArgs) || args[1] != name || args[2] != "-t" || args[3] != "x" {
+		wantArgs := []string{"tmux", name, "-t", "=x"}
+		if !slices.Equal(args, wantArgs) {
 			t.Errorf("%s cmd args = %v, want %v", name, args, wantArgs)
 		}
 		for _, entry := range envs[name] {
@@ -345,7 +345,7 @@ func TestProtectedAttachDisablesTmuxEnvironmentUpdate(t *testing.T) {
 
 	want := []string{
 		"tmux", "-L", "kwt-pr-0123456789abcdef",
-		"attach-session", "-E", "-t", "workspace",
+		"attach-session", "-E", "-t", "=workspace",
 	}
 	if !slices.Equal(cmd.Args, want) {
 		t.Fatalf("protected attach args = %v, want %v", cmd.Args, want)
@@ -398,7 +398,7 @@ func TestDirectNestedAttachStripsParentIdentityWithoutProtectedFlag(t *testing.T
 
 	want := []string{
 		"tmux", "-L", KWTServerSocketName,
-		"attach-session", "-t", "workspace",
+		"attach-session", "-t", "=workspace",
 	}
 	if !slices.Equal(cmd.Args, want) {
 		t.Fatalf("direct nested attach args = %v, want %v", cmd.Args, want)
@@ -486,7 +486,7 @@ func TestExternalAttachReplacesCurrentProcess(t *testing.T) {
 			},
 			wantArgs: []string{
 				executable, "-L", "kwt-test-socket",
-				"attach-session", "-t", "workspace",
+				"attach-session", "-t", "=workspace",
 			},
 			wantGone: []string{"EDITOR", "KWT_GITHUB_TOKEN"},
 		},
@@ -500,7 +500,7 @@ func TestExternalAttachReplacesCurrentProcess(t *testing.T) {
 			},
 			wantArgs: []string{
 				executable, "-L", "kwt-test-socket",
-				"attach-session", "-E", "-t", "workspace",
+				"attach-session", "-E", "-t", "=workspace",
 			},
 			wantGone: []string{
 				"EDITOR", "TMUX", "TMUX_PANE", "KWT_GITHUB_TOKEN",

--- a/internal/tmux/workspace_sessions.go
+++ b/internal/tmux/workspace_sessions.go
@@ -1,0 +1,271 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"go.kenn.io/kwt/pkg/models"
+)
+
+type workspaceSessionEnsurer interface {
+	Ensure(context.Context, string, string, models.Layout) error
+	EnsureWithGeneration(context.Context, string, string, string, models.Layout) error
+	RepairExisting(context.Context, string, string, models.Layout) error
+	RepairExistingWithGeneration(context.Context, string, string, string, models.Layout) error
+}
+
+type workspaceAttachCommand interface {
+	AttachSession(string) error
+	SwitchClient(string) error
+	AttachSessionNested(context.Context, string) error
+	ServerPIDContext(context.Context) (string, error)
+}
+
+// WorkspaceSessions resolves, establishes, and presents KWT workspace
+// sessions. Default-server adoption remains private to this coordinator.
+type WorkspaceSessions struct {
+	resolver             *endpointResolver
+	servers              serverCommands
+	resolveSession       func(context.Context, WorkspaceEndpointRequest) (resolvedWorkspaceSession, error)
+	workspaceForEndpoint func(SessionEndpoint) (workspaceSessionEnsurer, error)
+	attachForEndpoint    func(SessionEndpoint) (workspaceAttachCommand, error)
+	tmuxEnvironment      func() string
+}
+
+func NewWorkspaceSessions(options WorkspaceSessionsOptions) *WorkspaceSessions {
+	servers := newServerCommands(options)
+	resolver := newEndpointResolver(
+		servers.kwtServer(),
+		servers.defaultServer(),
+		options.ReportDiagnostic,
+	)
+	sessions := &WorkspaceSessions{
+		resolver:       resolver,
+		servers:        servers,
+		resolveSession: resolver.resolve,
+		tmuxEnvironment: func() string {
+			return os.Getenv("TMUX")
+		},
+	}
+	sessions.workspaceForEndpoint = func(
+		endpoint SessionEndpoint,
+	) (workspaceSessionEnsurer, error) {
+		command, err := servers.commandForEndpoint(endpoint)
+		if err != nil {
+			return nil, err
+		}
+		return NewWorkspaceRunner(command, options.StripNames), nil
+	}
+	sessions.attachForEndpoint = func(
+		endpoint SessionEndpoint,
+	) (workspaceAttachCommand, error) {
+		return servers.commandForEndpoint(endpoint)
+	}
+	return sessions
+}
+
+func (s *WorkspaceSessions) Resolve(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+) (WorkspaceSession, error) {
+	resolved, err := s.resolver.resolve(ctx, request)
+	if errors.Is(err, exec.ErrNotFound) {
+		return newResolvedWorkspaceSession(
+			request.SessionName,
+			false,
+			false,
+		).WorkspaceSession, nil
+	}
+	return resolved.WorkspaceSession, err
+}
+
+func (s *WorkspaceSessions) ResolveAll(
+	ctx context.Context,
+	requests []WorkspaceEndpointRequest,
+) ([]WorkspaceSession, error) {
+	resolved, err := s.resolver.resolveAll(ctx, requests)
+	if errors.Is(err, exec.ErrNotFound) {
+		sessions := make([]WorkspaceSession, len(requests))
+		for index := range requests {
+			sessions[index] = newResolvedWorkspaceSession(
+				requests[index].SessionName,
+				false,
+				false,
+			).WorkspaceSession
+		}
+		return sessions, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	sessions := make([]WorkspaceSession, len(resolved))
+	for index := range resolved {
+		sessions[index] = resolved[index].WorkspaceSession
+	}
+	return sessions, nil
+}
+
+// ResolveAllBestEffort resolves inventory endpoints without allowing one
+// stale session to suppress unrelated workspace records. Establishment and
+// attachment must continue to use Resolve or Establish, which fail closed.
+func (s *WorkspaceSessions) ResolveAllBestEffort(
+	ctx context.Context,
+	requests []WorkspaceEndpointRequest,
+) ([]WorkspaceSessionResolution, error) {
+	resolved, err := s.resolver.resolveAllBestEffort(ctx, requests)
+	if errors.Is(err, exec.ErrNotFound) {
+		results := make([]WorkspaceSessionResolution, len(requests))
+		for index := range requests {
+			results[index].Session = newResolvedWorkspaceSession(
+				requests[index].SessionName,
+				false,
+				false,
+			).WorkspaceSession
+		}
+		return results, nil
+	}
+	return resolved, err
+}
+
+// LiveEndpoints returns every verified live endpoint for one workspace. It is
+// intended for operations that must clean up duplicate sessions across shared
+// servers rather than select one endpoint for attachment.
+func (s *WorkspaceSessions) LiveEndpoints(
+	ctx context.Context,
+	request WorkspaceEndpointRequest,
+) ([]SessionEndpoint, error) {
+	endpoints, err := s.resolver.liveEndpoints(ctx, request)
+	if errors.Is(err, exec.ErrNotFound) {
+		return []SessionEndpoint{}, nil
+	}
+	return endpoints, err
+}
+
+func (s *WorkspaceSessions) Establish(
+	ctx context.Context,
+	session, workspacePath string,
+	layout models.Layout,
+) (SessionEndpoint, error) {
+	return s.establish(ctx, session, workspacePath, "", layout)
+}
+
+func (s *WorkspaceSessions) EstablishWithGeneration(
+	ctx context.Context,
+	session, workspacePath, generation string,
+	layout models.Layout,
+) (SessionEndpoint, error) {
+	return s.establish(ctx, session, workspacePath, generation, layout)
+}
+
+func (s *WorkspaceSessions) establish(
+	ctx context.Context,
+	session, workspacePath, generation string,
+	layout models.Layout,
+) (SessionEndpoint, error) {
+	request := WorkspaceEndpointRequest{
+		SessionName:         session,
+		WorkspacePath:       workspacePath,
+		WorkspaceGeneration: generation,
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		resolved, err := s.resolveSession(ctx, request)
+		if err != nil {
+			return SessionEndpoint{}, err
+		}
+		effectiveSession := resolved.Endpoint.SessionName
+		workspace, err := s.workspaceForEndpoint(resolved.Endpoint)
+		if err != nil {
+			return SessionEndpoint{}, err
+		}
+		if resolved.adopted {
+			// compat(kag1): default-server adoption
+			if generation == "" {
+				err = workspace.RepairExisting(
+					ctx, effectiveSession, workspacePath, layout,
+				)
+			} else {
+				err = workspace.RepairExistingWithGeneration(
+					ctx, effectiveSession, workspacePath, generation, layout,
+				)
+			}
+			if errors.Is(err, errWorkspaceSessionAbsent) && attempt == 0 {
+				continue
+			}
+		} else if generation == "" {
+			err = workspace.Ensure(
+				ctx, effectiveSession, workspacePath, layout,
+			)
+		} else {
+			err = workspace.EnsureWithGeneration(
+				ctx, effectiveSession, workspacePath, generation, layout,
+			)
+		}
+		if err != nil {
+			return SessionEndpoint{}, err
+		}
+		return resolved.Endpoint, nil
+	}
+	return SessionEndpoint{}, errWorkspaceSessionAbsent
+}
+
+func (s *WorkspaceSessions) Attach(
+	ctx context.Context,
+	endpoint SessionEndpoint,
+) error {
+	command, err := s.attachForEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+	return attachWorkspaceEndpoint(
+		ctx,
+		endpoint,
+		command,
+		s.tmuxEnvironment(),
+	)
+}
+
+// Kill terminates the exact direct-attachment endpoint supplied by inventory.
+func (s *WorkspaceSessions) Kill(endpoint SessionEndpoint) error {
+	command, err := s.servers.commandForEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+	return command.KillSessionIfPresentContext(
+		context.Background(),
+		endpoint.SessionName,
+	)
+}
+
+func attachWorkspaceEndpoint(
+	ctx context.Context,
+	endpoint SessionEndpoint,
+	command workspaceAttachCommand,
+	tmuxValue string,
+) error {
+	if tmuxValue == "" {
+		return command.AttachSession(endpoint.SessionName)
+	}
+	clientPID, err := parseTMUXServerPID(tmuxValue)
+	if err != nil {
+		return err
+	}
+	targetRaw, err := command.ServerPIDContext(ctx)
+	if err != nil {
+		return fmt.Errorf("read resolved tmux server PID: %w", err)
+	}
+	targetPID, err := parseCanonicalPID(strings.TrimSpace(targetRaw))
+	if err != nil {
+		return fmt.Errorf(
+			"resolved tmux server did not return a numeric PID; tmux 2.1 or newer is required: %w",
+			err,
+		)
+	}
+	if clientPID == targetPID {
+		return command.SwitchClient(endpoint.SessionName)
+	}
+	return command.AttachSessionNested(ctx, endpoint.SessionName)
+}

--- a/internal/tmux/workspace_sessions.go
+++ b/internal/tmux/workspace_sessions.go
@@ -25,6 +25,11 @@ type workspaceAttachCommand interface {
 	ServerPIDContext(context.Context) (string, error)
 }
 
+type workspaceResidentAttachCommand interface {
+	workspaceAttachCommand
+	AttachSessionNestedCommand(context.Context, string) *exec.Cmd
+}
+
 // WorkspaceSessions resolves, establishes, and presents KWT workspace
 // sessions. Default-server adoption remains private to this coordinator.
 type WorkspaceSessions struct {
@@ -228,6 +233,39 @@ func (s *WorkspaceSessions) Attach(
 	)
 }
 
+// PrepareResidentAttach switches a client that is already on the resolved
+// server. For a different server it returns the nested attach process without
+// starting it, so the resident terminal owner can suspend itself first.
+func (s *WorkspaceSessions) PrepareResidentAttach(
+	ctx context.Context,
+	endpoint SessionEndpoint,
+) (*exec.Cmd, error) {
+	rawCommand, err := s.attachForEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	command, ok := rawCommand.(workspaceResidentAttachCommand)
+	if !ok {
+		return nil, errors.New("tmux attach command cannot prepare a resident attach")
+	}
+	tmuxValue := s.tmuxEnvironment()
+	if tmuxValue == "" {
+		return nil, errors.New("resident tmux attach requires a current tmux client")
+	}
+	clientOnServer, err := clientOnResolvedServer(ctx, command, tmuxValue)
+	if err != nil {
+		return nil, err
+	}
+	if clientOnServer {
+		return nil, command.SwitchClient(endpoint.SessionName)
+	}
+	process := command.AttachSessionNestedCommand(ctx, endpoint.SessionName)
+	if process.Err != nil {
+		return nil, process.Err
+	}
+	return process, nil
+}
+
 // Kill terminates the exact direct-attachment endpoint supplied by inventory.
 func (s *WorkspaceSessions) Kill(endpoint SessionEndpoint) error {
 	command, err := s.servers.commandForEndpoint(endpoint)
@@ -264,23 +302,35 @@ func attachWorkspaceEndpoint(
 	if tmuxValue == "" {
 		return command.AttachSession(endpoint.SessionName)
 	}
-	clientPID, err := parseTMUXServerPID(tmuxValue)
+	clientOnServer, err := clientOnResolvedServer(ctx, command, tmuxValue)
 	if err != nil {
 		return err
 	}
+	if clientOnServer {
+		return command.SwitchClient(endpoint.SessionName)
+	}
+	return command.AttachSessionNested(ctx, endpoint.SessionName)
+}
+
+func clientOnResolvedServer(
+	ctx context.Context,
+	command workspaceAttachCommand,
+	tmuxValue string,
+) (bool, error) {
+	clientPID, err := parseTMUXServerPID(tmuxValue)
+	if err != nil {
+		return false, err
+	}
 	targetRaw, err := command.ServerPIDContext(ctx)
 	if err != nil {
-		return fmt.Errorf("read resolved tmux server PID: %w", err)
+		return false, fmt.Errorf("read resolved tmux server PID: %w", err)
 	}
 	targetPID, err := parseCanonicalPID(strings.TrimSpace(targetRaw))
 	if err != nil {
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"resolved tmux server did not return a numeric PID; tmux 2.1 or newer is required: %w",
 			err,
 		)
 	}
-	if clientPID == targetPID {
-		return command.SwitchClient(endpoint.SessionName)
-	}
-	return command.AttachSessionNested(ctx, endpoint.SessionName)
+	return clientPID == targetPID, nil
 }

--- a/internal/tmux/workspace_sessions.go
+++ b/internal/tmux/workspace_sessions.go
@@ -240,6 +240,21 @@ func (s *WorkspaceSessions) Kill(endpoint SessionEndpoint) error {
 	)
 }
 
+// KillMatching terminates only the session generation observed at the
+// supplied endpoint. A same-named replacement is left untouched.
+func (s *WorkspaceSessions) KillMatching(
+	ctx context.Context,
+	endpoint SessionEndpoint,
+	request WorkspaceEndpointRequest,
+) error {
+	command, err := s.servers.commandForEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+	request.SessionName = endpoint.SessionName
+	return killWorkspaceSessionIfMatching(ctx, command, request)
+}
+
 func attachWorkspaceEndpoint(
 	ctx context.Context,
 	endpoint SessionEndpoint,

--- a/internal/tmux/workspace_sessions.go
+++ b/internal/tmux/workspace_sessions.go
@@ -186,8 +186,12 @@ func (s *WorkspaceSessions) establish(
 		if err != nil {
 			return SessionEndpoint{}, err
 		}
+		repairOnly := resolved.Live && effectiveSession != request.SessionName
 		if resolved.adopted {
 			// compat(kag1): default-server adoption
+			repairOnly = true
+		}
+		if repairOnly {
 			if generation == "" {
 				err = workspace.RepairExisting(
 					ctx, effectiveSession, workspacePath, layout,

--- a/internal/tmux/workspace_sessions_integration_test.go
+++ b/internal/tmux/workspace_sessions_integration_test.go
@@ -113,6 +113,32 @@ func TestWorkspaceSessionsKillSucceedsWhenCapturedSessionAlreadyExited(t *testin
 	require.NoError(t, err)
 }
 
+func TestWorkspaceSessionsKillMatchingLeavesReplacementGeneration(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.createMatching(t, fixture.servers.kwtServer())
+	request := fixture.request()
+	endpoints, err := fixture.sessions.LiveEndpoints(fixture.ctx, request)
+	require.NoError(t, err)
+	require.Len(t, endpoints, 1)
+	require.NoError(t, fixture.servers.kwtServer().KillSession(fixture.session))
+	replacementGeneration := "fedcba9876543210fedcba9876543210"
+	require.NoError(t, NewWorkspaceRunner(
+		fixture.servers.kwtServer(), nil,
+	).EnsureWithGeneration(
+		fixture.ctx,
+		fixture.session,
+		fixture.workspace,
+		replacementGeneration,
+		BlankLayout(),
+	))
+
+	err = fixture.sessions.KillMatching(fixture.ctx, endpoints[0], request)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "different worktree generation")
+	assert.True(t, fixture.servers.kwtServer().HasSession(fixture.session))
+}
+
 func TestWorkspaceSessionsAdoptVerifiedDefaultServerSession(t *testing.T) {
 	fixture := newRealWorkspaceSessionsFixture(t)
 	fixture.createMatching(t, fixture.servers.defaultServer())

--- a/internal/tmux/workspace_sessions_integration_test.go
+++ b/internal/tmux/workspace_sessions_integration_test.go
@@ -141,7 +141,7 @@ func TestWorkspaceSessionsKillMatchingLeavesReplacementGeneration(t *testing.T) 
 
 func TestWorkspaceSessionsKillMatchingTerminatesExactMatchingSession(t *testing.T) {
 	fixture := newRealWorkspaceSessionsFixture(t)
-	fixture.session = `kwt-wt-topic;'$HOME"-01234567`
+	fixture.session = `kwt-wt-topic;'"-01234567`
 	fixture.createMatching(t, fixture.servers.kwtServer())
 	request := fixture.request()
 	endpoints, err := fixture.sessions.LiveEndpoints(fixture.ctx, request)

--- a/internal/tmux/workspace_sessions_integration_test.go
+++ b/internal/tmux/workspace_sessions_integration_test.go
@@ -1,0 +1,211 @@
+package tmux
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type realWorkspaceSessionsFixture struct {
+	ctx        context.Context
+	tempDir    string
+	workspace  string
+	session    string
+	generation string
+	servers    serverCommands
+	sessions   *WorkspaceSessions
+}
+
+func newRealWorkspaceSessionsFixture(t *testing.T) *realWorkspaceSessionsFixture {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux is unavailable on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	tempDir, err := os.MkdirTemp("/tmp", "kwt-sessions-")
+	require.NoError(t, err)
+	workspace, err := os.MkdirTemp("/tmp", "kwt-workspace-")
+	require.NoError(t, err)
+	servers := newServerCommands(WorkspaceSessionsOptions{
+		Command:              "tmux",
+		KWTServerTempDir:     tempDir,
+		DefaultServerTempDir: tempDir,
+	})
+	fixture := &realWorkspaceSessionsFixture{
+		ctx:        context.Background(),
+		tempDir:    tempDir,
+		workspace:  workspace,
+		session:    "kwt-wt-integration-main-01234567",
+		generation: resolverTestGeneration,
+		servers:    servers,
+		sessions: NewWorkspaceSessions(WorkspaceSessionsOptions{
+			Command:              "tmux",
+			KWTServerTempDir:     tempDir,
+			DefaultServerTempDir: tempDir,
+		}),
+	}
+	t.Cleanup(func() {
+		_ = fixture.servers.kwtServer().RunCommandContext(fixture.ctx, "kill-server")
+		_ = fixture.servers.defaultServer().RunCommandContext(fixture.ctx, "kill-server")
+		require.NoError(t, os.RemoveAll(workspace))
+		require.NoError(t, os.RemoveAll(tempDir))
+	})
+	return fixture
+}
+
+func (f *realWorkspaceSessionsFixture) request() WorkspaceEndpointRequest {
+	return WorkspaceEndpointRequest{
+		SessionName:         f.session,
+		WorkspacePath:       f.workspace,
+		WorkspaceGeneration: f.generation,
+	}
+}
+
+func (f *realWorkspaceSessionsFixture) createMatching(
+	t *testing.T,
+	command *TmuxCommand,
+) {
+	t.Helper()
+	require.NoError(t, NewWorkspaceRunner(command, nil).EnsureWithGeneration(
+		f.ctx,
+		f.session,
+		f.workspace,
+		f.generation,
+		BlankLayout(),
+	))
+}
+
+func TestWorkspaceSessionsCreateOnlyOnKWTServer(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+
+	got, err := fixture.sessions.EstablishWithGeneration(
+		fixture.ctx,
+		fixture.session,
+		fixture.workspace,
+		fixture.generation,
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, got.SocketName)
+	assert.True(t, fixture.servers.kwtServer().HasSession(fixture.session))
+	assert.False(t, fixture.servers.defaultServer().HasSession(fixture.session))
+}
+
+func TestWorkspaceSessionsKillSucceedsWhenCapturedSessionAlreadyExited(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.createMatching(t, fixture.servers.kwtServer())
+	endpoint := SessionEndpoint{
+		SessionName: fixture.session,
+		SocketName:  KWTServerSocketName,
+	}
+	require.NoError(t, fixture.servers.kwtServer().KillSession(fixture.session))
+
+	err := fixture.sessions.Kill(endpoint)
+
+	require.NoError(t, err)
+}
+
+func TestWorkspaceSessionsAdoptVerifiedDefaultServerSession(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.createMatching(t, fixture.servers.defaultServer())
+
+	got, err := fixture.sessions.EstablishWithGeneration(
+		fixture.ctx,
+		fixture.session,
+		fixture.workspace,
+		fixture.generation,
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, got.SocketName)
+	assert.True(t, fixture.servers.defaultServer().HasSession(fixture.session))
+	assert.False(t, fixture.servers.kwtServer().HasSession(fixture.session))
+}
+
+func TestWorkspaceSessionsPreferKWTServerWhenBothAreValid(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.createMatching(t, fixture.servers.kwtServer())
+	fixture.createMatching(t, fixture.servers.defaultServer())
+
+	got, err := fixture.sessions.Resolve(fixture.ctx, fixture.request())
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, got.Endpoint.SocketName)
+	assert.True(t, got.Live)
+}
+
+func TestWorkspaceSessionsEstablishOnKWTServerAfterAdoptedSessionExits(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.createMatching(t, fixture.servers.defaultServer())
+	inventoryEndpoint, err := fixture.sessions.Resolve(fixture.ctx, fixture.request())
+	require.NoError(t, err)
+	require.Empty(t, inventoryEndpoint.Endpoint.SocketName)
+	require.NoError(t, fixture.servers.defaultServer().KillSessionContext(
+		fixture.ctx,
+		fixture.session,
+	))
+
+	established, err := fixture.sessions.EstablishWithGeneration(
+		fixture.ctx,
+		fixture.session,
+		fixture.workspace,
+		fixture.generation,
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, established.SocketName)
+	assert.True(t, fixture.servers.kwtServer().HasSession(fixture.session))
+}
+
+func TestWorkspaceSessionsRejectKWTServerMarkerMismatch(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.createMatching(t, fixture.servers.kwtServer())
+	require.NoError(t, fixture.servers.kwtServer().RunCommandContext(
+		fixture.ctx,
+		"set-option",
+		"-t",
+		fixture.session,
+		workspaceIdentityOption,
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	))
+
+	_, err := fixture.sessions.Resolve(fixture.ctx, fixture.request())
+
+	var safety *SessionSafetyError
+	require.ErrorAs(t, err, &safety)
+	assert.Contains(t, safety.Error(), "different workspace identity")
+}
+
+func TestProtectedWorkspaceStillUsesUniqueSocket(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	socket := ProtectedWorkspaceSocketName(fixture.session, fixture.workspace)
+	protected := NewTmuxCommandForSocketInTempDirWithStripNames(
+		"tmux",
+		socket,
+		fixture.tempDir,
+		nil,
+	)
+	t.Cleanup(func() {
+		_ = protected.RunCommandContext(fixture.ctx, "kill-server")
+	})
+
+	require.NoError(t, NewProtectedWorkspaceRunner(protected, nil).Ensure(
+		fixture.ctx,
+		fixture.session,
+		fixture.workspace,
+		BlankLayout(),
+	))
+	assert.True(t, protected.HasSession(fixture.session))
+	assert.False(t, fixture.servers.kwtServer().HasSession(fixture.session))
+	assert.False(t, fixture.servers.defaultServer().HasSession(fixture.session))
+}

--- a/internal/tmux/workspace_sessions_integration_test.go
+++ b/internal/tmux/workspace_sessions_integration_test.go
@@ -139,6 +139,21 @@ func TestWorkspaceSessionsKillMatchingLeavesReplacementGeneration(t *testing.T) 
 	assert.True(t, fixture.servers.kwtServer().HasSession(fixture.session))
 }
 
+func TestWorkspaceSessionsKillMatchingTerminatesExactMatchingSession(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.session = `kwt-wt-topic;'$HOME"-01234567`
+	fixture.createMatching(t, fixture.servers.kwtServer())
+	request := fixture.request()
+	endpoints, err := fixture.sessions.LiveEndpoints(fixture.ctx, request)
+	require.NoError(t, err)
+	require.Len(t, endpoints, 1)
+
+	err = fixture.sessions.KillMatching(fixture.ctx, endpoints[0], request)
+
+	require.NoError(t, err)
+	assert.False(t, fixture.servers.kwtServer().HasSession(fixture.session))
+}
+
 func TestWorkspaceSessionsAdoptVerifiedDefaultServerSession(t *testing.T) {
 	fixture := newRealWorkspaceSessionsFixture(t)
 	fixture.createMatching(t, fixture.servers.defaultServer())

--- a/internal/tmux/workspace_sessions_test.go
+++ b/internal/tmux/workspace_sessions_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,9 +66,10 @@ func (r *recordingWorkspaceEnsurer) EnsureWithGeneration(
 }
 
 type recordingWorkspaceAttachCommand struct {
-	verb      string
-	session   string
-	serverPID string
+	verb            string
+	session         string
+	preparedSession string
+	serverPID       string
 }
 
 func (r *recordingWorkspaceAttachCommand) ServerPIDContext(context.Context) (string, error) {
@@ -93,6 +95,14 @@ func (r *recordingWorkspaceAttachCommand) AttachSessionNested(
 	r.verb = "nested-attach"
 	r.session = session
 	return nil
+}
+
+func (r *recordingWorkspaceAttachCommand) AttachSessionNestedCommand(
+	_ context.Context,
+	session string,
+) *exec.Cmd {
+	r.preparedSession = session
+	return exec.Command("tmux", "attach-session", "-t", session)
 }
 
 func TestWorkspaceSessionsEstablishesOnResolvedCanonicalEndpoint(t *testing.T) {
@@ -272,6 +282,52 @@ func TestWorkspaceSessionsRoutesAttachmentByClientMembership(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.wantVerb, command.verb)
 			assert.Equal(t, "workspace", command.session)
+		})
+	}
+}
+
+func TestWorkspaceSessionsPreparesCrossServerAttachForResidentUI(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		serverPID       string
+		wantVerb        string
+		wantPrepared    string
+		wantProcessArgs []string
+	}{
+		{
+			name:      "same server switches resident client",
+			serverPID: "42",
+			wantVerb:  "switch-client",
+		},
+		{
+			name:            "different server returns nested attach process",
+			serverPID:       "43",
+			wantPrepared:    "workspace",
+			wantProcessArgs: []string{"tmux", "attach-session", "-t", "workspace"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := &recordingWorkspaceAttachCommand{serverPID: test.serverPID}
+			runner := &WorkspaceSessions{
+				attachForEndpoint: func(SessionEndpoint) (workspaceAttachCommand, error) {
+					return command, nil
+				},
+				tmuxEnvironment: func() string { return "/tmp/default,42,0" },
+			}
+
+			process, err := runner.PrepareResidentAttach(
+				context.Background(), canonicalEndpoint("workspace"),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantVerb, command.verb)
+			assert.Equal(t, test.wantPrepared, command.preparedSession)
+			if test.wantProcessArgs == nil {
+				assert.Nil(t, process)
+			} else {
+				require.NotNil(t, process)
+				assert.Equal(t, test.wantProcessArgs, process.Args)
+			}
 		})
 	}
 }

--- a/internal/tmux/workspace_sessions_test.go
+++ b/internal/tmux/workspace_sessions_test.go
@@ -161,7 +161,7 @@ func TestWorkspaceSessionsEstablishesOnResolvedAdoptedEndpoint(t *testing.T) {
 	assert.True(t, ensurer.repaired)
 }
 
-func TestWorkspaceSessionsEstablishesResolvedSessionName(t *testing.T) {
+func TestWorkspaceSessionsRepairsResolvedSessionName(t *testing.T) {
 	for _, test := range []struct {
 		name       string
 		adopted    bool
@@ -202,46 +202,71 @@ func TestWorkspaceSessionsEstablishesResolvedSessionName(t *testing.T) {
 			assert.Equal(t, "existing-session", got.SessionName)
 			assert.Equal(t, "existing-session", ensurer.ensureSession)
 			assert.Equal(t, test.generation, ensurer.ensureGeneration)
-			assert.Equal(t, test.adopted, ensurer.repaired)
-			assert.Equal(t, !test.adopted, ensurer.ensured)
+			assert.True(t, ensurer.repaired)
+			assert.False(t, ensurer.ensured)
 		})
 	}
 }
 
-func TestWorkspaceSessionsNeverCreatesReplacementOnExitedAdoptedEndpoint(t *testing.T) {
-	adopted := &recordingWorkspaceEnsurer{repairErr: errWorkspaceSessionAbsent}
-	canonical := &recordingWorkspaceEnsurer{}
-	resolveCalls := 0
-	runner := &WorkspaceSessions{
-		resolveSession: func(context.Context, WorkspaceEndpointRequest) (resolvedWorkspaceSession, error) {
-			resolveCalls++
-			if resolveCalls == 1 {
-				return newResolvedWorkspaceSession("workspace", true, true), nil
-			}
-			return newResolvedWorkspaceSession("workspace", false, false), nil
+func TestWorkspaceSessionsNeverCreatesReplacementOnExitedResolvedEndpoint(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		resolvedName string
+		adopted      bool
+		generation   string
+	}{
+		{
+			name: "adopted endpoint", resolvedName: "workspace", adopted: true,
+			generation: resolverTestGeneration,
 		},
-		workspaceForEndpoint: func(endpoint SessionEndpoint) (workspaceSessionEnsurer, error) {
-			if endpoint.SocketName == "" {
-				return adopted, nil
+		{name: "canonical alias", resolvedName: "legacy$session"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			disappeared := &recordingWorkspaceEnsurer{repairErr: errWorkspaceSessionAbsent}
+			canonical := &recordingWorkspaceEnsurer{}
+			resolveCalls := 0
+			runner := &WorkspaceSessions{
+				resolveSession: func(
+					_ context.Context,
+					request WorkspaceEndpointRequest,
+				) (resolvedWorkspaceSession, error) {
+					assert.Equal(t, "workspace", request.SessionName)
+					resolveCalls++
+					if resolveCalls == 1 {
+						return newResolvedWorkspaceSession(
+							test.resolvedName, true, test.adopted,
+						), nil
+					}
+					return newResolvedWorkspaceSession("workspace", false, false), nil
+				},
+				workspaceForEndpoint: func(
+					endpoint SessionEndpoint,
+				) (workspaceSessionEnsurer, error) {
+					if endpoint != canonicalEndpoint("workspace") {
+						return disappeared, nil
+					}
+					return canonical, nil
+				},
 			}
-			return canonical, nil
-		},
+
+			got, err := runner.establish(
+				context.Background(),
+				"workspace",
+				"/work/widget",
+				test.generation,
+				BlankLayout(),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, 2, resolveCalls)
+			assert.True(t, disappeared.repaired)
+			assert.False(t, disappeared.ensured)
+			assert.True(t, canonical.ensured)
+			assert.Equal(t, "workspace", canonical.ensureSession)
+			assert.Equal(t, test.generation, canonical.ensureGeneration)
+			assert.Equal(t, canonicalEndpoint("workspace"), got)
+		})
 	}
-
-	got, err := runner.EstablishWithGeneration(
-		context.Background(),
-		"workspace",
-		"/work/widget",
-		resolverTestGeneration,
-		BlankLayout(),
-	)
-
-	require.NoError(t, err)
-	assert.True(t, adopted.repaired)
-	assert.False(t, adopted.ensured)
-	assert.True(t, canonical.ensured)
-	assert.Equal(t, "workspace", canonical.ensureSession)
-	assert.Equal(t, KWTServerSocketName, got.SocketName)
 }
 
 func TestWorkspaceSessionsRoutesAttachmentByClientMembership(t *testing.T) {

--- a/internal/tmux/workspace_sessions_test.go
+++ b/internal/tmux/workspace_sessions_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -102,7 +103,7 @@ func (r *recordingWorkspaceAttachCommand) AttachSessionNestedCommand(
 	session string,
 ) *exec.Cmd {
 	r.preparedSession = session
-	return exec.Command("tmux", "attach-session", "-t", session)
+	return exec.Command(os.Args[0], "attach-session", "-t", session)
 }
 
 func TestWorkspaceSessionsEstablishesOnResolvedCanonicalEndpoint(t *testing.T) {
@@ -287,6 +288,8 @@ func TestWorkspaceSessionsRoutesAttachmentByClientMembership(t *testing.T) {
 }
 
 func TestWorkspaceSessionsPreparesCrossServerAttachForResidentUI(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
 	for _, test := range []struct {
 		name            string
 		serverPID       string
@@ -303,7 +306,7 @@ func TestWorkspaceSessionsPreparesCrossServerAttachForResidentUI(t *testing.T) {
 			name:            "different server returns nested attach process",
 			serverPID:       "43",
 			wantPrepared:    "workspace",
-			wantProcessArgs: []string{"tmux", "attach-session", "-t", "workspace"},
+			wantProcessArgs: []string{os.Args[0], "attach-session", "-t", "workspace"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/tmux/workspace_sessions_test.go
+++ b/internal/tmux/workspace_sessions_test.go
@@ -1,0 +1,277 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/pkg/models"
+)
+
+type recordingWorkspaceEnsurer struct {
+	ensureSession    string
+	ensurePath       string
+	ensureGeneration string
+	repairErr        error
+	repaired         bool
+	ensured          bool
+}
+
+func (r *recordingWorkspaceEnsurer) RepairExisting(
+	_ context.Context,
+	session, path string,
+	_ models.Layout,
+) error {
+	r.repaired = true
+	r.ensureSession = session
+	r.ensurePath = path
+	return r.repairErr
+}
+
+func (r *recordingWorkspaceEnsurer) RepairExistingWithGeneration(
+	_ context.Context,
+	session, path, generation string,
+	_ models.Layout,
+) error {
+	r.repaired = true
+	r.ensureSession = session
+	r.ensurePath = path
+	r.ensureGeneration = generation
+	return r.repairErr
+}
+
+func (r *recordingWorkspaceEnsurer) Ensure(
+	_ context.Context,
+	session, path string,
+	_ models.Layout,
+) error {
+	r.ensured = true
+	r.ensureSession = session
+	r.ensurePath = path
+	return nil
+}
+
+func (r *recordingWorkspaceEnsurer) EnsureWithGeneration(
+	_ context.Context,
+	session, path, generation string,
+	_ models.Layout,
+) error {
+	r.ensured = true
+	r.ensureSession = session
+	r.ensurePath = path
+	r.ensureGeneration = generation
+	return nil
+}
+
+type recordingWorkspaceAttachCommand struct {
+	verb      string
+	session   string
+	serverPID string
+}
+
+func (r *recordingWorkspaceAttachCommand) ServerPIDContext(context.Context) (string, error) {
+	return r.serverPID, nil
+}
+
+func (r *recordingWorkspaceAttachCommand) AttachSession(session string) error {
+	r.verb = "attach-session"
+	r.session = session
+	return nil
+}
+
+func (r *recordingWorkspaceAttachCommand) SwitchClient(session string) error {
+	r.verb = "switch-client"
+	r.session = session
+	return nil
+}
+
+func (r *recordingWorkspaceAttachCommand) AttachSessionNested(
+	_ context.Context,
+	session string,
+) error {
+	r.verb = "nested-attach"
+	r.session = session
+	return nil
+}
+
+func TestWorkspaceSessionsEstablishesOnResolvedCanonicalEndpoint(t *testing.T) {
+	ensurer := &recordingWorkspaceEnsurer{}
+	var selected SessionEndpoint
+	runner := &WorkspaceSessions{
+		resolveSession: func(context.Context, WorkspaceEndpointRequest) (resolvedWorkspaceSession, error) {
+			return newResolvedWorkspaceSession("workspace", false, false), nil
+		},
+		workspaceForEndpoint: func(endpoint SessionEndpoint) (workspaceSessionEnsurer, error) {
+			selected = endpoint
+			return ensurer, nil
+		},
+	}
+
+	got, err := runner.EstablishWithGeneration(
+		context.Background(),
+		"workspace",
+		"/work/widget",
+		resolverTestGeneration,
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, KWTServerSocketName, selected.SocketName)
+	assert.Equal(t, KWTServerSocketName, got.SocketName)
+	assert.Equal(t, "workspace", ensurer.ensureSession)
+	assert.Equal(t, resolverTestGeneration, ensurer.ensureGeneration)
+}
+
+func TestWorkspaceSessionsEstablishesOnResolvedAdoptedEndpoint(t *testing.T) {
+	ensurer := &recordingWorkspaceEnsurer{}
+	var selected SessionEndpoint
+	runner := &WorkspaceSessions{
+		resolveSession: func(context.Context, WorkspaceEndpointRequest) (resolvedWorkspaceSession, error) {
+			return newResolvedWorkspaceSession("workspace", true, true), nil
+		},
+		workspaceForEndpoint: func(endpoint SessionEndpoint) (workspaceSessionEnsurer, error) {
+			selected = endpoint
+			return ensurer, nil
+		},
+	}
+
+	got, err := runner.Establish(
+		context.Background(),
+		"workspace",
+		"/work/widget",
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, selected.SocketName)
+	assert.Empty(t, got.SocketName)
+	assert.Empty(t, ensurer.ensureGeneration)
+	assert.True(t, ensurer.repaired)
+}
+
+func TestWorkspaceSessionsEstablishesResolvedSessionName(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		adopted    bool
+		generation string
+	}{
+		{name: "canonical"},
+		{name: "canonical with generation", generation: resolverTestGeneration},
+		{name: "adopted", adopted: true},
+		{name: "adopted with generation", adopted: true, generation: resolverTestGeneration},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ensurer := &recordingWorkspaceEnsurer{}
+			runner := &WorkspaceSessions{
+				resolveSession: func(
+					context.Context,
+					WorkspaceEndpointRequest,
+				) (resolvedWorkspaceSession, error) {
+					return newResolvedWorkspaceSession(
+						"existing-session", true, test.adopted,
+					), nil
+				},
+				workspaceForEndpoint: func(
+					SessionEndpoint,
+				) (workspaceSessionEnsurer, error) {
+					return ensurer, nil
+				},
+			}
+
+			got, err := runner.establish(
+				context.Background(),
+				"requested-session",
+				"/work/widget",
+				test.generation,
+				BlankLayout(),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, "existing-session", got.SessionName)
+			assert.Equal(t, "existing-session", ensurer.ensureSession)
+			assert.Equal(t, test.generation, ensurer.ensureGeneration)
+			assert.Equal(t, test.adopted, ensurer.repaired)
+			assert.Equal(t, !test.adopted, ensurer.ensured)
+		})
+	}
+}
+
+func TestWorkspaceSessionsNeverCreatesReplacementOnExitedAdoptedEndpoint(t *testing.T) {
+	adopted := &recordingWorkspaceEnsurer{repairErr: errWorkspaceSessionAbsent}
+	canonical := &recordingWorkspaceEnsurer{}
+	resolveCalls := 0
+	runner := &WorkspaceSessions{
+		resolveSession: func(context.Context, WorkspaceEndpointRequest) (resolvedWorkspaceSession, error) {
+			resolveCalls++
+			if resolveCalls == 1 {
+				return newResolvedWorkspaceSession("workspace", true, true), nil
+			}
+			return newResolvedWorkspaceSession("workspace", false, false), nil
+		},
+		workspaceForEndpoint: func(endpoint SessionEndpoint) (workspaceSessionEnsurer, error) {
+			if endpoint.SocketName == "" {
+				return adopted, nil
+			}
+			return canonical, nil
+		},
+	}
+
+	got, err := runner.EstablishWithGeneration(
+		context.Background(),
+		"workspace",
+		"/work/widget",
+		resolverTestGeneration,
+		BlankLayout(),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, adopted.repaired)
+	assert.False(t, adopted.ensured)
+	assert.True(t, canonical.ensured)
+	assert.Equal(t, "workspace", canonical.ensureSession)
+	assert.Equal(t, KWTServerSocketName, got.SocketName)
+}
+
+func TestWorkspaceSessionsRoutesAttachmentByClientMembership(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		tmuxValue string
+		serverPID string
+		wantVerb  string
+	}{
+		{
+			name:     "outside tmux",
+			wantVerb: "attach-session",
+		},
+		{
+			name:      "same server",
+			tmuxValue: "/tmp/default,42,0",
+			serverPID: "42",
+			wantVerb:  "switch-client",
+		},
+		{
+			name:      "different server",
+			tmuxValue: "/tmp/default,42,0",
+			serverPID: "43",
+			wantVerb:  "nested-attach",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := &recordingWorkspaceAttachCommand{serverPID: test.serverPID}
+			runner := &WorkspaceSessions{
+				attachForEndpoint: func(SessionEndpoint) (workspaceAttachCommand, error) {
+					return command, nil
+				},
+				tmuxEnvironment: func() string { return test.tmuxValue },
+			}
+			endpoint := canonicalEndpoint("workspace")
+
+			err := runner.Attach(context.Background(), endpoint)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantVerb, command.verb)
+			assert.Equal(t, "workspace", command.session)
+		})
+	}
+}

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.kenn.io/kwt/internal/discovery"
+	"go.kenn.io/kwt/internal/tmux"
 	"go.kenn.io/kwt/pkg/models"
 )
 
@@ -22,13 +23,14 @@ type Handoff struct {
 }
 
 type Row struct {
-	Entry       *discovery.GlobalWorktreeEntry
-	Status      *models.WorktreeStatus
-	Fleet       *FleetInfo
-	Workspace   *WorkspaceInfo
-	SessionName string
-	SessionLive bool
-	Creating    bool
+	Entry        *discovery.GlobalWorktreeEntry
+	Status       *models.WorktreeStatus
+	Fleet        *FleetInfo
+	Workspace    *WorkspaceInfo
+	SessionName  string
+	SessionLive  bool
+	TmuxEndpoint tmux.SessionEndpoint
+	Creating     bool
 }
 
 // WorkspaceInfo is the TUI-facing view of one registered directory workspace.

--- a/internal/tui/backend.go
+++ b/internal/tui/backend.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"os/exec"
 
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/tmux"
@@ -83,7 +84,7 @@ type Backend interface {
 	RemoveWorktree(ctx context.Context, row Row, force bool) error
 	UnregisterWorkspace(row Row) error
 	KillSession(row Row) error
-	OpenInTmux(ctx context.Context, row Row, layoutName string) error
+	OpenInTmux(ctx context.Context, row Row, layoutName string) (*exec.Cmd, error)
 	LayoutNames() []string
 	InsideTmux() bool
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1268,13 +1268,9 @@ func (m Model) startDelete() (Model, tea.Cmd) {
 		return m, nil
 	}
 	dirty := rowHasUncommittedChanges(row)
-	text := fmt.Sprintf("delete %s? [y/N]", rowLabel(row))
-	if dirty && row.SessionLive {
-		text = fmt.Sprintf("discard changes, delete %s, and kill its live workspace? [y/N]", rowLabel(row))
-	} else if dirty {
-		text = fmt.Sprintf("discard changes and delete %s? [y/N]", rowLabel(row))
-	} else if row.SessionLive {
-		text = fmt.Sprintf("delete %s and kill its live workspace? [y/N]", rowLabel(row))
+	text := fmt.Sprintf("delete %s and stop any matching workspace sessions? [y/N]", rowLabel(row))
+	if dirty {
+		text = fmt.Sprintf("discard changes, delete %s, and stop any matching workspace sessions? [y/N]", rowLabel(row))
 	}
 	m.confirm = confirmState{kind: confirmDelete, row: row, text: text, force: dirty}
 	return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"slices"
 	"sort"
 	"strings"
@@ -75,6 +76,12 @@ type actionDoneMsg struct {
 	refresh     bool
 	anchorPath  string
 	pendingPath string
+}
+
+type openInTmuxReadyMsg struct {
+	process *exec.Cmd
+	message string
+	err     error
 }
 
 type Model struct {
@@ -190,6 +197,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyFleetRows(msg)
 	case actionDoneMsg:
 		return m.applyActionDone(msg)
+	case openInTmuxReadyMsg:
+		return m.applyOpenInTmuxReady(msg)
 	case branchListMsg:
 		return m.applyBranchList(msg)
 	case tea.KeyPressMsg:
@@ -524,6 +533,18 @@ func (m Model) applyActionDone(msg actionDoneMsg) (Model, tea.Cmd) {
 		return m.startFetch()
 	}
 	return m, nil
+}
+
+func (m Model) applyOpenInTmuxReady(msg openInTmuxReadyMsg) (Model, tea.Cmd) {
+	if msg.err != nil {
+		return m.applyActionDone(actionDoneMsg{err: msg.err})
+	}
+	if msg.process == nil {
+		return m.applyActionDone(actionDoneMsg{message: msg.message, refresh: true})
+	}
+	return m, tea.ExecProcess(msg.process, func(err error) tea.Msg {
+		return actionDoneMsg{message: msg.message, err: err, refresh: err == nil}
+	})
 }
 
 func (m Model) applyBranchList(msg branchListMsg) (Model, tea.Cmd) {
@@ -1417,10 +1438,12 @@ func (m Model) killSessionCmd(row Row) tea.Cmd {
 func (m Model) openInTmuxCmd(row Row) tea.Cmd {
 	layoutName := m.selectedLayout
 	return func() tea.Msg {
-		if err := m.backend.OpenInTmux(context.Background(), row, layoutName); err != nil {
-			return actionDoneMsg{err: err}
+		process, err := m.backend.OpenInTmux(context.Background(), row, layoutName)
+		return openInTmuxReadyMsg{
+			process: process,
+			message: fmt.Sprintf("attached %s", rowLabel(row)),
+			err:     err,
 		}
-		return actionDoneMsg{message: fmt.Sprintf("attached %s", rowLabel(row)), refresh: true}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1322,7 +1322,7 @@ func TestModelDeleteLiveWorktreeConfirmsAndCallsRemove(t *testing.T) {
 	model, _ = updateModel(t, model, rowsMsg{rows: []Row{row}})
 
 	model, _ = updateModel(t, model, press("d"))
-	assert.Contains(t, viewContent(model), "delete kwt:feature and kill its live workspace? [y/N]")
+	assert.Contains(t, viewContent(model), "delete kwt:feature and stop any matching workspace sessions? [y/N]")
 
 	_, cmd := updateModel(t, model, press("y"))
 	require.NotNil(t, cmd)
@@ -1330,6 +1330,17 @@ func TestModelDeleteLiveWorktreeConfirmsAndCallsRemove(t *testing.T) {
 	assert.IsType(t, actionDoneMsg{}, msg)
 	assert.Equal(t, []string{"/w/kwt/feature"}, backend.removeCalls)
 	assert.Equal(t, []bool{false}, backend.removeForces)
+}
+
+func TestModelDeleteOfflineWorktreeDisclosesMatchingSessionCleanup(t *testing.T) {
+	row := testRow("kwt", "feature", "/w/kwt/feature")
+	row.SessionLive = false
+	model := NewModel(&fakeBackend{}, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{row}})
+
+	model, _ = updateModel(t, model, press("d"))
+
+	assert.Contains(t, viewContent(model), "delete kwt:feature and stop any matching workspace sessions? [y/N]")
 }
 
 func TestModelRefreshesAfterPartialRemovalWarning(t *testing.T) {
@@ -1390,7 +1401,7 @@ func TestModelDeleteDirtyWorktreeConfirmsDiscardAndForcesRemove(t *testing.T) {
 
 	model, _ = updateModel(t, model, press("d"))
 	content := stripANSI(viewContent(model))
-	assert.Contains(t, content, "discard changes and delete kwt:feature? [y/N]")
+	assert.Contains(t, content, "discard changes, delete kwt:feature, and stop any matching workspace sessions? [y/N]")
 	assert.NotContains(t, content, "kwt remove --force")
 
 	_, cmd := updateModel(t, model, press("y"))
@@ -1401,7 +1412,7 @@ func TestModelDeleteDirtyWorktreeConfirmsDiscardAndForcesRemove(t *testing.T) {
 	assert.Equal(t, []bool{true}, backend.removeForces)
 }
 
-func TestModelDeleteDirtyLiveWorktreeConfirmsDiscardAndKill(t *testing.T) {
+func TestModelDeleteDirtyLiveWorktreeDisclosesMatchingSessionCleanup(t *testing.T) {
 	row := testRow("kwt", "feature", "/w/kwt/feature")
 	row.SessionLive = true
 	row.SessionName = "kwt-workspace-kwt-feature"
@@ -1412,7 +1423,7 @@ func TestModelDeleteDirtyLiveWorktreeConfirmsDiscardAndKill(t *testing.T) {
 
 	model, _ = updateModel(t, model, press("d"))
 
-	assert.Contains(t, stripANSI(viewContent(model)), "discard changes, delete kwt:feature, and kill its live workspace? [y/N]")
+	assert.Contains(t, stripANSI(viewContent(model)), "discard changes, delete kwt:feature, and stop any matching workspace sessions? [y/N]")
 }
 
 func TestModelKillWorkspaceConfirm(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,6 +30,7 @@ type fakeBackend struct {
 	removeErr       error
 	killErr         error
 	openErr         error
+	openProcess     *exec.Cmd
 	branches        []models.Branch
 	branchErr       error
 	fastListCalls   int
@@ -126,9 +128,13 @@ func (b *fakeBackend) KillSession(row Row) error {
 	return b.killErr
 }
 
-func (b *fakeBackend) OpenInTmux(ctx context.Context, row Row, layoutName string) error {
+func (b *fakeBackend) OpenInTmux(
+	ctx context.Context,
+	row Row,
+	layoutName string,
+) (*exec.Cmd, error) {
 	b.openCalls = append(b.openCalls, rowPath(row)+":"+layoutName)
-	return b.openErr
+	return b.openProcess, b.openErr
 }
 
 func (b *fakeBackend) UnregisterWorkspace(row Row) error {
@@ -1467,9 +1473,29 @@ func TestModelInsideTmuxAttachRunsResidentAction(t *testing.T) {
 	model, cmd := updateModel(t, model, press("enter"))
 	require.NotNil(t, cmd)
 	msg := cmd()
-	assert.IsType(t, actionDoneMsg{}, msg)
+	ready, ok := msg.(openInTmuxReadyMsg)
+	require.True(t, ok)
+	assert.Nil(t, ready.process)
 	assert.Equal(t, []string{"/w/kwt/feature:quad"}, backend.openCalls)
 	assert.Equal(t, HandoffNone, model.Handoff().Kind)
+}
+
+func TestModelCrossServerAttachUsesBubbleTeaManagedProcess(t *testing.T) {
+	row := testRow("kwt", "feature", "/w/kwt/feature")
+	process := exec.Command("tmux", "attach-session", "-t", "workspace")
+	backend := &fakeBackend{insideTmux: true, openProcess: process}
+	model := NewModel(backend, "/worktrees")
+	model, _ = updateModel(t, model, rowsMsg{rows: []Row{row}})
+
+	model, openCmd := updateModel(t, model, press("enter"))
+	require.NotNil(t, openCmd)
+	ready, ok := openCmd().(openInTmuxReadyMsg)
+	require.True(t, ok)
+	assert.Same(t, process, ready.process)
+
+	_, managedCmd := updateModel(t, model, ready)
+	require.NotNil(t, managedCmd)
+	assert.Equal(t, "tea.execMsg", fmt.Sprintf("%T", managedCmd()))
 }
 
 func TestModelActionErrorDisplaysAndClearsOnNextKey(t *testing.T) {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -3,18 +3,32 @@ package models
 
 import "time"
 
+// TmuxAttachMode tells clients whether a selected tmux endpoint can be
+// attached directly or requires KWT's protected-workspace attach flow. Every
+// wire type that emits tmux_socket_name must emit tmux_attach_mode beside it;
+// clients must never infer attachment policy from the socket name.
+type TmuxAttachMode string
+
+const (
+	// TmuxAttachDirect selects direct tmux attachment on the returned socket.
+	TmuxAttachDirect TmuxAttachMode = "direct"
+	// TmuxAttachProtected requires KWT's protected pull-request attachment.
+	TmuxAttachProtected TmuxAttachMode = "protected"
+)
+
 // Worktree represents a Git worktree with its associated metadata.
 type Worktree struct {
-	Path           string    `json:"path"`                       // Absolute path to the worktree directory
-	Branch         string    `json:"branch"`                     // Branch name associated with this worktree
-	CommitHash     string    `json:"commit_hash"`                // Current HEAD commit hash
-	IsMain         bool      `json:"is_main"`                    // Whether this is the main worktree
-	CreatedAt      time.Time `json:"created_at"`                 // Worktree directory modification time
-	Generation     string    `json:"generation"`                 // Durable identity for this worktree registration
-	Repository     string    `json:"repository"`                 // Repository slug, e.g. github.com/owner/name
-	SessionName    string    `json:"session_name"`               // Computed tmux workspace session name
-	TmuxSocketName string    `json:"tmux_socket_name,omitempty"` // Protected alternate tmux socket
-	Prunable       bool      `json:"-"`                          // Git reports this worktree entry as stale/prunable
+	Path           string         `json:"path"`                       // Absolute path to the worktree directory
+	Branch         string         `json:"branch"`                     // Branch name associated with this worktree
+	CommitHash     string         `json:"commit_hash"`                // Current HEAD commit hash
+	IsMain         bool           `json:"is_main"`                    // Whether this is the main worktree
+	CreatedAt      time.Time      `json:"created_at"`                 // Worktree directory modification time
+	Generation     string         `json:"generation"`                 // Durable identity for this worktree registration
+	Repository     string         `json:"repository"`                 // Repository slug, e.g. github.com/owner/name
+	SessionName    string         `json:"session_name"`               // Computed tmux workspace session name
+	TmuxSocketName string         `json:"tmux_socket_name,omitempty"` // Selected endpoint; empty direct means default, empty protected means unresolved
+	TmuxAttachMode TmuxAttachMode `json:"tmux_attach_mode"`           // Client attachment policy for the selected endpoint
+	Prunable       bool           `json:"-"`                          // Git reports this worktree entry as stale/prunable
 }
 
 // Branch represents a Git branch with its metadata.


### PR DESCRIPTION
KWT workspaces and standalone jobs currently share tmux's default server with sessions that users manage themselves. This change moves new KWT-managed sessions to `tmux -L kwt`, giving KWT a clear namespace without changing the isolated sockets used by protected pull-request workspaces.

```mermaid
flowchart LR
    Open[Open workspace] --> Resolve{Resolve endpoint}
    Resolve -->|Existing or new KWT session| KWT[tmux -L kwt]
    Resolve -->|Verified adopted session| Default[Default tmux server]
    KWT --> Contract[Explicit socket and attach mode]
    Default --> Contract
    Contract --> Client[KWT, TUI, or Ghosthub]
```

The durable internal address is `SessionEndpoint{SessionName, SocketName}`. Liveness and resolver status stay separate, while `tmux_attach_mode` exists only at JSON boundaries so Ghosthub never has to infer protection from a named socket. Inventory v2 publishes the selected endpoint and liveness from one observation, and the TUI reuses that observation instead of resolving each row again.

KWT can reuse and repair a verified live workspace session on the default server, but it never creates or recreates one there. The adoption decision and private flag remain inside `internal/tmux`; the small temporary compatibility surface, including removal input validation, is tagged `compat(kag1)` for deletion. Attachment compares tmux server process IDs, preserving same-server switching and cross-server nesting without relying on socket-path normalization. The supported floor remains tmux 2.1 and is behavior-tested rather than enforced by a separate version probe.

Standalone `kwt tmux run` sessions now share the dedicated server safely: creation uses an inert bootstrap pane, installs session-scoped removal markers for configured credentials, and only then starts the requested command. Direct, nested, and switch-client attachment also apply the configured credential policy.

Removal guards inspect both shared servers before deleting direct or protected workspaces. Dashboard deletion no longer depends on tmux discovery before the worktree mutation; afterward it finds and stops every verified matching endpoint, treating already-absent sessions as cleaned. The guard binds default-server checks to the caller's `TMUX_TMPDIR` selector so an unrelated socket directory cannot hide a live adopted session.

Protected import results always emit `tmux_attach_mode: "protected"`. A missing socket is an explicit unresolved, unattachable state rather than the default server; `--start-session` reports that state, while `kwt pr attach` may resolve it only after revalidating live provenance.

Mixed old and new KWT versions remain a rollout limitation because old clients can create parallel default-server sessions and old removal guards cannot see the dedicated server. KWT and Ghosthub therefore need a coordinated upgrade during the short adoption window.
