### PR TITLE
Move short-lived SSH execution behind kwt

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -194,9 +194,10 @@ resolves the local source to an absolute literal path, and escapes SFTP batch
 metacharacters; the child receives only the daemon's
 generation-bound, fail-closed arguments. Consumers do not reconstruct those
 arguments or load SSH configuration again. Cancellation terminates the entire
-client process tree, the foreground process heartbeats the lease while the
-client runs, and it releases the daemon lease under a separate cleanup
-deadline.
+client process tree. An authenticated HTTP stream binds the lease to the
+foreground owner without depending on that process to run heartbeat code while
+job-control suspended; disconnecting the stream restores ordinary bounded
+expiry. The client releases the daemon lease under a separate cleanup deadline.
 
 `kwt projects` and `kwt list` auto-start or reuse the daemon and require a
 current inventory result. They fail instead of falling back to cached or direct

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -183,6 +183,18 @@ bound is exceeded. The daemon also caps the encoded public route snapshot at
 oversized snapshot fails as `ssh_resolution_failed`. Resolution does not create
 a connection, control socket, trust decision, credential prompt, or lease.
 
+`kwt ssh lease` may resolve and acquire in one CLI process when the caller has
+no prior snapshot. Clients performing a conditional launch continue supplying
+the reviewed route identity and projection policy. `kwt ssh exec` and
+`kwt ssh copy` use the combined form for one bounded command or transfer: the
+daemon owns route resolution, prompt handling, ProxyJump masters, and lease
+lifecycle, while the foreground kwt process owns the system SSH or SCP child
+and streams its output directly. The child receives only the daemon's
+generation-bound, fail-closed arguments. Consumers do not reconstruct those
+arguments or load SSH configuration again. Cancellation terminates the entire
+client process tree, and the foreground process releases the daemon lease under
+a separate cleanup deadline.
+
 `kwt projects` and `kwt list` auto-start or reuse the daemon and require a
 current inventory result. They fail instead of falling back to cached or direct
 filesystem data. The TUI may paint immediately from the derived last-known-good

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -189,8 +189,9 @@ the reviewed route identity and projection policy. `kwt ssh exec` and
 `kwt ssh copy` use the combined form for one bounded command or transfer: the
 daemon owns route resolution, prompt handling, ProxyJump masters, and lease
 lifecycle, while the foreground kwt process owns the system SSH or SFTP child
-and streams its output directly. Copy uses SFTP rather than a remote shell;
-the child receives only the daemon's
+and streams its output directly. Copy uses SFTP rather than a remote shell,
+resolves the local source to an absolute literal path, and escapes SFTP batch
+metacharacters; the child receives only the daemon's
 generation-bound, fail-closed arguments. Consumers do not reconstruct those
 arguments or load SSH configuration again. Cancellation terminates the entire
 client process tree, the foreground process heartbeats the lease while the

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -188,12 +188,14 @@ no prior snapshot. Clients performing a conditional launch continue supplying
 the reviewed route identity and projection policy. `kwt ssh exec` and
 `kwt ssh copy` use the combined form for one bounded command or transfer: the
 daemon owns route resolution, prompt handling, ProxyJump masters, and lease
-lifecycle, while the foreground kwt process owns the system SSH or SCP child
-and streams its output directly. The child receives only the daemon's
+lifecycle, while the foreground kwt process owns the system SSH or SFTP child
+and streams its output directly. Copy uses SFTP rather than a remote shell;
+the child receives only the daemon's
 generation-bound, fail-closed arguments. Consumers do not reconstruct those
 arguments or load SSH configuration again. Cancellation terminates the entire
-client process tree, and the foreground process releases the daemon lease under
-a separate cleanup deadline.
+client process tree, the foreground process heartbeats the lease while the
+client runs, and it releases the daemon lease under a separate cleanup
+deadline.
 
 `kwt projects` and `kwt list` auto-start or reuse the daemon and require a
 current inventory result. They fail instead of falling back to cached or direct

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -45,13 +45,16 @@ immediately, then continues reporting observed drain state while it waits.
 Active work and leases may finish until `daemon.replacement_grace`; the default
 is five minutes.
 
-The API schema is `1.10.0`. It exposes authenticated status, graceful shutdown,
+The API schema is `1.11.0`. It exposes authenticated status, graceful shutdown,
 worktree inventory, guarded project unregistration, and repository-config
 approval under `/api/v1`, proof-capable liveness at `/api/ping`, and
 credential-free OpenAPI at `/openapi.json`. Inventory clients require the
 `worktree.inventory.v1` capability; guarded unregistration requires
 `project.removal.v1`, SSH route resolution requires `ssh.resolve.v1`, and
-daemon-owned connection leases require `ssh.lifecycle.v1`.
+daemon-owned connection leases require `ssh.lifecycle.v1`. Clients that bind
+short commands to a connection-owned hold additionally require
+`ssh.lease.hold.v1`; stale development daemons fail capability negotiation
+before acquiring a lease rather than falling back to periodic touches.
 Daemons advertise `operation.stream.v1` when they can
 carry ordered domain-operation events and bound prompt responses. Advertising
 that transport capability does not start a domain operation or move any

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -102,9 +102,10 @@ unknown outcome rather than causing an automatic retry of a mutation.
 
 An SSH lease ID is likewise only a same-daemon routing handle. The daemon keeps
 the generation-bound lease and private projection state; clients receive only
-the arguments needed to reach that verified master. Lease touch and release
-require the owner-only bearer, and leases expire after thirty seconds without a
-heartbeat so a crashed CLI cannot pin authentication state indefinitely. During
+the arguments needed to reach that verified master. Lease touch, hold, and
+release require the owner-only bearer. A disconnected hold returns the lease to
+the thirty-second expiry policy, so a suspended foreground CLI keeps authority
+without letting a crashed CLI pin authentication state indefinitely. During
 replacement, new leases are refused, existing leases may finish within the
 advertised grace period, and remaining lease handles are invalidated before the
 SSH owner is closed. Live masters are never transferred to the successor.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -249,6 +249,9 @@ fail-closed control-socket behavior. Remote stdout and stderr are streamed as
 they arrive; connection progress is streamed to stderr unless `--quiet` is
 set. An OpenSSH or SCP exit status is preserved, including SSH's status 255,
 while failures before client execution keep kwt's stable typed error surface.
+Machine callers add `--json`: a kwt failure before SSH or SCP starts writes the
+shared error envelope to stdout, while successful client execution continues
+to stream the remote command's unmodified output.
 
 Both commands default to `--host-key-policy strict` for unattended callers.
 Use `--host-key-policy review` from a terminal to permit the daemon's bounded

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -259,10 +259,11 @@ Both commands default to `--host-key-policy strict` for unattended callers.
 Use `--host-key-policy review` from a terminal to permit the daemon's bounded
 host-key and authentication prompts. A nonterminal caller never answers a
 prompt implicitly and receives `ssh_interaction_required`. Copy accepts one
-local file and one remote path, quotes both as structured SFTP batch values,
-and never embeds the destination in a remote shell command. It translates the
-reviewed SSH projection into SFTP's option grammar internally, so consumers
-never handle control paths or the SSH/SFTP `-p` versus `-P` distinction.
+local file and one remote path, resolves the local source to an absolute
+literal path, escapes SFTP batch metacharacters in both paths, and never embeds
+the destination in a remote shell command. It translates the reviewed SSH
+projection into SFTP's option grammar internally, so consumers never handle
+control-path quoting or the SSH/SFTP `-p` versus `-P` distinction.
 
 When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -242,8 +242,10 @@ kwt ssh copy build.example.com ./kwt /tmp/kwt.incoming
 ```
 
 `kwt ssh exec` and `kwt ssh copy` resolve and acquire a daemon-owned route,
-run one system OpenSSH client through that generation-bound master, heartbeat
-the lease while it runs, and release the lease afterward. Kwt—not its
+run one system OpenSSH client through that generation-bound master, hold the
+lease through an authenticated owner stream while it runs, and release the
+lease afterward. The owner stream remains live when job control suspends the
+foreground CLI, but closes automatically if that process exits. Kwt—not its
 caller—constructs the SSH or SFTP invocation,
 including ProxyJump transport, port grammar, private projection files, and
 fail-closed control-socket behavior. Remote stdout and stderr are streamed as

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -184,7 +184,11 @@ kwt ssh lease build.example.com \
 ```
 
 `kwt ssh lease` is the long-lived native-client bridge to the same-machine
-daemon. It re-resolves the logical target, refuses a changed route, prepares
+daemon. Native clients that already reviewed a snapshot pass
+`--route-identity` and `--projection-policy`; kwt refuses a changed route.
+When those flags are omitted, the same CLI invocation resolves the route and
+immediately acquires it, avoiding a second helper process while retaining the
+daemon's pre- and post-connection revalidation. The daemon prepares
 every ProxyJump hop in order, and streams operation events as NDJSON. Prompt
 capable clients use `--host-key-policy review`, which requires an explicit
 OpenSSH review prompt unless the route already requires a known key.
@@ -229,6 +233,30 @@ master remains warm. Agent-forwarding masters disconnect immediately. Daemon
 replacement reports its active lease count, waits through
 `daemon.replacement_grace`, then invalidates remaining leases and terminates
 their verified masters; a successor never adopts them as live connections.
+
+## Short-lived SSH commands and copies
+
+```sh
+kwt ssh exec build.example.com -- uname -a
+kwt ssh copy build.example.com ./kwt /tmp/kwt.incoming
+```
+
+`kwt ssh exec` and `kwt ssh copy` resolve and acquire a daemon-owned route,
+run one system OpenSSH client through that generation-bound master, and release
+the lease afterward. Kwt—not its caller—constructs the SSH or SCP invocation,
+including ProxyJump transport, port grammar, private projection files, and
+fail-closed control-socket behavior. Remote stdout and stderr are streamed as
+they arrive; connection progress is streamed to stderr unless `--quiet` is
+set. An OpenSSH or SCP exit status is preserved, including SSH's status 255,
+while failures before client execution keep kwt's stable typed error surface.
+
+Both commands default to `--host-key-policy strict` for unattended callers.
+Use `--host-key-policy review` from a terminal to permit the daemon's bounded
+host-key and authentication prompts. A nonterminal caller never answers a
+prompt implicitly and receives `ssh_interaction_required`. Copy accepts one
+local file and one remote path; it translates the reviewed SSH projection into
+SCP's option grammar internally, so consumers never handle control paths or
+the SSH/SCP `-p` versus `-P` distinction.
 
 When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -242,24 +242,27 @@ kwt ssh copy build.example.com ./kwt /tmp/kwt.incoming
 ```
 
 `kwt ssh exec` and `kwt ssh copy` resolve and acquire a daemon-owned route,
-run one system OpenSSH client through that generation-bound master, and release
-the lease afterward. Kwt—not its caller—constructs the SSH or SCP invocation,
+run one system OpenSSH client through that generation-bound master, heartbeat
+the lease while it runs, and release the lease afterward. Kwt—not its
+caller—constructs the SSH or SFTP invocation,
 including ProxyJump transport, port grammar, private projection files, and
 fail-closed control-socket behavior. Remote stdout and stderr are streamed as
 they arrive; connection progress is streamed to stderr unless `--quiet` is
-set. An OpenSSH or SCP exit status is preserved, including SSH's status 255,
+set. An OpenSSH or SFTP exit status is preserved, including SSH's status 255,
 while failures before client execution keep kwt's stable typed error surface.
-Machine callers add `--json`: a kwt failure before SSH or SCP starts writes the
+Machine callers add `--json`: a kwt failure before SSH or SFTP starts writes the
 shared error envelope to stdout, while successful client execution continues
-to stream the remote command's unmodified output.
+to stream the remote command's unmodified output. Cleanup failures after the
+client starts are reported only on stderr and never append framing to stdout.
 
 Both commands default to `--host-key-policy strict` for unattended callers.
 Use `--host-key-policy review` from a terminal to permit the daemon's bounded
 host-key and authentication prompts. A nonterminal caller never answers a
 prompt implicitly and receives `ssh_interaction_required`. Copy accepts one
-local file and one remote path; it translates the reviewed SSH projection into
-SCP's option grammar internally, so consumers never handle control paths or
-the SSH/SCP `-p` versus `-P` distinction.
+local file and one remote path, quotes both as structured SFTP batch values,
+and never embeds the destination in a remote shell command. It translates the
+reviewed SSH projection into SFTP's option grammar internally, so consumers
+never handle control paths or the SSH/SFTP `-p` versus `-P` distinction.
 
 When `kwt add -b` creates a branch, it fetches `origin` and starts from its
 default branch. If that remote base is unavailable, it falls back to local

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -76,6 +76,25 @@ func requireSSHResolveCapability(observation kwtdaemon.Observation) error {
 	return nil
 }
 
+func requireSSHLifecycleCapabilities(observation kwtdaemon.Observation) error {
+	if observation.Client != nil && slices.Contains(
+		observation.Status.Capabilities,
+		kwtdaemon.CapabilitySSHLifecycle,
+	) && slices.Contains(
+		observation.Status.Capabilities,
+		kwtdaemon.CapabilitySSHLeaseHold,
+	) {
+		return nil
+	}
+	return service.NewError(
+		service.DaemonIncompatible,
+		"the running kwt daemon does not provide current SSH lifecycle management",
+		false,
+		nil,
+		nil,
+	)
+}
+
 type sshLeaseControl interface {
 	Touch(context.Context, string) error
 	Hold(context.Context, string) (io.ReadCloser, error)
@@ -110,15 +129,8 @@ func acquireSSHLeaseViaDaemon(
 		if err != nil {
 			return kwtdaemon.SSHLeaseResult{}, nil, err
 		}
-		if observation.Client == nil || !slices.Contains(
-			observation.Status.Capabilities,
-			kwtdaemon.CapabilitySSHLifecycle,
-		) {
-			return kwtdaemon.SSHLeaseResult{}, nil, service.NewError(
-				service.DaemonIncompatible,
-				"the running kwt daemon does not provide SSH lifecycle management",
-				false, nil, nil,
-			)
+		if err := requireSSHLifecycleCapabilities(observation); err != nil {
+			return kwtdaemon.SSHLeaseResult{}, nil, err
 		}
 		var exposed atomic.Bool
 		trackedCallbacks := kwtdaemon.OperationCallbacks{

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -78,6 +78,7 @@ func requireSSHResolveCapability(observation kwtdaemon.Observation) error {
 
 type sshLeaseControl interface {
 	Touch(context.Context, string) error
+	Hold(context.Context, string) (io.ReadCloser, error)
 	Release(context.Context, string) error
 }
 
@@ -85,6 +86,10 @@ type daemonSSHLeaseControl struct{ client *kwtdaemon.Client }
 
 func (c daemonSSHLeaseControl) Touch(ctx context.Context, leaseID string) error {
 	return c.client.TouchSSHLease(ctx, leaseID)
+}
+
+func (c daemonSSHLeaseControl) Hold(ctx context.Context, leaseID string) (io.ReadCloser, error) {
+	return c.client.HoldSSHLease(ctx, leaseID)
 }
 
 func (c daemonSSHLeaseControl) Release(ctx context.Context, leaseID string) error {

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -31,6 +31,7 @@ func TestAcquireSSHLeaseDoesNotRetryDrainAfterExposingOperation(t *testing.T) {
 					State:  kwtdaemon.RuntimeReady,
 					Client: &kwtdaemon.Client{},
 					Status: kwtdaemon.Status{Capabilities: []string{
+						kwtdaemon.CapabilitySSHLeaseHold,
 						kwtdaemon.CapabilitySSHLifecycle,
 					}},
 				}}, nil
@@ -90,6 +91,17 @@ func TestAcquireSSHLeaseDoesNotRetryDrainAfterExposingOperation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequireSSHLifecycleCapabilitiesRejectsDaemonWithoutLeaseHold(t *testing.T) {
+	err := requireSSHLifecycleCapabilities(kwtdaemon.Observation{
+		Client: &kwtdaemon.Client{},
+		Status: kwtdaemon.Status{Capabilities: []string{
+			kwtdaemon.CapabilitySSHLifecycle,
+		}},
+	})
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.DaemonIncompatible))
 }
 
 func TestInventoryDrainDeadlineRequiresDaemonDrainingCode(t *testing.T) {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -97,15 +97,33 @@ var sshLeaseCmd = &cobra.Command{
 var sshExecCmd = &cobra.Command{
 	Use:   "exec <hostname> <command> [arguments...]",
 	Short: "Run a command through a daemon-owned SSH connection",
-	Args:  cobra.MinimumNArgs(2),
-	RunE:  withGracefulSignals(runSSHExec),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) >= 2 {
+			return nil
+		}
+		return writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, service.NewError(
+			service.InvalidRequest,
+			fmt.Sprintf("expected an SSH hostname and command, received %d arguments", len(args)),
+			false, nil, nil,
+		))
+	},
+	RunE: withGracefulSignals(runSSHExec),
 }
 
 var sshCopyCmd = &cobra.Command{
 	Use:   "copy <hostname> <source> <destination>",
 	Short: "Copy a file through a daemon-owned SSH connection",
-	Args:  cobra.ExactArgs(3),
-	RunE:  withGracefulSignals(runSSHCopy),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 3 {
+			return nil
+		}
+		return writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, service.NewError(
+			service.InvalidRequest,
+			fmt.Sprintf("expected an SSH hostname, source, and destination, received %d arguments", len(args)),
+			false, nil, nil,
+		))
+	},
+	RunE: withGracefulSignals(runSSHCopy),
 }
 
 func init() {
@@ -151,6 +169,11 @@ func init() {
 	)
 	sshExecCmd.Flags().BoolVar(&sshExecQuiet, "quiet", false, "Suppress connection status output")
 	sshExecCmd.Flags().BoolVar(&sshExecJSON, "json", false, "Emit kwt failures as JSON on stdout")
+	sshExecCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, service.NewError(
+			service.InvalidRequest, err.Error(), false, nil, err,
+		))
+	})
 	sshCopyCmd.Flags().StringVar(&sshCopyUser, "user", "", "Override the SSH user")
 	sshCopyCmd.Flags().IntVar(&sshCopyPort, "port", 0, "Override the SSH port")
 	sshCopyCmd.Flags().StringVar(
@@ -159,6 +182,11 @@ func init() {
 	)
 	sshCopyCmd.Flags().BoolVar(&sshCopyQuiet, "quiet", false, "Suppress connection status output")
 	sshCopyCmd.Flags().BoolVar(&sshCopyJSON, "json", false, "Emit kwt failures as JSON on stdout")
+	sshCopyCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, service.NewError(
+			service.InvalidRequest, err.Error(), false, nil, err,
+		))
+	})
 }
 
 type sshClientExitError struct{ code int }
@@ -198,16 +226,16 @@ func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
 	arguments := append([]string(nil), result.Arguments...)
 	arguments = append(arguments, sshExecutionDestination(snapshot))
 	arguments = append(arguments, args[1:]...)
-	clientStarted = true
-	exitCode, err := runShortSSHClient(
+	exitCode, started, err := runShortSSHClient(
 		ctx, control, result.LeaseID,
-		func(processContext context.Context) (int, error) {
+		func(processContext context.Context) (int, bool, error) {
 			return runSSHClientProcess(
 				processContext, "ssh", arguments, workingDirectory, environment,
 				cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
 			)
 		},
 	)
+	clientStarted = started
 	return sshClientProcessResult(cmd, exitCode, err)
 }
 
@@ -238,22 +266,26 @@ func runSSHCopy(cmd *cobra.Command, args []string) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	batch, err := sftpPutBatch(args[1], args[2])
+	source := args[1]
+	if !filepath.IsAbs(source) {
+		source = filepath.Join(workingDirectory, source)
+	}
+	batch, err := sftpPutBatch(filepath.Clean(source), args[2])
 	if err != nil {
 		return service.NewError(service.InvalidRequest, err.Error(), false, nil, err)
 	}
 	arguments := sftpLeaseArguments(result.Arguments)
 	arguments = append(arguments, "-b", "-", sftpDestination(snapshot))
-	clientStarted = true
-	exitCode, err := runShortSSHClient(
+	exitCode, started, err := runShortSSHClient(
 		ctx, control, result.LeaseID,
-		func(processContext context.Context) (int, error) {
+		func(processContext context.Context) (int, bool, error) {
 			return runSSHClientProcess(
 				processContext, "sftp", arguments, workingDirectory, environment,
 				strings.NewReader(batch), cmd.OutOrStdout(), cmd.ErrOrStderr(),
 			)
 		},
 	)
+	clientStarted = started
 	return sshClientProcessResult(cmd, exitCode, err)
 }
 
@@ -358,7 +390,7 @@ func sftpLeaseArguments(arguments []string) []string {
 	for index := 0; index < len(arguments); index++ {
 		argument := arguments[index]
 		if index+1 < len(arguments) && argument == "-S" {
-			result = append(result, "-o", "ControlPath="+arguments[index+1])
+			result = append(result, "-o", "ControlPath="+sshConfigQuotedValue(arguments[index+1]))
 			index++
 			continue
 		}
@@ -391,28 +423,35 @@ func sftpBatchPath(path string) (string, error) {
 	if strings.ContainsAny(path, "\x00\r\n") {
 		return "", errors.New("path contains a line or null character")
 	}
-	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(path)
+	escaped := strings.NewReplacer(
+		`\`, `\\`, `"`, `\"`, `*`, `\*`, `?`, `\?`, `[`, `\[`, `]`, `\]`,
+	).Replace(path)
 	return `"` + escaped + `"`, nil
+}
+
+func sshConfigQuotedValue(value string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
+	return `"` + escaped + `"`
 }
 
 func runShortSSHClient(
 	ctx context.Context,
 	control sshLeaseControl,
 	leaseID string,
-	run func(context.Context) (int, error),
-) (int, error) {
+	run func(context.Context) (int, bool, error),
+) (int, bool, error) {
 	processContext, cancel := context.WithCancel(ctx)
 	heartbeatDone := make(chan error, 1)
 	go func() {
 		heartbeatDone <- heartbeatShortSSHLease(processContext, control, leaseID, cancel)
 	}()
-	exitCode, processErr := run(processContext)
+	exitCode, started, processErr := run(processContext)
 	cancel()
 	heartbeatErr := <-heartbeatDone
 	if heartbeatErr != nil {
-		return -1, errors.Join(heartbeatErr, processErr)
+		return -1, started, errors.Join(heartbeatErr, processErr)
 	}
-	return exitCode, processErr
+	return exitCode, started, processErr
 }
 
 func heartbeatShortSSHLease(
@@ -470,7 +509,11 @@ func isSSHClientExit(err error) bool {
 
 func writeSSHClientFailure(cmd *cobra.Command, prefix string, jsonRequested bool, err error) error {
 	typed := service.AsError(err)
-	return writeCommandFailure(cmd, typed.Descriptor, 1, jsonRequested, prefix)
+	exitCode := 1
+	if typed.Code == service.InvalidRequest || typed.Code == service.SSHInvalidTarget {
+		exitCode = 2
+	}
+	return writeCommandFailure(cmd, typed.Descriptor, exitCode, jsonRequested, prefix)
 }
 
 func runSSHResolve(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -8,12 +8,16 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	kwtdaemon "go.kenn.io/kwt/internal/daemon"
+	internalssh "go.kenn.io/kwt/internal/ssh"
 	"go.kenn.io/kwt/service"
 	"golang.org/x/term"
 )
@@ -28,9 +32,19 @@ var (
 	sshLeaseRouteIdentity    string
 	sshLeaseProjectionPolicy string
 	sshLeaseHostKeyPolicy    string
+	sshExecUser              string
+	sshExecPort              int
+	sshExecHostKeyPolicy     string
+	sshExecQuiet             bool
+	sshCopyUser              string
+	sshCopyPort              int
+	sshCopyHostKeyPolicy     string
+	sshCopyQuiet             bool
 
 	resolveSSHThroughDaemon      = resolveSSHViaDaemon
 	acquireSSHLeaseThroughDaemon = acquireSSHLeaseViaDaemon
+	runSSHClientProcess          = internalssh.RunClientProcess
+	captureSSHClientProcess      = sshClientProcessContext
 )
 
 const sshLeaseHeartbeatInterval = 10 * time.Second
@@ -78,10 +92,26 @@ var sshLeaseCmd = &cobra.Command{
 	RunE: withGracefulSignals(runSSHLease),
 }
 
+var sshExecCmd = &cobra.Command{
+	Use:   "exec <hostname> <command> [arguments...]",
+	Short: "Run a command through a daemon-owned SSH connection",
+	Args:  cobra.MinimumNArgs(2),
+	RunE:  withGracefulSignals(runSSHExec),
+}
+
+var sshCopyCmd = &cobra.Command{
+	Use:   "copy <hostname> <source> <destination>",
+	Short: "Copy a file through a daemon-owned SSH connection",
+	Args:  cobra.ExactArgs(3),
+	RunE:  withGracefulSignals(runSSHCopy),
+}
+
 func init() {
 	rootCmd.AddCommand(sshCmd)
 	sshCmd.AddCommand(sshResolveCmd)
 	sshCmd.AddCommand(sshLeaseCmd)
+	sshCmd.AddCommand(sshExecCmd)
+	sshCmd.AddCommand(sshCopyCmd)
 	sshResolveCmd.Flags().StringVar(&sshResolveUser, "user", "", "Override the SSH user")
 	sshResolveCmd.Flags().IntVar(&sshResolvePort, "port", 0, "Override the SSH port")
 	sshResolveCmd.Flags().BoolVar(&sshResolveJSON, "json", false, "Output a machine-readable route snapshot")
@@ -111,6 +141,230 @@ func init() {
 			service.InvalidRequest, err.Error(), false, nil, err,
 		))
 	})
+	sshExecCmd.Flags().StringVar(&sshExecUser, "user", "", "Override the SSH user")
+	sshExecCmd.Flags().IntVar(&sshExecPort, "port", 0, "Override the SSH port")
+	sshExecCmd.Flags().StringVar(
+		&sshExecHostKeyPolicy, "host-key-policy", string(kwt.SSHHostKeyPolicyStrict),
+		"Host-key handling: review or strict",
+	)
+	sshExecCmd.Flags().BoolVar(&sshExecQuiet, "quiet", false, "Suppress connection status output")
+	sshCopyCmd.Flags().StringVar(&sshCopyUser, "user", "", "Override the SSH user")
+	sshCopyCmd.Flags().IntVar(&sshCopyPort, "port", 0, "Override the SSH port")
+	sshCopyCmd.Flags().StringVar(
+		&sshCopyHostKeyPolicy, "host-key-policy", string(kwt.SSHHostKeyPolicyStrict),
+		"Host-key handling: review or strict",
+	)
+	sshCopyCmd.Flags().BoolVar(&sshCopyQuiet, "quiet", false, "Suppress connection status output")
+}
+
+type sshClientExitError struct{ code int }
+
+func (e *sshClientExitError) Error() string {
+	return fmt.Sprintf("SSH client exited with status %d", e.code)
+}
+func (e *sshClientExitError) ExitCode() int { return e.code }
+
+func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
+	ctx := commandContext(cmd)
+	target := kwt.SSHTarget{Hostname: args[0], User: sshExecUser, Port: sshExecPort}
+	snapshot, result, control, err := acquireShortSSHLease(
+		cmd, target, kwt.SSHHostKeyPolicy(sshExecHostKeyPolicy), sshExecQuiet,
+	)
+	if err != nil {
+		return writeSSHClientFailure(cmd, "ssh exec", err)
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, releaseShortSSHLease(ctx, control, result.LeaseID))
+		if returnErr != nil && !isSSHClientExit(returnErr) {
+			returnErr = writeSSHClientFailure(cmd, "ssh exec", returnErr)
+		}
+	}()
+	workingDirectory, environment, err := captureSSHClientProcess()
+	if err != nil {
+		return err
+	}
+	arguments := append([]string(nil), result.Arguments...)
+	arguments = append(arguments, sshExecutionDestination(snapshot))
+	arguments = append(arguments, args[1:]...)
+	exitCode, err := runSSHClientProcess(
+		ctx, "ssh", arguments, workingDirectory, environment,
+		cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+	)
+	return sshClientProcessResult(cmd, exitCode, err)
+}
+
+func runSSHCopy(cmd *cobra.Command, args []string) (returnErr error) {
+	ctx := commandContext(cmd)
+	target := kwt.SSHTarget{Hostname: args[0], User: sshCopyUser, Port: sshCopyPort}
+	snapshot, result, control, err := acquireShortSSHLease(
+		cmd, target, kwt.SSHHostKeyPolicy(sshCopyHostKeyPolicy), sshCopyQuiet,
+	)
+	if err != nil {
+		return writeSSHClientFailure(cmd, "ssh copy", err)
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, releaseShortSSHLease(ctx, control, result.LeaseID))
+		if returnErr != nil && !isSSHClientExit(returnErr) {
+			returnErr = writeSSHClientFailure(cmd, "ssh copy", returnErr)
+		}
+	}()
+	workingDirectory, environment, err := captureSSHClientProcess()
+	if err != nil {
+		return err
+	}
+	arguments := scpLeaseArguments(result.Arguments)
+	arguments = append(arguments, args[1], scpDestination(snapshot, args[2]))
+	exitCode, err := runSSHClientProcess(
+		ctx, "scp", arguments, workingDirectory, environment,
+		cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+	)
+	return sshClientProcessResult(cmd, exitCode, err)
+}
+
+func acquireShortSSHLease(
+	cmd *cobra.Command,
+	target kwt.SSHTarget,
+	policy kwt.SSHHostKeyPolicy,
+	quiet bool,
+) (kwt.SSHRouteSnapshot, kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+	ctx := commandContext(cmd)
+	snapshot, err := resolveSSHThroughDaemon(ctx, kwt.SSHResolveRequest{Target: target})
+	if err != nil {
+		return kwt.SSHRouteSnapshot{}, kwtdaemon.SSHLeaseResult{}, nil, err
+	}
+	callbacks := kwtdaemon.OperationCallbacks{Event: func(event service.OperationEvent) error {
+		if quiet {
+			return nil
+		}
+		if event.Kind != service.OperationEventProgress && event.Kind != service.OperationEventWarning {
+			return nil
+		}
+		_, err := fmt.Fprintln(cmd.ErrOrStderr(), event.Message)
+		return err
+	}}
+	input := cmd.InOrStdin()
+	if file, ok := input.(*os.File); ok && term.IsTerminal(int(file.Fd())) {
+		reader := bufio.NewReader(input)
+		callbacks.Prompt = func(ctx context.Context, prompt service.OperationPrompt) (string, error) {
+			if _, err := fmt.Fprint(
+				cmd.ErrOrStderr(), terminalSafeSSHPrompt(prompt.Message)+" ",
+			); err != nil {
+				return "", err
+			}
+			if prompt.Sensitive {
+				value, err := readTerminalPassword(ctx, file)
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+				return value, err
+			}
+			value, err := readSSHPrompt(ctx, func() (string, error) {
+				return reader.ReadString('\n')
+			})
+			return strings.TrimSuffix(strings.TrimSuffix(value, "\n"), "\r"), err
+		}
+	}
+	result, control, err := acquireSSHLeaseThroughDaemon(ctx, kwt.SSHLeaseRequest{
+		Snapshot: snapshot, HostKeyPolicy: policy,
+	}, callbacks)
+	return snapshot, result, control, err
+}
+
+func commandContext(cmd *cobra.Command) context.Context {
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+func sshClientProcessContext() (string, []string, error) {
+	snapshot, err := config.LoadGlobalSnapshot()
+	if err != nil {
+		return "", nil, err
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", nil, err
+	}
+	workingDirectory, err = filepath.Abs(workingDirectory)
+	if err != nil {
+		return "", nil, err
+	}
+	environment := credentials.StripEnvironment(
+		os.Environ(), credentials.ProtectedNames(snapshot.Config),
+	)
+	return workingDirectory, environment, nil
+}
+
+func sshExecutionDestination(snapshot kwt.SSHRouteSnapshot) string {
+	if len(snapshot.Targets) == 0 {
+		return snapshot.LogicalTarget.Display()
+	}
+	destination, _ := snapshot.Targets[len(snapshot.Targets)-1].EffectiveTarget.CommandDestination()
+	return destination
+}
+
+func scpDestination(snapshot kwt.SSHRouteSnapshot, path string) string {
+	target := snapshot.LogicalTarget
+	if len(snapshot.Targets) > 0 {
+		target = snapshot.Targets[len(snapshot.Targets)-1].EffectiveTarget
+	}
+	hostname := target.Hostname
+	if strings.Contains(hostname, ":") && !strings.HasPrefix(hostname, "[") {
+		hostname = "[" + hostname + "]"
+	}
+	if target.User != "" {
+		hostname = target.User + "@" + hostname
+	}
+	return hostname + ":" + path
+}
+
+func scpLeaseArguments(arguments []string) []string {
+	result := make([]string, 0, len(arguments))
+	for index := 0; index < len(arguments); index++ {
+		argument := arguments[index]
+		if index+1 < len(arguments) && argument == "-S" {
+			result = append(result, "-o", "ControlPath="+arguments[index+1])
+			index++
+			continue
+		}
+		if index+1 < len(arguments) && argument == "-p" {
+			result = append(result, "-P", arguments[index+1])
+			index++
+			continue
+		}
+		result = append(result, argument)
+	}
+	return result
+}
+
+func releaseShortSSHLease(ctx context.Context, control sshLeaseControl, leaseID string) error {
+	if control == nil || leaseID == "" {
+		return nil
+	}
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+	return control.Release(releaseCtx, leaseID)
+}
+
+func sshClientProcessResult(cmd *cobra.Command, exitCode int, err error) error {
+	if err == nil {
+		return nil
+	}
+	if exitCode >= 0 {
+		cmd.Root().SilenceUsage = true
+		cmd.Root().SilenceErrors = true
+		return &sshClientExitError{code: exitCode}
+	}
+	return err
+}
+
+func isSSHClientExit(err error) bool {
+	var exitErr *sshClientExitError
+	return errors.As(err, &exitErr)
+}
+
+func writeSSHClientFailure(cmd *cobra.Command, prefix string, err error) error {
+	typed := service.AsError(err)
+	return writeCommandFailure(cmd, typed.Descriptor, 1, false, prefix)
 }
 
 func runSSHResolve(cmd *cobra.Command, args []string) error {
@@ -151,14 +405,23 @@ func writeSSHResolveFailure(cmd *cobra.Command, err error) error {
 }
 
 func runSSHLease(cmd *cobra.Command, args []string) (returnErr error) {
-	if sshLeaseRouteIdentity == "" {
-		return writeSSHLeaseFailure(cmd, service.NewError(
-			service.InvalidRequest, "--route-identity is required", false, nil, nil,
-		))
-	}
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	target := kwt.SSHTarget{
+		Hostname: args[0], User: sshLeaseUser, Port: sshLeasePort,
+	}
+	snapshot := kwt.SSHRouteSnapshot{
+		LogicalTarget: target, RouteIdentity: sshLeaseRouteIdentity,
+		ProjectionPolicy: sshLeaseProjectionPolicy,
+	}
+	if sshLeaseRouteIdentity == "" {
+		var err error
+		snapshot, err = resolveSSHThroughDaemon(ctx, kwt.SSHResolveRequest{Target: target})
+		if err != nil {
+			return writeSSHLeaseFailure(cmd, err)
+		}
 	}
 	input := cmd.InOrStdin()
 	inputReader := bufio.NewReader(input)
@@ -223,13 +486,7 @@ func runSSHLease(cmd *cobra.Command, args []string) (returnErr error) {
 		ctx,
 		kwt.SSHLeaseRequest{
 			HostKeyPolicy: kwt.SSHHostKeyPolicy(sshLeaseHostKeyPolicy),
-			Snapshot: kwt.SSHRouteSnapshot{
-				LogicalTarget: kwt.SSHTarget{
-					Hostname: args[0], User: sshLeaseUser, Port: sshLeasePort,
-				},
-				RouteIdentity:    sshLeaseRouteIdentity,
-				ProjectionPolicy: sshLeaseProjectionPolicy,
-			},
+			Snapshot:      snapshot,
 		},
 		callbacks,
 	)

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -36,10 +36,12 @@ var (
 	sshExecPort              int
 	sshExecHostKeyPolicy     string
 	sshExecQuiet             bool
+	sshExecJSON              bool
 	sshCopyUser              string
 	sshCopyPort              int
 	sshCopyHostKeyPolicy     string
 	sshCopyQuiet             bool
+	sshCopyJSON              bool
 
 	resolveSSHThroughDaemon      = resolveSSHViaDaemon
 	acquireSSHLeaseThroughDaemon = acquireSSHLeaseViaDaemon
@@ -148,6 +150,7 @@ func init() {
 		"Host-key handling: review or strict",
 	)
 	sshExecCmd.Flags().BoolVar(&sshExecQuiet, "quiet", false, "Suppress connection status output")
+	sshExecCmd.Flags().BoolVar(&sshExecJSON, "json", false, "Emit kwt failures as JSON on stdout")
 	sshCopyCmd.Flags().StringVar(&sshCopyUser, "user", "", "Override the SSH user")
 	sshCopyCmd.Flags().IntVar(&sshCopyPort, "port", 0, "Override the SSH port")
 	sshCopyCmd.Flags().StringVar(
@@ -155,6 +158,7 @@ func init() {
 		"Host-key handling: review or strict",
 	)
 	sshCopyCmd.Flags().BoolVar(&sshCopyQuiet, "quiet", false, "Suppress connection status output")
+	sshCopyCmd.Flags().BoolVar(&sshCopyJSON, "json", false, "Emit kwt failures as JSON on stdout")
 }
 
 type sshClientExitError struct{ code int }
@@ -171,12 +175,12 @@ func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
 		cmd, target, kwt.SSHHostKeyPolicy(sshExecHostKeyPolicy), sshExecQuiet,
 	)
 	if err != nil {
-		return writeSSHClientFailure(cmd, "ssh exec", err)
+		return writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, err)
 	}
 	defer func() {
 		returnErr = errors.Join(returnErr, releaseShortSSHLease(ctx, control, result.LeaseID))
 		if returnErr != nil && !isSSHClientExit(returnErr) {
-			returnErr = writeSSHClientFailure(cmd, "ssh exec", returnErr)
+			returnErr = writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, returnErr)
 		}
 	}()
 	workingDirectory, environment, err := captureSSHClientProcess()
@@ -200,12 +204,12 @@ func runSSHCopy(cmd *cobra.Command, args []string) (returnErr error) {
 		cmd, target, kwt.SSHHostKeyPolicy(sshCopyHostKeyPolicy), sshCopyQuiet,
 	)
 	if err != nil {
-		return writeSSHClientFailure(cmd, "ssh copy", err)
+		return writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, err)
 	}
 	defer func() {
 		returnErr = errors.Join(returnErr, releaseShortSSHLease(ctx, control, result.LeaseID))
 		if returnErr != nil && !isSSHClientExit(returnErr) {
-			returnErr = writeSSHClientFailure(cmd, "ssh copy", returnErr)
+			returnErr = writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, returnErr)
 		}
 	}()
 	workingDirectory, environment, err := captureSSHClientProcess()
@@ -362,9 +366,9 @@ func isSSHClientExit(err error) bool {
 	return errors.As(err, &exitErr)
 }
 
-func writeSSHClientFailure(cmd *cobra.Command, prefix string, err error) error {
+func writeSSHClientFailure(cmd *cobra.Command, prefix string, jsonRequested bool, err error) error {
 	typed := service.AsError(err)
-	return writeCommandFailure(cmd, typed.Descriptor, 1, false, prefix)
+	return writeCommandFailure(cmd, typed.Descriptor, 1, jsonRequested, prefix)
 }
 
 func runSSHResolve(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -170,6 +170,7 @@ func (e *sshClientExitError) ExitCode() int { return e.code }
 
 func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
 	ctx := commandContext(cmd)
+	clientStarted := false
 	target := kwt.SSHTarget{Hostname: args[0], User: sshExecUser, Port: sshExecPort}
 	snapshot, result, control, err := acquireShortSSHLease(
 		cmd, target, kwt.SSHHostKeyPolicy(sshExecHostKeyPolicy), sshExecQuiet,
@@ -178,9 +179,16 @@ func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
 		return writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, err)
 	}
 	defer func() {
-		returnErr = errors.Join(returnErr, releaseShortSSHLease(ctx, control, result.LeaseID))
 		if returnErr != nil && !isSSHClientExit(returnErr) {
-			returnErr = writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, returnErr)
+			returnErr = writeSSHClientFailure(
+				cmd, "ssh exec", sshExecJSON && !clientStarted, returnErr,
+			)
+		}
+		if releaseErr := releaseShortSSHLease(ctx, control, result.LeaseID); releaseErr != nil {
+			returnErr = errors.Join(
+				returnErr,
+				writeSSHClientFailure(cmd, "ssh exec", false, releaseErr),
+			)
 		}
 	}()
 	workingDirectory, environment, err := captureSSHClientProcess()
@@ -190,15 +198,22 @@ func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
 	arguments := append([]string(nil), result.Arguments...)
 	arguments = append(arguments, sshExecutionDestination(snapshot))
 	arguments = append(arguments, args[1:]...)
-	exitCode, err := runSSHClientProcess(
-		ctx, "ssh", arguments, workingDirectory, environment,
-		cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+	clientStarted = true
+	exitCode, err := runShortSSHClient(
+		ctx, control, result.LeaseID,
+		func(processContext context.Context) (int, error) {
+			return runSSHClientProcess(
+				processContext, "ssh", arguments, workingDirectory, environment,
+				cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+			)
+		},
 	)
 	return sshClientProcessResult(cmd, exitCode, err)
 }
 
 func runSSHCopy(cmd *cobra.Command, args []string) (returnErr error) {
 	ctx := commandContext(cmd)
+	clientStarted := false
 	target := kwt.SSHTarget{Hostname: args[0], User: sshCopyUser, Port: sshCopyPort}
 	snapshot, result, control, err := acquireShortSSHLease(
 		cmd, target, kwt.SSHHostKeyPolicy(sshCopyHostKeyPolicy), sshCopyQuiet,
@@ -207,20 +222,37 @@ func runSSHCopy(cmd *cobra.Command, args []string) (returnErr error) {
 		return writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, err)
 	}
 	defer func() {
-		returnErr = errors.Join(returnErr, releaseShortSSHLease(ctx, control, result.LeaseID))
 		if returnErr != nil && !isSSHClientExit(returnErr) {
-			returnErr = writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, returnErr)
+			returnErr = writeSSHClientFailure(
+				cmd, "ssh copy", sshCopyJSON && !clientStarted, returnErr,
+			)
+		}
+		if releaseErr := releaseShortSSHLease(ctx, control, result.LeaseID); releaseErr != nil {
+			returnErr = errors.Join(
+				returnErr,
+				writeSSHClientFailure(cmd, "ssh copy", false, releaseErr),
+			)
 		}
 	}()
 	workingDirectory, environment, err := captureSSHClientProcess()
 	if err != nil {
 		return err
 	}
-	arguments := scpLeaseArguments(result.Arguments)
-	arguments = append(arguments, args[1], scpDestination(snapshot, args[2]))
-	exitCode, err := runSSHClientProcess(
-		ctx, "scp", arguments, workingDirectory, environment,
-		cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+	batch, err := sftpPutBatch(args[1], args[2])
+	if err != nil {
+		return service.NewError(service.InvalidRequest, err.Error(), false, nil, err)
+	}
+	arguments := sftpLeaseArguments(result.Arguments)
+	arguments = append(arguments, "-b", "-", sftpDestination(snapshot))
+	clientStarted = true
+	exitCode, err := runShortSSHClient(
+		ctx, control, result.LeaseID,
+		func(processContext context.Context) (int, error) {
+			return runSSHClientProcess(
+				processContext, "sftp", arguments, workingDirectory, environment,
+				strings.NewReader(batch), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+			)
+		},
 	)
 	return sshClientProcessResult(cmd, exitCode, err)
 }
@@ -306,7 +338,7 @@ func sshExecutionDestination(snapshot kwt.SSHRouteSnapshot) string {
 	return destination
 }
 
-func scpDestination(snapshot kwt.SSHRouteSnapshot, path string) string {
+func sftpDestination(snapshot kwt.SSHRouteSnapshot) string {
 	target := snapshot.LogicalTarget
 	if len(snapshot.Targets) > 0 {
 		target = snapshot.Targets[len(snapshot.Targets)-1].EffectiveTarget
@@ -318,10 +350,10 @@ func scpDestination(snapshot kwt.SSHRouteSnapshot, path string) string {
 	if target.User != "" {
 		hostname = target.User + "@" + hostname
 	}
-	return hostname + ":" + path
+	return hostname
 }
 
-func scpLeaseArguments(arguments []string) []string {
+func sftpLeaseArguments(arguments []string) []string {
 	result := make([]string, 0, len(arguments))
 	for index := 0; index < len(arguments); index++ {
 		argument := arguments[index]
@@ -338,6 +370,76 @@ func scpLeaseArguments(arguments []string) []string {
 		result = append(result, argument)
 	}
 	return result
+}
+
+func sftpPutBatch(source, destination string) (string, error) {
+	source, err := sftpBatchPath(source)
+	if err != nil {
+		return "", fmt.Errorf("invalid source path: %w", err)
+	}
+	destination, err = sftpBatchPath(destination)
+	if err != nil {
+		return "", fmt.Errorf("invalid destination path: %w", err)
+	}
+	return "put " + source + " " + destination + "\n", nil
+}
+
+func sftpBatchPath(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("path is empty")
+	}
+	if strings.ContainsAny(path, "\x00\r\n") {
+		return "", errors.New("path contains a line or null character")
+	}
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(path)
+	return `"` + escaped + `"`, nil
+}
+
+func runShortSSHClient(
+	ctx context.Context,
+	control sshLeaseControl,
+	leaseID string,
+	run func(context.Context) (int, error),
+) (int, error) {
+	processContext, cancel := context.WithCancel(ctx)
+	heartbeatDone := make(chan error, 1)
+	go func() {
+		heartbeatDone <- heartbeatShortSSHLease(processContext, control, leaseID, cancel)
+	}()
+	exitCode, processErr := run(processContext)
+	cancel()
+	heartbeatErr := <-heartbeatDone
+	if heartbeatErr != nil {
+		return -1, errors.Join(heartbeatErr, processErr)
+	}
+	return exitCode, processErr
+}
+
+func heartbeatShortSSHLease(
+	ctx context.Context,
+	control sshLeaseControl,
+	leaseID string,
+	cancelProcess context.CancelFunc,
+) error {
+	if control == nil || leaseID == "" {
+		return nil
+	}
+	ticker := time.NewTicker(sshLeaseHeartbeatEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := control.Touch(ctx, leaseID); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				cancelProcess()
+				return err
+			}
+		}
+	}
 }
 
 func releaseShortSSHLease(ctx context.Context, control sshLeaseControl, leaseID string) error {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -441,44 +441,43 @@ func runShortSSHClient(
 	run func(context.Context) (int, bool, error),
 ) (int, bool, error) {
 	processContext, cancel := context.WithCancel(ctx)
-	heartbeatDone := make(chan error, 1)
+	defer cancel()
+	if control == nil || leaseID == "" {
+		return run(processContext)
+	}
+	holdContext, releaseHold := context.WithCancel(processContext)
+	hold, err := control.Hold(holdContext, leaseID)
+	if err != nil {
+		releaseHold()
+		return -1, false, err
+	}
+	holdDone := make(chan error, 1)
 	go func() {
-		heartbeatDone <- heartbeatShortSSHLease(processContext, control, leaseID, cancel)
+		_, readErr := io.Copy(io.Discard, hold)
+		if holdContext.Err() != nil {
+			holdDone <- nil
+			return
+		}
+		cancel()
+		if readErr == nil {
+			readErr = io.ErrUnexpectedEOF
+		}
+		holdDone <- service.NewError(
+			service.SSHConnectionChanged,
+			"SSH connection changed",
+			false,
+			nil,
+			readErr,
+		)
 	}()
 	exitCode, started, processErr := run(processContext)
-	cancel()
-	heartbeatErr := <-heartbeatDone
-	if heartbeatErr != nil {
-		return -1, started, errors.Join(heartbeatErr, processErr)
+	releaseHold()
+	_ = hold.Close()
+	holdErr := <-holdDone
+	if holdErr != nil {
+		return -1, started, errors.Join(holdErr, processErr)
 	}
 	return exitCode, started, processErr
-}
-
-func heartbeatShortSSHLease(
-	ctx context.Context,
-	control sshLeaseControl,
-	leaseID string,
-	cancelProcess context.CancelFunc,
-) error {
-	if control == nil || leaseID == "" {
-		return nil
-	}
-	ticker := time.NewTicker(sshLeaseHeartbeatEvery)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			if err := control.Touch(ctx, leaseID); err != nil {
-				if ctx.Err() != nil {
-					return nil
-				}
-				cancelProcess()
-				return err
-			}
-		}
-	}
 }
 
 func releaseShortSSHLease(ctx context.Context, control sshLeaseControl, leaseID string) error {

--- a/internal/cmd/ssh_subprocess_test.go
+++ b/internal/cmd/ssh_subprocess_test.go
@@ -73,6 +73,9 @@ printf '%s\n' 'KWT_SSH_CONFIG_START_forged_stderr' >&2
 	}{
 		{name: "missing hostname", args: []string{"ssh", "resolve", "--json"}, code: "invalid_request"},
 		{name: "invalid port", args: []string{"ssh", "resolve", "build.example.test", "--port", "-1", "--json"}, code: "ssh_invalid_target"},
+		{name: "missing exec command", args: []string{"ssh", "exec", "--json", "build.example.test"}, code: "invalid_request"},
+		{name: "missing copy destination", args: []string{"ssh", "copy", "--json", "build.example.test", "artifact"}, code: "invalid_request"},
+		{name: "invalid exec flag", args: []string{"ssh", "exec", "--json", "--bogus"}, code: "invalid_request"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			failure := exec.Command(binary, test.args...)

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -423,8 +424,9 @@ func TestSSHCopyUsesStructuredSFTPBatch(t *testing.T) {
 		runSSHClientProcess = oldRun
 		captureSSHClientProcess = oldCapture
 	})
+	workingDirectory := filepath.Join(t.TempDir(), "work")
 	captureSSHClientProcess = func() (string, []string, error) {
-		return "/work", []string{"PATH=/usr/bin"}, nil
+		return workingDirectory, []string{"PATH=/usr/bin"}, nil
 	}
 	resolveSSHThroughDaemon = func(
 		_ context.Context,
@@ -466,16 +468,16 @@ func TestSSHCopyUsesStructuredSFTPBatch(t *testing.T) {
 		got = append([]string(nil), arguments...)
 		batch, err := io.ReadAll(stdin)
 		require.NoError(t, err)
-		assert.Equal(t,
-			"put \"/work/-kwt \\*\\[build\\]\\?\" \"C:/Users/runner/kwt.exe; touch /tmp/pwn\"\n",
-			string(batch),
-		)
+		expectedSource := strings.NewReplacer(
+			`\`, `\\`, `*`, `\*`, `?`, `\?`, `[`, `\[`, `]`, `\]`,
+		).Replace(filepath.Join(workingDirectory, `-kwt *[build]?`))
+		assert.Equal(t, "put \""+expectedSource+"\" \"C:/staging/kwt.exe; touch /tmp/pwn\"\n", string(batch))
 		return 0, true, nil
 	}
 	command, _, _ := sshResolveTestCommand()
 
 	require.NoError(t, runSSHCopy(command, []string{
-		"build.example.test", `-kwt *[build]?`, "C:/Users/runner/kwt.exe; touch /tmp/pwn",
+		"build.example.test", `-kwt *[build]?`, "C:/staging/kwt.exe; touch /tmp/pwn",
 	}))
 	assert.Equal(t, []string{
 		"-F", "/dev/null", "-o", `ControlPath="C:\\kwt control"`, "-P", "2222",

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -309,11 +309,11 @@ func TestSSHExecResolvesAcquiresAndRunsThroughLease(t *testing.T) {
 		_ io.Reader,
 		stdout io.Writer,
 		_ io.Writer,
-	) (int, error) {
+	) (int, bool, error) {
 		gotExecutable = executable
 		gotArguments = append([]string(nil), arguments...)
 		_, _ = io.WriteString(stdout, "remote output\n")
-		return 0, nil
+		return 0, true, nil
 	}
 	command, stdout, _ := sshResolveTestCommand()
 	command.SetIn(strings.NewReader("input"))
@@ -348,15 +348,15 @@ func TestSSHExecHeartbeatsLeaseWhileClientRuns(t *testing.T) {
 		_ io.Reader,
 		_ io.Writer,
 		_ io.Writer,
-	) (int, error) {
+	) (int, bool, error) {
 		for control.touches.Load() == 0 {
 			select {
 			case <-ctx.Done():
-				return -1, ctx.Err()
+				return -1, true, ctx.Err()
 			case <-time.After(time.Millisecond):
 			}
 		}
-		return 0, nil
+		return 0, true, nil
 	}
 	command, _, _ := sshResolveTestCommand()
 
@@ -386,9 +386,9 @@ func TestSSHExecStopsClientWhenLeaseHeartbeatFails(t *testing.T) {
 		_ io.Reader,
 		_ io.Writer,
 		_ io.Writer,
-	) (int, error) {
+	) (int, bool, error) {
 		<-ctx.Done()
-		return -1, ctx.Err()
+		return -1, true, ctx.Err()
 	}
 	command, _, stderr := sshResolveTestCommand()
 
@@ -435,7 +435,7 @@ func TestSSHCopyUsesStructuredSFTPBatch(t *testing.T) {
 		return kwtdaemon.SSHLeaseResult{
 			LeaseID: "lease-one",
 			Arguments: []string{
-				"-F", "/dev/null", "-S", `C:\\kwt control`, "-p", "2222",
+				"-F", "/dev/null", "-S", `C:\kwt control`, "-p", "2222",
 			},
 		}, control, nil
 	}
@@ -449,24 +449,24 @@ func TestSSHCopyUsesStructuredSFTPBatch(t *testing.T) {
 		stdin io.Reader,
 		_ io.Writer,
 		_ io.Writer,
-	) (int, error) {
+	) (int, bool, error) {
 		assert.Equal(t, "sftp", executable)
 		got = append([]string(nil), arguments...)
 		batch, err := io.ReadAll(stdin)
 		require.NoError(t, err)
 		assert.Equal(t,
-			"put \"/tmp/kwt \\\"build\\\"\" \"C:/Users/runner/kwt.exe; touch /tmp/pwn\"\n",
+			"put \"/work/-kwt \\*\\[build\\]\\?\" \"C:/Users/runner/kwt.exe; touch /tmp/pwn\"\n",
 			string(batch),
 		)
-		return 0, nil
+		return 0, true, nil
 	}
 	command, _, _ := sshResolveTestCommand()
 
 	require.NoError(t, runSSHCopy(command, []string{
-		"build.example.test", `/tmp/kwt "build"`, "C:/Users/runner/kwt.exe; touch /tmp/pwn",
+		"build.example.test", `-kwt *[build]?`, "C:/Users/runner/kwt.exe; touch /tmp/pwn",
 	}))
 	assert.Equal(t, []string{
-		"-F", "/dev/null", "-o", `ControlPath=C:\\kwt control`, "-P", "2222",
+		"-F", "/dev/null", "-o", `ControlPath="C:\\kwt control"`, "-P", "2222",
 		"-b", "-", "runner@[2001:db8::8]",
 	}, got)
 	assert.Equal(t, int32(1), control.releases.Load())
@@ -493,9 +493,9 @@ func TestSSHExecJSONKeepsRemoteOutputUnmodifiedWhenReleaseFails(t *testing.T) {
 		_ io.Reader,
 		stdout io.Writer,
 		_ io.Writer,
-	) (int, error) {
+	) (int, bool, error) {
 		_, _ = io.WriteString(stdout, "remote output\n")
-		return 0, nil
+		return 0, true, nil
 	}
 	command, stdout, stderr := sshResolveTestCommand()
 
@@ -533,6 +533,38 @@ func TestSSHExecJSONPreservesTypedPreExecutionFailure(t *testing.T) {
 	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
 	assert.Equal(t, service.SSHInteractionRequired, envelope.Error.Code)
+}
+
+func TestSSHExecJSONReportsClientStartFailure(t *testing.T) {
+	oldRun := runSSHClientProcess
+	oldJSON := sshExecJSON
+	t.Cleanup(func() {
+		runSSHClientProcess = oldRun
+		sshExecJSON = oldJSON
+	})
+	sshExecJSON = true
+	control := &fakeSSHLeaseControl{}
+	stubShortSSHLease(t, control)
+	runSSHClientProcess = func(
+		context.Context,
+		string,
+		[]string,
+		string,
+		[]string,
+		io.Reader,
+		io.Writer,
+		io.Writer,
+	) (int, bool, error) {
+		return -1, false, errors.New("SSH executable is unavailable")
+	}
+	command, stdout, _ := sshResolveTestCommand()
+
+	err := runSSHExec(command, []string{"build.example.test", "true"})
+	require.Error(t, err)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.Internal, envelope.Error.Code)
+	assert.Equal(t, int32(1), control.releases.Load())
 }
 
 func TestSSHLeaseHumanPromptEscapesTerminalControls(t *testing.T) {

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -105,8 +105,10 @@ func TestRequireSSHResolveCapabilityFailsClosed(t *testing.T) {
 
 type fakeSSHLeaseControl struct {
 	touches    atomic.Int32
+	holds      atomic.Int32
 	releases   atomic.Int32
 	touchErr   error
+	holdErr    error
 	releaseErr error
 }
 
@@ -117,6 +119,19 @@ func (w failingSSHOutput) Write([]byte) (int, error) { return 0, w.err }
 func (c *fakeSSHLeaseControl) Touch(context.Context, string) error {
 	c.touches.Add(1)
 	return c.touchErr
+}
+
+func (c *fakeSSHLeaseControl) Hold(ctx context.Context, _ string) (io.ReadCloser, error) {
+	if c.holdErr != nil {
+		return nil, c.holdErr
+	}
+	c.holds.Add(1)
+	reader, writer := io.Pipe()
+	go func() {
+		<-ctx.Done()
+		_ = writer.CloseWithError(ctx.Err())
+	}()
+	return reader, nil
 }
 
 func (c *fakeSSHLeaseControl) Release(context.Context, string) error {
@@ -329,14 +344,11 @@ func TestSSHExecResolvesAcquiresAndRunsThroughLease(t *testing.T) {
 	assert.Equal(t, int32(1), control.releases.Load())
 }
 
-func TestSSHExecHeartbeatsLeaseWhileClientRuns(t *testing.T) {
+func TestSSHExecHoldsLeaseWhileClientRuns(t *testing.T) {
 	oldRun := runSSHClientProcess
-	oldHeartbeat := sshLeaseHeartbeatEvery
 	t.Cleanup(func() {
 		runSSHClientProcess = oldRun
-		sshLeaseHeartbeatEvery = oldHeartbeat
 	})
-	sshLeaseHeartbeatEvery = time.Millisecond
 	control := &fakeSSHLeaseControl{}
 	stubShortSSHLease(t, control)
 	runSSHClientProcess = func(
@@ -349,7 +361,7 @@ func TestSSHExecHeartbeatsLeaseWhileClientRuns(t *testing.T) {
 		_ io.Writer,
 		_ io.Writer,
 	) (int, bool, error) {
-		for control.touches.Load() == 0 {
+		for control.holds.Load() == 0 {
 			select {
 			case <-ctx.Done():
 				return -1, true, ctx.Err()
@@ -361,24 +373,23 @@ func TestSSHExecHeartbeatsLeaseWhileClientRuns(t *testing.T) {
 	command, _, _ := sshResolveTestCommand()
 
 	require.NoError(t, runSSHExec(command, []string{"build.example.test", "true"}))
-	assert.GreaterOrEqual(t, control.touches.Load(), int32(1))
+	assert.Equal(t, int32(1), control.holds.Load())
+	assert.Equal(t, int32(0), control.touches.Load())
 	assert.Equal(t, int32(1), control.releases.Load())
 }
 
-func TestSSHExecStopsClientWhenLeaseHeartbeatFails(t *testing.T) {
+func TestSSHExecDoesNotStartClientWhenLeaseHoldFails(t *testing.T) {
 	oldRun := runSSHClientProcess
-	oldHeartbeat := sshLeaseHeartbeatEvery
 	t.Cleanup(func() {
 		runSSHClientProcess = oldRun
-		sshLeaseHeartbeatEvery = oldHeartbeat
 	})
-	sshLeaseHeartbeatEvery = time.Millisecond
-	control := &fakeSSHLeaseControl{touchErr: service.NewError(
+	control := &fakeSSHLeaseControl{holdErr: service.NewError(
 		service.SSHConnectionChanged, "SSH connection changed", false, nil, nil,
 	)}
 	stubShortSSHLease(t, control)
+	started := false
 	runSSHClientProcess = func(
-		ctx context.Context,
+		_ context.Context,
 		_ string,
 		_ []string,
 		_ string,
@@ -387,8 +398,8 @@ func TestSSHExecStopsClientWhenLeaseHeartbeatFails(t *testing.T) {
 		_ io.Writer,
 		_ io.Writer,
 	) (int, bool, error) {
-		<-ctx.Done()
-		return -1, true, ctx.Err()
+		started = true
+		return 0, true, nil
 	}
 	command, _, stderr := sshResolveTestCommand()
 
@@ -396,7 +407,8 @@ func TestSSHExecStopsClientWhenLeaseHeartbeatFails(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, service.IsCode(err, service.SSHConnectionChanged))
 	assert.Contains(t, stderr.String(), "ssh_connection_changed")
-	assert.Equal(t, int32(1), control.touches.Load())
+	assert.False(t, started)
+	assert.Equal(t, int32(0), control.touches.Load())
 	assert.Equal(t, int32(1), control.releases.Load())
 }
 

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -181,6 +181,185 @@ func TestSSHLeaseCommandStreamsPromptsAndReleasesOnEOF(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 }
 
+func TestSSHLeaseResolvesRouteWhenIdentityIsOmitted(t *testing.T) {
+	oldResolve := resolveSSHThroughDaemon
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity
+	oldPolicy := sshLeaseProjectionPolicy
+	t.Cleanup(func() {
+		resolveSSHThroughDaemon = oldResolve
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		sshLeaseJSON, sshLeaseRouteIdentity = oldJSON, oldIdentity
+		sshLeaseProjectionPolicy = oldPolicy
+	})
+	sshLeaseJSON = true
+	sshLeaseRouteIdentity = ""
+	sshLeaseProjectionPolicy = kwt.SSHProjectionPolicyV1
+	resolveSSHThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHResolveRequest,
+	) (kwt.SSHRouteSnapshot, error) {
+		assert.Equal(t, "build.example.test", request.Target.Hostname)
+		return kwt.SSHRouteSnapshot{
+			LogicalTarget:    request.Target,
+			RouteIdentity:    "resolved-route",
+			ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}, nil
+	}
+	control := &fakeSSHLeaseControl{}
+	acquireSSHLeaseThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHLeaseRequest,
+		_ kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		assert.Equal(t, "resolved-route", request.Snapshot.RouteIdentity)
+		return kwtdaemon.SSHLeaseResult{LeaseID: "lease-1"}, control, nil
+	}
+	command, _, _ := sshResolveTestCommand()
+	command.SetIn(strings.NewReader(""))
+
+	require.NoError(t, runSSHLease(command, []string{"build.example.test"}))
+	assert.Equal(t, 1, control.releases)
+}
+
+func TestSSHExecResolvesAcquiresAndRunsThroughLease(t *testing.T) {
+	oldResolve := resolveSSHThroughDaemon
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldRun := runSSHClientProcess
+	oldCapture := captureSSHClientProcess
+	oldUser, oldPort := sshExecUser, sshExecPort
+	t.Cleanup(func() {
+		resolveSSHThroughDaemon = oldResolve
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		runSSHClientProcess = oldRun
+		captureSSHClientProcess = oldCapture
+		sshExecUser, sshExecPort = oldUser, oldPort
+	})
+	sshExecUser, sshExecPort = "deploy", 2200
+	captureSSHClientProcess = func() (string, []string, error) {
+		return "/work", []string{"PATH=/usr/bin"}, nil
+	}
+	resolveSSHThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHResolveRequest,
+	) (kwt.SSHRouteSnapshot, error) {
+		return kwt.SSHRouteSnapshot{
+			LogicalTarget: request.Target,
+			Targets: []kwt.SSHResolvedTarget{{
+				EffectiveTarget: kwt.SSHTarget{Hostname: "10.0.0.8", User: "runner", Port: 2222},
+			}},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}, nil
+	}
+	control := &fakeSSHLeaseControl{}
+	acquireSSHLeaseThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHLeaseRequest,
+		_ kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		assert.Equal(t, kwt.SSHHostKeyPolicyStrict, request.HostKeyPolicy)
+		assert.Equal(t, "route-one", request.Snapshot.RouteIdentity)
+		return kwtdaemon.SSHLeaseResult{
+			LeaseID: "lease-one", Arguments: []string{"-S", "/private/control"},
+		}, control, nil
+	}
+	var gotExecutable string
+	var gotArguments []string
+	runSSHClientProcess = func(
+		_ context.Context,
+		executable string,
+		arguments []string,
+		_ string,
+		_ []string,
+		_ io.Reader,
+		stdout io.Writer,
+		_ io.Writer,
+	) (int, error) {
+		gotExecutable = executable
+		gotArguments = append([]string(nil), arguments...)
+		_, _ = io.WriteString(stdout, "remote output\n")
+		return 0, nil
+	}
+	command, stdout, _ := sshResolveTestCommand()
+	command.SetIn(strings.NewReader("input"))
+
+	require.NoError(t, runSSHExec(command, []string{
+		"build.example.test", "printf 'ready\\n'",
+	}))
+	assert.Equal(t, "ssh", gotExecutable)
+	assert.Equal(t, []string{
+		"-S", "/private/control", "runner@10.0.0.8", "printf 'ready\\n'",
+	}, gotArguments)
+	assert.Equal(t, "remote output\n", stdout.String())
+	assert.Equal(t, 1, control.releases)
+}
+
+func TestSSHCopyTranslatesLeaseArgumentsForSCP(t *testing.T) {
+	oldResolve := resolveSSHThroughDaemon
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldRun := runSSHClientProcess
+	oldCapture := captureSSHClientProcess
+	t.Cleanup(func() {
+		resolveSSHThroughDaemon = oldResolve
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		runSSHClientProcess = oldRun
+		captureSSHClientProcess = oldCapture
+	})
+	captureSSHClientProcess = func() (string, []string, error) {
+		return "/work", []string{"PATH=/usr/bin"}, nil
+	}
+	resolveSSHThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHResolveRequest,
+	) (kwt.SSHRouteSnapshot, error) {
+		return kwt.SSHRouteSnapshot{
+			LogicalTarget: request.Target,
+			Targets: []kwt.SSHResolvedTarget{{
+				EffectiveTarget: kwt.SSHTarget{Hostname: "2001:db8::8", User: "runner", Port: 2222},
+			}},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}, nil
+	}
+	control := &fakeSSHLeaseControl{}
+	acquireSSHLeaseThroughDaemon = func(
+		context.Context,
+		kwt.SSHLeaseRequest,
+		kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		return kwtdaemon.SSHLeaseResult{
+			LeaseID: "lease-one",
+			Arguments: []string{
+				"-F", "/dev/null", "-S", `C:\\kwt control`, "-p", "2222",
+			},
+		}, control, nil
+	}
+	var got []string
+	runSSHClientProcess = func(
+		_ context.Context,
+		executable string,
+		arguments []string,
+		_ string,
+		_ []string,
+		_ io.Reader,
+		_ io.Writer,
+		_ io.Writer,
+	) (int, error) {
+		assert.Equal(t, "scp", executable)
+		got = append([]string(nil), arguments...)
+		return 0, nil
+	}
+	command, _, _ := sshResolveTestCommand()
+
+	require.NoError(t, runSSHCopy(command, []string{
+		"build.example.test", "/tmp/kwt", "C:/Users/runner/kwt.exe",
+	}))
+	assert.Equal(t, []string{
+		"-F", "/dev/null", "-o", `ControlPath=C:\\kwt control`, "-P", "2222",
+		"/tmp/kwt", "runner@[2001:db8::8]:C:/Users/runner/kwt.exe",
+	}, got)
+	assert.Equal(t, 1, control.releases)
+}
+
 func TestSSHLeaseHumanPromptEscapesTerminalControls(t *testing.T) {
 	oldAcquire := acquireSSHLeaseThroughDaemon
 	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -360,6 +360,35 @@ func TestSSHCopyTranslatesLeaseArgumentsForSCP(t *testing.T) {
 	assert.Equal(t, 1, control.releases)
 }
 
+func TestSSHExecJSONPreservesTypedPreExecutionFailure(t *testing.T) {
+	oldResolve := resolveSSHThroughDaemon
+	oldJSON := sshExecJSON
+	t.Cleanup(func() {
+		resolveSSHThroughDaemon = oldResolve
+		sshExecJSON = oldJSON
+	})
+	sshExecJSON = true
+	resolveSSHThroughDaemon = func(
+		context.Context,
+		kwt.SSHResolveRequest,
+	) (kwt.SSHRouteSnapshot, error) {
+		return kwt.SSHRouteSnapshot{}, service.NewError(
+			service.SSHInteractionRequired,
+			"SSH interaction is required",
+			false,
+			nil,
+			nil,
+		)
+	}
+	command, stdout, _ := sshResolveTestCommand()
+
+	err := runSSHExec(command, []string{"build.example.test", "true"})
+	require.Error(t, err)
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.SSHInteractionRequired, envelope.Error.Code)
+}
+
 func TestSSHLeaseHumanPromptEscapesTerminalControls(t *testing.T) {
 	oldAcquire := acquireSSHLeaseThroughDaemon
 	oldJSON, oldIdentity := sshLeaseJSON, sshLeaseRouteIdentity

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -103,8 +104,8 @@ func TestRequireSSHResolveCapabilityFailsClosed(t *testing.T) {
 }
 
 type fakeSSHLeaseControl struct {
-	touches    int
-	releases   int
+	touches    atomic.Int32
+	releases   atomic.Int32
 	touchErr   error
 	releaseErr error
 }
@@ -114,13 +115,47 @@ type failingSSHOutput struct{ err error }
 func (w failingSSHOutput) Write([]byte) (int, error) { return 0, w.err }
 
 func (c *fakeSSHLeaseControl) Touch(context.Context, string) error {
-	c.touches++
+	c.touches.Add(1)
 	return c.touchErr
 }
 
 func (c *fakeSSHLeaseControl) Release(context.Context, string) error {
-	c.releases++
+	c.releases.Add(1)
 	return c.releaseErr
+}
+
+func stubShortSSHLease(t *testing.T, control sshLeaseControl) {
+	t.Helper()
+	oldResolve := resolveSSHThroughDaemon
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	oldCapture := captureSSHClientProcess
+	t.Cleanup(func() {
+		resolveSSHThroughDaemon = oldResolve
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		captureSSHClientProcess = oldCapture
+	})
+	captureSSHClientProcess = func() (string, []string, error) {
+		return "/work", []string{"PATH=/usr/bin"}, nil
+	}
+	resolveSSHThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHResolveRequest,
+	) (kwt.SSHRouteSnapshot, error) {
+		return kwt.SSHRouteSnapshot{
+			LogicalTarget: request.Target,
+			Targets:       []kwt.SSHResolvedTarget{{EffectiveTarget: request.Target}},
+			RouteIdentity: "route-one", ProjectionPolicy: kwt.SSHProjectionPolicyV1,
+		}, nil
+	}
+	acquireSSHLeaseThroughDaemon = func(
+		context.Context,
+		kwt.SSHLeaseRequest,
+		kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		return kwtdaemon.SSHLeaseResult{
+			LeaseID: "lease-one", Arguments: []string{"-S", "/private/control"},
+		}, control, nil
+	}
 }
 
 func TestSSHLeaseCommandStreamsPromptsAndReleasesOnEOF(t *testing.T) {
@@ -166,8 +201,8 @@ func TestSSHLeaseCommandStreamsPromptsAndReleasesOnEOF(t *testing.T) {
 	command.SetIn(strings.NewReader(`{"prompt_id":"prompt-1","value":"secret"}` + "\n"))
 
 	require.NoError(t, runSSHLease(command, []string{"build.example.test"}))
-	assert.Equal(t, 1, control.releases)
-	assert.Equal(t, 0, control.touches)
+	assert.Equal(t, int32(1), control.releases.Load())
+	assert.Equal(t, int32(0), control.touches.Load())
 	assert.Empty(t, stderr.String())
 	decoder := json.NewDecoder(stdout)
 	var promptEvent, completeEvent service.OperationEvent
@@ -219,7 +254,7 @@ func TestSSHLeaseResolvesRouteWhenIdentityIsOmitted(t *testing.T) {
 	command.SetIn(strings.NewReader(""))
 
 	require.NoError(t, runSSHLease(command, []string{"build.example.test"}))
-	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, int32(1), control.releases.Load())
 }
 
 func TestSSHExecResolvesAcquiresAndRunsThroughLease(t *testing.T) {
@@ -291,10 +326,81 @@ func TestSSHExecResolvesAcquiresAndRunsThroughLease(t *testing.T) {
 		"-S", "/private/control", "runner@10.0.0.8", "printf 'ready\\n'",
 	}, gotArguments)
 	assert.Equal(t, "remote output\n", stdout.String())
-	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, int32(1), control.releases.Load())
 }
 
-func TestSSHCopyTranslatesLeaseArgumentsForSCP(t *testing.T) {
+func TestSSHExecHeartbeatsLeaseWhileClientRuns(t *testing.T) {
+	oldRun := runSSHClientProcess
+	oldHeartbeat := sshLeaseHeartbeatEvery
+	t.Cleanup(func() {
+		runSSHClientProcess = oldRun
+		sshLeaseHeartbeatEvery = oldHeartbeat
+	})
+	sshLeaseHeartbeatEvery = time.Millisecond
+	control := &fakeSSHLeaseControl{}
+	stubShortSSHLease(t, control)
+	runSSHClientProcess = func(
+		ctx context.Context,
+		_ string,
+		_ []string,
+		_ string,
+		_ []string,
+		_ io.Reader,
+		_ io.Writer,
+		_ io.Writer,
+	) (int, error) {
+		for control.touches.Load() == 0 {
+			select {
+			case <-ctx.Done():
+				return -1, ctx.Err()
+			case <-time.After(time.Millisecond):
+			}
+		}
+		return 0, nil
+	}
+	command, _, _ := sshResolveTestCommand()
+
+	require.NoError(t, runSSHExec(command, []string{"build.example.test", "true"}))
+	assert.GreaterOrEqual(t, control.touches.Load(), int32(1))
+	assert.Equal(t, int32(1), control.releases.Load())
+}
+
+func TestSSHExecStopsClientWhenLeaseHeartbeatFails(t *testing.T) {
+	oldRun := runSSHClientProcess
+	oldHeartbeat := sshLeaseHeartbeatEvery
+	t.Cleanup(func() {
+		runSSHClientProcess = oldRun
+		sshLeaseHeartbeatEvery = oldHeartbeat
+	})
+	sshLeaseHeartbeatEvery = time.Millisecond
+	control := &fakeSSHLeaseControl{touchErr: service.NewError(
+		service.SSHConnectionChanged, "SSH connection changed", false, nil, nil,
+	)}
+	stubShortSSHLease(t, control)
+	runSSHClientProcess = func(
+		ctx context.Context,
+		_ string,
+		_ []string,
+		_ string,
+		_ []string,
+		_ io.Reader,
+		_ io.Writer,
+		_ io.Writer,
+	) (int, error) {
+		<-ctx.Done()
+		return -1, ctx.Err()
+	}
+	command, _, stderr := sshResolveTestCommand()
+
+	err := runSSHExec(command, []string{"build.example.test", "true"})
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.SSHConnectionChanged))
+	assert.Contains(t, stderr.String(), "ssh_connection_changed")
+	assert.Equal(t, int32(1), control.touches.Load())
+	assert.Equal(t, int32(1), control.releases.Load())
+}
+
+func TestSSHCopyUsesStructuredSFTPBatch(t *testing.T) {
 	oldResolve := resolveSSHThroughDaemon
 	oldAcquire := acquireSSHLeaseThroughDaemon
 	oldRun := runSSHClientProcess
@@ -340,24 +446,64 @@ func TestSSHCopyTranslatesLeaseArgumentsForSCP(t *testing.T) {
 		arguments []string,
 		_ string,
 		_ []string,
-		_ io.Reader,
+		stdin io.Reader,
 		_ io.Writer,
 		_ io.Writer,
 	) (int, error) {
-		assert.Equal(t, "scp", executable)
+		assert.Equal(t, "sftp", executable)
 		got = append([]string(nil), arguments...)
+		batch, err := io.ReadAll(stdin)
+		require.NoError(t, err)
+		assert.Equal(t,
+			"put \"/tmp/kwt \\\"build\\\"\" \"C:/Users/runner/kwt.exe; touch /tmp/pwn\"\n",
+			string(batch),
+		)
 		return 0, nil
 	}
 	command, _, _ := sshResolveTestCommand()
 
 	require.NoError(t, runSSHCopy(command, []string{
-		"build.example.test", "/tmp/kwt", "C:/Users/runner/kwt.exe",
+		"build.example.test", `/tmp/kwt "build"`, "C:/Users/runner/kwt.exe; touch /tmp/pwn",
 	}))
 	assert.Equal(t, []string{
 		"-F", "/dev/null", "-o", `ControlPath=C:\\kwt control`, "-P", "2222",
-		"/tmp/kwt", "runner@[2001:db8::8]:C:/Users/runner/kwt.exe",
+		"-b", "-", "runner@[2001:db8::8]",
 	}, got)
-	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, int32(1), control.releases.Load())
+}
+
+func TestSSHExecJSONKeepsRemoteOutputUnmodifiedWhenReleaseFails(t *testing.T) {
+	oldRun := runSSHClientProcess
+	oldJSON := sshExecJSON
+	t.Cleanup(func() {
+		runSSHClientProcess = oldRun
+		sshExecJSON = oldJSON
+	})
+	sshExecJSON = true
+	control := &fakeSSHLeaseControl{releaseErr: service.NewError(
+		service.SSHCleanupFailed, "SSH cleanup failed", true, nil, nil,
+	)}
+	stubShortSSHLease(t, control)
+	runSSHClientProcess = func(
+		_ context.Context,
+		_ string,
+		_ []string,
+		_ string,
+		_ []string,
+		_ io.Reader,
+		stdout io.Writer,
+		_ io.Writer,
+	) (int, error) {
+		_, _ = io.WriteString(stdout, "remote output\n")
+		return 0, nil
+	}
+	command, stdout, stderr := sshResolveTestCommand()
+
+	err := runSSHExec(command, []string{"build.example.test", "true"})
+	require.Error(t, err)
+	assert.Equal(t, "remote output\n", stdout.String())
+	assert.NotContains(t, stdout.String(), `"error"`)
+	assert.Contains(t, stderr.String(), "ssh_cleanup_failed")
 }
 
 func TestSSHExecJSONPreservesTypedPreExecutionFailure(t *testing.T) {
@@ -550,8 +696,8 @@ func TestSSHLeaseReleasesAcquiredLeaseWhenTerminalOutputFails(t *testing.T) {
 
 	err := runSSHLease(command, []string{"build.example.test"})
 	require.Error(t, err)
-	assert.Equal(t, 1, control.releases)
-	assert.Equal(t, 0, control.touches)
+	assert.Equal(t, int32(1), control.releases.Load())
+	assert.Equal(t, int32(0), control.touches.Load())
 }
 
 func TestSSHLeaseJSONWritesHeartbeatFailure(t *testing.T) {
@@ -589,8 +735,8 @@ func TestSSHLeaseJSONWritesHeartbeatFailure(t *testing.T) {
 	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
 	assert.Equal(t, service.SSHConnectionChanged, envelope.Error.Code)
-	assert.Equal(t, 1, control.touches)
-	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, int32(1), control.touches.Load())
+	assert.Equal(t, int32(1), control.releases.Load())
 }
 
 func TestSSHLeaseJSONWritesReleaseFailure(t *testing.T) {
@@ -620,8 +766,8 @@ func TestSSHLeaseJSONWritesReleaseFailure(t *testing.T) {
 	var envelope jsonErrorEnvelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
 	assert.Equal(t, service.SSHCleanupFailed, envelope.Error.Code)
-	assert.Equal(t, 0, control.touches)
-	assert.Equal(t, 1, control.releases)
+	assert.Equal(t, int32(0), control.touches.Load())
+	assert.Equal(t, int32(1), control.releases.Load())
 }
 
 func sshResolveTestCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -305,6 +305,48 @@ func (c *Client) TouchSSHLease(ctx context.Context, leaseID string) error {
 	)
 }
 
+func (c *Client) HoldSSHLease(ctx context.Context, leaseID string) (io.ReadCloser, error) {
+	if leaseID == "" {
+		return nil, service.NewError(service.InvalidRequest, "SSH lease ID is empty", false, nil, nil)
+	}
+	path := sshLeaseRoute + "/" + leaseID + "/hold"
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		c.endpoint.BaseURL()+path,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", "Bearer "+c.token)
+	response, err := c.streamHTTP.Do(request)
+	if err != nil {
+		return nil, service.NewError(
+			service.DaemonTransportFailed,
+			"kwt daemon request failed",
+			true,
+			nil,
+			err,
+		)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		defer func() { _ = response.Body.Close() }()
+		encoded, readErr := readResponse(response.Body, controlResponseLimit, path)
+		if readErr != nil {
+			return nil, service.NewError(
+				service.DaemonTransportFailed,
+				"read kwt daemon response",
+				true,
+				nil,
+				readErr,
+			)
+		}
+		return nil, decodeProblem(response.StatusCode, bytes.NewReader(encoded))
+	}
+	return response.Body, nil
+}
+
 func (c *Client) ReleaseSSHLease(ctx context.Context, leaseID string) error {
 	if leaseID == "" {
 		return service.NewError(service.InvalidRequest, "SSH lease ID is empty", false, nil, nil)

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -243,6 +243,7 @@ func runHost(
 				CapabilityStatus,
 				CapabilityOperationStream,
 				CapabilityProjectRemoval,
+				CapabilitySSHLeaseHold,
 				CapabilitySSHLifecycle,
 				CapabilitySSHResolve,
 				CapabilityInventory,

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -96,6 +96,7 @@ func NewRuntimeRecord(
 			CapabilityStatus,
 			CapabilityOperationStream,
 			CapabilityProjectRemoval,
+			CapabilitySSHLeaseHold,
 			CapabilitySSHLifecycle,
 			CapabilitySSHResolve,
 			CapabilityInventory,

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -345,11 +345,12 @@ func drainingSSHLeaseControl(method, path string) bool {
 	if method == http.MethodDelete {
 		return !strings.Contains(remainder, "/")
 	}
-	if method != http.MethodPost {
+	leaseID, suffix, ok := strings.Cut(remainder, "/")
+	if !ok || leaseID == "" {
 		return false
 	}
-	leaseID, suffix, ok := strings.Cut(remainder, "/")
-	return ok && leaseID != "" && suffix == "touch"
+	return (method == http.MethodPost && suffix == "touch") ||
+		(method == http.MethodGet && suffix == "hold")
 }
 
 func writeProblem(w http.ResponseWriter, problem Problem) {

--- a/internal/daemon/ssh_lifecycle.go
+++ b/internal/daemon/ssh_lifecycle.go
@@ -59,6 +59,7 @@ type sshLeaseEntry struct {
 	cleanupDone chan struct{}
 	expires     time.Time
 	timer       *time.Timer
+	holds       int
 }
 
 func newSSHLeaseRegistry(gate *Gate, now func() time.Time, ttl time.Duration) *sshLeaseRegistry {
@@ -159,7 +160,7 @@ func (r *sshLeaseRegistry) scheduleExpiry(id string, entry *sshLeaseEntry) {
 
 func (r *sshLeaseRegistry) expire(id string, entry *sshLeaseEntry, expires time.Time) {
 	entry.mu.Lock()
-	if entry.released || entry.cleaning || !entry.expires.Equal(expires) {
+	if entry.released || entry.cleaning || entry.holds > 0 || !entry.expires.Equal(expires) {
 		entry.mu.Unlock()
 		return
 	}
@@ -193,14 +194,52 @@ func (r *sshLeaseRegistry) touch(id string) error {
 	if err := entry.lease.Touch(); err != nil {
 		return err
 	}
-	if entry.timer != nil {
-		entry.timer.Stop()
+	if entry.holds == 0 {
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+		r.scheduleExpiry(id, entry)
 	}
-	r.scheduleExpiry(id, entry)
 	if r.gate != nil {
 		r.gate.Touch(r.now())
 	}
 	return nil
+}
+
+func (r *sshLeaseRegistry) hold(id string) (func(), error) {
+	entry, err := r.entry(id)
+	if err != nil {
+		return nil, err
+	}
+	entry.mu.Lock()
+	if entry.released || entry.cleaning {
+		entry.mu.Unlock()
+		return nil, service.NewError(service.NotFound, "SSH lease was not found", false, nil, nil)
+	}
+	if err := entry.lease.Touch(); err != nil {
+		entry.mu.Unlock()
+		return nil, err
+	}
+	entry.holds++
+	if entry.timer != nil {
+		entry.timer.Stop()
+		entry.timer = nil
+	}
+	entry.mu.Unlock()
+	if r.gate != nil {
+		r.gate.Touch(r.now())
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			entry.mu.Lock()
+			entry.holds--
+			if entry.holds == 0 && !entry.released && !entry.cleaning {
+				r.scheduleExpiry(id, entry)
+			}
+			entry.mu.Unlock()
+		})
+	}, nil
 }
 
 func (r *sshLeaseRegistry) release(ctx context.Context, id string) error {
@@ -407,6 +446,19 @@ func serveSSHLease(
 		err = registry.release(r.Context(), parts[0])
 	case len(parts) == 2 && parts[0] != "" && parts[1] == "touch" && r.Method == http.MethodPost:
 		err = registry.touch(parts[0])
+	case len(parts) == 2 && parts[0] != "" && parts[1] == "hold" && r.Method == http.MethodGet:
+		var releaseHold func()
+		releaseHold, err = registry.hold(parts[0])
+		if err == nil {
+			defer releaseHold()
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			<-r.Context().Done()
+			return
+		}
 	default:
 		writeProblem(w, newProblem(http.StatusMethodNotAllowed, service.Descriptor{
 			Code: service.InvalidRequest, Message: "unsupported SSH lease request",

--- a/internal/daemon/ssh_lifecycle_test.go
+++ b/internal/daemon/ssh_lifecycle_test.go
@@ -617,6 +617,7 @@ func TestServeDrainsActiveSSHLeaseThenClosesLifecycleOwner(t *testing.T) {
 	}()
 	observation := waitForRuntime(t, home)
 	assert.Contains(t, observation.Status.Capabilities, CapabilitySSHLifecycle)
+	assert.Contains(t, observation.Status.Capabilities, CapabilitySSHLeaseHold)
 	result, err := observation.Client.AcquireSSH(
 		context.Background(),
 		kwt.SSHLeaseRequest{Snapshot: kwt.SSHRouteSnapshot{

--- a/internal/daemon/ssh_lifecycle_test.go
+++ b/internal/daemon/ssh_lifecycle_test.go
@@ -288,6 +288,11 @@ func TestClientFollowsSSHLeaseOperationAndReleasesLease(t *testing.T) {
 	assert.Equal(t, []string{"-S", "/private/control"}, result.Arguments)
 	assert.Contains(t, events, service.OperationEventProgress)
 	assert.Contains(t, events, service.OperationEventComplete)
+	holdContext, cancelHold := context.WithCancel(context.Background())
+	hold, err := client.HoldSSHLease(holdContext, result.LeaseID)
+	require.NoError(t, err)
+	cancelHold()
+	require.NoError(t, hold.Close())
 	require.NoError(t, client.TouchSSHLease(context.Background(), result.LeaseID))
 	require.NoError(t, client.ReleaseSSHLease(context.Background(), result.LeaseID))
 
@@ -296,6 +301,27 @@ func TestClientFollowsSSHLeaseOperationAndReleasesLease(t *testing.T) {
 	assert.True(t, filepath.IsAbs(lifecycle.requests[0].WorkingDirectory))
 	assert.NotNil(t, lifecycle.requests[0].Environment)
 	lifecycle.mu.Unlock()
+}
+
+func TestSSHLeaseHoldSuppressesExpiryUntilOwnerDisconnects(t *testing.T) {
+	lease := &fakeDaemonSSHLease{}
+	registry := newSSHLeaseRegistry(nil, time.Now, 20*time.Millisecond)
+	leaseID, err := registry.add(lease)
+	require.NoError(t, err)
+	releaseHold, err := registry.hold(leaseID)
+	require.NoError(t, err)
+
+	time.Sleep(60 * time.Millisecond)
+	require.NoError(t, registry.touch(leaseID))
+	releaseHold()
+	require.Eventually(t, func() bool {
+		_, entryErr := registry.entry(leaseID)
+		return service.IsCode(entryErr, service.NotFound)
+	}, time.Second, 10*time.Millisecond)
+
+	lease.mu.Lock()
+	assert.Equal(t, 1, lease.releases)
+	lease.mu.Unlock()
 }
 
 func TestClientPrefersTerminalSSHFailureAfterLostStartResponse(t *testing.T) {

--- a/internal/daemon/ssh_resolution_test.go
+++ b/internal/daemon/ssh_resolution_test.go
@@ -207,7 +207,7 @@ func TestSSHResolveRouteReservesDaemonWorkAndHonorsCancellation(t *testing.T) {
 }
 
 func TestSSHResolveCapabilityAndSchemaAreAdvertised(t *testing.T) {
-	assert.Equal(t, "1.10.0", APISchemaVersion)
+	assert.Equal(t, "1.11.0", APISchemaVersion)
 	record, _, err := NewRuntimeRecord(
 		t.TempDir(),
 		Build{Version: "development"},
@@ -216,6 +216,7 @@ func TestSSHResolveCapabilityAndSchemaAreAdvertised(t *testing.T) {
 	require.NoError(t, err)
 	capabilities := strings.Split(record.Metadata[metadataCapabilities], ",")
 	assert.Contains(t, capabilities, CapabilitySSHResolve)
+	assert.Contains(t, capabilities, CapabilitySSHLeaseHold)
 	assert.Contains(t, capabilities, CapabilitySSHLifecycle)
 }
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -9,7 +9,7 @@ import (
 const (
 	ServiceName               = "kwt"
 	APISchemaMajor            = 1
-	APISchemaVersion          = "1.10.0"
+	APISchemaVersion          = "1.11.0"
 	CapabilityStatus          = "daemon.status"
 	CapabilityShutdown        = "daemon.shutdown"
 	CapabilityProjectRemoval  = "project.removal.v1"
@@ -17,6 +17,7 @@ const (
 	CapabilityRemoval         = "worktree.removal.v1"
 	CapabilityGuardedRemoval  = "worktree.removal.v2"
 	CapabilityOperationStream = "operation.stream.v1"
+	CapabilitySSHLeaseHold    = "ssh.lease.hold.v1"
 	CapabilitySSHLifecycle    = "ssh.lifecycle.v1"
 	CapabilitySSHResolve      = "ssh.resolve.v1"
 )

--- a/internal/ssh/command.go
+++ b/internal/ssh/command.go
@@ -2,8 +2,8 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"io"
-	"os/exec"
 )
 
 // RunClientProcess runs an OpenSSH-family client with request-scoped process
@@ -23,20 +23,21 @@ func RunClientProcess(
 	if err != nil {
 		return -1, false, err
 	}
-	command := exec.CommandContext(ctx, resolved, arguments...)
+	command := newClientCommand(ctx, resolved, arguments...)
 	command.Dir = workingDirectory
 	command.Env = environment
 	command.Stdin = stdin
 	command.Stdout = stdout
 	command.Stderr = stderr
-	started, err := runClientCommand(command)
+	started, err := runClientCommand(ctx, command)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return -1, started, ctxErr
 	}
 	if err == nil {
 		return 0, started, nil
 	}
-	if exitErr, ok := err.(*exec.ExitError); ok {
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) {
 		return exitErr.ExitCode(), started, err
 	}
 	return -1, started, err

--- a/internal/ssh/command.go
+++ b/internal/ssh/command.go
@@ -1,0 +1,43 @@
+package ssh
+
+import (
+	"context"
+	"io"
+	"os/exec"
+)
+
+// RunClientProcess runs an OpenSSH-family client with request-scoped process
+// state. Cancellation terminates the complete process tree, including proxy
+// commands started by OpenSSH.
+func RunClientProcess(
+	ctx context.Context,
+	executable string,
+	arguments []string,
+	workingDirectory string,
+	environment []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+) (int, error) {
+	resolved, err := resolveExecutable(executable, environment, workingDirectory)
+	if err != nil {
+		return -1, err
+	}
+	command := exec.CommandContext(ctx, resolved, arguments...)
+	command.Dir = workingDirectory
+	command.Env = environment
+	command.Stdin = stdin
+	command.Stdout = stdout
+	command.Stderr = stderr
+	err = runResolverCommand(command)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return -1, ctxErr
+	}
+	if err == nil {
+		return 0, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), err
+	}
+	return -1, err
+}

--- a/internal/ssh/command.go
+++ b/internal/ssh/command.go
@@ -18,10 +18,10 @@ func RunClientProcess(
 	stdin io.Reader,
 	stdout io.Writer,
 	stderr io.Writer,
-) (int, error) {
+) (int, bool, error) {
 	resolved, err := resolveExecutable(executable, environment, workingDirectory)
 	if err != nil {
-		return -1, err
+		return -1, false, err
 	}
 	command := exec.CommandContext(ctx, resolved, arguments...)
 	command.Dir = workingDirectory
@@ -29,15 +29,15 @@ func RunClientProcess(
 	command.Stdin = stdin
 	command.Stdout = stdout
 	command.Stderr = stderr
-	err = runResolverCommand(command)
+	started, err := runClientCommand(command)
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return -1, ctxErr
+		return -1, started, ctxErr
 	}
 	if err == nil {
-		return 0, nil
+		return 0, started, nil
 	}
 	if exitErr, ok := err.(*exec.ExitError); ok {
-		return exitErr.ExitCode(), err
+		return exitErr.ExitCode(), started, err
 	}
-	return -1, err
+	return -1, started, err
 }

--- a/internal/ssh/command_test.go
+++ b/internal/ssh/command_test.go
@@ -1,0 +1,46 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const clientProcessHelper = "KWT_SSH_CLIENT_PROCESS_HELPER"
+
+func TestRunClientProcessStreamsStandardIO(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode, err := RunClientProcess(
+		context.Background(),
+		os.Args[0],
+		[]string{"-test.run=^TestSSHClientProcessHelper$"},
+		t.TempDir(),
+		append(os.Environ(), clientProcessHelper+"=1"),
+		strings.NewReader("request body"),
+		&stdout,
+		&stderr,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, exitCode)
+	assert.Equal(t, "stdout:request body", stdout.String())
+	assert.Equal(t, "stderr:request body", stderr.String())
+}
+
+func TestSSHClientProcessHelper(t *testing.T) {
+	if os.Getenv(clientProcessHelper) == "" {
+		return
+	}
+	value, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = os.Stdout.WriteString("stdout:" + string(value))
+	_, _ = os.Stderr.WriteString("stderr:" + string(value))
+	os.Exit(0)
+}

--- a/internal/ssh/command_test.go
+++ b/internal/ssh/command_test.go
@@ -16,7 +16,7 @@ const clientProcessHelper = "KWT_SSH_CLIENT_PROCESS_HELPER"
 
 func TestRunClientProcessStreamsStandardIO(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	exitCode, err := RunClientProcess(
+	exitCode, started, err := RunClientProcess(
 		context.Background(),
 		os.Args[0],
 		[]string{"-test.run=^TestSSHClientProcessHelper$"},
@@ -27,9 +27,26 @@ func TestRunClientProcessStreamsStandardIO(t *testing.T) {
 		&stderr,
 	)
 	require.NoError(t, err)
+	assert.True(t, started)
 	assert.Zero(t, exitCode)
 	assert.Equal(t, "stdout:request body", stdout.String())
 	assert.Equal(t, "stderr:request body", stderr.String())
+}
+
+func TestRunClientProcessReportsExecutableLookupBeforeStart(t *testing.T) {
+	exitCode, started, err := RunClientProcess(
+		context.Background(),
+		"kwt-missing-ssh-client",
+		nil,
+		t.TempDir(),
+		[]string{"PATH="},
+		strings.NewReader(""),
+		io.Discard,
+		io.Discard,
+	)
+	require.Error(t, err)
+	assert.Equal(t, -1, exitCode)
+	assert.False(t, started)
 }
 
 func TestSSHClientProcessHelper(t *testing.T) {

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -25,6 +25,7 @@ import (
 
 const interactiveClientProcessHelper = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_HELPER"
 const interactiveClientProcessResult = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_RESULT"
+const interactiveClientProcessBackgroundStart = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_BACKGROUND_START"
 
 func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	resultPath := t.TempDir() + "/result"
@@ -113,14 +114,34 @@ func TestRunClientProcessCancellationTerminatesInteractiveDescendants(t *testing
 }
 
 func TestRunClientProcessForegroundsTerminalOutputWithNonterminalInput(t *testing.T) {
-	testRunClientProcessTerminalOutputWithNonterminalInput(t, false)
+	testRunClientProcessTerminalOutputWithNonterminalInput(t, false, false)
 }
 
 func TestRunClientProcessDoesNotStealTerminalAfterBackgroundResume(t *testing.T) {
-	testRunClientProcessTerminalOutputWithNonterminalInput(t, true)
+	testRunClientProcessTerminalOutputWithNonterminalInput(t, false, true)
 }
 
-func testRunClientProcessTerminalOutputWithNonterminalInput(t *testing.T, background bool) {
+func TestRunClientProcessDoesNotStealTerminalWhenStartedInBackground(t *testing.T) {
+	testRunClientProcessTerminalOutputWithNonterminalInput(t, true, false)
+}
+
+func TestRunClientCommandRestoresTerminalAfterStartFailure(t *testing.T) {
+	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+	command.Env = append(
+		os.Environ(),
+		interactiveClientProcessHelper+"=start-failure",
+	)
+	terminal, err := pty.Start(command)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = terminal.Close() })
+	require.NoError(t, command.Wait())
+}
+
+func testRunClientProcessTerminalOutputWithNonterminalInput(
+	t *testing.T,
+	backgroundStart bool,
+	backgroundResume bool,
+) {
 	t.Helper()
 	resultPath := t.TempDir() + "/nonterminal"
 	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
@@ -129,6 +150,9 @@ func testRunClientProcessTerminalOutputWithNonterminalInput(t *testing.T, backgr
 		interactiveClientProcessHelper+"=nonterminal-parent",
 		interactiveClientProcessResult+"="+resultPath,
 	)
+	if backgroundStart {
+		command.Env = append(command.Env, interactiveClientProcessBackgroundStart+"=1")
+	}
 	terminal, err := pty.Start(command)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -138,37 +162,54 @@ func testRunClientProcessTerminalOutputWithNonterminalInput(t *testing.T, backgr
 		}
 	})
 	require.Eventually(t, func() bool {
-		_, err := os.Stat(resultPath + ".ready")
-		return err == nil
+		_, statErr := os.Stat(resultPath + ".shell")
+		return statErr == nil
 	}, 5*time.Second, 10*time.Millisecond)
-	childGroup, err := os.ReadFile(resultPath + ".ready")
-	require.NoError(t, err)
-	childGroupID, err := strconv.Atoi(string(childGroup))
-	require.NoError(t, err)
 	shellGroup, err := os.ReadFile(resultPath + ".shell")
 	require.NoError(t, err)
 	shellGroupID, err := strconv.Atoi(string(shellGroup))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = syscall.Kill(-shellGroupID, syscall.SIGKILL) })
-	foregroundGroup, err := terminalForegroundProcessGroup(terminal)
-	require.NoError(t, err)
-	assert.Equal(t, childGroupID, foregroundGroup)
-	require.NoError(t, syscall.Kill(-childGroupID, syscall.SIGTSTP))
-	var status syscall.WaitStatus
-	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
-	require.NoError(t, err)
-	require.True(t, status.Stopped() || status.Continued())
-	if background {
+	if backgroundStart {
 		require.NoError(t, os.WriteFile(resultPath+".background", nil, 0o600))
 		require.Eventually(t, func() bool {
 			_, readyErr := os.Stat(resultPath + ".background-ready")
 			return readyErr == nil
 		}, 5*time.Second, 10*time.Millisecond)
 	}
-	require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGCONT))
-	require.NoError(t, os.WriteFile(resultPath+".continue", nil, 0o600))
-	require.NoError(t, command.Wait())
-	if background {
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(resultPath + ".ready")
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	childGroup, err := os.ReadFile(resultPath + ".ready")
+	require.NoError(t, err)
+	childGroupID, err := strconv.Atoi(string(childGroup))
+	require.NoError(t, err)
+	foregroundGroup, err := terminalForegroundProcessGroup(terminal)
+	require.NoError(t, err)
+	if backgroundStart {
+		assert.Equal(t, shellGroupID, foregroundGroup)
+		require.NoError(t, os.WriteFile(resultPath+".continue", nil, 0o600))
+		require.NoError(t, command.Wait())
+	} else {
+		assert.Equal(t, childGroupID, foregroundGroup)
+		require.NoError(t, syscall.Kill(-childGroupID, syscall.SIGTSTP))
+		var status syscall.WaitStatus
+		_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
+		require.NoError(t, err)
+		require.True(t, status.Stopped() || status.Continued())
+		if backgroundResume {
+			require.NoError(t, os.WriteFile(resultPath+".background", nil, 0o600))
+			require.Eventually(t, func() bool {
+				_, readyErr := os.Stat(resultPath + ".background-ready")
+				return readyErr == nil
+			}, 5*time.Second, 10*time.Millisecond)
+		}
+		require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGCONT))
+		require.NoError(t, os.WriteFile(resultPath+".continue", nil, 0o600))
+		require.NoError(t, command.Wait())
+	}
+	if backgroundStart || backgroundResume {
 		encodedForeground, readErr := os.ReadFile(resultPath + ".final-foreground")
 		require.NoError(t, readErr)
 		foregroundGroup, err = strconv.Atoi(string(encodedForeground))
@@ -232,6 +273,28 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 		}
 		os.Exit(0)
 	}
+	if mode == "start-failure" {
+		before, err := terminalForegroundProcessGroup(os.Stdout)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		command := exec.Command("/path/that/does/not/exist")
+		command.Stdin = os.Stdin
+		command.Stdout = os.Stdout
+		command.Stderr = os.Stderr
+		started, startErr := runClientCommand(context.Background(), command)
+		if started || startErr == nil {
+			_, _ = fmt.Fprintln(os.Stderr, "invalid start result")
+			os.Exit(1)
+		}
+		after, err := terminalForegroundProcessGroup(os.Stdout)
+		if err != nil || after != before {
+			_, _ = fmt.Fprintf(os.Stderr, "terminal changed from %d to %d: %v\n", before, after, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 	if mode == "nonterminal-child" {
 		group := []byte(strconv.Itoa(syscall.Getpgrp()))
 		resultPath := os.Getenv(interactiveClientProcessResult)
@@ -286,6 +349,16 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 		); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
+		}
+		if os.Getenv(interactiveClientProcessBackgroundStart) == "1" {
+			for {
+				if _, err := os.Stat(
+					os.Getenv(interactiveClientProcessResult) + ".background-ready",
+				); err == nil {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
 		}
 		if err := os.Setenv(interactiveClientProcessHelper, "nonterminal-child"); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -59,17 +59,9 @@ func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 			_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 		}
 	})
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(resultPath + ".ready")
-		return err == nil
-	}, 5*time.Second, 10*time.Millisecond)
-	parentGroup, err := os.ReadFile(resultPath + ".parent")
-	require.NoError(t, err)
-	childGroup, err := os.ReadFile(resultPath + ".ready")
-	require.NoError(t, err)
-	require.NotEqual(t, string(parentGroup), string(childGroup))
-	childGroupID, err := strconv.Atoi(string(childGroup))
-	require.NoError(t, err)
+	parentGroupID := waitForProcessGroupFile(t, resultPath+".parent")
+	childGroupID := waitForProcessGroupFile(t, resultPath+".ready")
+	require.NotEqual(t, parentGroupID, childGroupID)
 	require.NoError(t, syscall.Kill(-childGroupID, syscall.SIGTSTP))
 	var status syscall.WaitStatus
 	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
@@ -177,14 +169,7 @@ func testRunClientProcessTerminalOutputWithNonterminalInput(
 			_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 		}
 	})
-	require.Eventually(t, func() bool {
-		_, statErr := os.Stat(resultPath + ".shell")
-		return statErr == nil
-	}, 5*time.Second, 10*time.Millisecond)
-	shellGroup, err := os.ReadFile(resultPath + ".shell")
-	require.NoError(t, err)
-	shellGroupID, err := strconv.Atoi(string(shellGroup))
-	require.NoError(t, err)
+	shellGroupID := waitForProcessGroupFile(t, resultPath+".shell")
 	t.Cleanup(func() { _ = syscall.Kill(-shellGroupID, syscall.SIGKILL) })
 	if backgroundStart {
 		require.NoError(t, os.WriteFile(resultPath+".background", nil, 0o600))
@@ -193,14 +178,7 @@ func testRunClientProcessTerminalOutputWithNonterminalInput(
 			return readyErr == nil
 		}, 5*time.Second, 10*time.Millisecond)
 	}
-	require.Eventually(t, func() bool {
-		_, statErr := os.Stat(resultPath + ".ready")
-		return statErr == nil
-	}, 5*time.Second, 10*time.Millisecond)
-	childGroup, err := os.ReadFile(resultPath + ".ready")
-	require.NoError(t, err)
-	childGroupID, err := strconv.Atoi(string(childGroup))
-	require.NoError(t, err)
+	childGroupID := waitForProcessGroupFile(t, resultPath+".ready")
 	foregroundGroup, err := terminalForegroundProcessGroup(terminal)
 	require.NoError(t, err)
 	if backgroundStart {
@@ -232,6 +210,20 @@ func testRunClientProcessTerminalOutputWithNonterminalInput(
 		require.NoError(t, err)
 		assert.Equal(t, shellGroupID, foregroundGroup)
 	}
+}
+
+func waitForProcessGroupFile(t *testing.T, path string) int {
+	t.Helper()
+	var processGroup int
+	require.Eventually(t, func() bool {
+		encoded, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		processGroup, err = strconv.Atoi(string(encoded))
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	return processGroup
 }
 
 func TestSSHInteractiveClientProcessHelper(t *testing.T) {

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -20,7 +22,7 @@ import (
 const interactiveClientProcessHelper = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_HELPER"
 const interactiveClientProcessResult = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_RESULT"
 
-func TestRunClientProcessKeepsInteractiveTerminalReadable(t *testing.T) {
+func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	resultPath := t.TempDir() + "/result"
 	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
 	command.Env = append(
@@ -33,9 +35,24 @@ func TestRunClientProcessKeepsInteractiveTerminalReadable(t *testing.T) {
 	t.Cleanup(func() {
 		_ = terminal.Close()
 		if command.Process != nil {
-			_ = command.Process.Kill()
+			_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 		}
 	})
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(resultPath + ".ready")
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	parentGroup, err := os.ReadFile(resultPath + ".parent")
+	require.NoError(t, err)
+	childGroup, err := os.ReadFile(resultPath + ".ready")
+	require.NoError(t, err)
+	require.Equal(t, string(parentGroup), string(childGroup))
+	require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGSTOP))
+	var status syscall.WaitStatus
+	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
+	require.NoError(t, err)
+	require.True(t, status.Stopped() || status.Continued())
+	require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGCONT))
 	_, err = io.WriteString(terminal, "interactive input\n")
 	require.NoError(t, err)
 
@@ -58,6 +75,11 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 		return
 	}
 	if mode == "child" {
+		group := []byte(strconv.Itoa(syscall.Getpgrp()))
+		if err := os.WriteFile(os.Getenv(interactiveClientProcessResult)+".ready", group, 0o600); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		value, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
@@ -70,6 +92,11 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 		os.Exit(0)
 	}
 	if err := os.Setenv(interactiveClientProcessHelper, "child"); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	group := []byte(strconv.Itoa(syscall.Getpgrp()))
+	if err := os.WriteFile(os.Getenv(interactiveClientProcessResult)+".parent", group, 0o600); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
@@ -20,15 +21,10 @@ import (
 	"github.com/creack/pty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 )
 
 const interactiveClientProcessHelper = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_HELPER"
 const interactiveClientProcessResult = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_RESULT"
-
-func terminalForegroundProcessGroup(terminal *os.File) (int, error) {
-	return unix.IoctlGetInt(int(terminal.Fd()), unix.TIOCGPGRP)
-}
 
 func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	resultPath := t.TempDir() + "/result"
@@ -117,6 +113,15 @@ func TestRunClientProcessCancellationTerminatesInteractiveDescendants(t *testing
 }
 
 func TestRunClientProcessForegroundsTerminalOutputWithNonterminalInput(t *testing.T) {
+	testRunClientProcessTerminalOutputWithNonterminalInput(t, false)
+}
+
+func TestRunClientProcessDoesNotStealTerminalAfterBackgroundResume(t *testing.T) {
+	testRunClientProcessTerminalOutputWithNonterminalInput(t, true)
+}
+
+func testRunClientProcessTerminalOutputWithNonterminalInput(t *testing.T, background bool) {
+	t.Helper()
 	resultPath := t.TempDir() + "/nonterminal"
 	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
 	command.Env = append(
@@ -140,6 +145,11 @@ func TestRunClientProcessForegroundsTerminalOutputWithNonterminalInput(t *testin
 	require.NoError(t, err)
 	childGroupID, err := strconv.Atoi(string(childGroup))
 	require.NoError(t, err)
+	shellGroup, err := os.ReadFile(resultPath + ".shell")
+	require.NoError(t, err)
+	shellGroupID, err := strconv.Atoi(string(shellGroup))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = syscall.Kill(-shellGroupID, syscall.SIGKILL) })
 	foregroundGroup, err := terminalForegroundProcessGroup(terminal)
 	require.NoError(t, err)
 	assert.Equal(t, childGroupID, foregroundGroup)
@@ -148,9 +158,23 @@ func TestRunClientProcessForegroundsTerminalOutputWithNonterminalInput(t *testin
 	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
 	require.NoError(t, err)
 	require.True(t, status.Stopped() || status.Continued())
+	if background {
+		require.NoError(t, os.WriteFile(resultPath+".background", nil, 0o600))
+		require.Eventually(t, func() bool {
+			_, readyErr := os.Stat(resultPath + ".background-ready")
+			return readyErr == nil
+		}, 5*time.Second, 10*time.Millisecond)
+	}
 	require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGCONT))
 	require.NoError(t, os.WriteFile(resultPath+".continue", nil, 0o600))
 	require.NoError(t, command.Wait())
+	if background {
+		encodedForeground, readErr := os.ReadFile(resultPath + ".final-foreground")
+		require.NoError(t, readErr)
+		foregroundGroup, err = strconv.Atoi(string(encodedForeground))
+		require.NoError(t, err)
+		assert.Equal(t, shellGroupID, foregroundGroup)
+	}
 }
 
 func TestSSHInteractiveClientProcessHelper(t *testing.T) {
@@ -222,7 +246,47 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+	if mode == "shell" {
+		signal.Ignore(syscall.SIGTTOU)
+		resultPath := os.Getenv(interactiveClientProcessResult)
+		for {
+			if _, err := os.Stat(resultPath + ".background"); err == nil {
+				if err := setTerminalForeground(os.Stdout, syscall.Getpgrp()); err != nil {
+					_, _ = fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				if err := os.WriteFile(resultPath+".background-ready", nil, 0o600); err != nil {
+					_, _ = fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				select {}
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 	if mode == "nonterminal-parent" {
+		shell := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+		shell.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		shell.Env = append(
+			os.Environ(),
+			interactiveClientProcessHelper+"=shell",
+			interactiveClientProcessResult+"="+os.Getenv(interactiveClientProcessResult),
+		)
+		shell.Stdin = os.Stdin
+		shell.Stdout = os.Stdout
+		shell.Stderr = os.Stderr
+		if err := shell.Start(); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(
+			os.Getenv(interactiveClientProcessResult)+".shell",
+			[]byte(strconv.Itoa(shell.Process.Pid)),
+			0o600,
+		); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		if err := os.Setenv(interactiveClientProcessHelper, "nonterminal-child"); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -241,6 +305,21 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 			_, _ = fmt.Fprintf(os.Stderr, "exit %d: %v\n", exitCode, err)
 			os.Exit(1)
 		}
+		foregroundGroup, err := terminalForegroundProcessGroup(os.Stdout)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(
+			os.Getenv(interactiveClientProcessResult)+".final-foreground",
+			[]byte(strconv.Itoa(foregroundGroup)),
+			0o600,
+		); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		_ = syscall.Kill(-shell.Process.Pid, syscall.SIGKILL)
+		_ = shell.Wait()
 		os.Exit(0)
 	}
 	if err := os.Setenv(interactiveClientProcessHelper, "child"); err != nil {

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -27,6 +27,22 @@ const interactiveClientProcessHelper = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_HELPE
 const interactiveClientProcessResult = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_RESULT"
 const interactiveClientProcessBackgroundStart = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_BACKGROUND_START"
 
+func TestClientWaitErrorPreservesSignalExitStatus(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		signal syscall.Signal
+		want   int
+	}{
+		{name: "interrupt", signal: syscall.SIGINT, want: 130},
+		{name: "terminate", signal: syscall.SIGTERM, want: 143},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := clientWaitError{status: syscall.WaitStatus(test.signal)}
+			assert.Equal(t, test.want, err.ExitCode())
+		})
+	}
+}
+
 func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	resultPath := t.TempDir() + "/result"
 	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -19,10 +20,15 @@ import (
 	"github.com/creack/pty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 const interactiveClientProcessHelper = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_HELPER"
 const interactiveClientProcessResult = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_RESULT"
+
+func terminalForegroundProcessGroup(terminal *os.File) (int, error) {
+	return unix.IoctlGetInt(int(terminal.Fd()), unix.TIOCGPGRP)
+}
 
 func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	resultPath := t.TempDir() + "/result"
@@ -110,6 +116,43 @@ func TestRunClientProcessCancellationTerminatesInteractiveDescendants(t *testing
 	}, time.Second, 10*time.Millisecond, "interactive descendant survived cancellation")
 }
 
+func TestRunClientProcessForegroundsTerminalOutputWithNonterminalInput(t *testing.T) {
+	resultPath := t.TempDir() + "/nonterminal"
+	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+	command.Env = append(
+		os.Environ(),
+		interactiveClientProcessHelper+"=nonterminal-parent",
+		interactiveClientProcessResult+"="+resultPath,
+	)
+	terminal, err := pty.Start(command)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = terminal.Close()
+		if command.Process != nil {
+			_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		}
+	})
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(resultPath + ".ready")
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	childGroup, err := os.ReadFile(resultPath + ".ready")
+	require.NoError(t, err)
+	childGroupID, err := strconv.Atoi(string(childGroup))
+	require.NoError(t, err)
+	foregroundGroup, err := terminalForegroundProcessGroup(terminal)
+	require.NoError(t, err)
+	assert.Equal(t, childGroupID, foregroundGroup)
+	require.NoError(t, syscall.Kill(-childGroupID, syscall.SIGTSTP))
+	var status syscall.WaitStatus
+	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
+	require.NoError(t, err)
+	require.True(t, status.Stopped() || status.Continued())
+	require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGCONT))
+	require.NoError(t, os.WriteFile(resultPath+".continue", nil, 0o600))
+	require.NoError(t, command.Wait())
+}
+
 func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 	mode := os.Getenv(interactiveClientProcessHelper)
 	if mode == "" {
@@ -161,6 +204,41 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 		)
 		if !errors.Is(err, context.Canceled) {
 			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	if mode == "nonterminal-child" {
+		group := []byte(strconv.Itoa(syscall.Getpgrp()))
+		resultPath := os.Getenv(interactiveClientProcessResult)
+		if err := os.WriteFile(resultPath+".ready", group, 0o600); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		for {
+			if _, err := os.Stat(resultPath + ".continue"); err == nil {
+				os.Exit(0)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if mode == "nonterminal-parent" {
+		if err := os.Setenv(interactiveClientProcessHelper, "nonterminal-child"); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		exitCode, _, err := RunClientProcess(
+			context.Background(),
+			os.Args[0],
+			[]string{"-test.run=^TestSSHInteractiveClientProcessHelper$"},
+			"",
+			os.Environ(),
+			strings.NewReader("batch input"),
+			os.Stdout,
+			os.Stderr,
+		)
+		if err != nil || exitCode != 0 {
+			_, _ = fmt.Fprintf(os.Stderr, "exit %d: %v\n", exitCode, err)
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package ssh
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const interactiveClientProcessHelper = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_HELPER"
+const interactiveClientProcessResult = "KWT_SSH_INTERACTIVE_CLIENT_PROCESS_RESULT"
+
+func TestRunClientProcessKeepsInteractiveTerminalReadable(t *testing.T) {
+	resultPath := t.TempDir() + "/result"
+	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+	command.Env = append(
+		os.Environ(),
+		interactiveClientProcessHelper+"=parent",
+		interactiveClientProcessResult+"="+resultPath,
+	)
+	terminal, err := pty.Start(command)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = terminal.Close()
+		if command.Process != nil {
+			_ = command.Process.Kill()
+		}
+	})
+	_, err = io.WriteString(terminal, "interactive input\n")
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("interactive SSH client did not read from its terminal")
+	}
+	output, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	assert.Equal(t, "interactive input\n", string(output))
+}
+
+func TestSSHInteractiveClientProcessHelper(t *testing.T) {
+	mode := os.Getenv(interactiveClientProcessHelper)
+	if mode == "" {
+		return
+	}
+	if mode == "child" {
+		value, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(os.Getenv(interactiveClientProcessResult), []byte(value), 0o600); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	if err := os.Setenv(interactiveClientProcessHelper, "child"); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	exitCode, _, err := RunClientProcess(
+		context.Background(),
+		os.Args[0],
+		[]string{"-test.run=^TestSSHInteractiveClientProcessHelper$"},
+		"",
+		os.Environ(),
+		os.Stdin,
+		os.Stdout,
+		os.Stderr,
+	)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if exitCode != 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "exit %d\n", exitCode)
+		os.Exit(exitCode)
+	}
+	os.Exit(0)
+}

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -4,7 +4,9 @@ package ssh
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -46,8 +48,10 @@ func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	require.NoError(t, err)
 	childGroup, err := os.ReadFile(resultPath + ".ready")
 	require.NoError(t, err)
-	require.Equal(t, string(parentGroup), string(childGroup))
-	require.NoError(t, syscall.Kill(-command.Process.Pid, syscall.SIGSTOP))
+	require.NotEqual(t, string(parentGroup), string(childGroup))
+	childGroupID, err := strconv.Atoi(string(childGroup))
+	require.NoError(t, err)
+	require.NoError(t, syscall.Kill(-childGroupID, syscall.SIGTSTP))
 	var status syscall.WaitStatus
 	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
 	require.NoError(t, err)
@@ -69,6 +73,43 @@ func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	assert.Equal(t, "interactive input\n", string(output))
 }
 
+func TestRunClientProcessCancellationTerminatesInteractiveDescendants(t *testing.T) {
+	resultPath := t.TempDir() + "/cancel"
+	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+	command.Env = append(
+		os.Environ(),
+		interactiveClientProcessHelper+"=cancel-parent",
+		interactiveClientProcessResult+"="+resultPath,
+	)
+	terminal, err := pty.Start(command)
+	require.NoError(t, err)
+	var terminalOutput bytes.Buffer
+	drained := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&terminalOutput, terminal)
+		close(drained)
+	}()
+	t.Cleanup(func() {
+		_ = terminal.Close()
+		if command.Process != nil {
+			_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		}
+	})
+	waitErr := command.Wait()
+	require.NoError(t, terminal.Close())
+	<-drained
+	require.NoError(t, waitErr, terminalOutput.String())
+
+	encoded, err := os.ReadFile(resultPath + ".descendant")
+	require.NoError(t, err)
+	pid, err := strconv.Atoi(string(encoded))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	require.Eventually(t, func() bool {
+		return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+	}, time.Second, 10*time.Millisecond, "interactive descendant survived cancellation")
+}
+
 func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 	mode := os.Getenv(interactiveClientProcessHelper)
 	if mode == "" {
@@ -86,6 +127,39 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 			os.Exit(1)
 		}
 		if err := os.WriteFile(os.Getenv(interactiveClientProcessResult), []byte(value), 0o600); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	if mode == "cancel-parent" {
+		pidPath := os.Getenv(interactiveClientProcessResult) + ".descendant"
+		script := fmt.Sprintf(
+			`sleep 30 & child=$!; printf '%%s' "$child" > %s; wait`,
+			shellQuote(pidPath),
+		)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			for {
+				if _, err := os.Stat(pidPath); err == nil {
+					cancel()
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+		_, _, err := RunClientProcess(
+			ctx,
+			"/bin/sh",
+			[]string{"-c", script},
+			"",
+			os.Environ(),
+			os.Stdin,
+			os.Stdout,
+			os.Stderr,
+		)
+		if !errors.Is(err, context.Canceled) {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/internal/ssh/command_unix_test.go
+++ b/internal/ssh/command_unix_test.go
@@ -84,6 +84,46 @@ func TestRunClientProcessPreservesInteractiveTerminalJobControl(t *testing.T) {
 	assert.Equal(t, "interactive input\n", string(output))
 }
 
+func TestRunClientProcessSuspendsPipelineSiblings(t *testing.T) {
+	resultPath := t.TempDir() + "/pipeline"
+	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+	command.Env = append(
+		os.Environ(),
+		interactiveClientProcessHelper+"=pipeline-parent",
+		interactiveClientProcessResult+"="+resultPath,
+	)
+	terminal, err := pty.Start(command)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = terminal.Close()
+		if command.Process != nil {
+			_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		}
+	})
+	parentGroupID := waitForProcessGroupFile(t, resultPath+".parent")
+	siblingGroupID := waitForProcessGroupFile(t, resultPath+".sibling-group")
+	require.Equal(t, parentGroupID, siblingGroupID)
+	childGroupID := waitForProcessGroupFile(t, resultPath+".ready")
+	require.NoError(t, syscall.Kill(-childGroupID, syscall.SIGTSTP))
+	var status syscall.WaitStatus
+	_, err = syscall.Wait4(command.Process.Pid, &status, syscall.WUNTRACED, nil)
+	require.NoError(t, err)
+	require.True(t, status.Stopped() || status.Continued())
+	require.NoError(t, os.WriteFile(resultPath+".sibling-probe", nil, 0o600))
+	require.Never(t, func() bool {
+		_, statErr := os.Stat(resultPath + ".sibling-observed")
+		return statErr == nil
+	}, 250*time.Millisecond, 10*time.Millisecond)
+	require.NoError(t, syscall.Kill(-parentGroupID, syscall.SIGCONT))
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(resultPath + ".sibling-observed")
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	_, err = io.WriteString(terminal, "pipeline input\n")
+	require.NoError(t, err)
+	require.NoError(t, command.Wait())
+}
+
 func TestRunClientProcessCancellationTerminatesInteractiveDescendants(t *testing.T) {
 	resultPath := t.TempDir() + "/cancel"
 	command := exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
@@ -403,6 +443,43 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 		_ = shell.Wait()
 		os.Exit(0)
 	}
+	if mode == "pipeline-sibling" {
+		resultPath := os.Getenv(interactiveClientProcessResult)
+		if err := os.WriteFile(
+			resultPath+".sibling-group",
+			[]byte(strconv.Itoa(syscall.Getpgrp())),
+			0o600,
+		); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		for {
+			if _, err := os.Stat(resultPath + ".sibling-probe"); err == nil {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if err := os.WriteFile(resultPath+".sibling-observed", nil, 0o600); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		select {}
+	}
+	var pipelineSibling *exec.Cmd
+	if mode == "pipeline-parent" {
+		pipelineSibling = exec.Command(os.Args[0], "-test.run=^TestSSHInteractiveClientProcessHelper$")
+		pipelineSibling.Env = append(
+			os.Environ(),
+			interactiveClientProcessHelper+"=pipeline-sibling",
+		)
+		pipelineSibling.Stdin = os.Stdin
+		pipelineSibling.Stdout = os.Stdout
+		pipelineSibling.Stderr = os.Stderr
+		if err := pipelineSibling.Start(); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
 	if err := os.Setenv(interactiveClientProcessHelper, "child"); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -429,6 +506,10 @@ func TestSSHInteractiveClientProcessHelper(t *testing.T) {
 	if exitCode != 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "exit %d\n", exitCode)
 		os.Exit(exitCode)
+	}
+	if pipelineSibling != nil {
+		_ = pipelineSibling.Process.Kill()
+		_ = pipelineSibling.Wait()
 	}
 	os.Exit(0)
 }

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -32,13 +32,12 @@ func runResolverCommand(command *exec.Cmd) error {
 }
 
 func runClientCommand(ctx context.Context, command *exec.Cmd) (bool, error) {
-	terminal, interactive := command.Stdin.(*os.File)
-	interactive = interactive && term.IsTerminal(int(terminal.Fd()))
+	terminal, terminalBacked := clientTerminal(command)
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if interactive {
+	if terminalBacked {
 		terminalForegroundMu.Lock()
 		defer terminalForegroundMu.Unlock()
 		signal.Ignore(syscall.SIGTTOU)
@@ -49,7 +48,7 @@ func runClientCommand(ctx context.Context, command *exec.Cmd) (bool, error) {
 	if err := command.Start(); err != nil {
 		return false, err
 	}
-	if interactive {
+	if terminalBacked {
 		defer command.Process.Release() //nolint:errcheck // wait4 below owns reaping.
 	}
 	cancelDone := make(chan struct{})
@@ -66,10 +65,21 @@ func runClientCommand(ctx context.Context, command *exec.Cmd) (bool, error) {
 		case <-cancelDone:
 		}
 	}()
-	if !interactive {
+	if !terminalBacked {
 		return true, command.Wait()
 	}
 	return true, waitInteractiveClient(command, terminal)
+}
+
+func clientTerminal(command *exec.Cmd) (*os.File, bool) {
+	streams := []any{command.Stdin, command.Stdout, command.Stderr}
+	for _, stream := range streams {
+		file, ok := stream.(*os.File)
+		if ok && term.IsTerminal(int(file.Fd())) {
+			return file, true
+		}
+	}
+	return nil, false
 }
 
 func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -3,40 +3,150 @@
 package ssh
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
+	"sync"
 	"syscall"
 
+	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
-func runResolverCommand(command *exec.Cmd) error {
-	_, err := runClientCommand(command)
-	return err
+var terminalForegroundMu sync.Mutex
+
+func newClientCommand(_ context.Context, executable string, arguments ...string) *exec.Cmd {
+	return exec.Command(executable, arguments...)
 }
 
-func runClientCommand(command *exec.Cmd) (bool, error) {
+func runResolverCommand(command *exec.Cmd) error {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error { return killProcessGroup(command) }
+	if err := command.Start(); err != nil {
+		return err
+	}
+	return command.Wait()
+}
+
+func runClientCommand(ctx context.Context, command *exec.Cmd) (bool, error) {
 	terminal, interactive := command.Stdin.(*os.File)
 	interactive = interactive && term.IsTerminal(int(terminal.Fd()))
-	if !interactive {
-		command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := ctx.Err(); err != nil {
+		return false, err
 	}
-	command.Cancel = func() error {
-		if command.Process == nil {
-			return os.ErrProcessDone
-		}
-		if interactive {
-			return command.Process.Kill()
-		}
-		err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
-		if errors.Is(err, syscall.ESRCH) {
-			return os.ErrProcessDone
-		}
-		return err
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if interactive {
+		terminalForegroundMu.Lock()
+		defer terminalForegroundMu.Unlock()
+		signal.Ignore(syscall.SIGTTOU)
+		defer signal.Reset(syscall.SIGTTOU)
+		command.SysProcAttr.Foreground = true
+		command.SysProcAttr.Ctty = int(terminal.Fd())
 	}
 	if err := command.Start(); err != nil {
 		return false, err
 	}
-	return true, command.Wait()
+	if interactive {
+		defer command.Process.Release() //nolint:errcheck // wait4 below owns reaping.
+	}
+	cancelDone := make(chan struct{})
+	cancelStopped := make(chan struct{})
+	defer func() {
+		close(cancelDone)
+		<-cancelStopped
+	}()
+	go func() {
+		defer close(cancelStopped)
+		select {
+		case <-ctx.Done():
+			_ = killProcessGroup(command)
+		case <-cancelDone:
+		}
+	}()
+	if !interactive {
+		return true, command.Wait()
+	}
+	return true, waitInteractiveClient(command, terminal)
+}
+
+func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
+	parentGroup := syscall.Getpgrp()
+	childGroup := command.Process.Pid
+	defer func() {
+		_ = setTerminalForeground(terminal, parentGroup)
+	}()
+	for {
+		var status syscall.WaitStatus
+		_, err := syscall.Wait4(
+			command.Process.Pid,
+			&status,
+			syscall.WUNTRACED,
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+		switch {
+		case status.Stopped():
+			if err := setTerminalForeground(terminal, parentGroup); err != nil {
+				return fmt.Errorf("restore terminal before suspension: %w", err)
+			}
+			// SIGSTOP is not discarded for an orphaned process group, which
+			// matters for terminal emulators and PTY owners without a shell in
+			// the same session. The shell still observes kwt as stopped and can
+			// resume it with the ordinary foreground-job path.
+			if err := syscall.Kill(os.Getpid(), syscall.SIGSTOP); err != nil {
+				return fmt.Errorf("suspend SSH client owner: %w", err)
+			}
+			if err := setTerminalForeground(terminal, childGroup); err != nil {
+				return fmt.Errorf("restore SSH client foreground process group: %w", err)
+			}
+			if err := syscall.Kill(-childGroup, syscall.SIGCONT); err != nil && !errors.Is(err, syscall.ESRCH) {
+				return fmt.Errorf("continue SSH client process group: %w", err)
+			}
+		case status.Exited():
+			if status.ExitStatus() == 0 {
+				return nil
+			}
+			return clientWaitError{status: status}
+		case status.Signaled():
+			return clientWaitError{status: status}
+		}
+	}
+}
+
+func setTerminalForeground(terminal *os.File, processGroup int) error {
+	return unix.IoctlSetPointerInt(
+		int(terminal.Fd()), unix.TIOCSPGRP, processGroup,
+	)
+}
+
+func killProcessGroup(command *exec.Cmd) error {
+	if command.Process == nil {
+		return os.ErrProcessDone
+	}
+	err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return os.ErrProcessDone
+	}
+	return err
+}
+
+type clientWaitError struct{ status syscall.WaitStatus }
+
+func (e clientWaitError) Error() string {
+	if e.status.Signaled() {
+		return fmt.Sprintf("SSH client terminated by signal %s", e.status.Signal())
+	}
+	return fmt.Sprintf("SSH client exited with status %d", e.status.ExitStatus())
+}
+
+func (e clientWaitError) ExitCode() int {
+	if e.status.Exited() {
+		return e.status.ExitStatus()
+	}
+	return -1
 }

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -37,13 +37,25 @@ func runClientCommand(ctx context.Context, command *exec.Cmd) (bool, error) {
 		return false, err
 	}
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	ownerGroup := syscall.Getpgrp()
+	childForeground := false
+	restoreGroup := 0
 	if terminalBacked {
 		terminalForegroundMu.Lock()
 		defer terminalForegroundMu.Unlock()
 		signal.Ignore(syscall.SIGTTOU)
 		defer signal.Reset(syscall.SIGTTOU)
-		command.SysProcAttr.Foreground = true
-		command.SysProcAttr.Ctty = int(terminal.Fd())
+		foregroundGroup, err := terminalForegroundProcessGroup(terminal)
+		if err != nil {
+			return false, fmt.Errorf("inspect terminal before SSH client start: %w", err)
+		}
+		restoreGroup = foregroundGroup
+		defer func() { _ = setTerminalForeground(terminal, restoreGroup) }()
+		if foregroundGroup == ownerGroup {
+			command.SysProcAttr.Foreground = true
+			command.SysProcAttr.Ctty = int(terminal.Fd())
+			childForeground = true
+		}
 	}
 	if err := command.Start(); err != nil {
 		return false, err
@@ -68,7 +80,13 @@ func runClientCommand(ctx context.Context, command *exec.Cmd) (bool, error) {
 	if !terminalBacked {
 		return true, command.Wait()
 	}
-	return true, waitInteractiveClient(command, terminal)
+	return true, waitInteractiveClient(
+		command,
+		terminal,
+		ownerGroup,
+		childForeground,
+		&restoreGroup,
+	)
 }
 
 func clientTerminal(command *exec.Cmd) (*os.File, bool) {
@@ -82,15 +100,14 @@ func clientTerminal(command *exec.Cmd) (*os.File, bool) {
 	return nil, false
 }
 
-func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
-	parentGroup := syscall.Getpgrp()
+func waitInteractiveClient(
+	command *exec.Cmd,
+	terminal *os.File,
+	ownerGroup int,
+	childForeground bool,
+	restoreGroup *int,
+) error {
 	childGroup := command.Process.Pid
-	childForeground := true
-	defer func() {
-		if childForeground {
-			_ = setTerminalForeground(terminal, parentGroup)
-		}
-	}()
 	for {
 		var status syscall.WaitStatus
 		_, err := syscall.Wait4(
@@ -105,7 +122,7 @@ func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
 		switch {
 		case status.Stopped():
 			if childForeground {
-				if err := setTerminalForeground(terminal, parentGroup); err != nil {
+				if err := setTerminalForeground(terminal, ownerGroup); err != nil {
 					return fmt.Errorf("restore terminal before suspension: %w", err)
 				}
 				childForeground = false
@@ -121,7 +138,8 @@ func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
 			if err != nil {
 				return fmt.Errorf("inspect terminal after SSH client resume: %w", err)
 			}
-			if foregroundGroup == parentGroup {
+			*restoreGroup = foregroundGroup
+			if foregroundGroup == ownerGroup {
 				if err := setTerminalForeground(terminal, childGroup); err != nil {
 					return fmt.Errorf("restore SSH client foreground process group: %w", err)
 				}

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -85,8 +85,11 @@ func clientTerminal(command *exec.Cmd) (*os.File, bool) {
 func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
 	parentGroup := syscall.Getpgrp()
 	childGroup := command.Process.Pid
+	childForeground := true
 	defer func() {
-		_ = setTerminalForeground(terminal, parentGroup)
+		if childForeground {
+			_ = setTerminalForeground(terminal, parentGroup)
+		}
 	}()
 	for {
 		var status syscall.WaitStatus
@@ -101,8 +104,11 @@ func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
 		}
 		switch {
 		case status.Stopped():
-			if err := setTerminalForeground(terminal, parentGroup); err != nil {
-				return fmt.Errorf("restore terminal before suspension: %w", err)
+			if childForeground {
+				if err := setTerminalForeground(terminal, parentGroup); err != nil {
+					return fmt.Errorf("restore terminal before suspension: %w", err)
+				}
+				childForeground = false
 			}
 			// SIGSTOP is not discarded for an orphaned process group, which
 			// matters for terminal emulators and PTY owners without a shell in
@@ -111,8 +117,15 @@ func waitInteractiveClient(command *exec.Cmd, terminal *os.File) error {
 			if err := syscall.Kill(os.Getpid(), syscall.SIGSTOP); err != nil {
 				return fmt.Errorf("suspend SSH client owner: %w", err)
 			}
-			if err := setTerminalForeground(terminal, childGroup); err != nil {
-				return fmt.Errorf("restore SSH client foreground process group: %w", err)
+			foregroundGroup, err := terminalForegroundProcessGroup(terminal)
+			if err != nil {
+				return fmt.Errorf("inspect terminal after SSH client resume: %w", err)
+			}
+			if foregroundGroup == parentGroup {
+				if err := setTerminalForeground(terminal, childGroup); err != nil {
+					return fmt.Errorf("restore SSH client foreground process group: %w", err)
+				}
+				childForeground = true
 			}
 			if err := syscall.Kill(-childGroup, syscall.SIGCONT); err != nil && !errors.Is(err, syscall.ESRCH) {
 				return fmt.Errorf("continue SSH client process group: %w", err)
@@ -132,6 +145,10 @@ func setTerminalForeground(terminal *os.File, processGroup int) error {
 	return unix.IoctlSetPointerInt(
 		int(terminal.Fd()), unix.TIOCSPGRP, processGroup,
 	)
+}
+
+func terminalForegroundProcessGroup(terminal *os.File) (int, error) {
+	return unix.IoctlGetInt(int(terminal.Fd()), unix.TIOCGPGRP)
 }
 
 func killProcessGroup(command *exec.Cmd) error {

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -4,18 +4,12 @@ package ssh
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
-	"sync"
 	"syscall"
 
-	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
-
-var terminalForegroundMu sync.Mutex
 
 func runResolverCommand(command *exec.Cmd) error {
 	_, err := runClientCommand(command)
@@ -25,20 +19,15 @@ func runResolverCommand(command *exec.Cmd) error {
 func runClientCommand(command *exec.Cmd) (bool, error) {
 	terminal, interactive := command.Stdin.(*os.File)
 	interactive = interactive && term.IsTerminal(int(terminal.Fd()))
-	if interactive {
-		terminalForegroundMu.Lock()
-		defer terminalForegroundMu.Unlock()
-		signal.Ignore(syscall.SIGTTOU)
-		defer signal.Reset(syscall.SIGTTOU)
-		command.SysProcAttr = &syscall.SysProcAttr{
-			Setpgid: true, Foreground: true, Ctty: int(terminal.Fd()),
-		}
-	} else {
+	if !interactive {
 		command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}
 	command.Cancel = func() error {
 		if command.Process == nil {
 			return os.ErrProcessDone
+		}
+		if interactive {
+			return command.Process.Kill()
 		}
 		err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 		if errors.Is(err, syscall.ESRCH) {
@@ -49,13 +38,5 @@ func runClientCommand(command *exec.Cmd) (bool, error) {
 	if err := command.Start(); err != nil {
 		return false, err
 	}
-	err := command.Wait()
-	if interactive {
-		if restoreErr := unix.IoctlSetPointerInt(
-			int(terminal.Fd()), unix.TIOCSPGRP, syscall.Getpgrp(),
-		); restoreErr != nil && err == nil {
-			err = fmt.Errorf("restore terminal foreground process group: %w", restoreErr)
-		}
-	}
-	return true, err
+	return true, command.Wait()
 }

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -4,10 +4,18 @@ package ssh
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
+	"sync"
 	"syscall"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 )
+
+var terminalForegroundMu sync.Mutex
 
 func runResolverCommand(command *exec.Cmd) error {
 	_, err := runClientCommand(command)
@@ -15,7 +23,19 @@ func runResolverCommand(command *exec.Cmd) error {
 }
 
 func runClientCommand(command *exec.Cmd) (bool, error) {
-	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	terminal, interactive := command.Stdin.(*os.File)
+	interactive = interactive && term.IsTerminal(int(terminal.Fd()))
+	if interactive {
+		terminalForegroundMu.Lock()
+		defer terminalForegroundMu.Unlock()
+		signal.Ignore(syscall.SIGTTOU)
+		defer signal.Reset(syscall.SIGTTOU)
+		command.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true, Foreground: true, Ctty: int(terminal.Fd()),
+		}
+	} else {
+		command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 	command.Cancel = func() error {
 		if command.Process == nil {
 			return os.ErrProcessDone
@@ -29,5 +49,13 @@ func runClientCommand(command *exec.Cmd) (bool, error) {
 	if err := command.Start(); err != nil {
 		return false, err
 	}
-	return true, command.Wait()
+	err := command.Wait()
+	if interactive {
+		if restoreErr := unix.IoctlSetPointerInt(
+			int(terminal.Fd()), unix.TIOCSPGRP, syscall.Getpgrp(),
+		); restoreErr != nil && err == nil {
+			err = fmt.Errorf("restore terminal foreground process group: %w", restoreErr)
+		}
+	}
+	return true, err
 }

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -10,6 +10,11 @@ import (
 )
 
 func runResolverCommand(command *exec.Cmd) error {
+	_, err := runClientCommand(command)
+	return err
+}
+
+func runClientCommand(command *exec.Cmd) (bool, error) {
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	command.Cancel = func() error {
 		if command.Process == nil {
@@ -21,5 +26,8 @@ func runResolverCommand(command *exec.Cmd) error {
 		}
 		return err
 	}
-	return command.Run()
+	if err := command.Start(); err != nil {
+		return false, err
+	}
+	return true, command.Wait()
 }

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -129,10 +129,10 @@ func waitInteractiveClient(
 			}
 			// SIGSTOP is not discarded for an orphaned process group, which
 			// matters for terminal emulators and PTY owners without a shell in
-			// the same session. The shell still observes kwt as stopped and can
-			// resume it with the ordinary foreground-job path.
-			if err := syscall.Kill(os.Getpid(), syscall.SIGSTOP); err != nil {
-				return fmt.Errorf("suspend SSH client owner: %w", err)
+			// the same session. Stop the complete shell job so pipeline siblings
+			// cannot keep running while kwt is suspended.
+			if err := syscall.Kill(-ownerGroup, syscall.SIGSTOP); err != nil {
+				return fmt.Errorf("suspend SSH client owner group: %w", err)
 			}
 			foregroundGroup, err := terminalForegroundProcessGroup(terminal)
 			if err != nil {

--- a/internal/ssh/process_unix.go
+++ b/internal/ssh/process_unix.go
@@ -193,5 +193,8 @@ func (e clientWaitError) ExitCode() int {
 	if e.status.Exited() {
 		return e.status.ExitStatus()
 	}
+	if e.status.Signaled() {
+		return 128 + int(e.status.Signal())
+	}
 	return -1
 }

--- a/internal/ssh/process_windows.go
+++ b/internal/ssh/process_windows.go
@@ -15,9 +15,14 @@ import (
 )
 
 func runResolverCommand(command *exec.Cmd) error {
+	_, err := runClientCommand(command)
+	return err
+}
+
+func runClientCommand(command *exec.Cmd) (bool, error) {
 	job, err := windows.CreateJobObject(nil, nil)
 	if err != nil {
-		return fmt.Errorf("create resolver job: %w", err)
+		return false, fmt.Errorf("create resolver job: %w", err)
 	}
 	var closeJobOnce sync.Once
 	closeJob := func() {
@@ -35,7 +40,7 @@ func runResolverCommand(command *exec.Cmd) error {
 		uintptr(unsafe.Pointer(&limits)),
 		uint32(unsafe.Sizeof(limits)),
 	); err != nil {
-		return fmt.Errorf("configure resolver job: %w", err)
+		return false, fmt.Errorf("configure resolver job: %w", err)
 	}
 
 	if command.SysProcAttr == nil {
@@ -50,7 +55,7 @@ func runResolverCommand(command *exec.Cmd) error {
 		return command.Process.Kill()
 	}
 	if err := command.Start(); err != nil {
-		return err
+		return false, err
 	}
 	setupComplete := false
 	defer func() {
@@ -68,7 +73,7 @@ func runResolverCommand(command *exec.Cmd) error {
 		uint32(command.Process.Pid),
 	)
 	if err != nil {
-		return fmt.Errorf("open resolver process: %w", err)
+		return true, fmt.Errorf("open resolver process: %w", err)
 	}
 	processOpen := true
 	defer func() {
@@ -77,10 +82,10 @@ func runResolverCommand(command *exec.Cmd) error {
 		}
 	}()
 	if err := windows.AssignProcessToJobObject(job, process); err != nil {
-		return fmt.Errorf("assign resolver job: %w", err)
+		return true, fmt.Errorf("assign resolver job: %w", err)
 	}
 	if err := resumeResolverProcess(uint32(command.Process.Pid)); err != nil {
-		return err
+		return true, err
 	}
 
 	setupComplete = true
@@ -90,7 +95,7 @@ func runResolverCommand(command *exec.Cmd) error {
 		_ = windows.CloseHandle(process)
 		closeJob()
 	}()
-	return command.Wait()
+	return true, command.Wait()
 }
 
 func resumeResolverProcess(processID uint32) error {

--- a/internal/ssh/process_windows.go
+++ b/internal/ssh/process_windows.go
@@ -3,6 +3,7 @@
 package ssh
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -14,12 +15,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+func newClientCommand(ctx context.Context, executable string, arguments ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, executable, arguments...)
+}
+
 func runResolverCommand(command *exec.Cmd) error {
-	_, err := runClientCommand(command)
+	_, err := runClientCommand(context.Background(), command)
 	return err
 }
 
-func runClientCommand(command *exec.Cmd) (bool, error) {
+func runClientCommand(_ context.Context, command *exec.Cmd) (bool, error) {
 	job, err := windows.CreateJobObject(nil, nil)
 	if err != nil {
 		return false, fmt.Errorf("create resolver job: %w", err)


### PR DESCRIPTION
Native consumers currently receive private OpenSSH connection arguments and must reconstruct command and copy invocations themselves. This moves short-lived execution behind a command-intent boundary so kwt owns the complete SSH lifecycle.

- Add `kwt ssh exec` and `kwt ssh copy`, with route resolution and lease acquisition performed in one foreground invocation.
- Stream SSH/SFTP output unchanged and preserve child exit status; emit machine-readable envelopes only before the client starts.
- Heartbeat the daemon lease for the complete child lifetime and release it under a separate cleanup deadline.
- Keep unattended commands strict and noninteractive, returning stable SSH errors instead of accepting host keys or opening a fallback route.
- Transfer exact local files through SFTP: source paths become absolute literals, batch metacharacters are escaped, and generated control paths use SSH-config quoting.
- Preserve explicit route-identity acquisition for long-lived or conditionally reviewed presentation leases.
- Leave grouped discovery and identity-bound destructive operations on explicit leases until those higher-level contracts exist.

Ghosthub's isolated Docker contract exercised this revision through direct and two-hop ProxyJump routes and confirmed command execution reached the target host.
