### PR TITLE
Bind SSH execution to a reviewed route

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -252,6 +252,9 @@ fail-closed control-socket behavior. Remote stdout and stderr are streamed as
 they arrive; connection progress is streamed to stderr unless `--quiet` is
 set. An OpenSSH or SFTP exit status is preserved, including SSH's status 255,
 while failures before client execution keep kwt's stable typed error surface.
+Destructive callers can pass `kwt ssh exec --route-identity <reviewed>` to
+require the same route they previously reviewed; route drift fails as
+`ssh_configuration_changed` before the remote command starts.
 Machine callers add `--json`: a kwt failure before SSH or SFTP starts writes the
 shared error envelope to stdout, while successful client execution continues
 to stream the remote command's unmodified output. Cleanup failures after the

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -34,6 +34,7 @@ var (
 	sshLeaseHostKeyPolicy    string
 	sshExecUser              string
 	sshExecPort              int
+	sshExecRouteIdentity     string
 	sshExecHostKeyPolicy     string
 	sshExecQuiet             bool
 	sshExecJSON              bool
@@ -164,6 +165,9 @@ func init() {
 	sshExecCmd.Flags().StringVar(&sshExecUser, "user", "", "Override the SSH user")
 	sshExecCmd.Flags().IntVar(&sshExecPort, "port", 0, "Override the SSH port")
 	sshExecCmd.Flags().StringVar(
+		&sshExecRouteIdentity, "route-identity", "", "Require this resolved SSH route identity",
+	)
+	sshExecCmd.Flags().StringVar(
 		&sshExecHostKeyPolicy, "host-key-policy", string(kwt.SSHHostKeyPolicyStrict),
 		"Host-key handling: review or strict",
 	)
@@ -201,7 +205,8 @@ func runSSHExec(cmd *cobra.Command, args []string) (returnErr error) {
 	clientStarted := false
 	target := kwt.SSHTarget{Hostname: args[0], User: sshExecUser, Port: sshExecPort}
 	snapshot, result, control, err := acquireShortSSHLease(
-		cmd, target, kwt.SSHHostKeyPolicy(sshExecHostKeyPolicy), sshExecQuiet,
+		cmd, target, kwt.SSHHostKeyPolicy(sshExecHostKeyPolicy),
+		sshExecRouteIdentity, sshExecQuiet,
 	)
 	if err != nil {
 		return writeSSHClientFailure(cmd, "ssh exec", sshExecJSON, err)
@@ -244,7 +249,7 @@ func runSSHCopy(cmd *cobra.Command, args []string) (returnErr error) {
 	clientStarted := false
 	target := kwt.SSHTarget{Hostname: args[0], User: sshCopyUser, Port: sshCopyPort}
 	snapshot, result, control, err := acquireShortSSHLease(
-		cmd, target, kwt.SSHHostKeyPolicy(sshCopyHostKeyPolicy), sshCopyQuiet,
+		cmd, target, kwt.SSHHostKeyPolicy(sshCopyHostKeyPolicy), "", sshCopyQuiet,
 	)
 	if err != nil {
 		return writeSSHClientFailure(cmd, "ssh copy", sshCopyJSON, err)
@@ -293,12 +298,22 @@ func acquireShortSSHLease(
 	cmd *cobra.Command,
 	target kwt.SSHTarget,
 	policy kwt.SSHHostKeyPolicy,
+	expectedRouteIdentity string,
 	quiet bool,
 ) (kwt.SSHRouteSnapshot, kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
 	ctx := commandContext(cmd)
 	snapshot, err := resolveSSHThroughDaemon(ctx, kwt.SSHResolveRequest{Target: target})
 	if err != nil {
 		return kwt.SSHRouteSnapshot{}, kwtdaemon.SSHLeaseResult{}, nil, err
+	}
+	if expectedRouteIdentity != "" && snapshot.RouteIdentity != expectedRouteIdentity {
+		return kwt.SSHRouteSnapshot{}, kwtdaemon.SSHLeaseResult{}, nil, service.NewError(
+			service.SSHConfigurationChanged,
+			"SSH configuration changed",
+			true,
+			nil,
+			nil,
+		)
 	}
 	callbacks := kwtdaemon.OperationCallbacks{Event: func(event service.OperationEvent) error {
 		if quiet {

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -379,6 +379,42 @@ func TestSSHExecHoldsLeaseWhileClientRuns(t *testing.T) {
 	assert.Equal(t, int32(1), control.releases.Load())
 }
 
+func TestSSHExecRejectsChangedReviewedRouteBeforeAcquisition(t *testing.T) {
+	oldResolve := resolveSSHThroughDaemon
+	oldAcquire := acquireSSHLeaseThroughDaemon
+	t.Cleanup(func() {
+		resolveSSHThroughDaemon = oldResolve
+		acquireSSHLeaseThroughDaemon = oldAcquire
+		require.NoError(t, sshExecCmd.Flags().Set("route-identity", ""))
+	})
+	require.NoError(t, sshExecCmd.Flags().Set("route-identity", "reviewed-route"))
+	resolveSSHThroughDaemon = func(
+		_ context.Context,
+		request kwt.SSHResolveRequest,
+	) (kwt.SSHRouteSnapshot, error) {
+		return kwt.SSHRouteSnapshot{
+			LogicalTarget: request.Target,
+			RouteIdentity: "changed-route",
+		}, nil
+	}
+	acquired := false
+	acquireSSHLeaseThroughDaemon = func(
+		context.Context,
+		kwt.SSHLeaseRequest,
+		kwtdaemon.OperationCallbacks,
+	) (kwtdaemon.SSHLeaseResult, sshLeaseControl, error) {
+		acquired = true
+		return kwtdaemon.SSHLeaseResult{}, nil, nil
+	}
+	command, _, _ := sshResolveTestCommand()
+
+	err := runSSHExec(command, []string{"build.example.test", "true"})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.SSHConfigurationChanged))
+	assert.False(t, acquired)
+}
+
 func TestSSHExecDoesNotStartClientWhenLeaseHoldFails(t *testing.T) {
 	oldRun := runSSHClientProcess
 	t.Cleanup(func() {


### PR DESCRIPTION
- Add `kwt ssh exec --route-identity` for conditionally reviewed commands.
- Reject route drift before acquiring a lease or starting the remote command.
- Keep the existing daemon snapshot revalidation authoritative during acquisition.
- Preserve the current v1 SSH lifecycle and error contract.