### PR TITLE
Allow PR reimport after worktree removal

### DIFF
--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -326,15 +326,18 @@ An imported list result adds the canonical workspace record:
 
 ## Import contract
 
-kwt chooses the deterministic local branch name and delegates remote
-selection, fetch, no-checkout worktree creation, materialization, and push
-routing to Kit. When the source branch is reachable, plain `git push` updates
+kwt chooses a deterministic local branch name for the initial import and
+delegates remote selection, fetch, no-checkout worktree creation,
+materialization, and push routing to Kit. If the recorded worktree was removed
+but its branch was preserved, another import creates a disambiguated branch
+and updates the PR's provenance to the new worktree. The preserved branch is
+left untouched. When the source branch is reachable, plain `git push` updates
 exactly the PR's original head branch. If Kit cannot establish that exact fork
 tracking, or KWT cannot validate it, import fails and rolls back the worktree
 instead of leaving a checkout whose plain push could fall back to the base
-repository. Unlike an ordinary `kwt add`, PR import does not apply
-`copy_files` or `setup_commands`; run any desired project setup explicitly
-after reviewing the imported files.
+repository. Unlike an ordinary `kwt add`, PR import does not apply `copy_files`
+or `setup_commands`; run any desired project setup explicitly after reviewing
+the imported files.
 When Kit creates a fork remote, it preserves the project's working push
 authentication transport, including SSH host aliases and explicit ports. KWT
 then verifies the effective push destination and rejects broader push behavior

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"go.kenn.io/kwt/internal/template"
 	"go.kenn.io/kwt/internal/tmux"
 	repositoryurl "go.kenn.io/kwt/internal/url"
 	"go.kenn.io/kwt/internal/utils"
@@ -126,7 +127,10 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 		return result, NewError(CodeInaccessibleHead, "pull-request head repository or branch is unavailable", false, nil)
 	}
 	pr.Source.IsFork = !EqualRepositoryIdentity(pr.Source.Repository.Identity, pr.Repository.Identity)
-	branch := importBranchName(pr)
+	branch, err := s.importBranch(ctx, project, pr)
+	if err != nil {
+		return result, err
+	}
 	if coordinator, ok := s.backend.(WorkspaceCreationCoordinator); ok {
 		release, acquireErr := coordinator.AcquireWorkspaceCreation(ctx, branch)
 		if acquireErr != nil {
@@ -161,6 +165,19 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 		byPath := make(map[string]Workspace, len(workspaces))
 		for _, workspace := range workspaces {
 			byPath[utils.CanonicalPath(workspace.Path)] = workspace
+		}
+		if currentBranch := s.importBranchFromState(
+			records,
+			byPath,
+			project,
+			pr,
+		); currentBranch != branch {
+			return NewError(
+				CodeConflict,
+				"pull-request import state changed; retry the import",
+				true,
+				nil,
+			)
 		}
 		recordKey, record, ok := s.findProvenance(records, pr)
 		if ok {
@@ -261,6 +278,67 @@ func (s *Service) Import(ctx context.Context, project Project, selector string) 
 		return ImportResult{}, AsError(err, CodeWorkspaceCreation, "pull-request import failed")
 	}
 	return result, err
+}
+
+func (s *Service) importBranch(
+	ctx context.Context,
+	project Project,
+	pr PullRequest,
+) (string, error) {
+	workspaces, err := s.backend.ListWorkspaces(ctx)
+	if err != nil {
+		return "", NewError(
+			CodeWorkspaceCreation,
+			"failed to inspect project workspaces",
+			false,
+			err,
+		)
+	}
+	byPath := make(map[string]Workspace, len(workspaces))
+	for _, workspace := range workspaces {
+		byPath[utils.CanonicalPath(workspace.Path)] = workspace
+	}
+	records := make(map[string]Provenance)
+	if err := s.store.View(ctx, func(current map[string]Provenance) error {
+		for key, record := range current {
+			records[key] = record
+		}
+		return nil
+	}); err != nil {
+		return "", NewError(
+			CodeWorkspaceCreation,
+			"failed to read pull-request provenance",
+			false,
+			err,
+		)
+	}
+	return s.importBranchFromState(records, byPath, project, pr), nil
+}
+
+func (s *Service) importBranchFromState(
+	records map[string]Provenance,
+	byPath map[string]Workspace,
+	project Project,
+	pr PullRequest,
+) string {
+	_, record, ok := s.findProvenance(records, pr)
+	if !ok || !s.sameProjectClone(record, project) {
+		return importBranchName(pr)
+	}
+	if workspace, live := matchingProvenanceWorkspace(byPath, record); live {
+		return workspace.Branch
+	}
+	return reassociationBranchName(pr, record.Workspace)
+}
+
+func reassociationBranchName(pr PullRequest, workspace Workspace) string {
+	association := strings.Join([]string{
+		workspace.ID,
+		workspace.Branch,
+		utils.CanonicalPath(workspace.Path),
+		workspace.Generation,
+	}, "\x00")
+	return importBranchName(pr) + "-" + template.ShortHash(association)
 }
 
 func (s *Service) findProvenance(

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -639,6 +639,68 @@ func TestImportIsIdempotent(t *testing.T) {
 	assert.Equal(t, 1, backend.createCalls)
 }
 
+func TestImportReassociatesAfterWorktreeRemovalPreservesBranch(t *testing.T) {
+	pr := testPR(43, false)
+	repositoryPath, backend := newBackendRepo(t)
+	service := newTestService(
+		&fakeProvider{prs: []PullRequest{pr}},
+		backend,
+		newMemoryStore(),
+	)
+	var preservedBranch string
+	originalCreate := createMergeRequestWorktree
+	createMergeRequestWorktree = func(
+		ctx context.Context,
+		opts managedworktree.MergeRequestWorktreeOptions,
+	) (managedworktree.CreateWorktreeResult, error) {
+		if opts.Branch == preservedBranch {
+			return managedworktree.CreateWorktreeResult{},
+				managedworktree.ErrBranchAlreadyExists
+		}
+		created, err := managedworktree.CreateWorktreeOnDisk(
+			ctx,
+			managedworktree.CreateWorktreeOptions{
+				ProjectRoot: opts.ProjectRoot,
+				Path:        opts.Path,
+				Branch:      opts.Branch,
+				BaseRef:     "HEAD",
+				Runner:      opts.Runner,
+			},
+		)
+		if err != nil {
+			return created, err
+		}
+		runGit(t, created.Path, "config", "branch."+opts.Branch+".remote", "origin")
+		runGit(t, created.Path, "config", "branch."+opts.Branch+".merge", "refs/heads/"+pr.Source.Name)
+		runGit(t, created.Path, "config", "branch."+opts.Branch+".pushRemote", "origin")
+		runGit(t, created.Path, "config", "push.default", "upstream")
+		return created, nil
+	}
+	t.Cleanup(func() { createMergeRequestWorktree = originalCreate })
+
+	first, err := service.Import(t.Context(), testProject(), "43")
+	require.NoError(t, err)
+	preservedBranch = first.Workspace.Branch
+	runGit(t, repositoryPath, "worktree", "remove", "--force", first.Workspace.Path)
+	assert.NoDirExists(t, first.Workspace.Path)
+	runGit(t, repositoryPath, "show-ref", "--verify", "refs/heads/"+preservedBranch)
+
+	second, err := service.Import(t.Context(), testProject(), "43")
+
+	require.NoError(t, err)
+	assert.Equal(t, ImportCreated, second.Status)
+	assert.NotEqual(t, preservedBranch, second.Workspace.Branch)
+	assert.DirExists(t, second.Workspace.Path)
+	listed, err := service.List(t.Context(), testProject(), "open")
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	require.NotNil(t, listed[0].Workspace)
+	assert.True(t, listed[0].Imported)
+	assert.Equal(t, second.Workspace.Path, listed[0].Workspace.Path)
+	assert.Equal(t, second.Workspace.Branch, listed[0].Workspace.Branch)
+	assert.Equal(t, second.Workspace.Generation, listed[0].Workspace.Generation)
+}
+
 func TestImportPreservesLegacyProtectedWorkspaceEndpoint(t *testing.T) {
 	pr := testPR(41, false)
 	branch := importBranchName(pr)


### PR DESCRIPTION
Fixes #97.

`kwt remove` deletes an imported PR's worktree but preserves its local branch. Importing that PR again then fails with `workspace_creation_failed` because KWT tries to create the same branch again.

After this change, KWT associates the PR with a new worktree and leaves the preserved branch alone.
