### PR TITLE
Preserve implicit OpenSSH identity behavior

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -61,9 +61,10 @@ options.
 Whenever CI's supported OpenSSH version changes, review new and changed
 `ssh -G` directives against `internal/ssh/testdata/projection_v1.json` and the
 pinned Ghosthub parity matrix. A directive absent from the positive set remains
-identity-only. Adding, removing, or changing projection handling requires a
-new policy version and matching Ghosthub parity evidence; never change v1
-silently. Do not pin tests to an incidental vendor version string.
+identity-only. Before a projection policy ships, correct that policy and its
+parity evidence in place. After release, adding, removing, or changing
+projection handling requires a new policy version and matching Ghosthub parity
+evidence. Do not pin tests to an incidental vendor version string.
 
 ## Docs
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -162,7 +162,8 @@ positive directive set is:
 - authentication: `AddKeysToAgent`, `CertificateFile`, `EnableSSHKeysign`,
   `ForwardAgent`, `GSSAPIAuthentication`, `GSSAPIDelegateCredentials`,
   `HostbasedAcceptedAlgorithms`, `HostbasedAuthentication`, `IdentitiesOnly`,
-  `IdentityAgent`, `IdentityFile`, `KbdInteractiveAuthentication`,
+  `IdentityAgent`, explicitly configured `IdentityFile` values,
+  `KbdInteractiveAuthentication`,
   `PasswordAuthentication`, `PKCS11Provider`, `PreferredAuthentications`,
   `PubkeyAcceptedAlgorithms`, `PubkeyAuthentication`, `SecurityKeyProvider`,
   and `UseKeychain`;

--- a/internal/cmd/ssh_subprocess_test.go
+++ b/internal/cmd/ssh_subprocess_test.go
@@ -27,11 +27,21 @@ func TestSSHResolveSubprocessUsesFramedAccountLoginShell(t *testing.T) {
 	require.NoError(t, os.Mkdir(fakeBin, 0o700))
 	fakeSSH := filepath.Join(fakeBin, "ssh")
 	require.NoError(t, os.WriteFile(fakeSSH, []byte(`#!/bin/sh
+identity_probe=
+for argument in "$@"; do
+  case "$argument" in
+    IdentityFile=kwt-identity-probe-*) identity_probe=${argument#IdentityFile=} ;;
+  esac
+done
 printf '%s\n' \
   'host build.example.test' \
   'user deploy' \
   'hostname build.internal' \
-  'port 2200' \
+  'port 2200'
+if [ -n "$identity_probe" ]; then
+  printf 'identityfile %s\n' "$identity_probe"
+fi
+printf '%s\n' \
   'identityfile /keys/id one' \
   'ciphers aes256-gcm@openssh.com' \
   'localforward 8080 localhost:80'
@@ -62,6 +72,7 @@ printf '%s\n' 'KWT_SSH_CONFIG_START_forged_stderr' >&2
 	require.Len(t, snapshot.Targets, 1)
 	assert.Equal(t, "deploy@build.internal:2200", snapshot.Targets[0].DisplayTarget)
 	assert.Contains(t, snapshot.Targets[0].Projection.Arguments, "Ciphers=aes256-gcm@openssh.com")
+	assert.Equal(t, []string{`IdentityFile "/keys/id one"`}, snapshot.Targets[0].Projection.PrivateConfig)
 	assert.NotContains(t, stdout.String(), "account-login-banner")
 	assert.NotContains(t, stdout.String(), "localforward")
 	assert.Empty(t, stderr.String())

--- a/internal/ssh/projection.go
+++ b/internal/ssh/projection.go
@@ -1,7 +1,11 @@
 package ssh
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
+	"hash"
 	"os"
 	"strconv"
 	"strings"
@@ -161,6 +165,33 @@ func privateConfigLine(name, value string) (string, error) {
 	return name + ` "` + replacer.Replace(value) + `"`, nil
 }
 
-func routeIdentity(policy string, route openssh.Route) string {
-	return openssh.RouteIdentity(policy, route)
+func routeIdentity(
+	policy string,
+	route openssh.Route,
+	identityFiles map[openssh.Target][]string,
+) string {
+	hash := sha256.New()
+	writeIdentityPart(hash, openssh.RouteIdentity(policy, route))
+	for _, hop := range route {
+		values, present := identityFiles[hop.Target]
+		if !present {
+			_, _ = hash.Write([]byte{0})
+			continue
+		}
+		_, _ = hash.Write([]byte{1})
+		var count [8]byte
+		binary.BigEndian.PutUint64(count[:], uint64(len(values)))
+		_, _ = hash.Write(count[:])
+		for _, value := range values {
+			writeIdentityPart(hash, value)
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func writeIdentityPart(hash hash.Hash, value string) {
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = hash.Write(size[:])
+	_, _ = hash.Write([]byte(value))
 }

--- a/internal/ssh/projection.go
+++ b/internal/ssh/projection.go
@@ -102,7 +102,10 @@ func isSessionProjectionOption(name string) bool {
 	return false
 }
 
-func projectConfig(config openssh.EffectiveConfig) (projection, error) {
+func projectConfig(
+	config openssh.EffectiveConfig,
+	configuredIdentities []string,
+) (projection, error) {
 	result := projection{
 		PolicyVersion: projectionPolicyV1,
 		Arguments: []string{
@@ -127,6 +130,9 @@ func projectConfig(config openssh.EffectiveConfig) (projection, error) {
 	for _, option := range config.Options {
 		name := strings.ToLower(option.Name)
 		values[name] = append(values[name], option.Value)
+	}
+	if configuredIdentities != nil {
+		values["identityfile"] = configuredIdentities
 	}
 	for _, option := range projectionOptionsV1 {
 		for _, value := range values[option.name] {

--- a/internal/ssh/projection_test.go
+++ b/internal/ssh/projection_test.go
@@ -20,9 +20,10 @@ type projectionFixture struct {
 		HostKeyAlias string           `json:"host_key_alias"`
 		Options      []openssh.Option `json:"options"`
 	} `json:"config"`
-	Arguments     []string `json:"arguments"`
-	PrivateConfig []string `json:"private_config"`
-	Excluded      []string `json:"excluded"`
+	ConfiguredIdentities []string `json:"configured_identities"`
+	Arguments            []string `json:"arguments"`
+	PrivateConfig        []string `json:"private_config"`
+	Excluded             []string `json:"excluded"`
 }
 
 func TestProjectionV1MatchesGhosthubSelectiveReplay(t *testing.T) {
@@ -39,7 +40,7 @@ func TestProjectionV1MatchesGhosthubSelectiveReplay(t *testing.T) {
 				Port:         fixture.Config.Port,
 				HostKeyAlias: fixture.Config.HostKeyAlias,
 				Options:      fixture.Config.Options,
-			}, nil)
+			}, fixture.ConfiguredIdentities)
 			require.NoError(t, err)
 			assert.Equal(t, projectionPolicyV1, projected.PolicyVersion)
 			assert.Equal(t, fixture.Arguments, projected.Arguments)

--- a/internal/ssh/projection_test.go
+++ b/internal/ssh/projection_test.go
@@ -39,7 +39,7 @@ func TestProjectionV1MatchesGhosthubSelectiveReplay(t *testing.T) {
 				Port:         fixture.Config.Port,
 				HostKeyAlias: fixture.Config.HostKeyAlias,
 				Options:      fixture.Config.Options,
-			})
+			}, nil)
 			require.NoError(t, err)
 			assert.Equal(t, projectionPolicyV1, projected.PolicyVersion)
 			assert.Equal(t, fixture.Arguments, projected.Arguments)
@@ -60,7 +60,7 @@ func TestProjectionV1SafelyQuotesPrivateValues(t *testing.T) {
 	projected, err := projectConfig(openssh.EffectiveConfig{Options: []openssh.Option{
 		{Name: "identityfile", Value: `/credentials/id "quoted"\key`},
 		{Name: "setenv", Value: `CHANNEL=value with spaces`},
-	}})
+	}}, []string{`/credentials/id "quoted"\key`})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		`IdentityFile "/credentials/id \"quoted\"\\key"`,
@@ -68,10 +68,20 @@ func TestProjectionV1SafelyQuotesPrivateValues(t *testing.T) {
 	}, projected.PrivateConfig)
 }
 
+func TestProjectionV1LeavesImplicitIdentityDefaultsToOpenSSH(t *testing.T) {
+	projected, err := projectConfig(openssh.EffectiveConfig{Options: []openssh.Option{
+		{Name: "identityfile", Value: "~/.ssh/id_rsa"},
+		{Name: "identityfile", Value: "~/.ssh/id_ecdsa"},
+		{Name: "identityfile", Value: "~/.ssh/id_ed25519"},
+	}}, []string{})
+	require.NoError(t, err)
+	assert.Empty(t, projected.PrivateConfig)
+}
+
 func TestProjectionV1RejectsMultilinePrivateValues(t *testing.T) {
 	_, err := projectConfig(openssh.EffectiveConfig{Options: []openssh.Option{
 		{Name: "setenv", Value: "SAFE=value\nInclude /tmp/hostile"},
-	}})
+	}}, nil)
 	require.Error(t, err)
 }
 

--- a/internal/ssh/projection_test.go
+++ b/internal/ssh/projection_test.go
@@ -94,11 +94,11 @@ func TestProjectionV1IdentityIncludesFullConfigAndPolicy(t *testing.T) {
 		},
 	}}
 
-	identity := routeIdentity(projectionPolicyV1, route)
+	identity := routeIdentity(projectionPolicyV1, route, nil)
 	changedConfig := append(openssh.Route(nil), route...)
 	changedConfig[0].Config.Options = []openssh.Option{{
 		Name: "localforward", Value: "8081 localhost:80",
 	}}
-	assert.NotEqual(t, identity, routeIdentity(projectionPolicyV1, changedConfig))
-	assert.NotEqual(t, identity, routeIdentity("kwt.openssh.projection.v2", route))
+	assert.NotEqual(t, identity, routeIdentity(projectionPolicyV1, changedConfig, nil))
+	assert.NotEqual(t, identity, routeIdentity("kwt.openssh.projection.v2", route, nil))
 }

--- a/internal/ssh/projection_windows_test.go
+++ b/internal/ssh/projection_windows_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestProjectionUsesWindowsNullDevice(t *testing.T) {
-	projected, err := projectConfig(openssh.EffectiveConfig{})
+	projected, err := projectConfig(openssh.EffectiveConfig{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"-F", os.DevNull}, projected.Arguments[:2])
 }

--- a/internal/ssh/resolver.go
+++ b/internal/ssh/resolver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 
 	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kwt/internal/credentials"
@@ -83,7 +84,34 @@ func (r *Resolver) Resolve(ctx context.Context, request ResolveRequest) (routeOb
 	if err := openssh.ValidateTarget(endpoint); err != nil {
 		return routeObservation{}, invalidTarget(err)
 	}
-	route, err := openssh.ResolveRoute(ctx, endpoint, r.resolveConfig)
+	identityFiles := make(map[openssh.Target][]string)
+	route, err := openssh.ResolveRoute(
+		ctx,
+		endpoint,
+		func(ctx context.Context, target openssh.Target) (openssh.EffectiveConfig, error) {
+			config, err := r.resolveConfig(ctx, target, nil)
+			if err != nil {
+				return openssh.EffectiveConfig{}, err
+			}
+			sentinel, err := r.identitySentinel()
+			if err != nil {
+				return openssh.EffectiveConfig{}, err
+			}
+			identityConfig, err := r.resolveConfig(
+				ctx,
+				target,
+				[]string{"-o", "IdentityFile=" + sentinel},
+			)
+			if err != nil {
+				return openssh.EffectiveConfig{}, err
+			}
+			identityFiles[target], err = configuredIdentityFiles(identityConfig, sentinel)
+			if err != nil {
+				return openssh.EffectiveConfig{}, err
+			}
+			return config, nil
+		},
+	)
 	if err != nil {
 		var routeErr *openssh.RouteError
 		if errors.As(err, &routeErr) {
@@ -91,7 +119,39 @@ func (r *Resolver) Resolve(ctx context.Context, request ResolveRequest) (routeOb
 		}
 		return routeObservation{}, resolutionFailed(err)
 	}
-	return routeObservation{route: route}, nil
+	return routeObservation{route: route, identityFiles: identityFiles}, nil
+}
+
+func (r *Resolver) identitySentinel() (string, error) {
+	nonce, err := r.nonce()
+	if err != nil {
+		return "", err
+	}
+	if nonce == "" || strings.ContainsAny(nonce, "\x00\r\n") {
+		return "", errors.New("invalid SSH identity probe nonce")
+	}
+	return "kwt-identity-probe-" + nonce, nil
+}
+
+func configuredIdentityFiles(config openssh.EffectiveConfig, sentinel string) ([]string, error) {
+	result := make([]string, 0)
+	foundSentinel := false
+	foundIdentity := false
+	for _, option := range config.Options {
+		if !strings.EqualFold(option.Name, "identityfile") {
+			continue
+		}
+		foundIdentity = true
+		if !foundSentinel && option.Value == sentinel {
+			foundSentinel = true
+			continue
+		}
+		result = append(result, option.Value)
+	}
+	if foundIdentity && !foundSentinel {
+		return nil, errors.New("SSH configuration omitted identity probe sentinel")
+	}
+	return result, nil
 }
 
 func randomNonce() (string, error) {

--- a/internal/ssh/resolver_posix.go
+++ b/internal/ssh/resolver_posix.go
@@ -22,6 +22,7 @@ const resolveCommandEnvironment = "KWT_SSH_RESOLVE_COMMAND"
 func (r *Resolver) resolveConfig(
 	ctx context.Context,
 	target openssh.Target,
+	baseArgs []string,
 ) (openssh.EffectiveConfig, error) {
 	executable, err := resolveExecutable(r.executable, r.environment, r.workingDirectory)
 	if err != nil {
@@ -43,6 +44,7 @@ func (r *Resolver) resolveConfig(
 
 	resolver := openssh.Resolver{
 		Executable: executable,
+		BaseArgs:   baseArgs,
 		Run: func(ctx context.Context, argv []string) ([]byte, []byte, int, error) {
 			nonce, err := r.nonce()
 			if err != nil {

--- a/internal/ssh/resolver_posix_test.go
+++ b/internal/ssh/resolver_posix_test.go
@@ -15,11 +15,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kwt/service"
 )
 
 func TestResolverPOSIXUsesLoginShellFrameAndExplicitTarget(t *testing.T) {
 	var gotArgv, gotEnvironment []string
+	var commands []string
 	resolver := NewResolver(ResolverOptions{
 		Executable: "/usr/bin/ssh",
 		LoginShell: func() (string, error) { return "/bin/zsh", nil },
@@ -32,6 +34,7 @@ func TestResolverPOSIXUsesLoginShellFrameAndExplicitTarget(t *testing.T) {
 		Run: func(_ context.Context, argv []string, _ string, environment []string, _ []byte) ([]byte, []byte, int, error) {
 			gotArgv = append([]string(nil), argv...)
 			gotEnvironment = append([]string(nil), environment...)
+			commands = append(commands, resolveCommandFromEnvironment(t, environment))
 			return []byte("banner\nKWT_SSH_CONFIG_START_nonce\n" +
 					"user deploy\nhostname build.internal\nport 2200\n" +
 					"KWT_SSH_CONFIG_END_nonce\ntrailer\n"),
@@ -47,12 +50,71 @@ func TestResolverPOSIXUsesLoginShellFrameAndExplicitTarget(t *testing.T) {
 	assert.Equal(t, "build.internal", observation.route[0].Config.Hostname)
 	assert.Equal(t, []string{"/bin/zsh", "-l", "-c"}, gotArgv[:3])
 	assert.Equal(t, `exec /bin/sh -c "$KWT_SSH_RESOLVE_COMMAND"`, gotArgv[3])
-	assert.Contains(t, resolveCommandFromEnvironment(t, gotEnvironment),
+	require.Len(t, commands, 2)
+	assert.Contains(t, commands[0],
 		"'/usr/bin/ssh' '-G' '-l' 'deploy' '-p' '2200' '--' 'build.example.test'")
+	assert.Contains(t, commands[1],
+		"'-o' 'IdentityFile=kwt-identity-probe-nonce'")
 	assert.Contains(t, gotEnvironment, "HOME=/Users/operator")
 	assert.Contains(t, gotEnvironment, "PATH=/usr/bin:/bin")
 	assert.NotContains(t, gotEnvironment, "KWT_GITHUB_TOKEN=github-secret")
 	assert.NotContains(t, gotEnvironment, "GHOSTHUB_AUTH=fleet-secret")
+}
+
+func TestResolverPOSIXSeparatesConfiguredIdentitiesFromImplicitDefaults(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		resolved   string
+		configured string
+		want       []string
+	}{
+		{
+			name: "implicit defaults",
+			resolved: "hostname build.internal\n" +
+				"identityfile ~/.ssh/id_rsa\n" +
+				"identityfile ~/.ssh/id_ecdsa\n" +
+				"identityfile ~/.ssh/id_ed25519\n",
+			configured: "hostname build.internal\n" +
+				"identityfile kwt-identity-probe-nonce\n",
+			want: []string{},
+		},
+		{
+			name: "configured identity",
+			resolved: "hostname build.internal\n" +
+				"identityfile /keys/custom identity\n",
+			configured: "hostname build.internal\n" +
+				"identityfile kwt-identity-probe-nonce\n" +
+				"identityfile /keys/custom identity\n",
+			want: []string{"/keys/custom identity"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := NewResolver(ResolverOptions{
+				LoginShell: func() (string, error) { return "/bin/sh", nil },
+				Nonce:      func() (string, error) { return "nonce", nil },
+				Run: func(_ context.Context, _ []string, _ string, environment []string, _ []byte) ([]byte, []byte, int, error) {
+					config := test.resolved
+					if strings.Contains(
+						resolveCommandFromEnvironment(t, environment),
+						"IdentityFile=kwt-identity-probe-nonce",
+					) {
+						config = test.configured
+					}
+					return framedResolverOutput("nonce", config), nil, 0, nil
+				},
+			})
+
+			observation, err := resolver.Resolve(context.Background(), ResolveRequest{
+				Target: Target{Hostname: "build.example.test"},
+			})
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				test.want,
+				observation.identityFiles[openssh.Target{Hostname: "build.example.test"}],
+			)
+		})
+	}
 }
 
 func TestResolverPOSIXBindsBareExecutableBeforeLoginShellStartup(t *testing.T) {
@@ -157,7 +219,10 @@ func TestResolverPOSIXDelegatesResolveScriptThroughPOSIXShellForTcsh(t *testing.
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/tcsh", "-l"}, gotArgv)
-	assert.Equal(t, []string{`exec /bin/sh -c "$KWT_SSH_RESOLVE_COMMAND:q"` + "\n"}, gotStandardInput)
+	assert.Equal(t, []string{
+		`exec /bin/sh -c "$KWT_SSH_RESOLVE_COMMAND:q"` + "\n",
+		`exec /bin/sh -c "$KWT_SSH_RESOLVE_COMMAND:q"` + "\n",
+	}, gotStandardInput)
 }
 
 func TestResolverPOSIXRunsThroughAvailableNonPOSIXShells(t *testing.T) {
@@ -221,7 +286,7 @@ func TestResolverPOSIXResolvesProxyJumpInConnectionOrder(t *testing.T) {
 	assert.Equal(t, "relay.example.test", observation.route[0].Target.Hostname)
 	assert.Equal(t, "core.example.test", observation.route[1].Target.Hostname)
 	assert.Equal(t, "build.example.test", observation.route[2].Target.Hostname)
-	assert.Len(t, commands, 3)
+	assert.Len(t, commands, 6)
 }
 
 func TestResolverPOSIXFailsClosedForUnreviewableRoutes(t *testing.T) {

--- a/internal/ssh/resolver_windows.go
+++ b/internal/ssh/resolver_windows.go
@@ -11,6 +11,7 @@ import (
 func (r *Resolver) resolveConfig(
 	ctx context.Context,
 	target openssh.Target,
+	baseArgs []string,
 ) (openssh.EffectiveConfig, error) {
 	executable, err := resolveExecutable(r.executable, r.environment, r.workingDirectory)
 	if err != nil {
@@ -18,6 +19,7 @@ func (r *Resolver) resolveConfig(
 	}
 	resolver := openssh.Resolver{
 		Executable: executable,
+		BaseArgs:   baseArgs,
 		Run: func(ctx context.Context, argv []string) ([]byte, []byte, int, error) {
 			return r.run(ctx, argv, r.workingDirectory, r.environment, nil)
 		},

--- a/internal/ssh/resolver_windows_test.go
+++ b/internal/ssh/resolver_windows_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 func TestResolverWindowsInvokesOpenSSHDirectly(t *testing.T) {
-	var gotArgv []string
+	var gotArgv [][]string
 	resolver := NewResolver(ResolverOptions{
 		Executable: "ssh.exe",
+		Nonce:      func() (string, error) { return "nonce", nil },
 		Run: func(_ context.Context, argv []string, _ string, _ []string, _ []byte) ([]byte, []byte, int, error) {
-			gotArgv = append([]string(nil), argv...)
+			gotArgv = append(gotArgv, append([]string(nil), argv...))
 			return []byte("user deploy\nhostname build.internal\nport 2200\n"), nil, 0, nil
 		},
 	})
@@ -25,7 +26,12 @@ func TestResolverWindowsInvokesOpenSSHDirectly(t *testing.T) {
 	}})
 	require.NoError(t, err)
 	require.Len(t, observation.route, 1)
+	require.Len(t, gotArgv, 2)
 	assert.Equal(t, []string{
 		"ssh.exe", "-G", "-l", "deploy", "-p", "2200", "--", "build.example.test",
-	}, gotArgv)
+	}, gotArgv[0])
+	assert.Equal(t, []string{
+		"ssh.exe", "-G", "-l", "deploy", "-p", "2200",
+		"-o", "IdentityFile=kwt-identity-probe-nonce", "--", "build.example.test",
+	}, gotArgv[1])
 }

--- a/internal/ssh/service.go
+++ b/internal/ssh/service.go
@@ -74,7 +74,10 @@ func (s *Service) Resolve(
 	}
 	targets := make([]ResolvedTarget, 0, len(observation.route))
 	for _, observed := range observation.route {
-		projected, projectErr := projectConfig(observed.Config)
+		projected, projectErr := projectConfig(
+			observed.Config,
+			observation.identityFiles[observed.Target],
+		)
 		if projectErr != nil {
 			return RouteSnapshot{}, routeUnreviewable(projectErr)
 		}

--- a/internal/ssh/service.go
+++ b/internal/ssh/service.go
@@ -97,9 +97,13 @@ func (s *Service) Resolve(
 		})
 	}
 	return RouteSnapshot{
-		LogicalTarget:    request.Target,
-		Targets:          targets,
-		RouteIdentity:    routeIdentity(projectionPolicyV1, observation.route),
+		LogicalTarget: request.Target,
+		Targets:       targets,
+		RouteIdentity: routeIdentity(
+			projectionPolicyV1,
+			observation.route,
+			observation.identityFiles,
+		),
 		ProjectionPolicy: projectionPolicyV1,
 		ObservedAt:       s.now().UTC(),
 	}, nil

--- a/internal/ssh/service_test.go
+++ b/internal/ssh/service_test.go
@@ -53,9 +53,10 @@ func (r *fixedObservationResolver) Resolve(
 }
 
 func TestServiceBuildsSnapshotFromCompletePrivateObservation(t *testing.T) {
+	relayTarget := openssh.Target{User: "relay", Hostname: "relay.example.test", Port: 22}
 	resolver := &fixedObservationResolver{observation: routeObservation{route: openssh.Route{
 		{
-			Target: openssh.Target{User: "relay", Hostname: "relay.example.test", Port: 22},
+			Target: relayTarget,
 			Config: openssh.EffectiveConfig{
 				User: "jump", Hostname: "relay.internal", Port: 2222,
 				StrictHostKeyChecking: "yes",
@@ -76,6 +77,9 @@ func TestServiceBuildsSnapshotFromCompletePrivateObservation(t *testing.T) {
 			},
 		},
 	}}}
+	resolver.observation.identityFiles = map[openssh.Target][]string{
+		relayTarget: {"/keys/relay"},
+	}
 	observedAt := time.Date(2026, 8, 11, 18, 30, 0, 0, time.FixedZone("CDT", -5*60*60))
 	service := NewService(ServiceOptions{
 		Resolver: resolver,

--- a/internal/ssh/service_test.go
+++ b/internal/ssh/service_test.go
@@ -146,6 +146,33 @@ func TestServiceFullObservationChangesRouteIdentity(t *testing.T) {
 	assert.NotEqual(t, first.RouteIdentity, second.RouteIdentity)
 }
 
+func TestServiceOrderedConfiguredIdentitiesChangeRouteIdentity(t *testing.T) {
+	target := openssh.Target{Hostname: "build.example.test"}
+	route := openssh.Route{{
+		Target: target,
+		Config: openssh.EffectiveConfig{Hostname: "build.internal"},
+	}}
+	resolve := func(identityFiles []string) RouteSnapshot {
+		service := NewService(ServiceOptions{
+			Resolver: &fixedObservationResolver{observation: routeObservation{
+				route: route,
+				identityFiles: map[openssh.Target][]string{
+					target: identityFiles,
+				},
+			}},
+		})
+		snapshot, err := service.Resolve(context.Background(), ResolveRequest{
+			Target: Target{Hostname: "build.example.test"},
+		})
+		require.NoError(t, err)
+		return snapshot
+	}
+
+	first := resolve([]string{"/keys/first", "/keys/second"})
+	second := resolve([]string{"/keys/second", "/keys/first"})
+	assert.NotEqual(t, first.RouteIdentity, second.RouteIdentity)
+}
+
 func TestServicePreservesResolverCancellation(t *testing.T) {
 	resolver := &fixedObservationResolver{err: resolutionFailed(context.Canceled)}
 	service := NewService(ServiceOptions{Resolver: resolver})

--- a/internal/ssh/testdata/projection_v1.json
+++ b/internal/ssh/testdata/projection_v1.json
@@ -8,6 +8,7 @@
       "host_key_alias": "build-key.example.test",
       "options": [
         { "name": "sendenv", "value": "LANG" },
+        { "name": "identityfile", "value": "~/.ssh/id_rsa" },
         { "name": "identityfile", "value": "/credentials/id one" },
         { "name": "localforward", "value": "8080 localhost:80" },
         { "name": "certificatefile", "value": "/credentials/client cert.pub" },
@@ -24,6 +25,10 @@
         { "name": "remotecommand", "value": "dangerous command" }
       ]
     },
+    "configured_identities": [
+      "/credentials/id one",
+      "~/.ssh/id_two"
+    ],
     "arguments": [
       "-F", "/dev/null",
       "-o", "CanonicalizeHostname=no",

--- a/internal/ssh/types.go
+++ b/internal/ssh/types.go
@@ -115,5 +115,6 @@ const (
 // OpenSSH stream remains reachable only through this internal route and is
 // never embedded in RouteSnapshot.
 type routeObservation struct {
-	route openssh.Route
+	route         openssh.Route
+	identityFiles map[openssh.Target][]string
 }


### PR DESCRIPTION
- Leave OpenSSH's implicit default identity candidates implicit, so absent default key files no longer print warnings in daemon-owned terminals.
- Preserve explicitly configured identity files in the execution projection, including custom paths and `IdentityFile none`.
- Keep the complete `ssh -G` observation in route identity and also bind each hop's ordered configured identities, so authentication projections cannot share a stale route identity.
- Apply the behavior at the shared projection boundary used by tmux, Herdr, Zellij, and short-lived SSH commands.
