### PR TITLE
Add generation-safe worktree change inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Run `kwt <command> --help` for flags and examples.
 
 - Git 2.20+
   - Git 2.31+ for `kwt doctor` and `kwt prune --expired` or `--merged`
-- Go 1.26+ to build from source
+- Go 1.27+ to build from source
 - tmux for workspace launch and `kwt tmux`
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ import kwt "go.kenn.io/kwt"
 
 inventory := kwt.NewInventoryService(kwt.InventoryServiceOptions{Source: source})
 removals := kwt.NewRemovalService(kwt.RemovalServiceOptions{Home: kwtHome})
+inspections := kwt.NewInspectionService(kwt.InspectionServiceOptions{
+    Inventory: inventory,
+})
 ```
 
-The root package contains transport-neutral inventory and worktree lifecycle
-contracts. The CLI/TUI adapt them to kwt's local daemon; Go applications can
-construct the same services directly without Huma, Cobra, or daemon ownership.
+The root package contains transport-neutral inventory, lifecycle, and
+generation-safe change-inspection contracts. The CLI/TUI adapt them to kwt's
+local daemon; Go applications can construct the same services directly without
+Huma, Cobra, or daemon ownership.
 
 ## Install
 
@@ -84,6 +88,8 @@ kwt open ~/notes --start-session
 # Inspect worktrees and git status
 kwt list
 kwt status
+kwt changes
+kwt changes /path/to/worktree --json
 
 # Discover and import a GitHub PR without launching tmux
 kwt pr list --project github.com/acme/widget --json

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -45,11 +45,15 @@ immediately, then continues reporting observed drain state while it waits.
 Active work and leases may finish until `daemon.replacement_grace`; the default
 is five minutes.
 
-The API schema is `1.11.0`. It exposes authenticated status, graceful shutdown,
+The API schema is `1.12.0`. It exposes authenticated status, graceful shutdown,
 worktree inventory, guarded project unregistration, and repository-config
 approval under `/api/v1`, proof-capable liveness at `/api/ping`, and
 credential-free OpenAPI at `/openapi.json`. Inventory clients require the
-`worktree.inventory.v2` capability; guarded unregistration requires
+`worktree.inventory.v2` capability. Foreground change inspection additionally
+requires `worktree.inventory.config.v1`, which guarantees that repository
+inventory carries the effective global configuration used to derive protected
+environment-variable names. A client fails closed rather than running Git when
+that capability or configuration is absent. Guarded unregistration requires
 `project.removal.v1`, SSH route resolution requires `ssh.resolve.v1`, and
 daemon-owned connection leases require `ssh.lifecycle.v1`. Worktree removal
 uses `worktree.removal.v2` for session, branch, and HEAD guards. Clients that bind

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -12,6 +12,7 @@ abstraction belongs in `kwt`.
 - [TUI and project registry](tui-projects.md)
 - [Multi-machine sync architecture](multi-machine-sync.md)
 - [Worktree maintenance](worktree-maintenance.md)
+- [Worktree change inspection](worktree-changes.md)
 - [Local service daemon](daemon.md)
 
 Feature specs and implementation plans should be folded into these maintained

--- a/docs/design/worktree-changes.md
+++ b/docs/design/worktree-changes.md
@@ -1,0 +1,109 @@
+# Worktree Change Inspection
+
+Kwt has a local Git change engine for the transport-neutral Go inspection
+service and the focused `kwt changes` command. It remains deliberately separate
+from the lightweight status collector used by list, TUI, and fleet surfaces.
+This note records the ownership and correctness boundaries between them.
+
+## Shared core
+
+`internal/status` owns local Git change facts. `CollectChanges` performs one
+bounded `git status --porcelain=v2 -z --untracked-files=all` read and produces:
+
+- NUL-delimited per-path index and working-tree states without a secondary
+  line or whitespace delimiter;
+- deterministic path ordering and original paths for renames and copies;
+- mutually exclusive modified, added, deleted, untracked, and conflict counts;
+- an orthogonal staged count that excludes unmerged index slots; and
+- overall clean, modified, staged, or conflicted precedence.
+
+The collector disables optional index writes, fixes the Git locale, bounds
+stdout and stderr independently, and removes Kwt-protected credentials from
+the Git process environment. Protected names include both Kwt's built-ins and
+the effective global `fleet.token_env` value. Unknown NUL-framed porcelain
+records are skipped for forward compatibility; malformed recognized records
+still fail the snapshot. Compatible records with the same resulting path are
+coalesced into one file entry while preserving independent index, worktree,
+and original-path fields; incompatible duplicates fail the snapshot.
+
+The module root aliases these values and `InspectionService`, so an in-process
+consumer can use the same contract without Cobra, HTTP, or daemon ownership.
+
+## Exact identity and generation fence
+
+An inspection begins with current authoritative repository inventory for the
+requested absolute path. Exactly one platform-canonical path must match, and
+its repository identity, path, and durable generation must be complete.
+Optional expected repository and generation values are compare-and-fail
+guards, not selectors.
+
+The service reads the durable generation from Git administration immediately
+before and after collecting changes. A missing, moved, removed, or replaced
+worktree returns retryable `registration_changed` and discards the file
+snapshot. The fence prevents pairing a replacement checkout's files with an
+older inventory identity. It does not claim branch or HEAD atomicity; the
+result is a bounded local status observation. One five-second Git-operation
+budget covers the pre-read, status collection, and post-read together. Git
+process cleanup adds at most 100 milliseconds if a descendant retains an
+output descriptor. Exhausting the internal budget returns retryable
+`inspection_failed`; caller cancellation remains the caller's context error.
+
+## CLI boundary
+
+`kwt changes [path]` resolves the caller's literal path to an absolute path and
+adapts `InspectionService`. The same-machine daemon supplies current inventory,
+but the generation reads and Git status process stay in the invoking foreground
+client. This preserves the foreground process's cancellation and credential
+boundary while keeping the daemon free of status polling or file snapshots.
+
+Human output is for direct inspection. The JSON `InspectionResult` is the
+stable machine contract: authoritative worktree identity, canonical change
+summary, deterministic file records, and observation time. Clean results retain
+an explicit empty `files` array. JSON losslessly represents valid UTF-8 path
+strings, including embedded whitespace and newlines; it cannot preserve an
+ill-formed UTF-8 Unix filename byte-for-byte. Stable failures use the shared
+service error envelope; prose messages are not part of the machine contract.
+
+## Trust model
+
+Ordinary Git inspection after checkout is inside Kwt's accepted local-user
+trust boundary. Repository content remains data, while trusted machine-level
+Git configuration may influence Git just as it does for a direct user command.
+The inspection process does not expose Kwt-managed credentials, enable optional
+index writes, approve repository-local Kwt configuration, or persist its
+result. The foreground client requires config-bearing inventory, and the
+inspection service fails closed before Git when effective configuration is
+absent. Inventory ignores untrusted repository-local Kwt configuration for
+this noninteractive read.
+
+Native path comparison is platform-aware: existing symlink aliases converge on
+Unix-like systems, and Windows comparison normalizes separators and case. Kwt
+does not return a platform-specific unsupported result for inspection.
+
+## Status collector boundary
+
+`StatusCollector` retains its own one-shot porcelain-v2 snapshot, parser,
+summary accounting, bounded workers, per-row diagnostics, remote state, and
+activity calculation. Filtering, sorting, CSV, table, JSON, TUI, and fleet
+responsibilities remain on their established paths and retain their schemas.
+Detailed file records and the inspection service's semantic buckets are not
+added to those surfaces.
+
+The only shared integration is process isolation: every Git command owned by
+`StatusCollector` receives the same built-in and configured protected-name set
+from the CLI, TUI, or fleet caller. This keeps credentials out of foreground
+and long-lived inventory processes without changing status accounting or TUI
+presentation.
+
+## Non-goals
+
+Change inspection does not:
+
+- fetch remotes or calculate ahead/behind state or activity;
+- calculate diff, numstat, patches, or file contents;
+- mutate the index or worktree;
+- discover or batch sibling worktrees;
+- watch, poll, cache, or persist change snapshots;
+- move Git status ownership into the daemon;
+- depend on tmux or workspace-session state; or
+- introduce consumer-specific types or presentation policy.

--- a/docs/design/worktree-changes.md
+++ b/docs/design/worktree-changes.md
@@ -26,6 +26,11 @@ still fail the snapshot. Compatible records with the same resulting path are
 coalesced into one file entry while preserving independent index, worktree,
 and original-path fields; incompatible duplicates fail the snapshot.
 
+The Git adapter limits stdout and stderr to 1 MiB each. If an exact change list
+exceeds the stdout limit, inspection never returns a partial snapshot. Its safe
+public message is `worktree change list is too large to inspect`; the original
+limit error remains available only to the in-process caller.
+
 The module root aliases these values and `InspectionService`, so an in-process
 consumer can use the same contract without Cobra, HTTP, or daemon ownership.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -12,7 +12,7 @@ verified with the repo's commands.
 | `internal/tui`       | Bubble Tea dashboard model, rendering, and pure TUI helpers. |
 | `internal/config`    | Global and local config loading, trust, and persistence.     |
 | `internal/discovery` | Worktree discovery.                                          |
-| `internal/status`    | Git status collection.                                       |
+| `internal/status`    | Git status collection and worktree change inspection.        |
 | `internal/tmux`      | tmux session, layout, and runner behavior.                   |
 | `internal/worktree`  | Worktree creation, setup commands, and copied files.         |
 | `pkg/models`         | Shared data models.                                          |

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -7,7 +7,7 @@ commands, but the worktree-oriented CLI can still be used without it.
 
 ## Install with Go
 
-If you have Go 1.26 or newer, install the latest tagged version:
+If you have Go 1.27 or newer, install the latest tagged version:
 
 ```sh
 go install go.kenn.io/kwt/cmd/kwt@latest

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -1,9 +1,10 @@
 # Install kwt
 
-kwt supports macOS, Linux, and Windows. Git 2.20 or newer is required. The
-`kwt doctor` command and `kwt prune --expired` or `--merged` policies require
-Git 2.31 or newer. tmux is required for workspace launch and the `kwt tmux`
-commands, but the worktree-oriented CLI can still be used without it.
+kwt supports macOS 13 or later, Linux, and Windows. Git 2.20 or newer is
+required. The `kwt doctor` command and `kwt prune --expired` or `--merged`
+policies require Git 2.31 or newer. tmux is required for workspace launch and
+the `kwt tmux` commands, but the worktree-oriented CLI can still be used without
+it.
 
 ## Install with Go
 
@@ -32,7 +33,7 @@ For tags published through the current release pipeline, the
 [GitHub Releases](https://github.com/kenn-io/kwt/releases) page provides
 archives for:
 
-- macOS on Apple silicon and Intel;
+- macOS 13 or later on Apple silicon and Intel;
 - Linux on ARM64 and AMD64; and
 - Windows on ARM64 and AMD64.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,12 +61,15 @@ kwt add -b feature/new-ui              # isolated checkout + tmux workspace
 kwt exec feature/new-ui -- make test   # run a command in the worktree
 cd "$(kwt get feature/new-ui)"         # resolve a worktree path
 kwt list --json                        # machine-readable worktree state
+kwt changes --json                     # exact changed-file snapshot
 kwt remove -b feature/new-ui           # delete the worktree and its branch
 ```
 
 `kwt pr import` checks a GitHub pull request out into a fresh worktree, and
 `kwt status` shows which branches are dirty, ahead, or behind — useful when
-several agents are working in parallel. Configurable
+several agents are working in parallel. `kwt changes [path]` inspects one exact
+worktree when a script needs deterministic staged and working-tree file states.
+Configurable
 [layouts](workflows/agent-workspaces.md) define the tmux panes each workspace
 starts with, from a single shell to a preset arrangement of agents.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,6 +19,7 @@ Other PID lookup failures report the underlying tmux error.
 | `kwt open`       | Open or establish a workspace session.                 |
 | `kwt list`       | List worktrees.                                        |
 | `kwt status`     | Show Git status, sync state, and activity.             |
+| `kwt changes`    | Inspect changed files in one exact worktree.           |
 | `kwt projects`   | List registered project repositories.                  |
 | `kwt pr`         | Discover and import pull requests through JSON.        |
 | `kwt get`        | Print a matching worktree path.                        |
@@ -45,6 +46,10 @@ kwt branches --json
 kwt open parser
 kwt open /path/to/worktree --start-session
 kwt status
+kwt changes --json
+kwt changes /path/to/worktree \
+  --expected-repository github.com/acme/widget \
+  --expected-generation <worktree.generation> --json
 kwt pr list --project github.com/acme/widget --json
 kwt pr import 17 --project github.com/acme/widget \
   --expected-repository github.com/acme/widget \
@@ -77,17 +82,17 @@ override when you intend to install an otherwise unordered build. Replacement
 and restart print drain progress to stderr before waiting; JSON stdout and
 ordinary command exit behavior remain unchanged.
 
-`kwt projects`, `kwt list`, `kwt remove`, and TUI inventory/removal auto-start
-or reuse a compatible local daemon. CLI inventory requires a current refresh
-and fails if one cannot complete; it never prints cached data. When available,
-the TUI paints the daemon's last-known-good cache; a cold start waits for the
-initial current inventory. It then refreshes the displayed repository
-with Git status, and refreshes the global catalog without status once in the
-background. Cached rows permit shells in directories that still exist and
-attachment to sessions that Kwt re-verifies as live. Mutations and new session
-creation wait for current inventory. SSH connection lifecycle remains on its
-existing path until its complete service migration. `kwt ssh resolve` is the
-non-connecting Stage 1 exception described below.
+`kwt projects`, `kwt list`, `kwt changes`, `kwt remove`, and TUI
+inventory/removal auto-start or reuse a compatible local daemon. CLI inventory
+requires a current refresh and fails if one cannot complete; it never prints
+cached data. When available, the TUI paints the daemon's last-known-good cache;
+a cold start waits for the initial current inventory. It then refreshes the
+displayed repository with Git status, and refreshes the global catalog without
+status once in the background. Cached rows permit shells in directories that
+still exist and attachment to sessions that Kwt re-verifies as live. Mutations
+and new session creation wait for current inventory. SSH connection lifecycle
+remains on its existing path until its complete service migration. `kwt ssh
+resolve` is the non-connecting Stage 1 exception described below.
 
 Successful `kwt list --json` and `kwt projects --json` output remains a bare
 top-level array. A daemon or inventory failure instead writes this shared
@@ -399,6 +404,97 @@ without a client creating it bare or bypassing protected attach policy. See
 `kwt open` and dashboard open actions refuse protected pull-request imports
 and direct the user through `kwt pr attach`.
 `created_at` and `generation` are populated in both local and `-g` mode.
+
+## `kwt changes`
+
+```sh
+kwt changes
+kwt changes /path/to/worktree
+kwt changes /path/to/worktree --json
+kwt changes /path/to/worktree \
+  --expected-repository github.com/acme/widget \
+  --expected-generation 0123456789abcdef0123456789abcdef \
+  --json
+```
+
+`changes` returns one point-in-time local change set for one exact registered
+worktree. The optional path defaults to the current directory. The foreground
+CLI converts the literal path to an absolute path without resolving it to a
+different spelling; inventory then applies the platform's native canonical
+path comparison and returns the authoritative worktree path.
+
+Human output identifies the quoted repository and worktree path, durable
+generation, and observation time before listing quoted changed paths. Each
+path has separate `staged` and `working tree` states; `-` means that side has no
+change, including an unmerged index slot that is not a staged change. Rename
+output shows the quoted original and resulting paths. A clean worktree says
+`No changed files`.
+
+`--json` emits one `InspectionResult` object:
+
+```json
+{
+  "worktree": {
+    "repository": "github.com/acme/widget",
+    "path": "/work/widget",
+    "generation": "0123456789abcdef0123456789abcdef"
+  },
+  "changes": {
+    "state": "modified",
+    "summary": {
+      "modified": 1,
+      "added": 0,
+      "deleted": 0,
+      "untracked": 0,
+      "staged": 0,
+      "conflicts": 0
+    },
+    "files": [
+      {
+        "path": "README.md",
+        "worktree": "modified"
+      }
+    ]
+  },
+  "observed_at": "2026-08-20T18:00:00Z"
+}
+```
+
+`files` is always present, including `"files": []` for a clean worktree.
+Paths are JSON strings, so valid UTF-8 names containing spaces, tabs, newlines,
+and native Windows path forms do not require a secondary delimiter convention.
+Ill-formed UTF-8 Unix filename bytes are not a lossless part of this JSON
+contract. File order is deterministic. `index` and `worktree` describe the two
+porcelain-v2 sides; `original_path` is present for a rename or copy.
+`summary.staged` is orthogonal to the mutually exclusive semantic buckets and
+does not include conflicted paths.
+
+The optional expected repository and generation flags are independent
+compare-and-fail guards. A mismatch returns retryable `registration_changed`;
+the caller must refresh instead of presenting the discarded snapshot. The
+other stable command codes are `invalid_request`, `not_found`, and
+`inspection_failed`, plus the shared daemon and inventory codes that can occur
+while obtaining current authoritative inventory. `invalid_request` and
+`not_found` exit `2`; other domain failures exit `1`. With `--json`, failures
+use the shared `{ "error": ... }` envelope. Error `code`, `retryable`, and
+documented detail types are contractual; `message` remains explanatory prose.
+Exhausting the command's internal Git budget returns retryable
+`inspection_failed`; cancellation by the caller remains a context cancellation.
+
+Inventory comes from the same-machine daemon, but both durable-generation
+checks and the bounded porcelain-v2 status read execute in the invoking
+foreground process. The command strips Kwt-protected credentials, disables
+optional Git index writes, uses a locale-independent parser, and honors the
+five-second Git-operation budget; cleanup is additionally bounded to 100
+milliseconds when a descendant retains an output descriptor. `kwt changes`
+requires the daemon's config-bearing inventory capability and fails closed if
+effective configuration is absent. A compatible older daemon without that
+capability returns `daemon_incompatible`; with `daemon.auto_restart = "newer"`
+a provably newer client may replace it, while `"never"` requires an explicit
+daemon restart. The command does not fetch, calculate activity or
+ahead/behind state, run diff or numstat, generate patches, discover siblings,
+watch, or require tmux. The same command and JSON contract are available on
+macOS, Linux, and Windows.
 
 ## `kwt tmux`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -469,6 +469,13 @@ porcelain-v2 sides; `original_path` is present for a rename or copy.
 `summary.staged` is orthogonal to the mutually exclusive semantic buckets and
 does not include conflicted paths.
 
+An untracked-only worktree has overall `state: "modified"`; use
+`summary.untracked` and each file's `worktree: "untracked"` value to distinguish
+it from tracked modifications. If the exact change list exceeds the bounded
+status-output limit, the command returns non-retryable `inspection_failed` with
+`worktree change list is too large to inspect` rather than returning partial
+file records.
+
 The optional expected repository and generation flags are independent
 compare-and-fail guards. A mismatch returns retryable `registration_changed`;
 the caller must refresh instead of presenting the discarded snapshot. The

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/kwt
 
-go 1.26.6
+go 1.27.0
 
 require (
 	charm.land/bubbles/v2 v2.1.1

--- a/internal/cmd/changes.go
+++ b/internal/cmd/changes.go
@@ -1,0 +1,263 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/service"
+)
+
+var (
+	changesJSON               bool
+	changesExpectedRepository string
+	changesExpectedGeneration string
+	queryChangesInventory     = queryInspectionInventoryForCLI
+	newChangesInspector       = func(cmd *cobra.Command) kwt.Inspector {
+		return kwt.NewInspectionService(kwt.InspectionServiceOptions{
+			Inventory: changesCLIInventory{stderr: cmd.ErrOrStderr()},
+		})
+	}
+)
+
+var changesCmd = &cobra.Command{
+	Use:   "changes [path]",
+	Short: "Inspect changed files in one worktree",
+	Long: `Inspect staged and working-tree file states for one exact worktree.
+
+The optional path defaults to the current directory. This bounded foreground
+inspection does not fetch, watch, generate diffs, or require tmux. Use the
+expected identity flags to reject a worktree registration that changed after a
+prior observation.`,
+	Example: `  kwt changes
+  kwt changes [path] --json
+  kwt changes /path/to/worktree \
+    --expected-repository github.com/acme/widget \
+    --expected-generation 0123456789abcdef0123456789abcdef --json`,
+	Args:              changesMaximumOneArg,
+	PersistentPreRunE: changesPreRun,
+	RunE:              withGracefulSignals(runChanges),
+}
+
+func changesPreRun(cmd *cobra.Command, args []string) error {
+	if err := globalOnlyPreRun(cmd, args); err != nil {
+		return writeChangesFailure(cmd, service.NewError(
+			service.InspectionFailed,
+			fmt.Sprintf("failed to %v", err),
+			false,
+			nil,
+			err,
+		))
+	}
+	return nil
+}
+
+func changesMaximumOneArg(cmd *cobra.Command, args []string) error {
+	if len(args) <= 1 {
+		return nil
+	}
+	return writeCommandFailure(
+		cmd,
+		service.Descriptor{
+			Code: service.InvalidRequest, Message: "expected at most one worktree path",
+		},
+		2,
+		changesJSON,
+		"changes",
+	)
+}
+
+type changesCLIInventory struct {
+	stderr io.Writer
+}
+
+func (i changesCLIInventory) Query(
+	ctx context.Context,
+	request kwt.Request,
+) (kwt.Result, error) {
+	return queryChangesInventory(ctx, request, false, i.stderr)
+}
+
+func (changesCLIInventory) ApproveConfig(
+	context.Context,
+	kwt.ConfigApproval,
+) error {
+	return service.NewError(
+		service.Unsupported,
+		"configuration approval is unavailable during worktree inspection",
+		false,
+		nil,
+		nil,
+	)
+}
+
+func init() {
+	rootCmd.AddCommand(changesCmd)
+	changesCmd.Flags().BoolVar(&changesJSON, "json", false, "Output a machine-readable inspection result")
+	changesCmd.Flags().StringVar(
+		&changesExpectedRepository,
+		"expected-repository",
+		"",
+		"Require the exact credential-free repository identity",
+	)
+	changesCmd.Flags().StringVar(
+		&changesExpectedGeneration,
+		"expected-generation",
+		"",
+		"Require the exact observed worktree generation",
+	)
+	changesCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return writeCommandFailure(
+			cmd,
+			service.Descriptor{
+				Code: service.InvalidRequest, Message: err.Error(),
+			},
+			2,
+			changesJSONRequested(),
+			"changes",
+		)
+	})
+}
+
+func changesJSONRequested() bool {
+	if changesJSON {
+		return true
+	}
+	// pflag stops at the first parse error, so a later --json never reaches
+	// the bound variable. Preserve the caller's output choice from raw argv.
+	requested := false
+	for _, argument := range os.Args[1:] {
+		if argument == "--" {
+			break
+		}
+		if argument == "--json" {
+			requested = true
+			continue
+		}
+		name, value, ok := strings.Cut(argument, "=")
+		if !ok || name != "--json" {
+			continue
+		}
+		enabled, err := strconv.ParseBool(value)
+		if err == nil {
+			requested = enabled
+		}
+	}
+	return requested
+}
+
+func runChanges(cmd *cobra.Command, args []string) error {
+	path, err := changesPath(args)
+	if err != nil {
+		return writeChangesFailure(cmd, err)
+	}
+	result, err := newChangesInspector(cmd).Inspect(
+		cmd.Context(),
+		kwt.InspectionRequest{
+			Path:               path,
+			ExpectedRepository: changesExpectedRepository,
+			ExpectedGeneration: changesExpectedGeneration,
+		},
+	)
+	if err != nil {
+		return writeChangesFailure(cmd, err)
+	}
+	if !changesJSON {
+		return writeChangesHuman(cmd.OutOrStdout(), result)
+	}
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}
+
+func writeChangesFailure(cmd *cobra.Command, err error) error {
+	var typed *service.Error
+	if !errors.As(err, &typed) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		typed = service.AsError(err)
+	}
+	exitCode := 1
+	if typed.Code == service.InvalidRequest || typed.Code == service.NotFound {
+		exitCode = 2
+	}
+	return writeCommandFailure(
+		cmd,
+		typed.Descriptor,
+		exitCode,
+		changesJSON,
+		"changes",
+	)
+}
+
+func writeChangesHuman(output io.Writer, result kwt.InspectionResult) error {
+	var body strings.Builder
+	_, _ = fmt.Fprintf(
+		&body,
+		"Repository: %s\nWorktree: %s\nGeneration: %s\nObserved at: %s\n",
+		strconv.Quote(result.Worktree.Repository),
+		strconv.Quote(result.Worktree.Path),
+		result.Worktree.Generation,
+		result.ObservedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+	)
+	if len(result.Changes.Files) == 0 {
+		body.WriteString("No changed files\n")
+		_, err := io.WriteString(output, body.String())
+		return err
+	}
+	body.WriteString("Changes:\n")
+	for _, file := range result.Changes.Files {
+		body.WriteString("  ")
+		if file.OriginalPath != "" {
+			body.WriteString(strconv.Quote(file.OriginalPath))
+			body.WriteString(" -> ")
+		}
+		body.WriteString(strconv.Quote(file.Path))
+		body.WriteByte('\n')
+		_, _ = fmt.Fprintf(
+			&body,
+			"    staged: %s\n    working tree: %s\n",
+			changesStagedStateLabel(file.Index),
+			changesStateLabel(file.Worktree),
+		)
+	}
+	_, err := io.WriteString(output, body.String())
+	return err
+}
+
+func changesStagedStateLabel(state kwt.FileState) string {
+	if state == kwt.FileStateConflicted {
+		return "-"
+	}
+	return changesStateLabel(state)
+}
+
+func changesStateLabel(state kwt.FileState) string {
+	if state == "" {
+		return "-"
+	}
+	return string(state)
+}
+
+func changesPath(args []string) (string, error) {
+	path := ""
+	if len(args) == 0 {
+		var err error
+		path, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		path = args[0]
+	}
+	return filepath.Abs(path)
+}

--- a/internal/cmd/changes.go
+++ b/internal/cmd/changes.go
@@ -51,7 +51,7 @@ func changesPreRun(cmd *cobra.Command, args []string) error {
 	if err := globalOnlyPreRun(cmd, args); err != nil {
 		return writeChangesFailure(cmd, service.NewError(
 			service.InspectionFailed,
-			fmt.Sprintf("failed to %v", err),
+			"failed to initialize configuration",
 			false,
 			nil,
 			err,
@@ -190,13 +190,15 @@ func writeChangesFailure(cmd *cobra.Command, err error) error {
 	if typed.Code == service.InvalidRequest || typed.Code == service.NotFound {
 		exitCode = 2
 	}
-	return writeCommandFailure(
+	failure := writeCommandFailure(
 		cmd,
 		typed.Descriptor,
 		exitCode,
 		changesJSON,
 		"changes",
 	)
+	failure.cause = typed.Err
+	return failure
 }
 
 func writeChangesHuman(output io.Writer, result kwt.InspectionResult) error {

--- a/internal/cmd/changes_subprocess_test.go
+++ b/internal/cmd/changes_subprocess_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	kwt "go.kenn.io/kwt"
 	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/service"
 )
 
@@ -28,8 +29,16 @@ func TestChangesSubprocessInspectsPrimaryAndLinkedWorktreesWithGuards(t *testing
 	linkedResult := runChangesSubprocessJSON(t, binary, home, linked, linked)
 	assert.Equal(t, "github.com/acme/widget", primaryResult.Worktree.Repository)
 	assert.Equal(t, "github.com/acme/widget", linkedResult.Worktree.Repository)
-	assert.Equal(t, canonicalTestPath(t, primary), primaryResult.Worktree.Path)
-	assert.Equal(t, canonicalTestPath(t, linked), linkedResult.Worktree.Path)
+	assert.Equal(
+		t,
+		utils.PathKey(canonicalTestPath(t, primary)),
+		utils.PathKey(primaryResult.Worktree.Path),
+	)
+	assert.Equal(
+		t,
+		utils.PathKey(canonicalTestPath(t, linked)),
+		utils.PathKey(linkedResult.Worktree.Path),
+	)
 	assert.NotEqual(t, primaryResult.Worktree.Generation, linkedResult.Worktree.Generation)
 
 	stdout, stderr, err := runInventoryCommand(

--- a/internal/cmd/changes_subprocess_test.go
+++ b/internal/cmd/changes_subprocess_test.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/service"
+)
+
+func TestChangesSubprocessInspectsPrimaryAndLinkedWorktreesWithGuards(t *testing.T) {
+	binary, cleanupBinary := buildDaemonTestBinaries(t)
+	primary, linked := newChangesSubprocessWorktrees(t)
+	home := newChangesSubprocessHome(t, primary)
+	registerDaemonCleanup(t, cleanupBinary, home)
+
+	primaryResult := runChangesSubprocessJSON(t, binary, home, primary, primary)
+	linkedResult := runChangesSubprocessJSON(t, binary, home, linked, linked)
+	assert.Equal(t, "github.com/acme/widget", primaryResult.Worktree.Repository)
+	assert.Equal(t, "github.com/acme/widget", linkedResult.Worktree.Repository)
+	assert.Equal(t, canonicalTestPath(t, primary), primaryResult.Worktree.Path)
+	assert.Equal(t, canonicalTestPath(t, linked), linkedResult.Worktree.Path)
+	assert.NotEqual(t, primaryResult.Worktree.Generation, linkedResult.Worktree.Generation)
+
+	stdout, stderr, err := runInventoryCommand(
+		t,
+		binary,
+		home,
+		linked,
+		"changes",
+		linked,
+		"--expected-repository",
+		linkedResult.Worktree.Repository,
+		"--expected-generation",
+		linkedResult.Worktree.Generation,
+		"--json",
+	)
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout, stderr)
+	var guarded kwt.InspectionResult
+	require.NoError(t, json.Unmarshal(stdout, &guarded))
+	assert.Equal(t, linkedResult.Worktree, guarded.Worktree)
+
+	for _, mismatch := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "repository",
+			args: []string{
+				"--expected-repository", "github.com/other/widget",
+			},
+		},
+		{
+			name: "generation",
+			args: []string{
+				"--expected-generation", primaryResult.Worktree.Generation,
+			},
+		},
+	} {
+		t.Run(mismatch.name+" mismatch", func(t *testing.T) {
+			args := append([]string{"changes", linked}, mismatch.args...)
+			args = append(args, "--json")
+			stdout, stderr, err := runInventoryCommand(
+				t, binary, home, linked, args...,
+			)
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr, "stdout=%s stderr=%s", stdout, stderr)
+			assert.Equal(t, 1, exitErr.ExitCode())
+			var envelope jsonErrorEnvelope
+			require.NoError(t, json.Unmarshal(stdout, &envelope))
+			assert.Equal(t, service.RegistrationChanged, envelope.Error.Code)
+			assert.True(t, envelope.Error.Retryable)
+		})
+	}
+}
+
+func TestChangesSubprocessPreservesUnusualFilenamesAndCommandBoundary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("command recorder uses a POSIX shell")
+	}
+	binary, cleanupBinary := buildDaemonTestBinaries(t)
+	primary, _ := newChangesSubprocessWorktrees(t)
+	home := newChangesSubprocessHome(t, primary)
+	registerDaemonCleanup(t, cleanupBinary, home)
+	filenames := []string{
+		"line\nbreak.txt",
+		"space name.txt",
+		"tab\tname.txt",
+	}
+	for _, name := range filenames {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(primary, name),
+			[]byte("untracked\n"),
+			0o644,
+		))
+	}
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	wrapperDir := t.TempDir()
+	logPath := filepath.Join(wrapperDir, "git.log")
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	require.NoError(t, os.WriteFile(wrapperPath, []byte(`#!/bin/sh
+{
+  printf 'git'
+  for argument in "$@"; do
+    printf '\t%s' "$argument"
+  done
+  printf '\n'
+} >> "$KWT_TEST_GIT_LOG"
+exec "$KWT_TEST_REAL_GIT" "$@"
+`), 0o755))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KWT_TEST_GIT_LOG", logPath)
+	t.Setenv("KWT_TEST_REAL_GIT", realGit)
+
+	result := runChangesSubprocessJSON(t, binary, home, primary, primary)
+	paths := make([]string, len(result.Changes.Files))
+	for index, file := range result.Changes.Files {
+		paths[index] = file.Path
+	}
+	slices.Sort(filenames)
+	assert.Equal(t, filenames, paths)
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	commands := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	var statusReads int
+	for _, command := range commands {
+		fields := strings.Split(command, "\t")
+		if slices.Equal(fields, []string{
+			"git", "status", "--porcelain=v2", "-z", "--untracked-files=all",
+		}) {
+			statusReads++
+		}
+		for _, forbidden := range []string{"fetch", "diff", "numstat"} {
+			assert.NotContains(t, fields[1:], forbidden, "command=%q", command)
+		}
+	}
+	assert.Equal(t, 1, statusReads, "commands=%q", commands)
+
+	stdout, stderr, err := runInventoryCommand(
+		t, binary, home, primary, "status", "--json", "--no-fetch",
+	)
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout, stderr)
+	var legacy map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(stdout, &legacy))
+	assert.ElementsMatch(t, []string{"summary", "worktrees"}, mapKeys(legacy))
+	assert.NotContains(t, string(stdout), `"files"`)
+	assert.NotContains(t, string(stdout), `"worktree":{"repository"`)
+}
+
+func TestChangesSubprocessRejectsInventoryWithoutConfigCapability(t *testing.T) {
+	binary, _ := buildDaemonTestBinaries(t)
+	fixture := buildDaemonFixture(t)
+	primary, _ := newChangesSubprocessWorktrees(t)
+	home := newDaemonTestHome(t, strings.Replace(
+		validDaemonConfig+fmt.Sprintf(`
+[fleet]
+token_env = "CUSTOM_FLEET_TOKEN"
+
+[[projects]]
+repository = "github.com/acme/widget"
+name = "widget"
+path = %q
+`, filepath.ToSlash(primary)),
+		`auto_restart = "newer"`,
+		`auto_restart = "never"`,
+		1,
+	))
+	t.Setenv("CUSTOM_FLEET_TOKEN", "must-not-reach-git")
+	startDaemonFixture(t, fixture, home, "legacy_inventory")
+
+	stdout, stderr, err := runInventoryCommand(
+		t,
+		binary,
+		home,
+		primary,
+		"changes",
+		primary,
+		"--json",
+	)
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "stdout=%s stderr=%s", stdout, stderr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout, &envelope))
+	assert.Equal(t, service.DaemonIncompatible, envelope.Error.Code)
+	assert.False(t, envelope.Error.Retryable)
+}
+
+func runChangesSubprocessJSON(
+	t *testing.T,
+	binary string,
+	home string,
+	directory string,
+	path string,
+) kwt.InspectionResult {
+	t.Helper()
+	stdout, stderr, err := runInventoryCommand(
+		t, binary, home, directory, "changes", path, "--json",
+	)
+	require.NoError(t, err, "stdout=%s stderr=%s", stdout, stderr)
+	var result kwt.InspectionResult
+	require.NoError(t, json.Unmarshal(stdout, &result), "stdout=%s", stdout)
+	return result
+}
+
+func newChangesSubprocessWorktrees(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	linked := filepath.Join(root, "linked")
+	runTUITestGit(t, "", "init", "-b", "main", primary)
+	runTUITestGit(t, primary, "config", "user.name", "Test User")
+	runTUITestGit(t, primary, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(primary, "README.md"),
+		[]byte("# widget\n"),
+		0o644,
+	))
+	runTUITestGit(t, primary, "add", ".")
+	runTUITestGit(t, primary, "commit", "-m", "Initial commit")
+	runTUITestGit(t, primary, "worktree", "add", "-b", "feature", linked)
+	worktrees, err := git.New(primary).ListWorktrees()
+	require.NoError(t, err)
+	require.Len(t, worktrees, 2)
+	return canonicalTestPath(t, primary), canonicalTestPath(t, linked)
+}
+
+func newChangesSubprocessHome(t *testing.T, primary string) string {
+	t.Helper()
+	return newDaemonTestHome(t, validDaemonConfig+fmt.Sprintf(`
+[[projects]]
+repository = "github.com/acme/widget"
+name = "widget"
+path = %q
+`, filepath.ToSlash(primary)))
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return resolved
+}
+
+func mapKeys(values map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/internal/cmd/changes_test.go
+++ b/internal/cmd/changes_test.go
@@ -1,0 +1,431 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/service"
+)
+
+const changesTestGeneration = "0123456789abcdef0123456789abcdef"
+
+type changesInspectorFunc func(
+	context.Context,
+	kwt.InspectionRequest,
+) (kwt.InspectionResult, error)
+
+func (f changesInspectorFunc) Inspect(
+	ctx context.Context,
+	request kwt.InspectionRequest,
+) (kwt.InspectionResult, error) {
+	return f(ctx, request)
+}
+
+func TestRunChangesDefaultsToAbsoluteCwdAndWritesInspectionJSON(t *testing.T) {
+	resetChangesCommand(t)
+	worktree := t.TempDir()
+	t.Chdir(worktree)
+	wantObserved := time.Date(2026, 8, 20, 18, 0, 0, 0, time.UTC)
+	var gotRequest kwt.InspectionRequest
+	newChangesInspector = func(*cobra.Command) kwt.Inspector {
+		return changesInspectorFunc(func(
+			_ context.Context,
+			request kwt.InspectionRequest,
+		) (kwt.InspectionResult, error) {
+			gotRequest = request
+			return kwt.InspectionResult{
+				Worktree: kwt.WorktreeIdentity{
+					Repository: "github.com/acme/widget",
+					Path:       worktree,
+					Generation: changesTestGeneration,
+				},
+				Changes: kwt.ChangeSet{
+					State: kwt.ChangeStateClean,
+					Files: []kwt.FileChange{},
+				},
+				ObservedAt: wantObserved,
+			}, nil
+		})
+	}
+	changesJSON = true
+	var stdout, stderr bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&stderr)
+
+	err := runChanges(changesCmd, nil)
+
+	require.NoError(t, err)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	wantPath, err := filepath.Abs(cwd)
+	require.NoError(t, err)
+	assert.Equal(t, kwt.InspectionRequest{Path: wantPath}, gotRequest)
+	var got kwt.InspectionResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Equal(t, "github.com/acme/widget", got.Worktree.Repository)
+	assert.Equal(t, changesTestGeneration, got.Worktree.Generation)
+	assert.Equal(t, wantObserved, got.ObservedAt)
+	assert.NotNil(t, got.Changes.Files)
+	assert.Empty(t, got.Changes.Files)
+	assert.Empty(t, stderr.String())
+}
+
+func TestRunChangesPassesAbsoluteLiteralPathAndIndependentGuards(t *testing.T) {
+	resetChangesCommand(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	literal := filepath.Join("nested", "..", "linked")
+	wantPath, err := filepath.Abs(literal)
+	require.NoError(t, err)
+	var gotRequest kwt.InspectionRequest
+	newChangesInspector = func(*cobra.Command) kwt.Inspector {
+		return changesInspectorFunc(func(
+			_ context.Context,
+			request kwt.InspectionRequest,
+		) (kwt.InspectionResult, error) {
+			gotRequest = request
+			return cleanChangesResult(wantPath), nil
+		})
+	}
+	changesJSON = true
+	changesExpectedRepository = "github.com/acme/widget"
+	changesExpectedGeneration = changesTestGeneration
+	changesCmd.SetOut(&bytes.Buffer{})
+	changesCmd.SetErr(&bytes.Buffer{})
+
+	err = runChanges(changesCmd, []string{literal})
+
+	require.NoError(t, err)
+	assert.Equal(t, kwt.InspectionRequest{
+		Path:               wantPath,
+		ExpectedRepository: "github.com/acme/widget",
+		ExpectedGeneration: changesTestGeneration,
+	}, gotRequest)
+}
+
+func TestRunChangesWritesDeterministicHumanOutput(t *testing.T) {
+	resetChangesCommand(t)
+	observed := time.Date(2026, 8, 20, 18, 0, 0, 123, time.UTC)
+	result := kwt.InspectionResult{
+		Worktree: kwt.WorktreeIdentity{
+			Repository: "local/acme\twidget",
+			Path:       "/worktrees/widget\nlinked",
+			Generation: changesTestGeneration,
+		},
+		Changes: kwt.ChangeSet{
+			State: kwt.ChangeStateConflicted,
+			Summary: kwt.ChangeSummary{
+				Modified: 1, Staged: 1, Conflicts: 1,
+			},
+			Files: []kwt.FileChange{
+				{
+					Path:     "conflict\tname.txt",
+					Index:    kwt.FileStateConflicted,
+					Worktree: kwt.FileStateConflicted,
+				},
+				{
+					Path:         "renamed\nname.txt",
+					OriginalPath: "old name.txt",
+					Index:        kwt.FileStateRenamed,
+				},
+			},
+		},
+		ObservedAt: observed,
+	}
+	newChangesInspector = func(*cobra.Command) kwt.Inspector {
+		return changesInspectorFunc(func(
+			context.Context,
+			kwt.InspectionRequest,
+		) (kwt.InspectionResult, error) {
+			return result, nil
+		})
+	}
+	var stdout, stderr bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&stderr)
+
+	err := runChanges(changesCmd, []string{"/worktrees/widget"})
+
+	require.NoError(t, err)
+	assert.Equal(t, `Repository: "local/acme\twidget"
+Worktree: "/worktrees/widget\nlinked"
+Generation: 0123456789abcdef0123456789abcdef
+Observed at: 2026-08-20T18:00:00.000000123Z
+Changes:
+  "conflict\tname.txt"
+    staged: -
+    working tree: conflicted
+  "old name.txt" -> "renamed\nname.txt"
+    staged: renamed
+    working tree: -
+`, stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestRunChangesCleanHumanOutputSaysNoChangedFiles(t *testing.T) {
+	resetChangesCommand(t)
+	result := cleanChangesResult("/worktrees/widget")
+	newChangesInspector = func(*cobra.Command) kwt.Inspector {
+		return changesInspectorFunc(func(
+			context.Context,
+			kwt.InspectionRequest,
+		) (kwt.InspectionResult, error) {
+			return result, nil
+		})
+	}
+	var stdout bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&bytes.Buffer{})
+
+	err := runChanges(changesCmd, []string{"/worktrees/widget"})
+
+	require.NoError(t, err)
+	assert.Equal(t, `Repository: "github.com/acme/widget"
+Worktree: "/worktrees/widget"
+Generation: 0123456789abcdef0123456789abcdef
+Observed at: 2026-08-20T18:00:00Z
+No changed files
+`, stdout.String())
+}
+
+func TestChangesInitializationFailureUsesSharedJSONEnvelope(t *testing.T) {
+	resetChangesCommand(t)
+	changesJSON = true
+	originalInitErr := configInitErr
+	configInitErr = errors.New("config unavailable")
+	t.Cleanup(func() { configInitErr = originalInitErr })
+	var stdout, stderr bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&stderr)
+
+	err := changesCmd.PersistentPreRunE(changesCmd, nil)
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 1, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.InspectionFailed, envelope.Error.Code)
+	assert.False(t, envelope.Error.Retryable)
+	assert.Contains(t, envelope.Error.Message, "config unavailable")
+	assert.Equal(
+		t,
+		"kwt changes: inspection_failed: failed to initialize configuration: config unavailable\n",
+		stderr.String(),
+	)
+}
+
+func TestRunChangesWritesStableJSONFailures(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		code      service.Code
+		retryable bool
+		exitCode  int
+	}{
+		{name: "invalid request", code: service.InvalidRequest, exitCode: 2},
+		{name: "missing worktree", code: service.NotFound, exitCode: 2},
+		{
+			name: "repository mismatch", code: service.RegistrationChanged,
+			retryable: true, exitCode: 1,
+		},
+		{name: "malformed inventory", code: service.InspectionFailed, exitCode: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetChangesCommand(t)
+			newChangesInspector = func(*cobra.Command) kwt.Inspector {
+				return changesInspectorFunc(func(
+					context.Context,
+					kwt.InspectionRequest,
+				) (kwt.InspectionResult, error) {
+					return kwt.InspectionResult{}, service.NewError(
+						tt.code,
+						"stable failure",
+						tt.retryable,
+						nil,
+						errors.New("private cause"),
+					)
+				})
+			}
+			changesJSON = true
+			var stdout, stderr bytes.Buffer
+			changesCmd.SetOut(&stdout)
+			changesCmd.SetErr(&stderr)
+
+			err := runChanges(changesCmd, []string{"/worktrees/widget"})
+
+			var coded interface{ ExitCode() int }
+			require.ErrorAs(t, err, &coded)
+			assert.Equal(t, tt.exitCode, coded.ExitCode())
+			var envelope jsonErrorEnvelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+			assert.Equal(t, tt.code, envelope.Error.Code)
+			assert.Equal(t, tt.retryable, envelope.Error.Retryable)
+			assert.NotContains(t, stdout.String(), "private cause")
+			assert.Equal(t, "kwt changes: "+string(tt.code)+": stable failure\n", stderr.String())
+		})
+	}
+}
+
+func TestRunChangesPreservesCallerContextErrors(t *testing.T) {
+	for _, contextErr := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(contextErr.Error(), func(t *testing.T) {
+			resetChangesCommand(t)
+			newChangesInspector = func(*cobra.Command) kwt.Inspector {
+				return changesInspectorFunc(func(
+					context.Context,
+					kwt.InspectionRequest,
+				) (kwt.InspectionResult, error) {
+					return kwt.InspectionResult{}, contextErr
+				})
+			}
+			changesJSON = true
+			var stdout, stderr bytes.Buffer
+			changesCmd.SetOut(&stdout)
+			changesCmd.SetErr(&stderr)
+
+			err := runChanges(changesCmd, []string{"/worktrees/widget"})
+
+			require.ErrorIs(t, err, contextErr)
+			assert.Empty(t, stdout.String())
+			assert.Empty(t, stderr.String())
+		})
+	}
+}
+
+func TestRunChangesWritesTypedInspectionTimeoutAsJSONFailure(t *testing.T) {
+	resetChangesCommand(t)
+	newChangesInspector = func(*cobra.Command) kwt.Inspector {
+		return changesInspectorFunc(func(
+			context.Context,
+			kwt.InspectionRequest,
+		) (kwt.InspectionResult, error) {
+			return kwt.InspectionResult{}, service.NewError(
+				service.InspectionFailed,
+				"worktree inspection timed out",
+				true,
+				nil,
+				context.DeadlineExceeded,
+			)
+		})
+	}
+	changesJSON = true
+	var stdout, stderr bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&stderr)
+
+	err := runChanges(changesCmd, []string{"/worktrees/widget"})
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 1, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.InspectionFailed, envelope.Error.Code)
+	assert.True(t, envelope.Error.Retryable)
+	assert.Equal(t, "worktree inspection timed out", envelope.Error.Message)
+	assert.Equal(
+		t,
+		"kwt changes: inspection_failed: worktree inspection timed out\n",
+		stderr.String(),
+	)
+}
+
+func TestChangesArgumentFailureUsesSharedJSONEnvelope(t *testing.T) {
+	resetChangesCommand(t)
+	changesJSON = true
+	var stdout, stderr bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&stderr)
+
+	err := changesCmd.Args(changesCmd, []string{"one", "two"})
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 2, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.InvalidRequest, envelope.Error.Code)
+	assert.Equal(t, "kwt changes: invalid_request: expected at most one worktree path\n", stderr.String())
+}
+
+func TestChangesFlagFailureFindsJSONAfterUnknownFlag(t *testing.T) {
+	resetChangesCommand(t)
+	originalArgs := os.Args
+	os.Args = []string{"kwt", "changes", "--bogus", "--json"}
+	t.Cleanup(func() { os.Args = originalArgs })
+	var stdout, stderr bytes.Buffer
+	changesCmd.SetOut(&stdout)
+	changesCmd.SetErr(&stderr)
+	flagError := changesCmd.FlagErrorFunc()
+	require.NotNil(t, flagError)
+
+	err := flagError(changesCmd, errors.New("unknown flag: --bogus"))
+
+	var coded interface{ ExitCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 2, coded.ExitCode())
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, service.InvalidRequest, envelope.Error.Code)
+	assert.Equal(t, "kwt changes: invalid_request: unknown flag: --bogus\n", stderr.String())
+}
+
+func TestChangesHelpDocumentsFocusedInspectionAndGuards(t *testing.T) {
+	help := changesCmd.Long + "\n" + changesCmd.Example
+
+	assert.Contains(t, help, "one exact worktree")
+	assert.Contains(t, help, "does not fetch")
+	assert.Contains(t, help, "kwt changes [path] --json")
+	assert.Contains(t, help, "--expected-repository")
+	assert.Contains(t, help, "--expected-generation")
+}
+
+func cleanChangesResult(path string) kwt.InspectionResult {
+	return kwt.InspectionResult{
+		Worktree: kwt.WorktreeIdentity{
+			Repository: "github.com/acme/widget",
+			Path:       path,
+			Generation: changesTestGeneration,
+		},
+		Changes: kwt.ChangeSet{
+			State: kwt.ChangeStateClean,
+			Files: []kwt.FileChange{},
+		},
+		ObservedAt: time.Date(2026, 8, 20, 18, 0, 0, 0, time.UTC),
+	}
+}
+
+func resetChangesCommand(t *testing.T) {
+	t.Helper()
+	originalFactory := newChangesInspector
+	originalJSON := changesJSON
+	originalRepository := changesExpectedRepository
+	originalGeneration := changesExpectedGeneration
+	originalOut := changesCmd.OutOrStdout()
+	originalErr := changesCmd.ErrOrStderr()
+	originalSilenceUsage := rootCmd.SilenceUsage
+	originalSilenceErrors := rootCmd.SilenceErrors
+	t.Cleanup(func() {
+		newChangesInspector = originalFactory
+		changesJSON = originalJSON
+		changesExpectedRepository = originalRepository
+		changesExpectedGeneration = originalGeneration
+		changesCmd.SetOut(originalOut)
+		changesCmd.SetErr(originalErr)
+		rootCmd.SilenceUsage = originalSilenceUsage
+		rootCmd.SilenceErrors = originalSilenceErrors
+	})
+	changesJSON = false
+	changesExpectedRepository = ""
+	changesExpectedGeneration = ""
+}

--- a/internal/cmd/changes_test.go
+++ b/internal/cmd/changes_test.go
@@ -202,7 +202,8 @@ func TestChangesInitializationFailureUsesSharedJSONEnvelope(t *testing.T) {
 	resetChangesCommand(t)
 	changesJSON = true
 	originalInitErr := configInitErr
-	configInitErr = errors.New("config unavailable")
+	privateConfigErr := errors.New("private config path: /private/config.toml")
+	configInitErr = privateConfigErr
 	t.Cleanup(func() { configInitErr = originalInitErr })
 	var stdout, stderr bytes.Buffer
 	changesCmd.SetOut(&stdout)
@@ -217,12 +218,13 @@ func TestChangesInitializationFailureUsesSharedJSONEnvelope(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
 	assert.Equal(t, service.InspectionFailed, envelope.Error.Code)
 	assert.False(t, envelope.Error.Retryable)
-	assert.Contains(t, envelope.Error.Message, "config unavailable")
+	assert.Equal(t, "failed to initialize configuration", envelope.Error.Message)
 	assert.Equal(
 		t,
-		"kwt changes: inspection_failed: failed to initialize configuration: config unavailable\n",
+		"kwt changes: inspection_failed: failed to initialize configuration\n",
 		stderr.String(),
 	)
+	assert.ErrorIs(t, err, privateConfigErr)
 }
 
 func TestRunChangesWritesStableJSONFailures(t *testing.T) {

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -258,6 +258,37 @@ func queryInventoryForCLI(
 	interactive bool,
 	stderr io.Writer,
 ) (kwt.Result, error) {
+	return queryInventoryForCLIWithRequirement(
+		ctx,
+		request,
+		interactive,
+		stderr,
+		requireInventoryCapability,
+	)
+}
+
+func queryInspectionInventoryForCLI(
+	ctx context.Context,
+	request kwt.Request,
+	interactive bool,
+	stderr io.Writer,
+) (kwt.Result, error) {
+	return queryInventoryForCLIWithRequirement(
+		ctx,
+		request,
+		interactive,
+		stderr,
+		requireInspectionInventoryCapability,
+	)
+}
+
+func queryInventoryForCLIWithRequirement(
+	ctx context.Context,
+	request kwt.Request,
+	interactive bool,
+	stderr io.Writer,
+	requireCapability func(kwtdaemon.Observation) error,
+) (kwt.Result, error) {
 	controller, err := newDaemonController()
 	if err != nil {
 		return kwt.Result{}, err
@@ -269,7 +300,12 @@ func queryInventoryForCLI(
 	}
 	declined := false
 	for {
-		result, queryErr := queryDaemonInventory(ctx, controller, request)
+		result, queryErr := queryDaemonInventory(
+			ctx,
+			controller,
+			request,
+			requireCapability,
+		)
 		if queryErr == nil {
 			writeConfigNotes(stderr, result.Notes, interactive, declined)
 			return result, nil
@@ -294,7 +330,7 @@ func queryInventoryForCLI(
 		if startErr != nil {
 			return kwt.Result{}, startErr
 		}
-		if err := requireInventoryCapability(observation); err != nil {
+		if err := requireCapability(observation); err != nil {
 			return kwt.Result{}, err
 		}
 		if err := observation.Client.ApproveConfig(ctx, kwt.ConfigApproval{
@@ -310,13 +346,14 @@ func queryDaemonInventory(
 	ctx context.Context,
 	controller daemonController,
 	request kwt.Request,
+	requireCapability func(kwtdaemon.Observation) error,
 ) (kwt.Result, error) {
 	for {
 		observation, err := controller.Start(ctx)
 		if err != nil {
 			return kwt.Result{}, err
 		}
-		if err := requireInventoryCapability(observation); err != nil {
+		if err := requireCapability(observation); err != nil {
 			return kwt.Result{}, err
 		}
 		result, err := observation.Client.Inventory(ctx, request)
@@ -354,6 +391,27 @@ func requireInventoryCapability(observation kwtdaemon.Observation) error {
 		return service.NewError(
 			service.DaemonIncompatible,
 			"the running kwt daemon does not provide worktree inventory",
+			false,
+			nil,
+			nil,
+		)
+	}
+	return nil
+}
+
+func requireInspectionInventoryCapability(
+	observation kwtdaemon.Observation,
+) error {
+	if err := requireInventoryCapability(observation); err != nil {
+		return err
+	}
+	if !slices.Contains(
+		observation.Status.Capabilities,
+		kwtdaemon.CapabilityInventoryConfig,
+	) {
+		return service.NewError(
+			service.DaemonIncompatible,
+			"the running kwt daemon does not provide config-bearing worktree inventory",
 			false,
 			nil,
 			nil,

--- a/internal/cmd/daemon_subprocess_test.go
+++ b/internal/cmd/daemon_subprocess_test.go
@@ -55,6 +55,7 @@ func buildDaemonTestBinary(t *testing.T, build daemonTestBuild) string {
 	command := exec.Command(
 		"go",
 		"build",
+		"-buildvcs=false",
 		"-ldflags",
 		"-X go.kenn.io/kwt/internal/cmd.version="+build.Version+
 			" -X go.kenn.io/kwt/internal/cmd.commit="+build.Revision+

--- a/internal/cmd/json_error.go
+++ b/internal/cmd/json_error.go
@@ -15,12 +15,13 @@ type jsonErrorEnvelope struct {
 type commandFailure struct {
 	descriptor service.Descriptor
 	exitCode   int
+	cause      error
 }
 
 func (e *commandFailure) Error() string { return e.descriptor.Message }
 func (e *commandFailure) ExitCode() int { return e.exitCode }
 func (e *commandFailure) Unwrap() error {
-	return service.NewDescriptorError(e.descriptor, nil)
+	return service.NewDescriptorError(e.descriptor, e.cause)
 }
 
 func writeCommandFailure(
@@ -29,7 +30,7 @@ func writeCommandFailure(
 	exitCode int,
 	jsonRequested bool,
 	prefix string,
-) error {
+) *commandFailure {
 	cmd.Root().SilenceUsage = true
 	cmd.Root().SilenceErrors = true
 	if jsonRequested {

--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -2316,18 +2316,18 @@ func TestRunPRAttachUsesTransferredProvenanceAliasHistory(t *testing.T) {
 	) (pullrequest.Project, []pullrequest.Workspace, error) {
 		assert.Equal(t, record, got)
 		return pullrequest.Project{
-				Identity: registeredIdentity,
-				Path:     record.Project.Path,
-			}, []pullrequest.Workspace{{
-				Path:       workspacePath,
-				Branch:     branch,
-				Repository: registeredIdentity,
-				SessionName: tmux.WorkspaceSessionName(
-					registeredInfo,
-					branch,
-					workspacePath,
-				),
-			}}, nil
+			Identity: registeredIdentity,
+			Path:     record.Project.Path,
+		}, []pullrequest.Workspace{{
+			Path:       workspacePath,
+			Branch:     branch,
+			Repository: registeredIdentity,
+			SessionName: tmux.WorkspaceSessionName(
+				registeredInfo,
+				branch,
+				workspacePath,
+			),
+		}}, nil
 	}
 	attached := false
 	attachExistingPRWorkspaceSession = func(

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kwt/internal/config"
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/status"
@@ -233,6 +234,7 @@ func collectWorktreeStatuses(ctx context.Context, cfg *models.Config, printer *u
 		FetchRemote:    !statusNoFetch,
 		StaleThreshold: time.Duration(statusStaleDays) * 24 * time.Hour,
 		BaseDir:        cfg.Worktree.BaseDir,
+		ProtectedNames: credentials.ProtectedNames(cfg),
 	})
 	collection, err := collector.CollectAll(ctx, worktrees)
 	if err != nil {

--- a/internal/cmd/testdata/daemonfixture/main.go
+++ b/internal/cmd/testdata/daemonfixture/main.go
@@ -68,6 +68,17 @@ func main() {
 		schemaVersion = "2.0.0"
 		record.Metadata["schema_major"] = strconv.Itoa(schemaMajor)
 		record.Metadata["schema_version"] = schemaVersion
+	} else if *mode == "legacy_inventory" {
+		schemaVersion = "1.11.0"
+		record.Metadata["schema_version"] = schemaVersion
+		capabilities := strings.Split(record.Metadata["capabilities"], ",")
+		kept := capabilities[:0]
+		for _, capability := range capabilities {
+			if capability != "worktree.inventory.config.v1" {
+				kept = append(kept, capability)
+			}
+		}
+		record.Metadata["capabilities"] = strings.Join(kept, ",")
 	}
 	if _, err := kwtdaemon.RuntimeStore(*home).Write(record); err != nil {
 		log.Fatal(err)

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -48,7 +48,7 @@ type tuiBackend struct {
 	discoverGlobalWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
 	discoverProjectWorktrees  func(string) ([]*discovery.GlobalWorktreeEntry, error)
 	discoverLaunchWorktrees   func(string) ([]*discovery.GlobalWorktreeEntry, error)
-	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, []string, error)
+	collectStatuses           func(context.Context, string, []*discovery.GlobalWorktreeEntry, []string) (map[string]*models.WorktreeStatus, []string, error)
 	resolveSessions           func(context.Context, []tmux.WorkspaceEndpointRequest) ([]tmux.WorkspaceSession, error)
 	liveEndpoints             func(context.Context, tmux.WorkspaceEndpointRequest) ([]tmux.SessionEndpoint, error)
 	resolveLive               func(context.Context, tmux.WorkspaceEndpointRequest) (tmux.SessionEndpoint, error)
@@ -125,6 +125,7 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		},
 		discoverProjectWorktrees: discoverLaunchRepoWorktrees,
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
+		collectStatuses:          collectTUIStatuses,
 		resolveSessions: bestEffortDashboardSessionResolver(
 			sessions.ResolveAllBestEffort,
 			tmuxDiagnosticReporter(os.Stderr),
@@ -149,13 +150,6 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 	backend.killProtectedEndpoint = backend.killProtectedTUIEndpoint
 	backend.loadTargetConfig = func(repoRoot string, interactive bool) (*models.Config, error) {
 		return config.LoadForTargetFrom(backend.cfg, repoRoot, interactive)
-	}
-	backend.collectStatuses = func(
-		ctx context.Context,
-		baseDir string,
-		entries []*discovery.GlobalWorktreeEntry,
-	) (map[string]*models.WorktreeStatus, []string, error) {
-		return collectTUIStatuses(ctx, baseDir, entries, backend.protectedNames)
 	}
 	return backend
 }
@@ -212,6 +206,11 @@ func (b *tuiBackend) LoadInventory(ctx context.Context, request dashboard.Invent
 	for _, entry := range result.Snapshot.Entries {
 		entries = append(entries, dashboardInventoryEntry(entry))
 	}
+	var repositoryProtectedNames []string
+	if request.Scope == dashboard.InventoryCurrentRepository &&
+		result.Freshness == kwt.Fresh && result.Snapshot.Config != nil {
+		repositoryProtectedNames = credentials.ProtectedNames(result.Snapshot.Config)
+	}
 
 	b.mu.Lock()
 	if request.Scope == dashboard.InventoryCurrentDashboard && result.Freshness == kwt.Fresh {
@@ -235,13 +234,17 @@ func (b *tuiBackend) LoadInventory(ctx context.Context, request dashboard.Invent
 		}
 	}
 	collectStatuses := b.collectStatuses
+	protectedNames := append([]string(nil), b.protectedNames...)
+	if repositoryProtectedNames != nil {
+		protectedNames = repositoryProtectedNames
+	}
 	resolveSessions := b.resolveSessions
 	b.mu.Unlock()
 
 	var statusByPath map[string]*models.WorktreeStatus
 	var warnings []string
 	if request.CollectStatuses && collectStatuses != nil {
-		statusByPath, warnings, err = collectStatuses(ctx, baseDir, entries)
+		statusByPath, warnings, err = collectStatuses(ctx, baseDir, entries, protectedNames)
 		if err != nil {
 			return dashboard.InventoryResult{}, err
 		}
@@ -379,6 +382,7 @@ func (b *tuiBackend) list(ctx context.Context, includeStatuses bool) ([]dashboar
 			ctx,
 			b.cfg.Worktree.BaseDir,
 			entries,
+			b.protectedNames,
 		)
 		if discoveryErr != nil {
 			return nil, nil, discoveryErr
@@ -431,7 +435,12 @@ func (b *tuiBackend) listDaemon(ctx context.Context, includeStatuses bool) ([]da
 	var statusByPath map[string]*models.WorktreeStatus
 	var statusWarnings []string
 	if includeStatuses {
-		statusByPath, statusWarnings, err = b.collectStatuses(ctx, b.cfg.Worktree.BaseDir, entries)
+		statusByPath, statusWarnings, err = b.collectStatuses(
+			ctx,
+			b.cfg.Worktree.BaseDir,
+			entries,
+			b.protectedNames,
+		)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/cmd/tui_backend.go
+++ b/internal/cmd/tui_backend.go
@@ -125,7 +125,6 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 		},
 		discoverProjectWorktrees: discoverLaunchRepoWorktrees,
 		discoverLaunchWorktrees:  discoverLaunchRepoWorktrees,
-		collectStatuses:          collectTUIStatuses,
 		resolveSessions: bestEffortDashboardSessionResolver(
 			sessions.ResolveAllBestEffort,
 			tmuxDiagnosticReporter(os.Stderr),
@@ -150,6 +149,13 @@ func newTUIBackendWithLaunchDir(cfg *models.Config, launchDir string) *tuiBacken
 	backend.killProtectedEndpoint = backend.killProtectedTUIEndpoint
 	backend.loadTargetConfig = func(repoRoot string, interactive bool) (*models.Config, error) {
 		return config.LoadForTargetFrom(backend.cfg, repoRoot, interactive)
+	}
+	backend.collectStatuses = func(
+		ctx context.Context,
+		baseDir string,
+		entries []*discovery.GlobalWorktreeEntry,
+	) (map[string]*models.WorktreeStatus, []string, error) {
+		return collectTUIStatuses(ctx, baseDir, entries, backend.protectedNames)
 	}
 	return backend
 }
@@ -1197,6 +1203,7 @@ func collectTUIStatuses(
 	ctx context.Context,
 	baseDir string,
 	entries []*discovery.GlobalWorktreeEntry,
+	protectedNames []string,
 ) (map[string]*models.WorktreeStatus, []string, error) {
 	worktrees := make([]*models.Worktree, 0, len(entries))
 	for _, entry := range entries {
@@ -1213,7 +1220,7 @@ func collectTUIStatuses(
 		})
 	}
 
-	collector := status.NewStatusCollectorWithOptions(tuiStatusCollectorOptions(baseDir))
+	collector := status.NewStatusCollectorWithOptions(tuiStatusCollectorOptions(baseDir, protectedNames))
 	collection, err := collector.CollectAll(ctx, worktrees)
 	if err != nil {
 		return nil, nil, err
@@ -1232,10 +1239,11 @@ func collectTUIStatuses(
 	return statusByPath, warnings, nil
 }
 
-func tuiStatusCollectorOptions(baseDir string) status.StatusCollectorOptions {
+func tuiStatusCollectorOptions(baseDir string, protectedNames []string) status.StatusCollectorOptions {
 	return status.StatusCollectorOptions{
-		FetchRemote: true,
-		BaseDir:     baseDir,
+		FetchRemote:    true,
+		BaseDir:        baseDir,
+		ProtectedNames: append([]string(nil), protectedNames...),
 	}
 }
 

--- a/internal/cmd/tui_daemon_inventory_test.go
+++ b/internal/cmd/tui_daemon_inventory_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,7 +28,7 @@ func TestTUIBackendInventoryModesSeparateCurrencyAndStatus(t *testing.T) {
 	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	var requests []kwt.Request
 	var statusCalls int
-	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, []string, error) {
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry, []string) (map[string]*models.WorktreeStatus, []string, error) {
 		statusCalls++
 		return map[string]*models.WorktreeStatus{}, nil, nil
 	}
@@ -144,6 +148,59 @@ func TestRepositoryInventoryRejectsDeletedWorkingDirectoryBeforeQuery(t *testing
 	assert.False(t, queried)
 }
 
+func TestRepositoryInventoryUsesFreshCredentialNamesForStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("command recorder uses a POSIX shell")
+	}
+	repository := newTUITestRepo(t)
+	backend := newTUIBackendWithLaunchDir(&models.Config{
+		Fleet: models.FleetConfig{TokenEnv: "OLD_FLEET_TOKEN"},
+	}, repository)
+	backend.resolveSessions = resolveStoppedWorkspaceSessions
+	backend.queryInventory = func(context.Context, kwt.Request, bool, io.Writer) (kwt.Result, error) {
+		return kwt.Result{Freshness: kwt.Fresh, Snapshot: kwt.Snapshot{
+			Config: &models.Config{Fleet: models.FleetConfig{TokenEnv: "NEW_FLEET_TOKEN"}},
+			Entries: []kwt.Entry{{
+				Path: repository, Branch: "main", IsMain: true,
+				Repository: kwt.Repository{FullPath: "github.com/acme/widget"},
+			}},
+		}}, nil
+	}
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	wrapperDir := t.TempDir()
+	logPath := filepath.Join(wrapperDir, "git.log")
+	require.NoError(t, os.WriteFile(filepath.Join(wrapperDir, "git"), []byte(`#!/bin/sh
+if [ "${NEW_FLEET_TOKEN+x}" = x ]; then
+  credential=present
+else
+  credential=absent
+fi
+printf '%s|%s\n' "$*" "$credential" >> "$KWT_TEST_GIT_LOG"
+exec "$KWT_TEST_REAL_GIT" "$@"
+`), 0o755))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KWT_TEST_GIT_LOG", logPath)
+	t.Setenv("KWT_TEST_REAL_GIT", realGit)
+	t.Setenv("NEW_FLEET_TOKEN", "must-not-reach-git")
+
+	_, err = backend.LoadInventory(context.Background(), dashboard.InventoryRequest{
+		Scope: dashboard.InventoryCurrentRepository, WorkingDirectory: repository,
+		ProjectIdentity: "github.com/acme/widget", CollectStatuses: true,
+	})
+
+	require.NoError(t, err)
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	require.NotEmpty(t, lines)
+	for _, line := range lines {
+		assert.True(t, strings.HasSuffix(line, "|absent"), "credential reached git command %q", line)
+	}
+	assert.Equal(t, "OLD_FLEET_TOKEN", backend.cfg.Fleet.TokenEnv)
+}
+
 func TestTUIBackendApplyInventoryConfigRewiresCleanupResolver(t *testing.T) {
 	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing"))
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
@@ -181,7 +238,7 @@ func TestTUIBackendMutationUsesLatestDaemonConfiguration(t *testing.T) {
 	currentBase := filepath.Join(t.TempDir(), "current")
 	backend := newTUIBackendWithLaunchDir(&models.Config{}, "")
 	backend.resolveSessions = resolveStoppedWorkspaceSessions
-	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, []string, error) {
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry, []string) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{}, nil, nil
 	}
 	backend.queryInventory = func(
@@ -226,7 +283,7 @@ func TestTUIBackendDaemonInventoryUsesCacheThenCurrent(t *testing.T) {
 	backend := newTUIBackendWithLaunchDir(cfg, "/launch")
 	backend.resolveSessions = resolveStoppedWorkspaceSessions
 	var statusBaseDirectory string
-	backend.collectStatuses = func(_ context.Context, baseDirectory string, _ []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, []string, error) {
+	backend.collectStatuses = func(_ context.Context, baseDirectory string, _ []*discovery.GlobalWorktreeEntry, _ []string) (map[string]*models.WorktreeStatus, []string, error) {
 		statusBaseDirectory = baseDirectory
 		return map[string]*models.WorktreeStatus{}, nil, nil
 	}
@@ -376,7 +433,7 @@ func TestTUIBackendRegistersOnlyCurrentLaunchInventory(t *testing.T) {
 		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
 	}, "/launch")
 	backend.resolveSessions = resolveStoppedWorkspaceSessions
-	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, []string, error) {
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry, []string) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{}, nil, nil
 	}
 	backend.registerWorkspace = nil
@@ -433,7 +490,7 @@ func TestTUIBackendCurrentInventoryIncludesNewLaunchWorkspace(t *testing.T) {
 		Worktree: models.WorktreeConfig{BaseDir: t.TempDir()},
 	}, "/launch")
 	backend.resolveSessions = resolveStoppedWorkspaceSessions
-	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry) (map[string]*models.WorktreeStatus, []string, error) {
+	backend.collectStatuses = func(context.Context, string, []*discovery.GlobalWorktreeEntry, []string) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{}, nil, nil
 	}
 	backend.registerProject = nil

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -314,6 +314,7 @@ func TestTUIBackendListAndMergeFleetAreConcurrencySafe(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -369,6 +370,7 @@ func TestTUIBackendListIncludesLaunchRepositoryWorktrees(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		assert.Equal(t, "/global", baseDir)
 		assert.Len(t, entries, 2)
@@ -411,6 +413,7 @@ func TestTUIBackendListFastSkipsStatusCollection(t *testing.T) {
 		context.Context,
 		string,
 		[]*discovery.GlobalWorktreeEntry,
+		[]string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		t.Fatal("fast listing must not collect Git status")
 		return nil, nil, nil
@@ -446,6 +449,7 @@ func TestTUIBackendListCollectsStatusForImportedWorktree(t *testing.T) {
 		_ context.Context,
 		_ string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		require.Equal(t, []*discovery.GlobalWorktreeEntry{entry}, entries)
 		return map[string]*models.WorktreeStatus{
@@ -546,6 +550,7 @@ func TestTUIBackendListIncludesRegisteredProjectWorktrees(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		assert.ElementsMatch(t, []string{globalEntry.Path, projectEntry.Path}, []string{
 			entries[0].Path,
@@ -731,6 +736,7 @@ func TestTUIBackendMergeFleetIncludesRemoteOnlyFleetRows(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			localEntry.Path: {Path: localEntry.Path, Branch: localEntry.Branch},
@@ -809,6 +815,7 @@ func TestTUIBackendMergeFleetDoesNotOfferSyncWithoutRegisteredProject(t *testing
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -872,6 +879,7 @@ func TestTUIBackendMergeFleetLocalPresenceComesFromLocalDiscovery(t *testing.T) 
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			localEntry.Path: {Path: localEntry.Path, Branch: localEntry.Branch},
@@ -977,6 +985,7 @@ func TestTUIBackendMergeFleetRendersFleetStatusFromLocalObservations(t *testing.
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			localEntry.Path: {Path: localEntry.Path, Branch: localEntry.Branch},
@@ -1077,6 +1086,7 @@ func TestTUIBackendMergeFleetMatchesLocalDetachedWorktreeToFleetRow(t *testing.T
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			detachedEntry.Path: {Path: detachedEntry.Path},
@@ -1128,6 +1138,7 @@ func TestTUIBackendListIncludesRegisteredProjectWithoutOrigin(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		require.Len(t, entries, 1)
 		return map[string]*models.WorktreeStatus{
@@ -1185,6 +1196,7 @@ func TestTUIBackendListPrefersRegisteredIdentityForGlobalLocalOnlyDuplicate(t *t
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		require.Len(t, entries, 1)
 		require.NotNil(t, entries[0].RepositoryInfo)
@@ -1236,6 +1248,7 @@ func TestTUIBackendListRegistersLaunchRepositoryBestEffort(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch},
@@ -1282,6 +1295,7 @@ func TestTUIBackendRegistersLaunchRepositoryOnceAcrossStagedLoad(t *testing.T) {
 		context.Context,
 		string,
 		[]*discovery.GlobalWorktreeEntry,
+		[]string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -1325,6 +1339,7 @@ func TestTUIBackendListAddsLaunchRepositoryToInMemoryProjects(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch},
@@ -1377,6 +1392,7 @@ func TestTUIBackendLaunchRegistrationReusesExistingProjectByPath(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return map[string]*models.WorktreeStatus{
 			launchEntry.Path: {Path: launchEntry.Path, Branch: launchEntry.Branch},
@@ -3793,6 +3809,7 @@ func TestTUIBackendMergeFleetReturnsHubWarnings(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -3828,6 +3845,7 @@ func TestTUIBackendListIncludesWorkspaceRows(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -3870,6 +3888,7 @@ func TestTUIBackendAutoRegistersNonGitLaunchDir(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -3902,6 +3921,7 @@ func TestTUIBackendSkipsAutoRegisterWhenAlreadyRegisteredWithCustomName(t *testi
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -3933,6 +3953,7 @@ func TestTUIBackendAutoRegistersLaunchWorkspaceOnlyOnce(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -3982,6 +4003,7 @@ func TestTUIBackendNeverRegistersWorkspaceForGitLaunchDir(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -4011,6 +4033,7 @@ func TestTUIBackendNeverAutoRegistersHomeDir(t *testing.T) {
 		ctx context.Context,
 		baseDir string,
 		entries []*discovery.GlobalWorktreeEntry,
+		_ []string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		return nil, nil, nil
 	}
@@ -4738,6 +4761,7 @@ func TestTUIBackendSerializesUnregisterWithFullLoad(t *testing.T) {
 	release := make(chan struct{})
 	backend.collectStatuses = func(
 		context.Context, string, []*discovery.GlobalWorktreeEntry,
+		[]string,
 	) (map[string]*models.WorktreeStatus, []string, error) {
 		close(collecting)
 		<-release

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -210,10 +210,13 @@ func TestBuildTUIRowMarksLiveSessionWhenRepositoryInfoPresent(t *testing.T) {
 }
 
 func TestTUIStatusCollectorOptionsFetchesSyncState(t *testing.T) {
-	opts := tuiStatusCollectorOptions("/worktrees")
+	protectedNames := []string{"CUSTOM_FLEET_TOKEN"}
+	opts := tuiStatusCollectorOptions("/worktrees", protectedNames)
+	protectedNames[0] = "MUTATED_AFTER_CALL"
 
 	assert.True(t, opts.FetchRemote)
 	assert.Equal(t, "/worktrees", opts.BaseDir)
+	assert.Equal(t, []string{"CUSTOM_FLEET_TOKEN"}, opts.ProtectedNames)
 }
 
 func TestCollectTUIStatusesSurfacesPerRowDiagnostic(t *testing.T) {
@@ -223,7 +226,7 @@ func TestCollectTUIStatusesSurfacesPerRowDiagnostic(t *testing.T) {
 		RepositoryInfo: &url.RepositoryInfo{FullPath: "github.com/acme/widget"},
 	}
 
-	statuses, warnings, err := collectTUIStatuses(context.Background(), t.TempDir(), []*discovery.GlobalWorktreeEntry{entry})
+	statuses, warnings, err := collectTUIStatuses(context.Background(), t.TempDir(), []*discovery.GlobalWorktreeEntry{entry}, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, statuses, missing)

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -246,6 +246,7 @@ func runHost(
 				CapabilitySSHLeaseHold,
 				CapabilitySSHLifecycle,
 				CapabilitySSHResolve,
+				CapabilityInventoryConfig,
 				CapabilityInventory,
 				CapabilityRemoval,
 				CapabilityGuardedRemoval,

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -99,6 +99,7 @@ func NewRuntimeRecord(
 			CapabilitySSHLeaseHold,
 			CapabilitySSHLifecycle,
 			CapabilitySSHResolve,
+			CapabilityInventoryConfig,
 			CapabilityInventory,
 			CapabilityRemoval,
 			CapabilityGuardedRemoval,

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -190,6 +190,7 @@ func TestNewRuntimeRecordAdvertisesCurrentDomainContracts(t *testing.T) {
 	capabilities := strings.Split(record.Metadata[metadataCapabilities], ",")
 	assert.Contains(t, capabilities, "worktree.inventory.v2")
 	assert.NotContains(t, capabilities, "worktree.inventory.v1")
+	assert.Contains(t, capabilities, "worktree.inventory.config.v1")
 	assert.Contains(t, capabilities, "project.removal.v1")
 	assert.Contains(t, capabilities, "worktree.removal.v1")
 	assert.Contains(t, capabilities, "worktree.removal.v2")

--- a/internal/daemon/ssh_resolution_test.go
+++ b/internal/daemon/ssh_resolution_test.go
@@ -207,7 +207,7 @@ func TestSSHResolveRouteReservesDaemonWorkAndHonorsCancellation(t *testing.T) {
 }
 
 func TestSSHResolveCapabilityAndSchemaAreAdvertised(t *testing.T) {
-	assert.Equal(t, "1.11.0", APISchemaVersion)
+	assert.Equal(t, "1.12.0", APISchemaVersion)
 	record, _, err := NewRuntimeRecord(
 		t.TempDir(),
 		Build{Version: "development"},

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -9,10 +9,11 @@ import (
 const (
 	ServiceName               = "kwt"
 	APISchemaMajor            = 1
-	APISchemaVersion          = "1.11.0"
+	APISchemaVersion          = "1.12.0"
 	CapabilityStatus          = "daemon.status"
 	CapabilityShutdown        = "daemon.shutdown"
 	CapabilityProjectRemoval  = "project.removal.v1"
+	CapabilityInventoryConfig = "worktree.inventory.config.v1"
 	CapabilityInventory       = "worktree.inventory.v2"
 	CapabilityRemoval         = "worktree.removal.v1"
 	CapabilityGuardedRemoval  = "worktree.removal.v2"

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/kwt/internal/credentials"
 	"go.kenn.io/kwt/internal/discovery"
 	"go.kenn.io/kwt/internal/git"
 	"go.kenn.io/kwt/internal/status"
@@ -391,8 +392,9 @@ func collectChangeStatus(ctx context.Context, cfg *models.Config, worktree model
 	}
 	worktree.Branch = branch
 	collector := status.NewStatusCollectorWithOptions(status.StatusCollectorOptions{
-		FetchRemote: false,
-		BaseDir:     cfg.Worktree.BaseDir,
+		FetchRemote:    false,
+		BaseDir:        cfg.Worktree.BaseDir,
+		ProtectedNames: credentials.ProtectedNames(cfg),
 	})
 	collection, err := collector.CollectAll(ctx, []*models.Worktree{&worktree})
 	if err != nil || len(collection.Statuses) == 0 || collection.Statuses[0] == nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -96,12 +96,21 @@ func inventoryEnvironment(env, protectedNames []string) []string {
 	result := make([]string, 0, len(filtered)+1)
 	for _, entry := range filtered {
 		name, _, ok := strings.Cut(entry, "=")
-		if ok && strings.HasPrefix(strings.ToUpper(name), "GIT_") {
+		if ok && isInventoryGitRedirect(name) {
 			continue
 		}
 		result = append(result, entry)
 	}
 	return append(result, "GIT_TERMINAL_PROMPT=0")
+}
+
+func isInventoryGitRedirect(name string) bool {
+	switch strings.ToUpper(name) {
+	case "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_NAMESPACE":
+		return true
+	default:
+		return false
+	}
 }
 
 // NewFromCwd creates a new Git instance using the current working directory.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,19 +4,61 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
+	"time"
 
 	"go.kenn.io/kwt/internal/credentials"
 )
+
+const (
+	commandOutputLimit = 1 << 20
+	commandWaitDelay   = 100 * time.Millisecond
+)
+
+var (
+	ErrStdoutLimitExceeded = errors.New("git stdout limit exceeded")
+	ErrStderrLimitExceeded = errors.New("git stderr limit exceeded")
+)
+
+type boundedBuffer struct {
+	buffer   bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buffer.Len()
+	if remaining > len(p) {
+		remaining = len(p)
+	}
+	if remaining > 0 {
+		_, _ = b.buffer.Write(p[:remaining])
+	}
+	if remaining < len(p) {
+		b.exceeded = true
+	}
+	return len(p), nil
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
+}
+
+func (b *boundedBuffer) String() string {
+	return b.buffer.String()
+}
 
 // Git provides Git command operations.
 type Git struct {
 	workDir     string
 	ctx         context.Context
 	environment []string
+	executable  string
 }
 
 // New creates a new Git instance.
@@ -92,6 +134,87 @@ func (g *Git) RunWithContext(ctx context.Context, args ...string) (string, error
 	return g.runWithContext(ctx, args...)
 }
 
+// RunBytesWithEnvironment executes a Git command with deterministic
+// environment overrides and returns stdout without text conversion.
+func (g *Git) RunBytesWithEnvironment(
+	overrides map[string]string,
+	args ...string,
+) ([]byte, error) {
+	cmd := g.command(args...)
+	if g.workDir != "" {
+		cmd.Dir = g.workDir
+	}
+	environment := os.Environ()
+	if g.environment != nil {
+		environment = g.environment
+	}
+	cmd.Env = environmentWithOverrides(environment, overrides)
+
+	stdout := boundedBuffer{limit: commandOutputLimit}
+	stderr := boundedBuffer{limit: commandOutputLimit}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	var limitErrors []error
+	if stdout.exceeded {
+		limitErrors = append(limitErrors, ErrStdoutLimitExceeded)
+	}
+	if stderr.exceeded {
+		limitErrors = append(limitErrors, ErrStderrLimitExceeded)
+	}
+	if len(limitErrors) > 0 {
+		if runErr != nil {
+			limitErrors = append(limitErrors, runErr)
+		}
+		return nil, fmt.Errorf(
+			"git %s: %w",
+			strings.Join(args, " "),
+			errors.Join(limitErrors...),
+		)
+	}
+	if runErr != nil {
+		if g.ctx != nil && g.ctx.Err() != nil {
+			return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), g.ctx.Err())
+		}
+		if stderr.String() == "" {
+			return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), runErr)
+		}
+		return nil, fmt.Errorf(
+			"git %s: %w: %s",
+			strings.Join(args, " "),
+			runErr,
+			stderr.String(),
+		)
+	}
+	return append([]byte(nil), stdout.Bytes()...), nil
+}
+
+func environmentWithOverrides(
+	environment []string,
+	overrides map[string]string,
+) []string {
+	names := make(map[string]bool, len(overrides))
+	keys := make([]string, 0, len(overrides))
+	for name := range overrides {
+		names[strings.ToLower(name)] = true
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+
+	result := make([]string, 0, len(environment)+len(overrides))
+	for _, entry := range environment {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && names[strings.ToLower(name)] {
+			continue
+		}
+		result = append(result, entry)
+	}
+	for _, name := range keys {
+		result = append(result, name+"="+overrides[name])
+	}
+	return result
+}
+
 // run executes a git command.
 func (g *Git) run(args ...string) (string, error) {
 	cmd := g.command(args...)
@@ -103,7 +226,7 @@ func (g *Git) run(args ...string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil && !successfulAfterWaitDelay(cmd, err) {
 		if g.ctx != nil && g.ctx.Err() != nil {
 			return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), g.ctx.Err())
 		}
@@ -132,31 +255,51 @@ func (g *Git) runWithoutCredentials(
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil && !successfulAfterWaitDelay(cmd, err) {
 		if g.ctx != nil && g.ctx.Err() != nil {
 			return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), g.ctx.Err())
 		}
-		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), stderr.String())
+		if stderr.String() == "" {
+			return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		}
+		return "", fmt.Errorf(
+			"git %s: %w: %s",
+			strings.Join(args, " "),
+			err,
+			stderr.String(),
+		)
 	}
 	return stdout.String(), nil
 }
 
 func (g *Git) command(args ...string) *exec.Cmd {
+	executable := g.executable
+	if executable == "" {
+		executable = "git"
+	}
 	var cmd *exec.Cmd
 	if g.ctx != nil {
-		cmd = exec.CommandContext(g.ctx, "git", args...)
+		cmd = exec.CommandContext(g.ctx, executable, args...)
 	} else {
-		cmd = exec.Command("git", args...)
+		cmd = exec.Command(executable, args...)
 	}
 	if g.environment != nil {
 		cmd.Env = append([]string(nil), g.environment...)
 	}
+	cmd.WaitDelay = commandWaitDelay
 	return cmd
+}
+
+func successfulAfterWaitDelay(cmd *exec.Cmd, err error) bool {
+	return errors.Is(err, exec.ErrWaitDelay) &&
+		cmd.ProcessState != nil &&
+		cmd.ProcessState.Success()
 }
 
 // runWithContext executes a git command with context support.
 func (g *Git) runWithContext(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.WaitDelay = commandWaitDelay
 	if g.environment != nil {
 		cmd.Env = append([]string(nil), g.environment...)
 	}
@@ -168,7 +311,7 @@ func (g *Git) runWithContext(ctx context.Context, args ...string) (string, error
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil && !successfulAfterWaitDelay(cmd, err) {
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), ctx.Err())
 		}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,324 @@ import (
 	"go.kenn.io/kwt/internal/utils"
 	"go.kenn.io/kwt/pkg/models"
 )
+
+func TestRunBytesWithEnvironmentPreservesEmbeddedNUL(t *testing.T) {
+	g := NewForInventory(context.Background(), t.TempDir(), nil)
+	g.executable = os.Args[0]
+
+	got, err := g.RunBytesWithEnvironment(
+		map[string]string{"KWT_TEST_GIT_BYTE_HELPER": "1"},
+		"-test.run=^TestGitByteRunnerHelperProcess$",
+		"--",
+		"nul",
+	)
+
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal([]byte{'a', 0, 'b'}, got), "output = %v", got)
+}
+
+func TestRunBytesWithEnvironmentBoundsStdoutAndStderrIndependently(t *testing.T) {
+	tests := []struct {
+		name     string
+		scenario string
+		wantErr  error
+	}{
+		{name: "stdout", scenario: "stdout-limit", wantErr: ErrStdoutLimitExceeded},
+		{name: "stderr", scenario: "stderr-limit", wantErr: ErrStderrLimitExceeded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewForInventory(context.Background(), t.TempDir(), nil)
+			g.executable = os.Args[0]
+
+			_, err := g.RunBytesWithEnvironment(
+				map[string]string{"KWT_TEST_GIT_BYTE_HELPER": "1"},
+				"-test.run=^TestGitByteRunnerHelperProcess$",
+				"--",
+				tt.scenario,
+			)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestRunBytesWithEnvironmentPreservesRunErrorWhenOutputLimitExceeded(t *testing.T) {
+	g := NewForInventory(context.Background(), t.TempDir(), nil)
+	g.executable = os.Args[0]
+
+	_, err := g.RunBytesWithEnvironment(
+		map[string]string{"KWT_TEST_GIT_BYTE_HELPER": "1"},
+		"-test.run=^TestGitByteRunnerHelperProcess$",
+		"--",
+		"stderr-limit-exit",
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrStderrLimitExceeded)
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 7, exitErr.ExitCode())
+}
+
+func TestRunBytesWithEnvironmentPreservesRunErrorOnNonZeroExit(t *testing.T) {
+	g := NewForInventory(context.Background(), t.TempDir(), nil)
+	g.executable = os.Args[0]
+
+	_, err := g.RunBytesWithEnvironment(
+		map[string]string{"KWT_TEST_GIT_BYTE_HELPER": "1"},
+		"-test.run=^TestGitByteRunnerHelperProcess$",
+		"--",
+		"stderr-exit",
+	)
+
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 7, exitErr.ExitCode())
+	assert.ErrorContains(t, err, "bounded diagnostic")
+}
+
+func TestRunBytesWithEnvironmentPreservesExecutableLookupError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	g := NewForInventory(context.Background(), t.TempDir(), nil)
+
+	_, err := g.RunBytesWithEnvironment(nil, "status")
+
+	require.Error(t, err)
+	var executableErr *exec.Error
+	require.ErrorAs(t, err, &executableErr)
+	assert.NotEmpty(t, executableErr.Err)
+}
+
+func TestRunBytesWithEnvironmentHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	g := NewForInventory(ctx, t.TempDir(), nil)
+	g.executable = os.Args[0]
+
+	_, err := g.RunBytesWithEnvironment(
+		map[string]string{"KWT_TEST_GIT_BYTE_HELPER": "1"},
+		"-test.run=^TestGitByteRunnerHelperProcess$",
+		"--",
+		"sleep",
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRunBytesWithEnvironmentBoundsRetainedOutputPipes(t *testing.T) {
+	for _, descriptor := range []string{"stdout", "stderr"} {
+		t.Run(descriptor, func(t *testing.T) {
+			pidPath := filepath.Join(t.TempDir(), "descendant.pid")
+			t.Cleanup(func() {
+				data, err := os.ReadFile(pidPath)
+				if err != nil {
+					return
+				}
+				pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+				if err != nil {
+					return
+				}
+				process, err := os.FindProcess(pid)
+				if err == nil {
+					_ = process.Kill()
+				}
+			})
+			g := NewForInventory(context.Background(), t.TempDir(), nil)
+			g.executable = os.Args[0]
+
+			started := time.Now()
+			_, err := g.RunBytesWithEnvironment(
+				map[string]string{
+					"KWT_TEST_GIT_BYTE_HELPER":    "1",
+					"KWT_TEST_GIT_DESCENDANT_PID": pidPath,
+				},
+				"-test.run=^TestGitByteRunnerHelperProcess$",
+				"--",
+				"retain-"+descriptor,
+			)
+			elapsed := time.Since(started)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, exec.ErrWaitDelay)
+			assert.Less(t, elapsed, time.Second)
+		})
+	}
+}
+
+func TestRunCommandAllowsSuccessfulCommandsToFinishRetainedOutputPipes(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "descendant.pid")
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidPath)
+		if err != nil {
+			return
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return
+		}
+		process, err := os.FindProcess(pid)
+		if err == nil {
+			_ = process.Kill()
+		}
+	})
+	donePath := filepath.Join(t.TempDir(), "descendant.done")
+	t.Setenv("KWT_TEST_GIT_BYTE_HELPER", "1")
+	t.Setenv("KWT_TEST_GIT_DESCENDANT_PID", pidPath)
+	t.Setenv("KWT_TEST_GIT_PIPE_HOLDER_DONE", donePath)
+	t.Setenv("KWT_TEST_GIT_PIPE_HOLDER_DELAY", "2s")
+	g := New(t.TempDir())
+	g.executable = os.Args[0]
+
+	_, err := g.RunCommand(
+		"-test.run=^TestGitByteRunnerHelperProcess$",
+		"--",
+		"retain-stdout",
+	)
+
+	require.NoError(t, err)
+	assert.NoFileExists(t, donePath)
+}
+
+func TestInventoryGitAllowsBranchDeletionToFinishRetainedHookPipes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX Git hook")
+	}
+
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "delete-with-retained-hook-pipe")
+	require.NoError(t, repo.run("checkout", "main"))
+	hooksDir := t.TempDir()
+	donePath := filepath.Join(t.TempDir(), "hook-descendant.done")
+	t.Setenv("KWT_TEST_GIT_HOOK_DONE", donePath)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hooksDir, "reference-transaction"),
+		[]byte("#!/bin/sh\nif [ \"$1\" = committed ]; then\n  (sleep 2; : > \"$KWT_TEST_GIT_HOOK_DONE\") &\nfi\n"),
+		0o755,
+	))
+	require.NoError(t, repo.run("config", "core.hooksPath", hooksDir))
+	g := NewForInventory(context.Background(), repo.Path, nil)
+
+	err := g.DeleteBranch("delete-with-retained-hook-pipe", true)
+
+	require.NoError(t, err)
+	assert.NoFileExists(t, donePath)
+	_, err = g.RunCommand(
+		"show-ref",
+		"--verify",
+		"refs/heads/delete-with-retained-hook-pipe",
+	)
+	require.Error(t, err)
+}
+
+func TestRunBytesWithEnvironmentUsesInventoryEnvironmentAndOverrides(t *testing.T) {
+	t.Setenv("GIT_DIR", "/tmp/redirected.git")
+	t.Setenv("KWT_TEST_SECRET", "secret")
+	g := NewForInventory(
+		context.Background(),
+		t.TempDir(),
+		[]string{"KWT_TEST_SECRET"},
+	)
+	g.executable = os.Args[0]
+
+	got, err := g.RunBytesWithEnvironment(
+		map[string]string{
+			"GIT_OPTIONAL_LOCKS":       "0",
+			"KWT_TEST_GIT_BYTE_HELPER": "1",
+			"LC_ALL":                   "C",
+		},
+		"-test.run=^TestGitByteRunnerHelperProcess$",
+		"--",
+		"environment",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"git_dir=|secret=|locks=0|locale=C",
+		string(got),
+	)
+}
+
+func TestGitByteRunnerHelperProcess(t *testing.T) {
+	if os.Getenv("KWT_TEST_GIT_BYTE_HELPER") != "1" {
+		return
+	}
+	if os.Getenv("KWT_TEST_GIT_PIPE_HOLDER") == "1" {
+		delay := 2 * time.Second
+		if configured := os.Getenv("KWT_TEST_GIT_PIPE_HOLDER_DELAY"); configured != "" {
+			parsed, err := time.ParseDuration(configured)
+			if err != nil {
+				os.Exit(5)
+			}
+			delay = parsed
+		}
+		time.Sleep(delay)
+		if donePath := os.Getenv("KWT_TEST_GIT_PIPE_HOLDER_DONE"); donePath != "" {
+			if err := os.WriteFile(donePath, []byte("done\n"), 0o600); err != nil {
+				os.Exit(6)
+			}
+		}
+		os.Exit(0)
+	}
+
+	switch os.Args[len(os.Args)-1] {
+	case "nul":
+		_, _ = os.Stdout.Write([]byte{'a', 0, 'b'})
+	case "stdout-limit":
+		_, _ = os.Stdout.Write(bytes.Repeat([]byte{'o'}, commandOutputLimit+1))
+		_, _ = os.Stderr.Write([]byte("bounded diagnostic"))
+	case "stderr-limit":
+		_, _ = os.Stdout.Write([]byte("bounded output"))
+		_, _ = os.Stderr.Write(bytes.Repeat([]byte{'e'}, commandOutputLimit+1))
+	case "stderr-limit-exit":
+		_, _ = os.Stderr.Write(bytes.Repeat([]byte{'e'}, commandOutputLimit+1))
+		os.Exit(7)
+	case "stderr-exit":
+		_, _ = os.Stderr.Write([]byte("bounded diagnostic"))
+		os.Exit(7)
+	case "sleep":
+		time.Sleep(time.Minute)
+	case "retain-stdout", "retain-stderr":
+		descriptor := strings.TrimPrefix(os.Args[len(os.Args)-1], "retain-")
+		descendant := exec.Command(
+			os.Args[0],
+			"-test.run=^TestGitByteRunnerHelperProcess$",
+		)
+		descendant.Env = append(os.Environ(), "KWT_TEST_GIT_PIPE_HOLDER=1")
+		if descriptor == "stdout" {
+			descendant.Stdout = os.Stdout
+		} else {
+			descendant.Stderr = os.Stderr
+		}
+		if err := descendant.Start(); err != nil {
+			os.Exit(3)
+		}
+		if err := os.WriteFile(
+			os.Getenv("KWT_TEST_GIT_DESCENDANT_PID"),
+			[]byte(strconv.Itoa(descendant.Process.Pid)),
+			0o600,
+		); err != nil {
+			os.Exit(4)
+		}
+	case "environment":
+		_, _ = fmt.Fprintf(
+			os.Stdout,
+			"git_dir=%s|secret=%s|locks=%s|locale=%s",
+			os.Getenv("GIT_DIR"),
+			os.Getenv("KWT_TEST_SECRET"),
+			os.Getenv("GIT_OPTIONAL_LOCKS"),
+			os.Getenv("LC_ALL"),
+		)
+	default:
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
 
 func TestGitOperationsUseInstanceContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1465,6 +1785,25 @@ func TestReadWorktreeGenerationClassifiesMissingWorktree(t *testing.T) {
 	_, err := New(repo.Path).ReadWorktreeGeneration(
 		filepath.Join(t.TempDir(), "missing-worktree"),
 	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrWorktreeNotFound)
+}
+
+func TestReadWorktreeGenerationClassifiesRemovedWorkingDirectory(t *testing.T) {
+	repo := NewTestRepository(t)
+	repo.CreateBranch(t, "removed-worktree")
+	worktreePath := filepath.Join(t.TempDir(), "removed-worktree")
+	repo.CreateWorktree(t, worktreePath, "removed-worktree")
+	_, err := New(repo.Path).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(worktreePath))
+
+	_, err = NewForInventory(
+		context.Background(),
+		worktreePath,
+		nil,
+	).ReadWorktreeGeneration(worktreePath)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrWorktreeNotFound)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -355,7 +355,14 @@ func TestInventoryEnvironmentRemovesGitRoutingAndCredentials(t *testing.T) {
 		"HOME=/home/test",
 		"GIT_DIR=/tmp/redirected.git",
 		"git_work_tree=/tmp/redirected-worktree",
+		"GIT_COMMON_DIR=/tmp/redirected-common",
+		"GIT_INDEX_FILE=/tmp/redirected-index",
+		"GIT_NAMESPACE=redirected",
 		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=core.filemode",
+		"GIT_CONFIG_VALUE_0=false",
+		"GIT_CONFIG_GLOBAL=/tmp/global.gitconfig",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=/tmp/objects",
 		"KWT_GITHUB_TOKEN=builtin-secret",
 		"CUSTOM_FLEET_TOKEN=custom-secret",
 	}, []string{"CUSTOM_FLEET_TOKEN"})
@@ -363,6 +370,11 @@ func TestInventoryEnvironmentRemovesGitRoutingAndCredentials(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		"PATH=/usr/bin",
 		"HOME=/home/test",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=core.filemode",
+		"GIT_CONFIG_VALUE_0=false",
+		"GIT_CONFIG_GLOBAL=/tmp/global.gitconfig",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=/tmp/objects",
 		"GIT_TERMINAL_PROMPT=0",
 	}, got)
 }

--- a/internal/git/git_worktree.go
+++ b/internal/git/git_worktree.go
@@ -1898,6 +1898,12 @@ func (g *Git) worktreeGitDirWithoutCredentials(
 ) (string, error) {
 	commonDir, commonDirErr := g.worktreeCommonDir(protectedNames)
 	if commonDirErr != nil {
+		var pathErr *os.PathError
+		if errors.As(commonDirErr, &pathErr) &&
+			pathErr.Op == "chdir" &&
+			errors.Is(pathErr.Err, os.ErrNotExist) {
+			commonDirErr = errors.Join(ErrWorktreeNotFound, commonDirErr)
+		}
 		return "", fmt.Errorf(
 			"resolve worktree Git directory: %w",
 			commonDirErr,

--- a/internal/lifecycle/source.go
+++ b/internal/lifecycle/source.go
@@ -298,7 +298,7 @@ func (s *currentSource) loadRepository(
 	if request.ForceGlobal {
 		entries, loadErr := s.loadGlobal(ctx, resolved.Config)
 		return Result{Snapshot: Snapshot{
-			Projects: projects, Entries: entries,
+			Config: resolved.Config, Projects: projects, Entries: entries,
 			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
@@ -314,7 +314,7 @@ func (s *currentSource) loadRepository(
 	if !isRepository {
 		entries, loadErr := s.loadGlobal(ctx, resolved.Config)
 		return Result{Snapshot: Snapshot{
-			Projects: projects, Entries: entries,
+			Config: resolved.Config, Projects: projects, Entries: entries,
 			Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 		}, Notes: publicNotes(resolved.Notes)}, loadErr
 	}
@@ -337,7 +337,7 @@ func (s *currentSource) loadRepository(
 		return Result{}, err
 	}
 	return Result{Snapshot: Snapshot{
-		Projects: projects, Entries: entries,
+		Config: resolved.Config, Projects: projects, Entries: entries,
 		Workspaces: append([]models.Workspace(nil), resolved.Config.Workspaces...),
 	}, Notes: publicNotes(resolved.Notes)}, nil
 }

--- a/internal/lifecycle/source_test.go
+++ b/internal/lifecycle/source_test.go
@@ -264,6 +264,32 @@ func TestSourceSnapshotIncludesEffectiveGlobalConfig(t *testing.T) {
 	assert.Equal(t, "quad", result.Snapshot.Config.Layouts.Default)
 }
 
+func TestSourceRepositorySnapshotIncludesEffectiveGlobalConfig(t *testing.T) {
+	home := t.TempDir()
+	repository := filepath.Join(t.TempDir(), "repository")
+	for _, args := range [][]string{
+		{"init", "-b", "main", repository},
+		{"-C", repository, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial"},
+	} {
+		command := exec.Command("git", args...)
+		require.NoError(t, command.Run())
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[fleet]\ntoken_env = 'CUSTOM_FLEET_TOKEN'\n"),
+		0o600,
+	))
+
+	result, err := NewSource(SourceOptions{Home: home}).Load(context.Background(), Request{
+		View: ViewRepository, WorkingDirectory: repository,
+		Expansion: testExpansion(t), UntrustedConfig: IgnoreUntrustedConfig,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Snapshot.Config)
+	assert.Equal(t, "CUSTOM_FLEET_TOKEN", result.Snapshot.Config.Fleet.TokenEnv)
+}
+
 func TestSourceRejectsRelativeRepositoryDirectory(t *testing.T) {
 	_, err := NewSource(SourceOptions{Home: t.TempDir()}).Load(context.Background(), Request{
 		View: ViewRepository, WorkingDirectory: "relative", Expansion: testExpansion(t),

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -290,19 +290,6 @@ func (s *Service) importBranch(
 	project Project,
 	pr PullRequest,
 ) (string, error) {
-	workspaces, err := s.backend.ListWorkspaces(ctx)
-	if err != nil {
-		return "", NewError(
-			CodeWorkspaceCreation,
-			"failed to inspect project workspaces",
-			false,
-			err,
-		)
-	}
-	byPath := make(map[string]Workspace, len(workspaces))
-	for _, workspace := range workspaces {
-		byPath[utils.CanonicalPath(workspace.Path)] = workspace
-	}
 	records := make(map[string]Provenance)
 	if err := s.store.View(ctx, func(current map[string]Provenance) error {
 		for key, record := range current {
@@ -316,6 +303,22 @@ func (s *Service) importBranch(
 			false,
 			err,
 		)
+	}
+	// Workspace creation precedes its provenance commit. Read provenance first
+	// so a concurrent import cannot pair a new record with an older workspace
+	// snapshot and select a reassociation branch for a live import.
+	workspaces, err := s.backend.ListWorkspaces(ctx)
+	if err != nil {
+		return "", NewError(
+			CodeWorkspaceCreation,
+			"failed to inspect project workspaces",
+			false,
+			err,
+		)
+	}
+	byPath := make(map[string]Workspace, len(workspaces))
+	for _, workspace := range workspaces {
+		byPath[utils.CanonicalPath(workspace.Path)] = workspace
 	}
 	return s.importBranchFromState(records, byPath, project, pr), nil
 }

--- a/internal/status/changes.go
+++ b/internal/status/changes.go
@@ -1,0 +1,218 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.kenn.io/kwt/internal/git"
+)
+
+const (
+	collectChangesTimeout     = 5 * time.Second
+	collectUntrackedFilesAll  = "all"
+	collectUntrackedFilesNone = "no"
+)
+
+// FileState is the semantic state of one side of a changed path.
+type FileState string
+
+const (
+	FileStateModified   FileState = "modified"
+	FileStateAdded      FileState = "added"
+	FileStateDeleted    FileState = "deleted"
+	FileStateRenamed    FileState = "renamed"
+	FileStateCopied     FileState = "copied"
+	FileStateConflicted FileState = "conflicted"
+	FileStateUntracked  FileState = "untracked"
+)
+
+// FileChange describes the index and worktree state of one resulting path.
+type FileChange struct {
+	Path         string    `json:"path"`
+	OriginalPath string    `json:"original_path,omitempty"`
+	Index        FileState `json:"index,omitempty"`
+	Worktree     FileState `json:"worktree,omitempty"`
+}
+
+// ChangeState summarizes the highest-priority local state in a change set.
+type ChangeState string
+
+const (
+	ChangeStateClean      ChangeState = "clean"
+	ChangeStateModified   ChangeState = "modified"
+	ChangeStateStaged     ChangeState = "staged"
+	ChangeStateConflicted ChangeState = "conflicted"
+)
+
+// ChangeSummary contains canonical per-path counts. Staged is orthogonal to
+// the mutually exclusive semantic buckets.
+type ChangeSummary struct {
+	Modified  int `json:"modified"`
+	Added     int `json:"added"`
+	Deleted   int `json:"deleted"`
+	Untracked int `json:"untracked"`
+	Staged    int `json:"staged"`
+	Conflicts int `json:"conflicts"`
+}
+
+// ChangeSet is a point-in-time semantic view of local worktree changes.
+type ChangeSet struct {
+	State   ChangeState   `json:"state"`
+	Summary ChangeSummary `json:"summary"`
+	Files   []FileChange  `json:"files"`
+}
+
+// CollectChanges reads one bounded, foreground local-change snapshot.
+func CollectChanges(
+	ctx context.Context,
+	path string,
+	protectedNames []string,
+) (ChangeSet, error) {
+	return collectChanges(
+		ctx,
+		path,
+		protectedNames,
+		collectUntrackedFilesAll,
+	)
+}
+
+func collectChanges(
+	ctx context.Context,
+	path string,
+	protectedNames []string,
+	untrackedFiles string,
+) (ChangeSet, error) {
+	gitContext, cancel := context.WithTimeout(ctx, collectChangesTimeout)
+	defer cancel()
+
+	output, err := git.NewForInventory(
+		gitContext,
+		path,
+		protectedNames,
+	).RunBytesWithEnvironment(
+		map[string]string{
+			"GIT_OPTIONAL_LOCKS": "0",
+			"LC_ALL":             "C",
+		},
+		"status",
+		"--porcelain=v2",
+		"-z",
+		"--untracked-files="+untrackedFiles,
+	)
+	if err != nil {
+		if gitContext.Err() != nil {
+			return ChangeSet{}, fmt.Errorf(
+				"collect local changes: %w",
+				gitContext.Err(),
+			)
+		}
+		return ChangeSet{}, fmt.Errorf("collect local changes: %w", err)
+	}
+	files, err := parseChangePorcelainV2(output)
+	if err != nil {
+		return ChangeSet{}, fmt.Errorf("parse local changes: %w", err)
+	}
+	files, err = coalesceFileChanges(files)
+	if err != nil {
+		return ChangeSet{}, fmt.Errorf("coalesce local changes: %w", err)
+	}
+	return deriveChangeSet(files), nil
+}
+
+func coalesceFileChanges(files []FileChange) ([]FileChange, error) {
+	coalesced := make([]FileChange, 0, len(files))
+	byPath := make(map[string]int, len(files))
+	for _, file := range files {
+		index, exists := byPath[file.Path]
+		if !exists {
+			byPath[file.Path] = len(coalesced)
+			coalesced = append(coalesced, file)
+			continue
+		}
+
+		current := &coalesced[index]
+		if current.Index != "" && file.Index != "" && current.Index != file.Index {
+			return nil, fmt.Errorf("incompatible index states for path %q", file.Path)
+		}
+		if current.Worktree != "" && file.Worktree != "" && current.Worktree != file.Worktree {
+			return nil, fmt.Errorf("incompatible worktree states for path %q", file.Path)
+		}
+		if current.OriginalPath != "" && file.OriginalPath != "" && current.OriginalPath != file.OriginalPath {
+			return nil, fmt.Errorf("incompatible original path values for path %q", file.Path)
+		}
+		if current.Index == "" {
+			current.Index = file.Index
+		}
+		if current.Worktree == "" {
+			current.Worktree = file.Worktree
+		}
+		if current.OriginalPath == "" {
+			current.OriginalPath = file.OriginalPath
+		}
+	}
+	return coalesced, nil
+}
+
+func deriveChangeSet(files []FileChange) ChangeSet {
+	ordered := append([]FileChange(nil), files...)
+	if ordered == nil {
+		ordered = make([]FileChange, 0)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Path == ordered[j].Path {
+			return ordered[i].OriginalPath < ordered[j].OriginalPath
+		}
+		return ordered[i].Path < ordered[j].Path
+	})
+
+	result := ChangeSet{State: ChangeStateClean, Files: ordered}
+	for _, file := range ordered {
+		if file.Index != "" && file.Index != FileStateConflicted {
+			result.Summary.Staged++
+		}
+		switch primaryFileState(file) {
+		case FileStateConflicted:
+			result.Summary.Conflicts++
+		case FileStateUntracked:
+			result.Summary.Untracked++
+		case FileStateAdded:
+			result.Summary.Added++
+		case FileStateDeleted:
+			result.Summary.Deleted++
+		case FileStateModified, FileStateRenamed, FileStateCopied:
+			result.Summary.Modified++
+		}
+	}
+
+	switch {
+	case result.Summary.Conflicts > 0:
+		result.State = ChangeStateConflicted
+	case result.Summary.Staged > 0:
+		result.State = ChangeStateStaged
+	case len(result.Files) > 0:
+		result.State = ChangeStateModified
+	}
+	return result
+}
+
+func primaryFileState(file FileChange) FileState {
+	states := []FileState{file.Index, file.Worktree}
+	for _, candidate := range []FileState{
+		FileStateConflicted,
+		FileStateUntracked,
+		FileStateAdded,
+		FileStateDeleted,
+		FileStateRenamed,
+		FileStateCopied,
+		FileStateModified,
+	} {
+		for _, state := range states {
+			if state == candidate {
+				return candidate
+			}
+		}
+	}
+	return ""
+}

--- a/internal/status/changes.go
+++ b/internal/status/changes.go
@@ -9,11 +9,7 @@ import (
 	"go.kenn.io/kwt/internal/git"
 )
 
-const (
-	collectChangesTimeout     = 5 * time.Second
-	collectUntrackedFilesAll  = "all"
-	collectUntrackedFilesNone = "no"
-)
+const collectChangesTimeout = 5 * time.Second
 
 // FileState is the semantic state of one side of a changed path.
 type FileState string
@@ -70,20 +66,6 @@ func CollectChanges(
 	path string,
 	protectedNames []string,
 ) (ChangeSet, error) {
-	return collectChanges(
-		ctx,
-		path,
-		protectedNames,
-		collectUntrackedFilesAll,
-	)
-}
-
-func collectChanges(
-	ctx context.Context,
-	path string,
-	protectedNames []string,
-	untrackedFiles string,
-) (ChangeSet, error) {
 	gitContext, cancel := context.WithTimeout(ctx, collectChangesTimeout)
 	defer cancel()
 
@@ -99,7 +81,7 @@ func collectChanges(
 		"status",
 		"--porcelain=v2",
 		"-z",
-		"--untracked-files="+untrackedFiles,
+		"--untracked-files=all",
 	)
 	if err != nil {
 		if gitContext.Err() != nil {

--- a/internal/status/changes_test.go
+++ b/internal/status/changes_test.go
@@ -1,0 +1,360 @@
+package status
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitpkg "go.kenn.io/kwt/internal/git"
+)
+
+func TestDeriveChangeSetUsesCanonicalBucketsAndDeterministicOrder(t *testing.T) {
+	files := []FileChange{
+		{Path: "z-conflict", Index: FileStateConflicted, Worktree: FileStateConflicted},
+		{Path: "u-untracked", Worktree: FileStateUntracked},
+		{Path: "a-added", Index: FileStateAdded, Worktree: FileStateModified},
+		{Path: "d-deleted", Worktree: FileStateDeleted},
+		{Path: "r-renamed", OriginalPath: "old-renamed", Index: FileStateRenamed},
+		{Path: "c-copied", OriginalPath: "source", Index: FileStateCopied},
+		{Path: "m-modified", Worktree: FileStateModified},
+	}
+
+	got := deriveChangeSet(files)
+
+	assert.Equal(t, ChangeStateConflicted, got.State)
+	assert.Equal(t, ChangeSummary{
+		Modified:  3,
+		Added:     1,
+		Deleted:   1,
+		Untracked: 1,
+		Staged:    3,
+		Conflicts: 1,
+	}, got.Summary)
+	assert.Equal(t, []string{
+		"a-added",
+		"c-copied",
+		"d-deleted",
+		"m-modified",
+		"r-renamed",
+		"u-untracked",
+		"z-conflict",
+	}, changePaths(got.Files))
+	assert.Equal(t, "z-conflict", files[0].Path, "deriveChangeSet mutated its input")
+}
+
+func TestDeriveChangeSetDoesNotCountConflictAsStaged(t *testing.T) {
+	got := deriveChangeSet([]FileChange{{
+		Path:     "conflict.txt",
+		Index:    FileStateConflicted,
+		Worktree: FileStateConflicted,
+	}})
+
+	assert.Equal(t, ChangeStateConflicted, got.State)
+	assert.Equal(t, 1, got.Summary.Conflicts)
+	assert.Zero(t, got.Summary.Staged)
+}
+
+func TestDeriveChangeSetStatePrecedenceAndCleanFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []FileChange
+		want  ChangeState
+	}{
+		{name: "clean", files: nil, want: ChangeStateClean},
+		{
+			name:  "modified",
+			files: []FileChange{{Path: "file", Worktree: FileStateModified}},
+			want:  ChangeStateModified,
+		},
+		{
+			name:  "staged",
+			files: []FileChange{{Path: "file", Index: FileStateModified}},
+			want:  ChangeStateStaged,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveChangeSet(tt.files)
+
+			assert.Equal(t, tt.want, got.State)
+			if tt.files == nil {
+				assert.NotNil(t, got.Files)
+				assert.Empty(t, got.Files)
+			}
+		})
+	}
+}
+
+func TestCoalesceFileChangesMergesCompatibleRecords(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []FileChange
+		want  []FileChange
+	}{
+		{
+			name: "independent sides",
+			files: []FileChange{
+				{Path: "file.txt", Index: FileStateDeleted},
+				{Path: "file.txt", Worktree: FileStateUntracked},
+			},
+			want: []FileChange{{
+				Path: "file.txt", Index: FileStateDeleted, Worktree: FileStateUntracked,
+			}},
+		},
+		{
+			name: "identical records",
+			files: []FileChange{
+				{Path: "new.txt", OriginalPath: "old.txt", Index: FileStateRenamed},
+				{Path: "new.txt", OriginalPath: "old.txt", Index: FileStateRenamed},
+			},
+			want: []FileChange{{
+				Path: "new.txt", OriginalPath: "old.txt", Index: FileStateRenamed,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := coalesceFileChanges(tt.files)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCoalesceFileChangesRejectsIncompatibleRecords(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []FileChange
+	}{
+		{
+			name: "index",
+			files: []FileChange{
+				{Path: "file.txt", Index: FileStateAdded},
+				{Path: "file.txt", Index: FileStateDeleted},
+			},
+		},
+		{
+			name: "worktree",
+			files: []FileChange{
+				{Path: "file.txt", Worktree: FileStateModified},
+				{Path: "file.txt", Worktree: FileStateUntracked},
+			},
+		},
+		{
+			name: "original path",
+			files: []FileChange{
+				{Path: "file.txt", OriginalPath: "one.txt", Index: FileStateRenamed},
+				{Path: "file.txt", OriginalPath: "two.txt", Index: FileStateRenamed},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := coalesceFileChanges(tt.files)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "incompatible "+tt.name)
+			assert.ErrorContains(t, err, "file.txt")
+		})
+	}
+}
+
+func TestCollectChangesFromRealRepository(t *testing.T) {
+	repo := newChangesTestRepository(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "modified.txt"),
+		[]byte("modified after commit\n"),
+		0o644,
+	))
+	require.NoError(t, os.Remove(filepath.Join(repo, "deleted.txt")))
+	runStatusTestGit(t, repo, "mv", "rename-source.txt", "renamed.txt")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "added.txt"),
+		[]byte("staged addition\n"),
+		0o644,
+	))
+	runStatusTestGit(t, repo, "add", "added.txt")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "untracked.txt"),
+		[]byte("untracked\n"),
+		0o644,
+	))
+
+	got, err := CollectChanges(context.Background(), repo, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, ChangeStateStaged, got.State)
+	assert.Equal(t, ChangeSummary{
+		Modified:  2,
+		Added:     1,
+		Deleted:   1,
+		Untracked: 1,
+		Staged:    2,
+	}, got.Summary)
+	assert.Equal(t, []string{
+		"added.txt",
+		"deleted.txt",
+		"modified.txt",
+		"renamed.txt",
+		"untracked.txt",
+	}, changePaths(got.Files))
+	assert.Equal(t, "rename-source.txt", got.Files[3].OriginalPath)
+}
+
+func TestCollectChangesCoalescesStagedDeletionRecreatedAsUntracked(t *testing.T) {
+	repo := newChangesTestRepository(t)
+	runStatusTestGit(t, repo, "rm", "deleted.txt")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "deleted.txt"),
+		[]byte("recreated after staged deletion\n"),
+		0o644,
+	))
+
+	got, err := CollectChanges(context.Background(), repo, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, ChangeStateStaged, got.State)
+	assert.Equal(t, ChangeSummary{Untracked: 1, Staged: 1}, got.Summary)
+	assert.Equal(t, []FileChange{{
+		Path: "deleted.txt", Index: FileStateDeleted, Worktree: FileStateUntracked,
+	}}, got.Files)
+}
+
+func TestCollectChangesCleanRepositoryHasPresentEmptyFiles(t *testing.T) {
+	repo := newChangesTestRepository(t)
+
+	got, err := CollectChanges(context.Background(), repo, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, ChangeStateClean, got.State)
+	assert.NotNil(t, got.Files)
+	assert.Empty(t, got.Files)
+}
+
+func TestCollectChangesUsesOneSanitizedPorcelainV2StatusCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("command recorder uses a POSIX shell")
+	}
+	repo := newChangesTestRepository(t)
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	wrapperDir := t.TempDir()
+	logPath := filepath.Join(wrapperDir, "git.log")
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	require.NoError(t, os.WriteFile(wrapperPath, []byte(`#!/bin/sh
+{
+  for argument in "$@"; do
+    printf 'arg=%s\n' "$argument"
+  done
+  printf 'locks=%s\n' "$GIT_OPTIONAL_LOCKS"
+  printf 'locale=%s\n' "$LC_ALL"
+  printf 'builtin=%s\n' "$KWT_GITHUB_TOKEN"
+  printf 'custom=%s\n' "$CUSTOM_CHANGE_TOKEN"
+} >> "$KWT_TEST_GIT_LOG"
+exec "$KWT_TEST_REAL_GIT" "$@"
+`), 0o755))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KWT_TEST_GIT_LOG", logPath)
+	t.Setenv("KWT_TEST_REAL_GIT", realGit)
+	t.Setenv("KWT_GITHUB_TOKEN", "builtin-secret")
+	t.Setenv("CUSTOM_CHANGE_TOKEN", "custom-secret")
+
+	_, err = CollectChanges(
+		context.Background(),
+		repo,
+		[]string{"CUSTOM_CHANGE_TOKEN"},
+	)
+
+	require.NoError(t, err)
+	log, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Equal(t, "arg=status\n"+
+		"arg=--porcelain=v2\n"+
+		"arg=-z\n"+
+		"arg=--untracked-files=all\n"+
+		"locks=0\n"+
+		"locale=C\n"+
+		"builtin=\n"+
+		"custom=\n", string(log))
+}
+
+func TestCollectChangesAppliesFiveSecondBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("timeout helper uses a POSIX shell")
+	}
+	wrapperDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(wrapperDir, "git"),
+		[]byte("#!/bin/sh\nexec sleep 60\n"),
+		0o755,
+	))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	started := time.Now()
+
+	_, err := CollectChanges(context.Background(), t.TempDir(), nil)
+	elapsed := time.Since(started)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.GreaterOrEqual(t, elapsed, 4*time.Second)
+	assert.Less(t, elapsed, 8*time.Second)
+}
+
+func TestCollectChangesKeepsOversizedDiagnosticsBounded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("diagnostic helper uses a POSIX shell")
+	}
+	wrapperDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(wrapperDir, "git"),
+		[]byte("#!/bin/sh\nhead -c 1048577 /dev/zero >&2\nexit 1\n"),
+		0o755,
+	))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := CollectChanges(context.Background(), t.TempDir(), nil)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gitpkg.ErrStderrLimitExceeded)
+	assert.Less(t, len(err.Error()), 1024)
+}
+
+func newChangesTestRepository(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runStatusTestGit(t, repo, "init", "-b", "main")
+	runStatusTestGit(t, repo, "config", "user.name", "Test User")
+	runStatusTestGit(t, repo, "config", "user.email", "test@example.com")
+	for name, contents := range map[string]string{
+		"modified.txt":      "original modified file\n",
+		"deleted.txt":       "delete me\n",
+		"rename-source.txt": "this content is long enough for rename detection without ambiguity\n",
+	} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repo, name),
+			[]byte(contents),
+			0o644,
+		))
+	}
+	runStatusTestGit(t, repo, "add", ".")
+	runStatusTestGit(t, repo, "commit", "-m", "Initial commit")
+	return repo
+}
+
+func changePaths(changes []FileChange) []string {
+	paths := make([]string, len(changes))
+	for i, change := range changes {
+		paths[i] = change.Path
+	}
+	return paths
+}

--- a/internal/status/inspection.go
+++ b/internal/status/inspection.go
@@ -306,9 +306,13 @@ func inspectionInvalid(message string) error {
 }
 
 func inspectionFailure(cause error) error {
+	message := "worktree inspection failed"
+	if errors.Is(cause, git.ErrStdoutLimitExceeded) {
+		message = "worktree change list is too large to inspect"
+	}
 	return service.NewError(
 		service.InspectionFailed,
-		"worktree inspection failed",
+		message,
 		false,
 		nil,
 		cause,

--- a/internal/status/inspection.go
+++ b/internal/status/inspection.go
@@ -1,0 +1,336 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"time"
+
+	"go.kenn.io/kwt/internal/credentials"
+	"go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/lifecycle"
+	"go.kenn.io/kwt/internal/utils"
+	"go.kenn.io/kwt/service"
+)
+
+type InspectionRequest struct {
+	Path               string `json:"path"`
+	ExpectedRepository string `json:"expected_repository,omitempty"`
+	ExpectedGeneration string `json:"expected_generation,omitempty"`
+}
+
+type WorktreeIdentity struct {
+	Repository string `json:"repository"`
+	Path       string `json:"path"`
+	Generation string `json:"generation"`
+}
+
+type InspectionResult struct {
+	Worktree   WorktreeIdentity `json:"worktree"`
+	Changes    ChangeSet        `json:"changes"`
+	ObservedAt time.Time        `json:"observed_at"`
+}
+
+type Inspector interface {
+	Inspect(context.Context, InspectionRequest) (InspectionResult, error)
+}
+
+type InspectionServiceOptions struct {
+	Inventory lifecycle.Inventory
+}
+
+type inspectionService struct {
+	inventory        lifecycle.Inventory
+	captureExpansion func() (lifecycle.ExpansionContext, error)
+	readGeneration   func(context.Context, string, []string) (string, error)
+	collectChanges   func(context.Context, string, []string) (ChangeSet, error)
+	gitBudget        time.Duration
+	now              func() time.Time
+}
+
+func NewInspectionService(options InspectionServiceOptions) Inspector {
+	return &inspectionService{
+		inventory:        options.Inventory,
+		captureExpansion: lifecycle.CaptureExpansionContext,
+		readGeneration: func(
+			ctx context.Context,
+			path string,
+			protectedNames []string,
+		) (string, error) {
+			return git.NewForInventory(
+				ctx,
+				path,
+				protectedNames,
+			).ReadWorktreeGeneration(path)
+		},
+		collectChanges: CollectChanges,
+		gitBudget:      collectChangesTimeout,
+		now:            time.Now,
+	}
+}
+
+func (s *inspectionService) Inspect(
+	ctx context.Context,
+	request InspectionRequest,
+) (InspectionResult, error) {
+	if !filepath.IsAbs(request.Path) {
+		return InspectionResult{}, inspectionInvalid("worktree path must be absolute")
+	}
+	if request.ExpectedGeneration != "" {
+		if err := git.ValidateWorktreeGeneration(request.ExpectedGeneration); err != nil {
+			return InspectionResult{}, inspectionInvalid(
+				"expected generation must be a 32-character hexadecimal value",
+			)
+		}
+	}
+	if request.ExpectedRepository != "" &&
+		!validInspectionRepositoryIdentity(request.ExpectedRepository) {
+		return InspectionResult{}, inspectionInvalid(
+			"expected repository identity is invalid",
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return InspectionResult{}, err
+	}
+	if s.inventory == nil {
+		return InspectionResult{}, inspectionFailure(nil)
+	}
+	expansion, err := s.captureExpansion()
+	if err != nil {
+		return InspectionResult{}, inspectionFailure(err)
+	}
+	inventory, err := s.inventory.Query(ctx, lifecycle.Request{
+		View:             lifecycle.ViewRepository,
+		WorkingDirectory: request.Path,
+		Expansion:        expansion,
+		RequireCurrent:   true,
+		UntrustedConfig:  lifecycle.IgnoreUntrustedConfig,
+	})
+	if contextErr := ctx.Err(); contextErr != nil {
+		return InspectionResult{}, contextErr
+	}
+	if err != nil {
+		var typed *service.Error
+		if errors.As(err, &typed) {
+			return InspectionResult{}, err
+		}
+		return InspectionResult{}, inspectionFailure(err)
+	}
+	pathKey := utils.PathKey(request.Path)
+	matches := make([]lifecycle.Entry, 0, 1)
+	for _, entry := range inventory.Snapshot.Entries {
+		if utils.PathKey(entry.Path) == pathKey {
+			matches = append(matches, entry)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return InspectionResult{}, service.NewError(
+			service.NotFound,
+			"no inventory worktree matches the exact path",
+			false,
+			nil,
+			nil,
+		)
+	case 1:
+	default:
+		return InspectionResult{}, inspectionFailure(nil)
+	}
+	entry := matches[0]
+	if entry.Path == "" ||
+		!validInspectionRepositoryIdentity(entry.Repository.FullPath) ||
+		git.ValidateWorktreeGeneration(entry.Generation) != nil {
+		return InspectionResult{}, inspectionFailure(nil)
+	}
+	if request.ExpectedRepository != "" &&
+		!lifecycle.EqualProjectIdentity(
+			request.ExpectedRepository,
+			entry.Repository.FullPath,
+		) {
+		return InspectionResult{}, inspectionRegistrationChanged(
+			"worktree repository no longer matches the expected repository",
+			nil,
+		)
+	}
+	if request.ExpectedGeneration != "" &&
+		request.ExpectedGeneration != entry.Generation {
+		return InspectionResult{}, inspectionRegistrationChanged(
+			"worktree generation no longer matches the expected generation",
+			nil,
+		)
+	}
+	if inventory.Snapshot.Config == nil {
+		return InspectionResult{}, inspectionFailure(
+			errors.New("inventory omitted effective configuration"),
+		)
+	}
+	protectedNames := credentials.ProtectedNames(inventory.Snapshot.Config)
+	gitContext, cancel := context.WithTimeout(ctx, s.gitBudget)
+	defer cancel()
+	before, err := s.readGeneration(gitContext, entry.Path, protectedNames)
+	if err != nil {
+		if cancellation := inspectionContextError(ctx, gitContext, err); cancellation != nil {
+			return InspectionResult{}, cancellation
+		}
+		if inspectionRegistrationDidChange(err) {
+			return InspectionResult{}, inspectionRegistrationChanged(
+				"worktree registration changed after inventory",
+				err,
+			)
+		}
+		return InspectionResult{}, inspectionFailure(err)
+	}
+	if contextErr := inspectionExpiredContext(ctx, gitContext); contextErr != nil {
+		return InspectionResult{}, contextErr
+	}
+	if before != entry.Generation {
+		return InspectionResult{}, inspectionRegistrationChanged(
+			"worktree generation changed after inventory",
+			nil,
+		)
+	}
+	changes, err := s.collectChanges(gitContext, entry.Path, protectedNames)
+	if err != nil {
+		if cancellation := inspectionContextError(ctx, gitContext, err); cancellation != nil {
+			return InspectionResult{}, cancellation
+		}
+		after, generationErr := s.readGeneration(
+			gitContext,
+			entry.Path,
+			protectedNames,
+		)
+		if generationErr != nil {
+			if cancellation := inspectionContextError(
+				ctx,
+				gitContext,
+				generationErr,
+			); cancellation != nil {
+				return InspectionResult{}, cancellation
+			}
+			if inspectionRegistrationDidChange(generationErr) {
+				return InspectionResult{}, inspectionRegistrationChanged(
+					"worktree registration changed during inspection",
+					generationErr,
+				)
+			}
+			return InspectionResult{}, inspectionFailure(err)
+		}
+		if contextErr := inspectionExpiredContext(ctx, gitContext); contextErr != nil {
+			return InspectionResult{}, contextErr
+		}
+		if after != entry.Generation {
+			return InspectionResult{}, inspectionRegistrationChanged(
+				"worktree generation changed during inspection",
+				nil,
+			)
+		}
+		return InspectionResult{}, inspectionFailure(err)
+	}
+	if contextErr := inspectionExpiredContext(ctx, gitContext); contextErr != nil {
+		return InspectionResult{}, contextErr
+	}
+	after, err := s.readGeneration(gitContext, entry.Path, protectedNames)
+	if err != nil {
+		if cancellation := inspectionContextError(ctx, gitContext, err); cancellation != nil {
+			return InspectionResult{}, cancellation
+		}
+		if inspectionRegistrationDidChange(err) {
+			return InspectionResult{}, inspectionRegistrationChanged(
+				"worktree registration changed during inspection",
+				err,
+			)
+		}
+		return InspectionResult{}, inspectionFailure(err)
+	}
+	if contextErr := inspectionExpiredContext(ctx, gitContext); contextErr != nil {
+		return InspectionResult{}, contextErr
+	}
+	if after != entry.Generation {
+		return InspectionResult{}, inspectionRegistrationChanged(
+			"worktree generation changed during inspection",
+			nil,
+		)
+	}
+	return InspectionResult{
+		Worktree: WorktreeIdentity{
+			Repository: entry.Repository.FullPath,
+			Path:       entry.Path,
+			Generation: entry.Generation,
+		},
+		Changes:    changes,
+		ObservedAt: s.now().UTC(),
+	}, nil
+}
+
+func inspectionContextError(
+	parent context.Context,
+	operation context.Context,
+	err error,
+) error {
+	if cancellation := parent.Err(); cancellation != nil && errors.Is(err, cancellation) {
+		return cancellation
+	}
+	if timeout := operation.Err(); timeout != nil && errors.Is(err, timeout) {
+		return inspectionTimeout(err)
+	}
+	return nil
+}
+
+func inspectionExpiredContext(
+	parent context.Context,
+	operation context.Context,
+) error {
+	if cancellation := parent.Err(); cancellation != nil {
+		return cancellation
+	}
+	if timeout := operation.Err(); timeout != nil {
+		return inspectionTimeout(timeout)
+	}
+	return nil
+}
+
+func inspectionRegistrationDidChange(err error) bool {
+	return errors.Is(err, git.ErrWorktreeNotFound) ||
+		errors.Is(err, git.ErrWorktreeRepositoryMismatch) ||
+		errors.Is(err, git.ErrWorktreeGenerationNotFound)
+}
+
+func validInspectionRepositoryIdentity(identity string) bool {
+	// EqualProjectIdentity validates each operand before folding and comparing;
+	// self-comparison therefore provides validation without a second policy.
+	return lifecycle.EqualProjectIdentity(identity, identity)
+}
+
+func inspectionInvalid(message string) error {
+	return service.NewError(service.InvalidRequest, message, false, nil, nil)
+}
+
+func inspectionFailure(cause error) error {
+	return service.NewError(
+		service.InspectionFailed,
+		"worktree inspection failed",
+		false,
+		nil,
+		cause,
+	)
+}
+
+func inspectionTimeout(cause error) error {
+	return service.NewError(
+		service.InspectionFailed,
+		"worktree inspection timed out",
+		true,
+		nil,
+		cause,
+	)
+}
+
+func inspectionRegistrationChanged(message string, cause error) error {
+	return service.NewError(
+		service.RegistrationChanged,
+		message,
+		true,
+		nil,
+		cause,
+	)
+}

--- a/internal/status/inspection_test.go
+++ b/internal/status/inspection_test.go
@@ -1,0 +1,1101 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitpkg "go.kenn.io/kwt/internal/git"
+	"go.kenn.io/kwt/internal/lifecycle"
+	"go.kenn.io/kwt/pkg/models"
+	"go.kenn.io/kwt/service"
+)
+
+type inspectionTestInventory struct {
+	query func(context.Context, lifecycle.Request) (lifecycle.Result, error)
+}
+
+const (
+	inspectionTestGeneration      = "0123456789abcdef0123456789abcdef"
+	inspectionTestOtherGeneration = "fedcba9876543210fedcba9876543210"
+)
+
+func (f *inspectionTestInventory) Query(
+	ctx context.Context,
+	request lifecycle.Request,
+) (lifecycle.Result, error) {
+	return f.query(ctx, request)
+}
+
+func (*inspectionTestInventory) ApproveConfig(
+	context.Context,
+	lifecycle.ConfigApproval,
+) error {
+	return nil
+}
+
+func TestInspectionServiceRejectsInvalidRequestBeforeInventory(t *testing.T) {
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		t.Fatal("invalid request reached inventory")
+		return lifecycle.Result{}, nil
+	}}
+	inspector := NewInspectionService(InspectionServiceOptions{Inventory: inventory})
+
+	tests := []struct {
+		name    string
+		request InspectionRequest
+	}{
+		{name: "relative path", request: InspectionRequest{Path: "relative"}},
+		{
+			name: "malformed expected generation",
+			request: InspectionRequest{
+				Path: t.TempDir(), ExpectedGeneration: "not-a-generation",
+			},
+		},
+		{
+			name: "malformed expected repository",
+			request: InspectionRequest{
+				Path: t.TempDir(), ExpectedRepository: "not a repository",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := inspector.Inspect(context.Background(), tt.request)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.InvalidRequest))
+			assert.False(t, service.AsError(err).Retryable)
+		})
+	}
+}
+
+func TestInspectionServiceRequiresOneExactInventoryEntry(t *testing.T) {
+	path := t.TempDir()
+	tests := []struct {
+		name    string
+		entries []lifecycle.Entry
+		code    service.Code
+	}{
+		{name: "missing", code: service.NotFound},
+		{
+			name: "duplicate canonical path",
+			entries: []lifecycle.Entry{
+				inspectionInventoryEntry(path),
+				inspectionInventoryEntry(path),
+			},
+			code: service.InspectionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inventory := &inspectionTestInventory{query: func(
+				_ context.Context,
+				request lifecycle.Request,
+			) (lifecycle.Result, error) {
+				assert.Equal(t, lifecycle.ViewRepository, request.View)
+				assert.Equal(t, path, request.WorkingDirectory)
+				assert.True(t, request.RequireCurrent)
+				return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+					Entries: tt.entries,
+				}}, nil
+			}}
+
+			_, err := NewInspectionService(InspectionServiceOptions{
+				Inventory: inventory,
+			}).Inspect(context.Background(), InspectionRequest{Path: path})
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, tt.code))
+		})
+	}
+}
+
+func TestInspectionServiceRejectsExpectedIdentityDrift(t *testing.T) {
+	path := t.TempDir()
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+			Entries: []lifecycle.Entry{inspectionInventoryEntry(path)},
+		}}, nil
+	}}
+	inspector := NewInspectionService(InspectionServiceOptions{Inventory: inventory})
+
+	tests := []struct {
+		name    string
+		request InspectionRequest
+	}{
+		{
+			name: "repository",
+			request: InspectionRequest{
+				Path: path, ExpectedRepository: "github.com/acme/other",
+			},
+		},
+		{
+			name: "generation",
+			request: InspectionRequest{
+				Path: path, ExpectedGeneration: inspectionTestOtherGeneration,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := inspector.Inspect(context.Background(), tt.request)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.RegistrationChanged))
+			assert.True(t, service.AsError(err).Retryable)
+		})
+	}
+}
+
+func TestInspectionServiceRejectsIncompleteInventoryIdentity(t *testing.T) {
+	path := t.TempDir()
+	tests := []struct {
+		name  string
+		entry lifecycle.Entry
+	}{
+		{
+			name: "missing repository",
+			entry: lifecycle.Entry{
+				Path: path, Generation: inspectionTestGeneration,
+			},
+		},
+		{
+			name: "missing generation",
+			entry: lifecycle.Entry{
+				Path: path,
+				Repository: lifecycle.Repository{
+					FullPath: "github.com/acme/widget",
+				},
+			},
+		},
+		{
+			name: "malformed generation",
+			entry: lifecycle.Entry{
+				Path:       path,
+				Generation: "malformed",
+				Repository: lifecycle.Repository{
+					FullPath: "github.com/acme/widget",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inventory := &inspectionTestInventory{query: func(
+				context.Context,
+				lifecycle.Request,
+			) (lifecycle.Result, error) {
+				return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+					Entries: []lifecycle.Entry{tt.entry},
+				}}, nil
+			}}
+
+			_, err := NewInspectionService(InspectionServiceOptions{
+				Inventory: inventory,
+			}).Inspect(context.Background(), InspectionRequest{Path: path})
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.InspectionFailed))
+			assert.False(t, service.AsError(err).Retryable)
+		})
+	}
+}
+
+func TestInspectionServicePreservesTypedInventoryError(t *testing.T) {
+	want := service.NewError(
+		service.InventoryTimeout,
+		"inventory refresh timed out",
+		true,
+		nil,
+		context.DeadlineExceeded,
+	)
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{}, want
+	}}
+
+	_, err := NewInspectionService(InspectionServiceOptions{
+		Inventory: inventory,
+	}).Inspect(context.Background(), InspectionRequest{Path: t.TempDir()})
+
+	require.Error(t, err)
+	assert.Same(t, want, err)
+}
+
+func TestInspectionServiceHidesUnexpectedInventoryError(t *testing.T) {
+	cause := errors.New("credential-bearing private failure")
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{}, cause
+	}}
+
+	_, err := NewInspectionService(InspectionServiceOptions{
+		Inventory: inventory,
+	}).Inspect(context.Background(), InspectionRequest{Path: t.TempDir()})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.InspectionFailed))
+	assert.NotContains(t, err.Error(), "credential-bearing")
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestInspectionServiceReturnsOnlyDoubleCheckedGeneration(t *testing.T) {
+	path := t.TempDir()
+	observedAt := time.Date(2026, 8, 20, 15, 4, 5, 0, time.UTC)
+	inventory := inspectionInventoryWithConfig(path, "CUSTOM_FLEET_TOKEN")
+	reads := 0
+	inspector := inspectionServiceForTest(
+		inventory,
+		func(context.Context, string, []string) (string, error) {
+			reads++
+			return inspectionTestGeneration, nil
+		},
+		func(_ context.Context, gotPath string, protectedNames []string) (ChangeSet, error) {
+			assert.Equal(t, path, gotPath)
+			assert.ElementsMatch(t, []string{
+				"KWT_GITHUB_TOKEN",
+				"KWT_FLEET_TOKEN",
+				"CUSTOM_FLEET_TOKEN",
+			}, protectedNames)
+			return ChangeSet{
+				State: ChangeStateModified,
+				Summary: ChangeSummary{
+					Modified: 1,
+				},
+				Files: []FileChange{{
+					Path: "changed.txt", Worktree: FileStateModified,
+				}},
+			}, nil
+		},
+		func() time.Time { return observedAt },
+	)
+
+	got, err := inspector.Inspect(context.Background(), InspectionRequest{
+		Path:               path,
+		ExpectedRepository: "github.com/acme/widget",
+		ExpectedGeneration: inspectionTestGeneration,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, reads)
+	assert.Equal(t, InspectionResult{
+		Worktree: WorktreeIdentity{
+			Repository: "github.com/acme/widget",
+			Path:       path,
+			Generation: inspectionTestGeneration,
+		},
+		Changes: ChangeSet{
+			State: ChangeStateModified,
+			Summary: ChangeSummary{
+				Modified: 1,
+			},
+			Files: []FileChange{{
+				Path: "changed.txt", Worktree: FileStateModified,
+			}},
+		},
+		ObservedAt: observedAt,
+	}, got)
+}
+
+func TestInspectionServiceProductionInventoryCarriesConfiguredProtectedNames(t *testing.T) {
+	home := t.TempDir()
+	repository := t.TempDir()
+	runStatusTestGit(t, repository, "init", "-b", "main")
+	runStatusTestGit(t, repository, "config", "user.name", "Test User")
+	runStatusTestGit(t, repository, "config", "user.email", "test@example.com")
+	runStatusTestGit(t, repository, "commit", "--allow-empty", "-m", "initial")
+	generation, err := gitpkg.New(repository).EnsureWorktreeGeneration(repository)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.toml"),
+		[]byte("[fleet]\ntoken_env = 'CUSTOM_FLEET_TOKEN'\n"),
+		0o600,
+	))
+	inventory := lifecycle.NewInventoryService(lifecycle.InventoryServiceOptions{
+		Source: lifecycle.NewSource(lifecycle.SourceOptions{Home: home}),
+	})
+	var observed [][]string
+	inspector := NewInspectionService(InspectionServiceOptions{
+		Inventory: inventory,
+	}).(*inspectionService)
+	inspector.readGeneration = func(
+		_ context.Context,
+		_ string,
+		protectedNames []string,
+	) (string, error) {
+		observed = append(observed, append([]string(nil), protectedNames...))
+		return generation, nil
+	}
+	inspector.collectChanges = func(
+		_ context.Context,
+		_ string,
+		protectedNames []string,
+	) (ChangeSet, error) {
+		observed = append(observed, append([]string(nil), protectedNames...))
+		return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+	}
+
+	_, err = inspector.Inspect(context.Background(), InspectionRequest{Path: repository})
+
+	require.NoError(t, err)
+	require.Len(t, observed, 3)
+	for _, protectedNames := range observed {
+		assert.Contains(t, protectedNames, "CUSTOM_FLEET_TOKEN")
+	}
+}
+
+func TestInspectionServiceRejectsMissingInventoryConfigBeforeGit(t *testing.T) {
+	path := t.TempDir()
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+			Entries: []lifecycle.Entry{inspectionInventoryEntry(path)},
+		}}, nil
+	}}
+	gitCalled := false
+	inspector := inspectionServiceForTest(
+		inventory,
+		func(context.Context, string, []string) (string, error) {
+			gitCalled = true
+			return inspectionTestGeneration, nil
+		},
+		func(context.Context, string, []string) (ChangeSet, error) {
+			gitCalled = true
+			return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+		},
+		time.Now,
+	)
+
+	got, err := inspector.Inspect(
+		context.Background(),
+		InspectionRequest{Path: path},
+	)
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.InspectionFailed))
+	assert.False(t, service.AsError(err).Retryable)
+	assert.False(t, gitCalled)
+	assert.Equal(t, InspectionResult{}, got)
+}
+
+func TestInspectionServiceRejectsGenerationDriftBeforeCollection(t *testing.T) {
+	path := t.TempDir()
+	collected := false
+	inspector := inspectionServiceForTest(
+		inspectionInventoryWithConfig(path, ""),
+		func(context.Context, string, []string) (string, error) {
+			return inspectionTestOtherGeneration, nil
+		},
+		func(context.Context, string, []string) (ChangeSet, error) {
+			collected = true
+			return ChangeSet{}, nil
+		},
+		time.Now,
+	)
+
+	_, err := inspector.Inspect(context.Background(), InspectionRequest{Path: path})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.False(t, collected)
+}
+
+func TestInspectionServiceDiscardsChangesWhenGenerationDriftsAfterCollection(t *testing.T) {
+	path := t.TempDir()
+	reads := 0
+	inspector := inspectionServiceForTest(
+		inspectionInventoryWithConfig(path, ""),
+		func(context.Context, string, []string) (string, error) {
+			reads++
+			if reads == 1 {
+				return inspectionTestGeneration, nil
+			}
+			return inspectionTestOtherGeneration, nil
+		},
+		func(context.Context, string, []string) (ChangeSet, error) {
+			return ChangeSet{
+				State: ChangeStateModified,
+				Files: []FileChange{{
+					Path: "must-not-escape.txt", Worktree: FileStateModified,
+				}},
+			}, nil
+		},
+		time.Now,
+	)
+
+	got, err := inspector.Inspect(context.Background(), InspectionRequest{Path: path})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.RegistrationChanged))
+	assert.Equal(t, InspectionResult{}, got)
+}
+
+func TestInspectionServiceClassifiesReadAndCollectionFailures(t *testing.T) {
+	path := t.TempDir()
+	private := errors.New("private repository failure")
+	tests := []struct {
+		name       string
+		generation func(context.Context, string, []string) (string, error)
+		collect    func(context.Context, string, []string) (ChangeSet, error)
+		wantCode   service.Code
+	}{
+		{
+			name: "generation pre-read",
+			generation: func(context.Context, string, []string) (string, error) {
+				return "", private
+			},
+			collect: func(context.Context, string, []string) (ChangeSet, error) {
+				t.Fatal("collection ran after failed generation pre-read")
+				return ChangeSet{}, nil
+			},
+			wantCode: service.InspectionFailed,
+		},
+		{
+			name: "generation missing before collection",
+			generation: func(context.Context, string, []string) (string, error) {
+				return "", errors.Join(private, gitpkg.ErrWorktreeGenerationNotFound)
+			},
+			collect: func(context.Context, string, []string) (ChangeSet, error) {
+				t.Fatal("collection ran after missing generation pre-read")
+				return ChangeSet{}, nil
+			},
+			wantCode: service.RegistrationChanged,
+		},
+		{
+			name: "change collection",
+			generation: func(context.Context, string, []string) (string, error) {
+				return inspectionTestGeneration, nil
+			},
+			collect: func(context.Context, string, []string) (ChangeSet, error) {
+				return ChangeSet{}, private
+			},
+			wantCode: service.InspectionFailed,
+		},
+		{
+			name: "generation post-read",
+			generation: func() func(context.Context, string, []string) (string, error) {
+				reads := 0
+				return func(context.Context, string, []string) (string, error) {
+					reads++
+					if reads == 1 {
+						return inspectionTestGeneration, nil
+					}
+					return "", private
+				}
+			}(),
+			collect: func(context.Context, string, []string) (ChangeSet, error) {
+				return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+			},
+			wantCode: service.InspectionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector := inspectionServiceForTest(
+				inspectionInventoryWithConfig(path, ""),
+				tt.generation,
+				tt.collect,
+				time.Now,
+			)
+
+			got, err := inspector.Inspect(
+				context.Background(),
+				InspectionRequest{Path: path},
+			)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, tt.wantCode))
+			assert.NotContains(t, err.Error(), "private repository failure")
+			assert.ErrorIs(t, err, private)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServiceRechecksGenerationAfterCollectionFailure(t *testing.T) {
+	path := t.TempDir()
+	collectionFailure := errors.New("status collection failed")
+	for _, tt := range []struct {
+		name       string
+		generation string
+		err        error
+	}{
+		{
+			name:       "generation changed",
+			generation: inspectionTestOtherGeneration,
+		},
+		{
+			name: "generation disappeared",
+			err:  fmt.Errorf("generation disappeared: %w", gitpkg.ErrWorktreeGenerationNotFound),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reads := 0
+			inspector := inspectionServiceForTest(
+				inspectionInventoryWithConfig(path, ""),
+				func(context.Context, string, []string) (string, error) {
+					reads++
+					if reads == 1 {
+						return inspectionTestGeneration, nil
+					}
+					return tt.generation, tt.err
+				},
+				func(context.Context, string, []string) (ChangeSet, error) {
+					return ChangeSet{}, collectionFailure
+				},
+				time.Now,
+			)
+
+			got, err := inspector.Inspect(
+				context.Background(),
+				InspectionRequest{Path: path},
+			)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.RegistrationChanged))
+			assert.True(t, service.AsError(err).Retryable)
+			assert.NotErrorIs(t, err, collectionFailure)
+			assert.Equal(t, 2, reads)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServiceStopsBeforeInventoryWhenCanceled(t *testing.T) {
+	private := errors.New("inventory must not run")
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{}, private
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewInspectionService(InspectionServiceOptions{
+		Inventory: inventory,
+	}).Inspect(ctx, InspectionRequest{Path: t.TempDir()})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, private)
+}
+
+func TestInspectionServicePreservesCancellationAfterInventoryReturns(t *testing.T) {
+	path := t.TempDir()
+	for _, tt := range []struct {
+		name   string
+		result lifecycle.Result
+		err    error
+	}{
+		{
+			name: "successful empty inventory",
+			result: lifecycle.Result{Snapshot: lifecycle.Snapshot{
+				Entries: []lifecycle.Entry{},
+			}},
+		},
+		{
+			name: "typed inventory error",
+			err: service.NewError(
+				service.NotFound,
+				"inventory result must not replace cancellation",
+				false,
+				nil,
+				nil,
+			),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			inventory := &inspectionTestInventory{query: func(
+				context.Context,
+				lifecycle.Request,
+			) (lifecycle.Result, error) {
+				cancel()
+				return tt.result, tt.err
+			}}
+
+			got, err := NewInspectionService(InspectionServiceOptions{
+				Inventory: inventory,
+			}).Inspect(ctx, InspectionRequest{Path: path})
+
+			assert.Equal(t, context.Canceled, err)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServicePreservesCancellationDuringGitInspection(t *testing.T) {
+	for _, stage := range []string{"generation pre-read", "collection", "generation post-read"} {
+		t.Run(stage, func(t *testing.T) {
+			path := t.TempDir()
+			ctx, cancel := context.WithCancel(context.Background())
+			reads := 0
+			readGeneration := func(
+				context.Context,
+				string,
+				[]string,
+			) (string, error) {
+				reads++
+				if stage == "generation pre-read" ||
+					(stage == "generation post-read" && reads == 2) {
+					cancel()
+					return "", ctx.Err()
+				}
+				return inspectionTestGeneration, nil
+			}
+			collect := func(
+				context.Context,
+				string,
+				[]string,
+			) (ChangeSet, error) {
+				if stage == "collection" {
+					cancel()
+					return ChangeSet{}, ctx.Err()
+				}
+				return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+			}
+			inspector := inspectionServiceForTest(
+				inspectionInventoryWithConfig(path, ""),
+				readGeneration,
+				collect,
+				time.Now,
+			)
+
+			got, err := inspector.Inspect(ctx, InspectionRequest{Path: path})
+
+			require.Error(t, err)
+			assert.Equal(t, context.Canceled, err)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServicePreservesCallerDeadlineDuringGitInspection(t *testing.T) {
+	path := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	inspector := inspectionServiceForTest(
+		inspectionInventoryWithConfig(path, ""),
+		func(
+			callCtx context.Context,
+			_ string,
+			_ []string,
+		) (string, error) {
+			<-callCtx.Done()
+			return "", callCtx.Err()
+		},
+		func(context.Context, string, []string) (ChangeSet, error) {
+			t.Fatal("collection ran after caller deadline")
+			return ChangeSet{}, nil
+		},
+		time.Now,
+	)
+	inspector.gitBudget = time.Second
+
+	got, err := inspector.Inspect(ctx, InspectionRequest{Path: path})
+
+	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.Equal(t, InspectionResult{}, got)
+}
+
+func TestInspectionServiceClassifiesOwnGitBudgetTimeoutAsRetryable(t *testing.T) {
+	for _, stage := range []string{"generation pre-read", "collection", "generation post-read"} {
+		t.Run(stage, func(t *testing.T) {
+			path := t.TempDir()
+			reads := 0
+			readGeneration := func(
+				ctx context.Context,
+				_ string,
+				_ []string,
+			) (string, error) {
+				reads++
+				if stage == "generation pre-read" ||
+					(stage == "generation post-read" && reads == 2) {
+					<-ctx.Done()
+					return "", ctx.Err()
+				}
+				return inspectionTestGeneration, nil
+			}
+			collect := func(
+				ctx context.Context,
+				_ string,
+				_ []string,
+			) (ChangeSet, error) {
+				if stage == "collection" {
+					<-ctx.Done()
+					return ChangeSet{}, ctx.Err()
+				}
+				return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+			}
+			inspector := inspectionServiceForTest(
+				inspectionInventoryWithConfig(path, ""),
+				readGeneration,
+				collect,
+				time.Now,
+			)
+			inspector.gitBudget = 10 * time.Millisecond
+
+			got, err := inspector.Inspect(
+				context.Background(),
+				InspectionRequest{Path: path},
+			)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.InspectionFailed))
+			assert.True(t, service.AsError(err).Retryable)
+			assert.Equal(t, "worktree inspection timed out", err.Error())
+			assert.ErrorIs(t, err, context.DeadlineExceeded)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServiceRejectsSuccessfulStageAfterOwnGitBudgetExpires(t *testing.T) {
+	for _, stage := range []string{"generation pre-read", "collection", "generation post-read"} {
+		t.Run(stage, func(t *testing.T) {
+			path := t.TempDir()
+			reads := 0
+			readGeneration := func(
+				ctx context.Context,
+				_ string,
+				_ []string,
+			) (string, error) {
+				reads++
+				if stage == "generation pre-read" ||
+					(stage == "generation post-read" && reads == 2) {
+					<-ctx.Done()
+				}
+				return inspectionTestGeneration, nil
+			}
+			collect := func(
+				ctx context.Context,
+				_ string,
+				_ []string,
+			) (ChangeSet, error) {
+				if stage == "collection" {
+					<-ctx.Done()
+				}
+				return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+			}
+			inspector := inspectionServiceForTest(
+				inspectionInventoryWithConfig(path, ""),
+				readGeneration,
+				collect,
+				time.Now,
+			)
+			inspector.gitBudget = 10 * time.Millisecond
+
+			got, err := inspector.Inspect(
+				context.Background(),
+				InspectionRequest{Path: path},
+			)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.InspectionFailed))
+			assert.True(t, service.AsError(err).Retryable)
+			assert.Equal(t, "worktree inspection timed out", err.Error())
+			assert.ErrorIs(t, err, context.DeadlineExceeded)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServiceRejectsMissingInventoryDependency(t *testing.T) {
+	assert.NotPanics(t, func() {
+		_, err := NewInspectionService(InspectionServiceOptions{}).Inspect(
+			context.Background(),
+			InspectionRequest{Path: t.TempDir()},
+		)
+
+		require.Error(t, err)
+		assert.True(t, service.IsCode(err, service.InspectionFailed))
+	})
+}
+
+func TestInspectionServiceInspectsRealPrimaryAndLinkedWorktrees(t *testing.T) {
+	primary, linked, primaryGeneration, linkedGeneration :=
+		newInspectionTestWorktrees(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(primary, "tracked.txt"),
+		[]byte("modified\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(linked, "untracked.txt"),
+		[]byte("untracked\n"),
+		0o644,
+	))
+	requestPath := primary
+	if runtime.GOOS == "windows" {
+		requestPath = strings.ToUpper(primary)
+	} else {
+		requestPath = filepath.Join(filepath.Dir(primary), "primary-alias")
+		require.NoError(t, os.Symlink(primary, requestPath))
+	}
+	inventory := &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+			Config: &models.Config{},
+			Entries: []lifecycle.Entry{
+				{
+					Path: primary, Generation: primaryGeneration,
+					Repository: lifecycle.Repository{FullPath: "local/test-repository"},
+				},
+				{
+					Path: linked, Generation: linkedGeneration,
+					Repository: lifecycle.Repository{FullPath: "local/test-repository"},
+				},
+			},
+		}}, nil
+	}}
+	inspector := NewInspectionService(InspectionServiceOptions{Inventory: inventory})
+
+	primaryResult, err := inspector.Inspect(context.Background(), InspectionRequest{
+		Path: requestPath, ExpectedGeneration: primaryGeneration,
+	})
+	require.NoError(t, err)
+	linkedResult, err := inspector.Inspect(context.Background(), InspectionRequest{
+		Path: linked, ExpectedGeneration: linkedGeneration,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, primary, primaryResult.Worktree.Path)
+	assert.Equal(t, primaryGeneration, primaryResult.Worktree.Generation)
+	assert.Equal(t, ChangeSummary{Modified: 1}, primaryResult.Changes.Summary)
+	assert.Equal(t, []string{"tracked.txt"}, changePaths(primaryResult.Changes.Files))
+	assert.False(t, primaryResult.ObservedAt.IsZero())
+	assert.Equal(t, linked, linkedResult.Worktree.Path)
+	assert.Equal(t, linkedGeneration, linkedResult.Worktree.Generation)
+	assert.Equal(t, ChangeSummary{Untracked: 1}, linkedResult.Changes.Summary)
+	assert.Equal(t, []string{"untracked.txt"}, changePaths(linkedResult.Changes.Files))
+}
+
+func TestInspectionServiceRejectsRealGenerationReplacementOrRemoval(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "replacement",
+			mutate: func(t *testing.T, generationPath string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					generationPath,
+					[]byte(inspectionTestOtherGeneration+"\n"),
+					0o600,
+				))
+			},
+		},
+		{
+			name: "removal",
+			mutate: func(t *testing.T, generationPath string) {
+				t.Helper()
+				require.NoError(t, os.Remove(generationPath))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			primary, _, generation, _ := newInspectionTestWorktrees(t)
+			inventory := &inspectionTestInventory{query: func(
+				context.Context,
+				lifecycle.Request,
+			) (lifecycle.Result, error) {
+				return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+					Config: &models.Config{},
+					Entries: []lifecycle.Entry{{
+						Path: primary, Generation: generation,
+						Repository: lifecycle.Repository{
+							FullPath: "local/test-repository",
+						},
+					}},
+				}}, nil
+			}}
+			serviceImpl := NewInspectionService(InspectionServiceOptions{
+				Inventory: inventory,
+			}).(*inspectionService)
+			serviceImpl.collectChanges = func(
+				context.Context,
+				string,
+				[]string,
+			) (ChangeSet, error) {
+				tt.mutate(t, filepath.Join(primary, ".git", "kwt-generation"))
+				return ChangeSet{
+					State: ChangeStateModified,
+					Files: []FileChange{{
+						Path: "must-not-escape.txt", Worktree: FileStateModified,
+					}},
+				}, nil
+			}
+
+			got, err := serviceImpl.Inspect(
+				context.Background(),
+				InspectionRequest{Path: primary, ExpectedGeneration: generation},
+			)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.RegistrationChanged))
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func TestInspectionServiceClassifiesRemovedWorktreeAroundGenerationFence(
+	t *testing.T,
+) {
+	for _, stage := range []string{"before pre-read", "before post-read"} {
+		t.Run(stage, func(t *testing.T) {
+			_, linked, _, generation := newInspectionTestWorktrees(t)
+			inventory := &inspectionTestInventory{query: func(
+				context.Context,
+				lifecycle.Request,
+			) (lifecycle.Result, error) {
+				result := lifecycle.Result{Snapshot: lifecycle.Snapshot{
+					Config: &models.Config{},
+					Entries: []lifecycle.Entry{{
+						Path:       linked,
+						Generation: generation,
+						Repository: lifecycle.Repository{
+							FullPath: "local/test-repository",
+						},
+					}},
+				}}
+				if stage == "before pre-read" {
+					require.NoError(t, os.RemoveAll(linked))
+				}
+				return result, nil
+			}}
+			serviceImpl := NewInspectionService(InspectionServiceOptions{
+				Inventory: inventory,
+			}).(*inspectionService)
+			serviceImpl.collectChanges = func(
+				context.Context,
+				string,
+				[]string,
+			) (ChangeSet, error) {
+				if stage == "before pre-read" {
+					t.Fatal("collection ran after the worktree was removed")
+				}
+				require.NoError(t, os.RemoveAll(linked))
+				return ChangeSet{State: ChangeStateClean, Files: []FileChange{}}, nil
+			}
+
+			got, err := serviceImpl.Inspect(
+				context.Background(),
+				InspectionRequest{Path: linked, ExpectedGeneration: generation},
+			)
+
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, service.RegistrationChanged))
+			assert.True(t, service.AsError(err).Retryable)
+			assert.ErrorIs(t, err, gitpkg.ErrWorktreeNotFound)
+			assert.Equal(t, InspectionResult{}, got)
+		})
+	}
+}
+
+func inspectionInventoryWithConfig(
+	path string,
+	tokenEnv string,
+) *inspectionTestInventory {
+	return &inspectionTestInventory{query: func(
+		context.Context,
+		lifecycle.Request,
+	) (lifecycle.Result, error) {
+		return lifecycle.Result{Snapshot: lifecycle.Snapshot{
+			Config: &models.Config{Fleet: models.FleetConfig{TokenEnv: tokenEnv}},
+			Entries: []lifecycle.Entry{
+				inspectionInventoryEntry(path),
+			},
+		}}, nil
+	}}
+}
+
+func inspectionServiceForTest(
+	inventory lifecycle.Inventory,
+	readGeneration func(context.Context, string, []string) (string, error),
+	collectChanges func(context.Context, string, []string) (ChangeSet, error),
+	now func() time.Time,
+) *inspectionService {
+	return &inspectionService{
+		inventory: inventory,
+		captureExpansion: func() (lifecycle.ExpansionContext, error) {
+			return lifecycle.ExpansionContext{
+				WorkingDirectory: "/test/work",
+				HomeDirectory:    "/test/home",
+			}, nil
+		},
+		readGeneration: readGeneration,
+		collectChanges: collectChanges,
+		gitBudget:      collectChangesTimeout,
+		now:            now,
+	}
+}
+
+func inspectionInventoryEntry(path string) lifecycle.Entry {
+	return lifecycle.Entry{
+		Path:       path,
+		Generation: inspectionTestGeneration,
+		Repository: lifecycle.Repository{FullPath: "github.com/acme/widget"},
+	}
+}
+
+func newInspectionTestWorktrees(t *testing.T) (string, string, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	linked := filepath.Join(root, "linked")
+	require.NoError(t, os.Mkdir(primary, 0o755))
+	runStatusTestGit(t, primary, "init", "-b", "main")
+	runStatusTestGit(t, primary, "config", "user.name", "Test User")
+	runStatusTestGit(t, primary, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(primary, "tracked.txt"),
+		[]byte("original\n"),
+		0o644,
+	))
+	runStatusTestGit(t, primary, "add", "tracked.txt")
+	runStatusTestGit(
+		t,
+		primary,
+		"-c",
+		"core.hooksPath=/dev/null",
+		"commit",
+		"-m",
+		"initial",
+	)
+	runStatusTestGit(t, primary, "worktree", "add", "-b", "feature", linked)
+	primaryGeneration, err := gitpkg.New(primary).EnsureWorktreeGeneration(primary)
+	require.NoError(t, err)
+	linkedGeneration, err := gitpkg.New(primary).EnsureWorktreeGeneration(linked)
+	require.NoError(t, err)
+	return primary, linked, primaryGeneration, linkedGeneration
+}

--- a/internal/status/inspection_test.go
+++ b/internal/status/inspection_test.go
@@ -536,6 +536,34 @@ func TestInspectionServiceClassifiesReadAndCollectionFailures(t *testing.T) {
 	}
 }
 
+func TestInspectionServiceReportsOversizedChangeList(t *testing.T) {
+	path := t.TempDir()
+	inspector := inspectionServiceForTest(
+		inspectionInventoryWithConfig(path, ""),
+		func(context.Context, string, []string) (string, error) {
+			return inspectionTestGeneration, nil
+		},
+		func(context.Context, string, []string) (ChangeSet, error) {
+			return ChangeSet{}, fmt.Errorf(
+				"collect local changes: %w",
+				gitpkg.ErrStdoutLimitExceeded,
+			)
+		},
+		time.Now,
+	)
+
+	got, err := inspector.Inspect(
+		context.Background(),
+		InspectionRequest{Path: path},
+	)
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.InspectionFailed))
+	assert.Equal(t, "worktree change list is too large to inspect", err.Error())
+	assert.ErrorIs(t, err, gitpkg.ErrStdoutLimitExceeded)
+	assert.Equal(t, InspectionResult{}, got)
+}
+
 func TestInspectionServiceRechecksGenerationAfterCollectionFailure(t *testing.T) {
 	path := t.TempDir()
 	collectionFailure := errors.New("status collection failed")
@@ -850,7 +878,7 @@ func TestInspectionServiceInspectsRealPrimaryAndLinkedWorktrees(t *testing.T) {
 		[]byte("untracked\n"),
 		0o644,
 	))
-	requestPath := primary
+	var requestPath string
 	if runtime.GOOS == "windows" {
 		requestPath = strings.ToUpper(primary)
 	} else {

--- a/internal/status/porcelain_v2.go
+++ b/internal/status/porcelain_v2.go
@@ -174,9 +174,9 @@ func arePorcelainV2ObjectIDs(fields [][]byte) bool {
 			return false
 		}
 		for _, digit := range field {
-			if !((digit >= '0' && digit <= '9') ||
-				(digit >= 'a' && digit <= 'f') ||
-				(digit >= 'A' && digit <= 'F')) {
+			if (digit < '0' || digit > '9') &&
+				(digit < 'a' || digit > 'f') &&
+				(digit < 'A' || digit > 'F') {
 				return false
 			}
 		}

--- a/internal/status/porcelain_v2.go
+++ b/internal/status/porcelain_v2.go
@@ -1,0 +1,213 @@
+package status
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func parseChangePorcelainV2(input []byte) ([]FileChange, error) {
+	changes := make([]FileChange, 0)
+	for len(input) > 0 {
+		separator := bytes.IndexByte(input, 0)
+		if separator < 0 {
+			return nil, fmt.Errorf("porcelain v2 record is not NUL terminated")
+		}
+		record := input[:separator]
+		input = input[separator+1:]
+		if len(record) == 0 {
+			return nil, fmt.Errorf("porcelain v2 contains an empty record")
+		}
+
+		var change FileChange
+		var err error
+		switch record[0] {
+		case '2':
+			originalSeparator := bytes.IndexByte(input, 0)
+			if originalSeparator < 0 {
+				return nil, fmt.Errorf(
+					"porcelain v2 rename or copy record has no original path",
+				)
+			}
+			originalPath := input[:originalSeparator]
+			input = input[originalSeparator+1:]
+			change, err = parsePorcelainV2RenameOrCopy(record, originalPath)
+		case '1', '?', 'u':
+			change, err = parsePorcelainV2Record(record)
+		default:
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, change)
+	}
+	return changes, nil
+}
+
+func parsePorcelainV2RenameOrCopy(
+	record, originalPath []byte,
+) (FileChange, error) {
+	fields := bytes.SplitN(record, []byte{' '}, 10)
+	if len(fields) != 10 || string(fields[0]) != "2" ||
+		len(fields[1]) != 2 || !isPorcelainV2Submodule(fields[2]) ||
+		!arePorcelainV2Modes(fields[3:6]) ||
+		!arePorcelainV2ObjectIDs(fields[6:8]) || len(fields[9]) == 0 ||
+		len(originalPath) == 0 || !isPorcelainV2RenameOrCopyScore(
+		fields[8],
+		fields[1],
+	) {
+		return FileChange{}, fmt.Errorf("malformed porcelain v2 rename or copy record")
+	}
+	index, err := parsePorcelainV2State(fields[1][0])
+	if err != nil {
+		return FileChange{}, err
+	}
+	worktree, err := parsePorcelainV2State(fields[1][1])
+	if err != nil {
+		return FileChange{}, err
+	}
+	return FileChange{
+		Path:         string(fields[9]),
+		OriginalPath: string(originalPath),
+		Index:        index,
+		Worktree:     worktree,
+	}, nil
+}
+
+func isPorcelainV2RenameOrCopyScore(score, state []byte) bool {
+	if len(score) < 2 || len(score) > 4 || len(state) != 2 ||
+		(score[0] != 'R' && score[0] != 'C') ||
+		(state[0] != score[0] && state[1] != score[0]) {
+		return false
+	}
+	value := 0
+	for _, digit := range score[1:] {
+		if digit < '0' || digit > '9' {
+			return false
+		}
+		value = value*10 + int(digit-'0')
+	}
+	return value <= 100
+}
+
+func parsePorcelainV2Record(record []byte) (FileChange, error) {
+	switch record[0] {
+	case '1':
+		fields := bytes.SplitN(record, []byte{' '}, 9)
+		if len(fields) != 9 || string(fields[0]) != "1" ||
+			len(fields[1]) != 2 || !isPorcelainV2Submodule(fields[2]) ||
+			!arePorcelainV2Modes(fields[3:6]) ||
+			!arePorcelainV2ObjectIDs(fields[6:8]) || len(fields[8]) == 0 {
+			return FileChange{}, fmt.Errorf("malformed porcelain v2 ordinary record")
+		}
+		index, err := parsePorcelainV2State(fields[1][0])
+		if err != nil {
+			return FileChange{}, err
+		}
+		worktree, err := parsePorcelainV2State(fields[1][1])
+		if err != nil {
+			return FileChange{}, err
+		}
+		return FileChange{
+			Path:     string(fields[8]),
+			Index:    index,
+			Worktree: worktree,
+		}, nil
+	case '?':
+		if len(record) < 3 || record[1] != ' ' {
+			return FileChange{}, fmt.Errorf("malformed porcelain v2 untracked record")
+		}
+		return FileChange{
+			Path:     string(record[2:]),
+			Worktree: FileStateUntracked,
+		}, nil
+	case 'u':
+		fields := bytes.SplitN(record, []byte{' '}, 11)
+		if len(fields) != 11 || string(fields[0]) != "u" ||
+			!isPorcelainV2UnmergedCode(fields[1]) ||
+			!isPorcelainV2Submodule(fields[2]) ||
+			!arePorcelainV2Modes(fields[3:7]) ||
+			!arePorcelainV2ObjectIDs(fields[7:10]) ||
+			len(fields[10]) == 0 {
+			return FileChange{}, fmt.Errorf("malformed porcelain v2 unmerged record")
+		}
+		return FileChange{
+			Path:     string(fields[10]),
+			Index:    FileStateConflicted,
+			Worktree: FileStateConflicted,
+		}, nil
+	default:
+		return FileChange{}, fmt.Errorf(
+			"unknown porcelain v2 record type %q",
+			record[0],
+		)
+	}
+}
+
+func isPorcelainV2Submodule(field []byte) bool {
+	if bytes.Equal(field, []byte("N...")) {
+		return true
+	}
+	return len(field) == 4 && field[0] == 'S' &&
+		(field[1] == '.' || field[1] == 'C') &&
+		(field[2] == '.' || field[2] == 'M') &&
+		(field[3] == '.' || field[3] == 'U')
+}
+
+func arePorcelainV2Modes(fields [][]byte) bool {
+	for _, field := range fields {
+		if len(field) != 6 {
+			return false
+		}
+		for _, digit := range field {
+			if digit < '0' || digit > '7' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func arePorcelainV2ObjectIDs(fields [][]byte) bool {
+	for _, field := range fields {
+		if len(field) != 40 && len(field) != 64 {
+			return false
+		}
+		for _, digit := range field {
+			if !((digit >= '0' && digit <= '9') ||
+				(digit >= 'a' && digit <= 'f') ||
+				(digit >= 'A' && digit <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isPorcelainV2UnmergedCode(code []byte) bool {
+	switch string(code) {
+	case "DD", "AU", "UD", "UA", "DU", "AA", "UU":
+		return true
+	default:
+		return false
+	}
+}
+
+func parsePorcelainV2State(code byte) (FileState, error) {
+	switch code {
+	case '.':
+		return "", nil
+	case 'M', 'T':
+		return FileStateModified, nil
+	case 'A':
+		return FileStateAdded, nil
+	case 'D':
+		return FileStateDeleted, nil
+	case 'R':
+		return FileStateRenamed, nil
+	case 'C':
+		return FileStateCopied, nil
+	default:
+		return "", fmt.Errorf("unknown porcelain v2 state %q", code)
+	}
+}

--- a/internal/status/porcelain_v2_test.go
+++ b/internal/status/porcelain_v2_test.go
@@ -1,0 +1,142 @@
+package status
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePorcelainV2OrdinaryAndUntrackedRecords(t *testing.T) {
+	input := []byte(
+		"1 M. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb staged.txt\x00" +
+			"1 .M N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb worktree.txt\x00" +
+			"1 AM N... 000000 100644 100644 0000000000000000000000000000000000000000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb added-and-edited.txt\x00" +
+			"1 .D N... 100644 100644 000000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb deleted.txt\x00" +
+			"? untracked.txt\x00",
+	)
+
+	got, err := parseChangePorcelainV2(input)
+
+	require.NoError(t, err)
+	assert.Equal(t, []FileChange{
+		{Path: "staged.txt", Index: FileStateModified},
+		{Path: "worktree.txt", Worktree: FileStateModified},
+		{
+			Path:     "added-and-edited.txt",
+			Index:    FileStateAdded,
+			Worktree: FileStateModified,
+		},
+		{Path: "deleted.txt", Worktree: FileStateDeleted},
+		{Path: "untracked.txt", Worktree: FileStateUntracked},
+	}, got)
+}
+
+func TestParsePorcelainV2RenameAndCopyRecords(t *testing.T) {
+	input := []byte(
+		"2 R. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb R100 renamed.txt\x00original.txt\x00" +
+			"2 C. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb C075 copied.txt\x00source.txt\x00",
+	)
+
+	got, err := parseChangePorcelainV2(input)
+
+	require.NoError(t, err)
+	assert.Equal(t, []FileChange{
+		{
+			Path:         "renamed.txt",
+			OriginalPath: "original.txt",
+			Index:        FileStateRenamed,
+		},
+		{
+			Path:         "copied.txt",
+			OriginalPath: "source.txt",
+			Index:        FileStateCopied,
+		},
+	}, got)
+}
+
+func TestParsePorcelainV2AllUnmergedCodes(t *testing.T) {
+	for _, code := range []string{"DD", "AU", "UD", "UA", "DU", "AA", "UU"} {
+		t.Run(code, func(t *testing.T) {
+			input := []byte(fmt.Sprintf(
+				"u %s N... 100644 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc conflict-%s.txt\x00",
+				code,
+				code,
+			))
+
+			got, err := parseChangePorcelainV2(input)
+
+			require.NoError(t, err)
+			assert.Equal(t, []FileChange{{
+				Path:     "conflict-" + code + ".txt",
+				Index:    FileStateConflicted,
+				Worktree: FileStateConflicted,
+			}}, got)
+		})
+	}
+}
+
+func TestParsePorcelainV2PreservesUnusualPathBytes(t *testing.T) {
+	path := []byte{'o', 'd', 'd', '\t', 'l', 'i', 'n', 'e', '\n', 0xff, '.', 't', 'x', 't'}
+	input := append(
+		[]byte("1 .M N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "),
+		path...,
+	)
+	input = append(input, 0)
+
+	got, err := parseChangePorcelainV2(input)
+
+	require.NoError(t, err)
+	assert.Equal(t, string(path), got[0].Path)
+	assert.Equal(t, path, []byte(got[0].Path))
+}
+
+func TestParsePorcelainV2RejectsMalformedOrUnknownRecords(t *testing.T) {
+	ordinaryPrefix := "1 M. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "
+	renamePrefix := "2 R. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "
+	unmergedPrefix := "u MM N... 100644 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc conflict.txt\x00"
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{name: "missing NUL terminator", input: []byte(ordinaryPrefix + "file.txt")},
+		{name: "empty record", input: []byte{0}},
+		{name: "truncated ordinary", input: []byte("1 M. file.txt\x00")},
+		{name: "corrupt ordinary tag", input: []byte("1x M. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb file.txt\x00")},
+		{name: "unknown ordinary state", input: []byte("1 Z. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb file.txt\x00")},
+		{name: "invalid submodule field", input: []byte("1 M. BAD. 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb file.txt\x00")},
+		{name: "invalid mode", input: []byte("1 M. N... 10064x 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb file.txt\x00")},
+		{name: "invalid object ID", input: []byte("1 M. N... 100644 100644 100644 not-an-object-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb file.txt\x00")},
+		{name: "unknown unmerged code", input: []byte(unmergedPrefix)},
+		{name: "rename missing original path", input: []byte(renamePrefix + "R100 renamed.txt\x00")},
+		{name: "invalid rename score", input: []byte(renamePrefix + "X100 renamed.txt\x00original.txt\x00")},
+		{name: "mismatched copy score", input: []byte(renamePrefix + "C100 renamed.txt\x00original.txt\x00")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseChangePorcelainV2(tt.input)
+
+			require.Error(t, err)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestParsePorcelainV2SkipsUnknownFramedRecords(t *testing.T) {
+	input := []byte(
+		"1 M. N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb staged.txt\x00" +
+			"x future fields remain opaque\x00" +
+			"! ignored-by-current-command.txt\x00" +
+			"? untracked.txt\x00",
+	)
+
+	got, err := parseChangePorcelainV2(input)
+
+	require.NoError(t, err)
+	assert.Equal(t, []FileChange{
+		{Path: "staged.txt", Index: FileStateModified},
+		{Path: "untracked.txt", Worktree: FileStateUntracked},
+	}, got)
+}

--- a/internal/status/status_collector.go
+++ b/internal/status/status_collector.go
@@ -24,6 +24,7 @@ type StatusCollectorOptions struct {
 	StaleThreshold time.Duration
 	BaseDir        string
 	Workers        int
+	ProtectedNames []string
 }
 
 // StatusCollector collects status information for worktrees.
@@ -32,6 +33,7 @@ type StatusCollector struct {
 	staleThreshold  time.Duration
 	basedir         string
 	workers         int
+	protectedNames  []string
 	activityTimeout time.Duration
 	runHead         func(context.Context, string) (string, error)
 }
@@ -66,16 +68,19 @@ func NewStatusCollectorWithOptions(opts StatusCollectorOptions) *StatusCollector
 		opts.Workers = 1
 	}
 
-	return &StatusCollector{
+	collector := &StatusCollector{
 		fetchRemote:     opts.FetchRemote,
 		staleThreshold:  opts.StaleThreshold,
 		basedir:         opts.BaseDir,
 		workers:         opts.Workers,
+		protectedNames:  append([]string(nil), opts.ProtectedNames...),
 		activityTimeout: 5 * time.Second,
-		runHead: func(ctx context.Context, path string) (string, error) {
-			return git.New(path).RunWithContext(ctx, "show", "-s", "--format=%ct", "HEAD")
-		},
 	}
+	collector.runHead = func(ctx context.Context, path string) (string, error) {
+		return git.NewForInventory(ctx, path, collector.protectedNames).
+			RunWithContext(ctx, "show", "-s", "--format=%ct", "HEAD")
+	}
+	return collector
 }
 
 // CollectAll collects status for all provided worktrees with bounded concurrency.
@@ -162,7 +167,7 @@ submit:
 
 func (c *StatusCollector) collectOne(ctx context.Context, worktree *models.Worktree) (*models.WorktreeStatus, error) {
 	repository := strings.TrimSpace(worktree.Repository)
-	g := git.New(worktree.Path)
+	g := git.NewForInventory(ctx, worktree.Path, c.protectedNames)
 	if repository == "" {
 		repository = c.repositoryIdentity(g, worktree.Path)
 	}

--- a/internal/status/status_collector_test.go
+++ b/internal/status/status_collector_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -82,6 +83,51 @@ func TestCollectPorcelainUsesUAllForPerFileUntrackedCount(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 2, got.GitStatus.Untracked)
+}
+
+func TestStatusCollectorStripsConfiguredCredentialFromEveryGitCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("command recorder uses a POSIX shell")
+	}
+	repo := newStatusTestRepositoryAt(t, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	wrapperDir := t.TempDir()
+	logPath := filepath.Join(wrapperDir, "git.log")
+	require.NoError(t, os.WriteFile(filepath.Join(wrapperDir, "git"), []byte(`#!/bin/sh
+if [ "${CUSTOM_FLEET_TOKEN+x}" = x ]; then
+  credential=present
+else
+  credential=absent
+fi
+printf '%s|%s\n' "$*" "$credential" >> "$KWT_TEST_GIT_LOG"
+exec "$KWT_TEST_REAL_GIT" "$@"
+`), 0o755))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KWT_TEST_GIT_LOG", logPath)
+	t.Setenv("KWT_TEST_REAL_GIT", realGit)
+	t.Setenv("CUSTOM_FLEET_TOKEN", "must-not-reach-git")
+
+	protectedNames := []string{"CUSTOM_FLEET_TOKEN"}
+	collector := NewStatusCollectorWithOptions(StatusCollectorOptions{
+		ProtectedNames: protectedNames,
+	})
+	protectedNames[0] = "MUTATED_AFTER_CONSTRUCTION"
+	_, err = collector.CollectAll(context.Background(), []*models.Worktree{{
+		Path: repo, Branch: "main",
+	}})
+
+	require.NoError(t, err)
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	require.NotEmpty(t, lines)
+	for _, line := range lines {
+		assert.True(t, strings.HasSuffix(line, "|absent"), "credential reached git command %q", line)
+	}
+	log := string(logBytes)
+	assert.Contains(t, log, "status --porcelain=v2 --branch -uall -z --no-ahead-behind|absent")
+	assert.Contains(t, log, "show -s --format=%ct HEAD|absent")
 }
 
 func TestParsePorcelainV2WithoutUpstreamDefaultsAheadBehindToZero(t *testing.T) {

--- a/internal/tmux/resolver_test.go
+++ b/internal/tmux/resolver_test.go
@@ -76,13 +76,13 @@ func newResolverTestCommands(path, session string) (*fakeEndpointCommand, *fakeE
 		workspaceGenerationOption: resolverTestGeneration,
 	}
 	return &fakeEndpointCommand{
-			options:      cloneStringMap(matching),
-			optionErrors: make(map[string]error),
-		}, &fakeEndpointCommand{
-			options:            cloneStringMap(matching),
-			optionErrors:       make(map[string]error),
-			requireEnumeration: true,
-		}
+		options:      cloneStringMap(matching),
+		optionErrors: make(map[string]error),
+	}, &fakeEndpointCommand{
+		options:            cloneStringMap(matching),
+		optionErrors:       make(map[string]error),
+		requireEnumeration: true,
+	}
 }
 
 func cloneStringMap(values map[string]string) map[string]string {

--- a/kwt.go
+++ b/kwt.go
@@ -1,7 +1,10 @@
 // Package kwt provides embeddable worktree inventory and lifecycle services.
 package kwt
 
-import "go.kenn.io/kwt/internal/lifecycle"
+import (
+	"go.kenn.io/kwt/internal/lifecycle"
+	"go.kenn.io/kwt/internal/status"
+)
 
 type (
 	View                         = lifecycle.View
@@ -33,6 +36,16 @@ type (
 	ProjectRemovalResult         = lifecycle.ProjectRemovalResult
 	ProjectRemover               = lifecycle.ProjectRemover
 	ProjectRemovalServiceOptions = lifecycle.ProjectRemovalServiceOptions
+	FileState                    = status.FileState
+	FileChange                   = status.FileChange
+	ChangeState                  = status.ChangeState
+	ChangeSummary                = status.ChangeSummary
+	ChangeSet                    = status.ChangeSet
+	InspectionRequest            = status.InspectionRequest
+	WorktreeIdentity             = status.WorktreeIdentity
+	InspectionResult             = status.InspectionResult
+	Inspector                    = status.Inspector
+	InspectionServiceOptions     = status.InspectionServiceOptions
 )
 
 const (
@@ -49,6 +62,19 @@ const (
 
 	RequireConfigInteraction = lifecycle.RequireConfigInteraction
 	IgnoreUntrustedConfig    = lifecycle.IgnoreUntrustedConfig
+
+	FileStateModified   = status.FileStateModified
+	FileStateAdded      = status.FileStateAdded
+	FileStateDeleted    = status.FileStateDeleted
+	FileStateRenamed    = status.FileStateRenamed
+	FileStateCopied     = status.FileStateCopied
+	FileStateConflicted = status.FileStateConflicted
+	FileStateUntracked  = status.FileStateUntracked
+
+	ChangeStateClean      = status.ChangeStateClean
+	ChangeStateModified   = status.ChangeStateModified
+	ChangeStateStaged     = status.ChangeStateStaged
+	ChangeStateConflicted = status.ChangeStateConflicted
 )
 
 func CaptureExpansionContext() (ExpansionContext, error) {
@@ -73,4 +99,8 @@ func NewRemovalService(options RemovalServiceOptions) Remover {
 
 func NewProjectRemovalService(options ProjectRemovalServiceOptions) ProjectRemover {
 	return lifecycle.NewProjectRemovalService(options)
+}
+
+func NewInspectionService(options InspectionServiceOptions) Inspector {
+	return status.NewInspectionService(options)
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.6"
+go = "1.27.0"
 prek = "latest"
 "golangci-lint" = "latest"
 "npm:oxfmt" = "latest"

--- a/public_test.go
+++ b/public_test.go
@@ -17,6 +17,24 @@ func TestRootPackageExposesWorktreeServices(t *testing.T) {
 	}
 }
 
+func TestRootPackageExposesInspectionService(t *testing.T) {
+	inspector := kwt.NewInspectionService(kwt.InspectionServiceOptions{})
+	if inspector == nil {
+		t.Fatal("inspection service is unavailable from the root package")
+	}
+	var _ kwt.Inspector = inspector
+	var _ = kwt.InspectionRequest{}
+	var _ = kwt.InspectionResult{
+		Worktree: kwt.WorktreeIdentity{},
+		Changes: kwt.ChangeSet{
+			State: kwt.ChangeStateClean,
+			Files: []kwt.FileChange{{
+				Index: kwt.FileStateAdded,
+			}},
+		},
+	}
+}
+
 func TestRootPackageExposesSSHAskpassDispatch(t *testing.T) {
 	exitCode, handled := kwt.RunSSHAskpassHelper(
 		[]string{"host-application"},

--- a/public_test.go
+++ b/public_test.go
@@ -22,7 +22,6 @@ func TestRootPackageExposesInspectionService(t *testing.T) {
 	if inspector == nil {
 		t.Fatal("inspection service is unavailable from the root package")
 	}
-	var _ kwt.Inspector = inspector
 	var _ = kwt.InspectionRequest{}
 	var _ = kwt.InspectionResult{
 		Worktree: kwt.WorktreeIdentity{},

--- a/service/error.go
+++ b/service/error.go
@@ -25,6 +25,7 @@ const (
 	DaemonTransportFailed                Code = "daemon_transport_failed"
 	InventoryTimeout                     Code = "inventory_timeout"
 	InventoryFailed                      Code = "inventory_failed"
+	InspectionFailed                     Code = "inspection_failed"
 	RemovalFailed                        Code = "removal_failed"
 	ProjectNotFound                      Code = "project_not_found"
 	RegistrationChanged                  Code = "registration_changed"


### PR DESCRIPTION
This adds `kwt changes [path]`, a focused command for seeing exactly which files changed in one registered worktree. It reports staged and working-tree changes separately, including untracked files, renames, copies, deletions, and conflicts. Human output is intended for interactive use; `--json` provides deterministic ordering and a stable contract. The same inspection API is available to Go consumers.

Kwt checks the worktree’s durable generation before and after reading Git status. If the worktree is removed or replaced during inspection, kwt discards the result instead of returning changes for the wrong checkout.

The daemon supplies current inventory and configuration, while Git runs in the foreground client with bounded time and output. Kwt credentials and repository-routing variables are removed from Git’s environment while trusted Git configuration remains available. If an exact change list exceeds the output limit, kwt returns an actionable error instead of partial file records.

This does not change the status accounting or TUI presentation introduced in #104. The TUI-related code here only keeps credential filtering current during repository refreshes.

This PR also raises kwt’s source-build baseline to Go 1.27.0, matching the other Go projects. The resulting macOS support floor is version 13.

Out of scope: patches or file contents, fetching, watching, caching, sibling-worktree discovery, and daemon-owned status polling.
