### PR TITLE
Block worktree removal while processes use it

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,6 +55,10 @@ Notable user-facing changes to kwt, grouped by release.
 
 ### Safety
 
+- Refuse to remove a worktree while a visible live process has its current
+  working directory at or below the worktree path. The conflict lists the
+  offending process IDs. An uninspectable live process owned by the current
+  user also blocks removal; explicit `kwt remove --force` bypasses either guard.
 - Bind project unregistration to the exact registry entry observed through
   `kwt projects --json`. Machine callers now send its opaque registration
   fingerprint alongside the exact path and credential-free repository

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -529,6 +529,12 @@ Removal is executed by the same-machine daemon through kwt's public Go service.
 The daemon reopens the named repository and revalidates the exact path,
 generation, main-worktree status, and lock state while holding the repository's
 cross-process mutation lock. It also performs generation-safe registry cleanup.
+Immediately before removal, it rejects a worktree used as the current working
+directory of a visible live process, including a process whose working
+directory is nested inside the worktree. The conflict lists the process IDs to
+stop. If the operating system refuses working-directory inspection for a live
+process owned by the current user, removal also fails closed with that PID.
+`--force` bypasses both process checks and Git's dirty-worktree refusal.
 The CLI and TUI retain selection, output, fleet publication, and tmux-session
 cleanup; stale inventory alone never authorizes deletion.
 Automation that has confirmed terminal-session state can add

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.28
 	github.com/muesli/cancelreader v0.2.2
 	github.com/pelletier/go-toml/v2 v2.4.3
+	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
@@ -52,7 +53,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -65,7 +65,7 @@ Use -g flag to always show all worktrees from the base directory.`,
   # Delete by pattern matching
   kwt remove feature/old
 
-  # Force delete even if dirty
+  # Force delete even if dirty or in use by a process
   kwt remove -f feature/broken
 
   # Delete worktree and branch
@@ -91,7 +91,7 @@ Use -g flag to always show all worktrees from the base directory.`,
 func init() {
 	rootCmd.AddCommand(removeCmd)
 
-	removeCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Force delete even if dirty")
+	removeCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Force delete even if dirty or in use by a process")
 	removeCmd.Flags().BoolVarP(&removeDryRun, "dry-run", "d", false, "Show deletion targets only")
 	removeCmd.Flags().BoolVarP(&removeGlobal, "global", "g", false, "Remove from any worktree in the configured base directory")
 	removeCmd.Flags().StringVar(&removeIfGeneration, "if-generation", "", "Remove only if the worktree generation matches")

--- a/internal/lifecycle/process_guard.go
+++ b/internal/lifecycle/process_guard.go
@@ -1,0 +1,117 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"os/user"
+	"slices"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/process"
+	"go.kenn.io/kwt/internal/utils"
+)
+
+type worktreeProcessConditionError struct{ pids []int32 }
+
+type worktreeProcessInspectionError struct{ pids []int32 }
+
+type worktreeProcess interface {
+	pid() int32
+	CwdWithContext(context.Context) (string, error)
+	StatusWithContext(context.Context) ([]string, error)
+	UsernameWithContext(context.Context) (string, error)
+}
+
+type systemWorktreeProcess struct{ *process.Process }
+
+func (p systemWorktreeProcess) pid() int32 { return p.Pid }
+
+func (e *worktreeProcessConditionError) Error() string {
+	values := processIDStrings(e.pids)
+	if len(values) == 1 {
+		return fmt.Sprintf(
+			"worktree is in use by a process with its working directory inside it (PID %s); stop the process or rerun with --force",
+			values[0],
+		)
+	}
+	return fmt.Sprintf(
+		"worktree is in use by processes with working directories inside it (PIDs %s); stop the processes or rerun with --force",
+		strings.Join(values, ", "),
+	)
+}
+
+func (e *worktreeProcessInspectionError) Error() string {
+	values := processIDStrings(e.pids)
+	if len(values) == 1 {
+		return fmt.Sprintf(
+			"cannot verify whether process PID %s uses the worktree because its working directory could not be inspected; stop the process or rerun with --force",
+			values[0],
+		)
+	}
+	return fmt.Sprintf(
+		"cannot verify whether processes with PIDs %s use the worktree because their working directories could not be inspected; stop the processes or rerun with --force",
+		strings.Join(values, ", "),
+	)
+}
+
+func processIDStrings(pids []int32) []string {
+	values := make([]string, len(pids))
+	for index, pid := range pids {
+		values[index] = fmt.Sprintf("%d", pid)
+	}
+	return values
+}
+
+func rejectProcessesUsingWorktree(ctx context.Context, path string) error {
+	processes, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("inspect process working directories: %w", err)
+	}
+	candidates := make([]worktreeProcess, len(processes))
+	for index, candidate := range processes {
+		candidates[index] = systemWorktreeProcess{Process: candidate}
+	}
+	return rejectProcessCandidatesUsingWorktree(ctx, path, candidates)
+}
+
+func rejectProcessCandidatesUsingWorktree(
+	ctx context.Context,
+	path string,
+	processes []worktreeProcess,
+) error {
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("resolve current user for process inspection: %w", err)
+	}
+	pids := make([]int32, 0)
+	uninspectablePIDs := make([]int32, 0)
+	for _, candidate := range processes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		workingDirectory, err := candidate.CwdWithContext(ctx)
+		if err != nil || workingDirectory == "" {
+			statuses, statusErr := candidate.StatusWithContext(ctx)
+			if statusErr == nil && slices.Contains(statuses, process.Zombie) {
+				continue
+			}
+			username, usernameErr := candidate.UsernameWithContext(ctx)
+			if usernameErr == nil && username == currentUser.Username {
+				uninspectablePIDs = append(uninspectablePIDs, candidate.pid())
+			}
+			continue
+		}
+		if utils.IsSameOrChildPath(workingDirectory, path) {
+			pids = append(pids, candidate.pid())
+		}
+	}
+	if len(pids) > 0 {
+		slices.Sort(pids)
+		return &worktreeProcessConditionError{pids: pids}
+	}
+	if len(uninspectablePIDs) > 0 {
+		slices.Sort(uninspectablePIDs)
+		return &worktreeProcessInspectionError{pids: uninspectablePIDs}
+	}
+	return nil
+}

--- a/internal/lifecycle/process_guard_test.go
+++ b/internal/lifecycle/process_guard_test.go
@@ -1,0 +1,103 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"os/user"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kwt/service"
+)
+
+type fakeWorktreeProcess struct {
+	processID        int32
+	workingDirectory string
+	workingDirErr    error
+	statuses         []string
+	username         string
+}
+
+func (p fakeWorktreeProcess) pid() int32 { return p.processID }
+
+func (p fakeWorktreeProcess) CwdWithContext(context.Context) (string, error) {
+	return p.workingDirectory, p.workingDirErr
+}
+
+func (p fakeWorktreeProcess) StatusWithContext(context.Context) ([]string, error) {
+	return p.statuses, nil
+}
+
+func (p fakeWorktreeProcess) UsernameWithContext(context.Context) (string, error) {
+	return p.username, nil
+}
+
+func TestProcessGuardRejectsUninspectableCurrentUserProcess(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	err = rejectProcessCandidatesUsingWorktree(
+		context.Background(),
+		"/worktrees/topic",
+		[]worktreeProcess{fakeWorktreeProcess{
+			processID:     42,
+			workingDirErr: errors.New("permission denied"),
+			statuses:      []string{"running"},
+			username:      currentUser.Username,
+		}},
+	)
+
+	var inspectionErr *worktreeProcessInspectionError
+	require.ErrorAs(t, err, &inspectionErr)
+	require.Contains(t, err.Error(), "PID 42")
+}
+
+func TestProcessGuardRejectsEmptyWorkingDirectoryForCurrentUserProcess(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	err = rejectProcessCandidatesUsingWorktree(
+		context.Background(),
+		"/worktrees/topic",
+		[]worktreeProcess{fakeWorktreeProcess{
+			processID: 42,
+			statuses:  []string{"running"},
+			username:  currentUser.Username,
+		}},
+	)
+
+	var inspectionErr *worktreeProcessInspectionError
+	require.ErrorAs(t, err, &inspectionErr)
+	require.Contains(t, err.Error(), "PID 42")
+}
+
+func TestProcessGuardIgnoresZombieWithNoWorkingDirectory(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	err = rejectProcessCandidatesUsingWorktree(
+		context.Background(),
+		"/worktrees/topic",
+		[]worktreeProcess{fakeWorktreeProcess{
+			processID:     42,
+			workingDirErr: errors.New("working directory unavailable"),
+			statuses:      []string{process.Zombie},
+			username:      currentUser.Username,
+		}},
+	)
+
+	require.NoError(t, err)
+}
+
+func TestClassifyRemovalErrorReportsIndeterminateProcessInspection(t *testing.T) {
+	err := classifyRemovalError(
+		&worktreeProcessInspectionError{pids: []int32{42}},
+		RemovalResult{Path: "/worktrees/topic"},
+	)
+
+	assert.True(t, service.IsCode(err, service.Conflict))
+	typed := service.AsError(err)
+	assert.Equal(t, "process_working_directory_indeterminate", typed.Details["reason"])
+}

--- a/internal/lifecycle/removal.go
+++ b/internal/lifecycle/removal.go
@@ -206,8 +206,20 @@ func (s *removalService) Remove(
 						return err
 					}
 					if err := quiescePreflightAndTerminate(
-						ctx, s.sessionGuard, sessionCondition, preflight,
+						ctx, s.sessionGuard, sessionCondition, func() error {
+							if err := preflight(); err != nil {
+								return err
+							}
+							if request.Force {
+								return nil
+							}
+							return rejectProcessesUsingWorktree(ctx, request.Path)
+						},
 					); err != nil {
+						return err
+					}
+				} else if !request.Force {
+					if err := rejectProcessesUsingWorktree(ctx, request.Path); err != nil {
 						return err
 					}
 				}
@@ -317,6 +329,16 @@ func classifyRemovalError(err error, result RemovalResult) error {
 	if errors.As(err, &sessionCondition) {
 		details["reason"] = sessionCondition.Error()
 		return service.NewError(service.Conflict, sessionCondition.Error(), true, details, err)
+	}
+	var processCondition *worktreeProcessConditionError
+	if errors.As(err, &processCondition) {
+		details["reason"] = "process_working_directory_live"
+		return service.NewError(service.Conflict, processCondition.Error(), true, details, err)
+	}
+	var processInspection *worktreeProcessInspectionError
+	if errors.As(err, &processInspection) {
+		details["reason"] = "process_working_directory_indeterminate"
+		return service.NewError(service.Conflict, processInspection.Error(), true, details, err)
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return service.NewError(service.Busy, "worktree removal canceled", true, details, err)

--- a/internal/lifecycle/removal_test.go
+++ b/internal/lifecycle/removal_test.go
@@ -972,6 +972,100 @@ func TestRemovalServiceRejectsActiveCreation(t *testing.T) {
 	assert.True(t, registered)
 }
 
+func TestRemovalServiceRejectsProcessWithWorkingDirectoryInsideWorktree(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "process-cwd")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	workingDirectory := filepath.Join(worktreePath, "nested")
+	require.NoError(t, os.Mkdir(workingDirectory, 0o755))
+	command := startRemovalProcess(t, workingDirectory)
+
+	result, err := NewRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
+		context.Background(),
+		RemovalRequest{
+			RepositoryPath: repositoryPath,
+			Path:           worktreePath, ExpectedGeneration: generation,
+		},
+	)
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.Conflict))
+	assert.Contains(t, err.Error(), fmt.Sprintf("PID %d", command.Process.Pid))
+	assert.False(t, result.WorktreeRemoved)
+	assert.DirExists(t, worktreePath)
+}
+
+func TestRemovalServiceForceRemovesWorktreeUsedAsProcessWorkingDirectory(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "force-process-cwd")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	command := startRemovalProcess(t, worktreePath)
+
+	result, err := NewRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
+		context.Background(),
+		RemovalRequest{
+			RepositoryPath: repositoryPath,
+			Path:           worktreePath, ExpectedGeneration: generation,
+			Force: true,
+		},
+	)
+
+	require.NoError(t, err, "process PID %d should be bypassed by force", command.Process.Pid)
+	assert.True(t, result.WorktreeRemoved)
+	assert.NoDirExists(t, worktreePath)
+}
+
+func TestRemovalServiceResumesGuardedSessionWhenProcessUsesWorktree(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "guarded-process-cwd")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	home := t.TempDir()
+	registerRemovalRepository(t, home, repositoryPath)
+	guard := &recordingRemovalSessionGuard{}
+	command := startRemovalProcess(t, worktreePath)
+
+	result, err := NewRemovalService(RemovalServiceOptions{
+		Home: home, SessionGuard: guard,
+	}).Remove(context.Background(), RemovalRequest{
+		RepositoryPath: repositoryPath,
+		Path:           worktreePath, ExpectedGeneration: generation,
+		Expansion: testExpansion(t),
+		Session: &RemovalSessionCondition{
+			SessionName: removalSessionName(t, worktreePath, "guarded-process-cwd"),
+			Absent:      true,
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, service.IsCode(err, service.Conflict))
+	assert.Contains(t, err.Error(), fmt.Sprintf("PID %d", command.Process.Pid))
+	assert.True(t, guard.quiesced)
+	assert.True(t, guard.resumed)
+	assert.False(t, guard.terminated)
+	assert.False(t, result.WorktreeRemoved)
+	assert.DirExists(t, worktreePath)
+}
+
+func startRemovalProcess(t *testing.T, workingDirectory string) *exec.Cmd {
+	t.Helper()
+	command := exec.Command(os.Args[0], "-test.run=TestRemovalProcessHelper")
+	command.Dir = workingDirectory
+	command.Env = append(os.Environ(), "KWT_REMOVAL_PROCESS_HELPER=1")
+	require.NoError(t, command.Start())
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	})
+	return command
+}
+
+func TestRemovalProcessHelper(t *testing.T) {
+	if os.Getenv("KWT_REMOVAL_PROCESS_HELPER") != "1" {
+		return
+	}
+	select {}
+}
+
 func TestRemovalServiceIgnoresDaemonRepositoryRoutingEnvironment(t *testing.T) {
 	repositoryPath, worktreePath := removalRepository(t, "routed-remove")
 	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)


### PR DESCRIPTION
Removing a worktree could delete the current working directory from under an
agent, shell, or other process launched outside KWT's tmux session. The existing
session guard could not see those processes.

This adds a process working-directory check at the lifecycle service's final
pre-removal boundary, covering CLI, TUI, and daemon callers. Default removal
now reports the blocking PIDs, fails closed for an uninspectable live process
owned by the current user, and ignores defunct processes. `--force` remains the
explicit override.

Closes #110
