### PR TITLE
Cover branch-stable session resolution

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -384,6 +384,11 @@ added to the top-level JSON array.
 identity for conditional removal), `repository` (the `host/owner/name` slug,
 or a `local/<path>` fallback for a repository without a usable remote — see
 below), `session_name`, `tmux_socket_name`, and `tmux_attach_mode`.
+When a branch is switched or renamed while its session remains live,
+`session_name` reports that verified live name even though its branch component
+is stale. Otherwise it reports the canonical name kwt will use for the next
+launch. Kwt verifies the worktree generation before associating a live session,
+so a worktree recreated at the same path does not inherit the previous session.
 `tmux_socket_name` selects the endpoint; `tmux_attach_mode` selects direct or
 protected attachment behavior. For a stopped workspace, inventory
 reports the intended `kwt`/`direct` endpoint. It reports the empty default

--- a/internal/tmux/resolver_test.go
+++ b/internal/tmux/resolver_test.go
@@ -416,6 +416,30 @@ func TestResolverBatchEnumeratesEachEndpointOnce(t *testing.T) {
 	assert.Equal(t, []string{"list-sessions"}, defaultServer.calls)
 }
 
+func TestResolverBatchPreservesLiveSessionNameAfterBranchChange(t *testing.T) {
+	request := resolverTestRequest()
+	suffix := "-" + template.ShortHash(request.WorkspacePath)
+	request.SessionName = "kwt-wt-widget-feature-b" + suffix
+	originalName := "kwt-wt-widget-feature-a" + suffix
+	canonical, defaultServer := newResolverTestCommands(
+		request.WorkspacePath,
+		request.SessionName,
+	)
+	canonical.sessions = []string{originalName}
+	resolver := newEndpointResolver(canonical, defaultServer, nil)
+
+	got, err := resolver.resolveAllBestEffort(
+		context.Background(),
+		[]WorkspaceEndpointRequest{request},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NoError(t, got[0].Err)
+	assert.Equal(t, canonicalEndpoint(originalName), got[0].Session.Endpoint)
+	assert.True(t, got[0].Session.Live)
+}
+
 func TestResolverBatchKeepsResolvingAfterWorkspaceSafetyError(t *testing.T) {
 	first := WorkspaceEndpointRequest{
 		SessionName:         "kwt-wt-widget-main-01234567",


### PR DESCRIPTION
`kwt list` already resolves a live worktree session by path and generation, so
a branch switch or rename does not break the association. Issue #109 exposed
that this behavior was neither covered at the inventory batch boundary nor
explicit in the CLI reference.

This adds focused coverage with different current and launched branch names
and documents the effective `session_name` semantics, including the generation
check that prevents a same-path replacement from inheriting an old session.

The runtime behavior was introduced by #94; this PR locks down and publishes
that contract.

Closes #109
