### PR TITLE
Make v0.5 release checks portable

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,23 @@ description: Release history for kwt
 
 # Changelog
 
+## 0.5.1
+
+<small>2026-08-29</small>
+
+kwt 0.5.1 is the publishable build of the 0.5 release. The original 0.5.0 tag
+did not produce release artifacts because its verification jobs depended on
+the host runner's process table and path syntax. This release makes those
+checks portable without changing the CLI's removal safeguards.
+
+Applications that embed kwt can now supply
+`RemovalServiceOptions.ProcessGuard` when they already have their own way to
+detect processes that use a worktree. kwt's default remains unchanged: removal
+stops when a process uses the worktree or when that check is inconclusive,
+unless the caller explicitly uses `Force`.
+
+[Compare v0.5.0...v0.5.1](https://github.com/kenn-io/kwt/compare/v0.5.0...v0.5.1)
+
 ## 0.5.0
 
 <small>2026-08-28</small>

--- a/docs/integrations/embedding.md
+++ b/docs/integrations/embedding.md
@@ -45,6 +45,13 @@ later mutation applies only to the checkout or project entry that the user
 reviewed. The inspection service returns one generation-safe changed-file
 snapshot.
 
+The removal service checks the host process table by default and refuses to
+remove a worktree when it is in use or the check is inconclusive. An embedder
+that already owns an equivalent process-isolation boundary can supply
+`RemovalServiceOptions.ProcessGuard`. That callback replaces kwt's default
+check, so the embedder is responsible for preserving its own worktree-use
+policy. Callers can still request the documented `Force` override explicitly.
+
 An SSH lifecycle owner also supplies an executable that dispatches
 `kwt.RunSSHAskpassHelper` before normal application startup. This keeps prompt
 transport inside kwt's reviewed boundary.

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -871,6 +871,7 @@ func TestDirectOpenCannotRaceGuardedRemoval(t *testing.T) {
 	go func() {
 		_, removeErr := lifecycle.NewRemovalService(lifecycle.RemovalServiceOptions{
 			Home: home, SessionGuard: removalGuard,
+			ProcessGuard: allowTestRemovalProcesses,
 		}).Remove(context.Background(), lifecycle.RemovalRequest{
 			RepositoryPath: repoPath,
 			Path:           worktreePath, ExpectedGeneration: generation,

--- a/internal/cmd/remove_test.go
+++ b/internal/cmd/remove_test.go
@@ -655,10 +655,13 @@ func resetRemoveCommandFlags(t *testing.T) {
 		request kwt.RemovalRequest,
 	) (kwt.RemovalResult, error) {
 		return kwt.NewRemovalService(kwt.RemovalServiceOptions{
-			Home: os.Getenv("KWT_HOME"),
+			Home:         os.Getenv("KWT_HOME"),
+			ProcessGuard: allowTestRemovalProcesses,
 		}).Remove(ctx, request)
 	}
 }
+
+func allowTestRemovalProcesses(context.Context, string) error { return nil }
 
 func removalConditionTestCommand() *cobra.Command {
 	cmd := &cobra.Command{}

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -2239,7 +2239,9 @@ func useInProcessTUIRemoval(t *testing.T, backend *tuiBackend) {
 		return nil, nil
 	}
 	backend.removeWorktree = kwt.NewRemovalService(
-		kwt.RemovalServiceOptions{Home: home},
+		kwt.RemovalServiceOptions{
+			Home: home, ProcessGuard: allowTestRemovalProcesses,
+		},
 	).Remove
 }
 
@@ -4274,6 +4276,7 @@ func TestTUIWorktreeAttachCannotRaceGuardedRemoval(t *testing.T) {
 	go func() {
 		_, removeErr := lifecycle.NewRemovalService(lifecycle.RemovalServiceOptions{
 			Home: home, SessionGuard: removalGuard,
+			ProcessGuard: allowTestRemovalProcesses,
 		}).Remove(context.Background(), lifecycle.RemovalRequest{
 			RepositoryPath: repoPath,
 			Path:           worktreePath, ExpectedGeneration: generation,

--- a/internal/lifecycle/removal.go
+++ b/internal/lifecycle/removal.go
@@ -45,11 +45,15 @@ type Remover interface {
 type RemovalServiceOptions struct {
 	Home         string
 	SessionGuard tmux.RemovalSessionGuard
+	// ProcessGuard replaces the default live-process check. Embedders that set
+	// it are responsible for enforcing their own worktree-use policy.
+	ProcessGuard func(context.Context, string) error
 }
 
 type removalService struct {
 	home         string
 	sessionGuard tmux.RemovalSessionGuard
+	processGuard func(context.Context, string) error
 }
 
 var newRemovalInventoryGit = git.NewForInventory
@@ -59,7 +63,15 @@ func NewRemovalService(options RemovalServiceOptions) Remover {
 	if guard == nil {
 		guard = tmux.NewRemovalSessionGuard("")
 	}
-	return &removalService{home: options.Home, sessionGuard: guard}
+	processGuard := options.ProcessGuard
+	if processGuard == nil {
+		processGuard = rejectProcessesUsingWorktree
+	}
+	return &removalService{
+		home:         options.Home,
+		sessionGuard: guard,
+		processGuard: processGuard,
+	}
 }
 
 func (s *removalService) Remove(
@@ -213,13 +225,13 @@ func (s *removalService) Remove(
 							if request.Force {
 								return nil
 							}
-							return rejectProcessesUsingWorktree(ctx, request.Path)
+							return s.processGuard(ctx, request.Path)
 						},
 					); err != nil {
 						return err
 					}
 				} else if !request.Force {
-					if err := rejectProcessesUsingWorktree(ctx, request.Path); err != nil {
+					if err := s.processGuard(ctx, request.Path); err != nil {
 						return err
 					}
 				}

--- a/internal/lifecycle/removal_test.go
+++ b/internal/lifecycle/removal_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,13 @@ type recordingRemovalSessionGuard struct {
 type signalingRemovalSessionGuard struct {
 	called chan struct{}
 	err    error
+}
+
+func newFixtureRemovalService(options RemovalServiceOptions) Remover {
+	if options.ProcessGuard == nil {
+		options.ProcessGuard = func(context.Context, string) error { return nil }
+	}
+	return NewRemovalService(options)
 }
 
 func (g *signalingRemovalSessionGuard) Quiesce(
@@ -91,7 +99,7 @@ func TestRemovalServiceRemovesWorktreeAndRegistryRecord(t *testing.T) {
 		Generation: generation,
 	}))
 
-	result, err := NewRemovalService(RemovalServiceOptions{Home: home}).Remove(
+	result, err := newFixtureRemovalService(RemovalServiceOptions{Home: home}).Remove(
 		context.Background(),
 		RemovalRequest{
 			RepositoryPath: repositoryPath,
@@ -112,10 +120,34 @@ func TestRemovalServiceRemovesWorktreeAndRegistryRecord(t *testing.T) {
 	assert.False(t, registered)
 }
 
+func TestRemovalServiceUsesConfiguredProcessGuard(t *testing.T) {
+	repositoryPath, worktreePath := removalRepository(t, "process-guard")
+	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
+	require.NoError(t, err)
+	guardCalled := false
+
+	result, err := NewRemovalService(RemovalServiceOptions{
+		Home: t.TempDir(),
+		ProcessGuard: func(context.Context, string) error {
+			guardCalled = true
+			return errors.New("fixture process guard rejected removal")
+		},
+	}).Remove(context.Background(), RemovalRequest{
+		RepositoryPath:     repositoryPath,
+		Path:               worktreePath,
+		ExpectedGeneration: generation,
+	})
+
+	require.Error(t, err)
+	assert.True(t, guardCalled)
+	assert.False(t, result.WorktreeRemoved)
+	assert.DirExists(t, worktreePath)
+}
+
 func TestRemovalServiceRejectsChangedGeneration(t *testing.T) {
 	repositoryPath, worktreePath := removalRepository(t, "keep-me")
 
-	result, err := NewRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
+	result, err := newFixtureRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
 		context.Background(),
 		RemovalRequest{
 			RepositoryPath:     repositoryPath,
@@ -162,7 +194,7 @@ func TestRemovalServiceRejectsChangedCheckout(t *testing.T) {
 			require.NoError(t, err)
 			tt.change(t, worktreePath)
 
-			result, err := NewRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
+			result, err := newFixtureRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
 				context.Background(),
 				RemovalRequest{
 					RepositoryPath:     repositoryPath,
@@ -197,7 +229,7 @@ func TestRemovalServiceTerminatesConfirmedSessionBeforeRemovingWorktree(t *testi
 	}
 	expansion := testExpansion(t)
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -226,7 +258,7 @@ func TestRemovalServiceReloadsConfiguredProtectedNamesPerRequest(t *testing.T) {
 	require.NoError(t, err)
 	home := t.TempDir()
 	guard := &recordingRemovalSessionGuard{}
-	service := NewRemovalService(RemovalServiceOptions{Home: home, SessionGuard: guard})
+	service := newFixtureRemovalService(RemovalServiceOptions{Home: home, SessionGuard: guard})
 	originalNewGit := newRemovalInventoryGit
 	t.Cleanup(func() { newRemovalInventoryGit = originalNewGit })
 	var gitProtectedNames [][]string
@@ -277,7 +309,7 @@ func TestGuardedRemovalSupportsUnregisteredRepository(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), nil, 0o600))
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -304,7 +336,7 @@ func TestRemovalServicePreservesWorktreeWhenSessionConditionChanges(t *testing.T
 		Reason: "tmux session identity changed",
 	}}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -334,7 +366,7 @@ func TestRemovalServiceRejectsStaleSessionNameAfterBranchSwitch(t *testing.T) {
 	registerRemovalRepository(t, home, repositoryPath)
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -375,7 +407,7 @@ func TestRemovalServiceRejectsOldBranchSessionForCurrentWorktree(t *testing.T) {
 		return nil
 	}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -423,7 +455,7 @@ func TestRemovalServiceRejectsStaleSessionSocket(t *testing.T) {
 	}))
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -460,7 +492,7 @@ func TestRemovalServiceAcceptsDirectSessionOnCanonicalSocketEndpoint(t *testing.
 	expansion := testExpansion(t)
 	expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")] = "/srv/tmux"
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -491,7 +523,7 @@ func TestRemovalServiceRejectsDirectSessionSocketDirectoryOutsideRequest(t *test
 	expansion := testExpansion(t)
 	expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")] = "/srv/expected-tmux"
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -523,7 +555,7 @@ func TestRemovalServiceUsesRequestSocketDirectoryWhenConditionOmitsIt(t *testing
 	expansion := testExpansion(t)
 	expansion.Environment[normalizedEnvironmentName("TMUX_TMPDIR")] = "/srv/request-tmux"
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -551,7 +583,7 @@ func TestRemovalServiceRejectsDirectSessionOnArbitraryNamedSocket(t *testing.T) 
 	registerRemovalRepository(t, home, repositoryPath)
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -590,7 +622,7 @@ func TestRemovalServiceCarriesDurableGenerationAfterWorktreeMove(t *testing.T) {
 		Absent:      true,
 	}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -638,7 +670,7 @@ func TestRemovalServiceAcceptsCurrentProtectedSessionEndpoint(t *testing.T) {
 	}))
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -691,7 +723,7 @@ func TestRemovalServiceFindsProtectedProvenanceAfterWorktreeMove(t *testing.T) {
 	runRemovalGit(t, repositoryPath, "worktree", "move", originalPath, movedPath)
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath:     repositoryPath,
@@ -725,7 +757,7 @@ func TestRemovalServicePreservesConfirmedSessionWhenDirtyWorktreeCannotBeRemoved
 	home := t.TempDir()
 	registerRemovalRepository(t, home, repositoryPath)
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -753,7 +785,7 @@ func TestRemovalServicePreservesNativeDirtyErrorWithoutSessionGuard(t *testing.T
 		0o644,
 	))
 
-	result, err := NewRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
+	result, err := newFixtureRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
 		context.Background(),
 		RemovalRequest{
 			RepositoryPath: repositoryPath,
@@ -785,7 +817,7 @@ func TestRemovalServiceUsesClientExpansionForProjectFence(t *testing.T) {
 	expansion.Environment[normalizedEnvironmentName("PROJECT_ROOT")] = projectRoot
 	guard := &recordingRemovalSessionGuard{}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -826,7 +858,7 @@ func TestRemovalServiceWaitsForProjectSessionStartupFence(t *testing.T) {
 	}
 	result := make(chan error, 1)
 	go func() {
-		_, removeErr := NewRemovalService(RemovalServiceOptions{
+		_, removeErr := newFixtureRemovalService(RemovalServiceOptions{
 			Home: home, SessionGuard: guard,
 		}).Remove(context.Background(), RemovalRequest{
 			RepositoryPath: repositoryPath,
@@ -888,7 +920,7 @@ func TestRemovalServicePreservesConfirmedSessionForInitializedSubmodule(t *testi
 	home := t.TempDir()
 	registerRemovalRepository(t, home, repositoryPath)
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -915,7 +947,7 @@ func TestRemovalServiceResumesSessionWhenCheckoutChangesDuringQuiesce(t *testing
 		return os.WriteFile(filepath.Join(worktreePath, "late-change.txt"), []byte("keep me\n"), 0o644)
 	}}
 
-	result, err := NewRemovalService(RemovalServiceOptions{
+	result, err := newFixtureRemovalService(RemovalServiceOptions{
 		Home: home, SessionGuard: guard,
 	}).Remove(context.Background(), RemovalRequest{
 		RepositoryPath: repositoryPath,
@@ -951,7 +983,7 @@ func TestRemovalServiceRejectsActiveCreation(t *testing.T) {
 	require.True(t, acquired)
 	t.Cleanup(func() { require.NoError(t, release()) })
 
-	result, err := NewRemovalService(RemovalServiceOptions{Home: home}).Remove(
+	result, err := newFixtureRemovalService(RemovalServiceOptions{Home: home}).Remove(
 		context.Background(),
 		RemovalRequest{
 			RepositoryPath: repositoryPath,
@@ -973,6 +1005,7 @@ func TestRemovalServiceRejectsActiveCreation(t *testing.T) {
 }
 
 func TestRemovalServiceRejectsProcessWithWorkingDirectoryInsideWorktree(t *testing.T) {
+	useHostProcessTable(t)
 	repositoryPath, worktreePath := removalRepository(t, "process-cwd")
 	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
 	require.NoError(t, err)
@@ -1016,6 +1049,7 @@ func TestRemovalServiceForceRemovesWorktreeUsedAsProcessWorkingDirectory(t *test
 }
 
 func TestRemovalServiceResumesGuardedSessionWhenProcessUsesWorktree(t *testing.T) {
+	useHostProcessTable(t)
 	repositoryPath, worktreePath := removalRepository(t, "guarded-process-cwd")
 	generation, err := git.New(repositoryPath).WorktreeGeneration(worktreePath)
 	require.NoError(t, err)
@@ -1059,6 +1093,13 @@ func startRemovalProcess(t *testing.T, workingDirectory string) *exec.Cmd {
 	return command
 }
 
+func useHostProcessTable(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "linux" {
+		t.Setenv("HOST_PROC", "/proc")
+	}
+}
+
 func TestRemovalProcessHelper(t *testing.T) {
 	if os.Getenv("KWT_REMOVAL_PROCESS_HELPER") != "1" {
 		return
@@ -1074,7 +1115,7 @@ func TestRemovalServiceIgnoresDaemonRepositoryRoutingEnvironment(t *testing.T) {
 	t.Setenv("GIT_DIR", filepath.Join(otherRepository, ".git"))
 	t.Setenv("GIT_WORK_TREE", otherRepository)
 
-	result, err := NewRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
+	result, err := newFixtureRemovalService(RemovalServiceOptions{Home: t.TempDir()}).Remove(
 		context.Background(),
 		RemovalRequest{
 			RepositoryPath:     repositoryPath,

--- a/internal/ssh/askpass_test.go
+++ b/internal/ssh/askpass_test.go
@@ -264,7 +264,13 @@ func TestAskpassHelperSubprocessReturnsPromptResponse(t *testing.T) {
 	command.Stderr = &stderr
 	output, err := command.Output()
 
-	require.NoError(t, err)
+	require.NoErrorf(
+		t,
+		err,
+		"askpass helper stderr = %q; transport error = %v",
+		stderr.String(),
+		transport.Err(),
+	)
 	assert.Equal(t, "subprocess-secret\n", string(output))
 	assert.Empty(t, stderr.String())
 }

--- a/internal/testharness/runner.go
+++ b/internal/testharness/runner.go
@@ -183,6 +183,13 @@ func runWith(
 		_ = cleanup()
 		return 1
 	}
+	// gopsutil reads HOST_PROC on Linux. An empty process table keeps removal
+	// fixtures independent of unrelated processes on the test host.
+	if err = os.Mkdir(filepath.Join(scratch, "proc"), 0o700); err != nil {
+		_, _ = fmt.Fprintf(stderr, "create isolated process table: %v\n", err)
+		_ = cleanup()
+		return 1
+	}
 	if err = os.WriteFile(filepath.Join(scratch, "gitconfig"), nil, 0o600); err != nil {
 		_, _ = fmt.Fprintf(stderr, "create isolated Git config: %v\n", err)
 		_ = cleanup()
@@ -341,19 +348,21 @@ func preparationEnvironment(base, protectedNames []string, scratch string) []str
 }
 
 func isolatedEnvironment(base, protectedNames []string, scratch, proxyAddress string) []string {
-	return appendOwnedEnvironment(
+	environment := appendOwnedEnvironment(
 		withoutEnvironment(credentials.StripEnvironment(base, protectedNames), func(key string) bool {
 			upper := strings.ToUpper(key)
 			return strings.HasPrefix(upper, "GIT_") ||
 				strings.EqualFold(key, "KWT_HOME") ||
 				strings.EqualFold(key, "KWT_TEST_HARNESS") ||
 				strings.EqualFold(key, callerKwtHomeEnvironment) ||
+				strings.EqualFold(key, "HOST_PROC") ||
 				upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" ||
 				upper == "ALL_PROXY" || upper == "NO_PROXY"
 		}),
 		scratch,
 		proxyAddress,
 	)
+	return append(environment, "HOST_PROC="+filepath.Join(scratch, "proc"))
 }
 
 func appendOwnedEnvironment(environment []string, scratch, proxyAddress string) []string {

--- a/internal/testharness/runner_test.go
+++ b/internal/testharness/runner_test.go
@@ -97,6 +97,7 @@ func TestIsolatedEnvironmentReplacesGitKWTAndProxyState(t *testing.T) {
 	assertEnvironmentValue(t, got, "GOCACHE", "/developer/go-cache")
 	assertEnvironmentValue(t, got, "KWT_HOME", filepath.Join(scratch, "kwt"))
 	assertEnvironmentValue(t, got, "KWT_TEST_HARNESS", filepath.Join(scratch, "kwt"))
+	assertEnvironmentValue(t, got, "HOST_PROC", filepath.Join(scratch, "proc"))
 	assertEnvironmentValue(t, got, "GIT_CONFIG_GLOBAL", filepath.Join(scratch, "gitconfig"))
 	assertEnvironmentValue(t, got, "GIT_CONFIG_NOSYSTEM", "1")
 	assertEnvironmentValue(t, got, "GIT_TERMINAL_PROMPT", "0")

--- a/tools/testbootstrap/main_test.go
+++ b/tools/testbootstrap/main_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestBootstrapEnvironmentUsesStrictAllowlist(t *testing.T) {
 	scratch := t.TempDir()
+	callerKwtHome := filepath.Join(t.TempDir(), "ambient", "kwt")
 	got := bootstrapEnvironment([]string{
 		"PATH=/tools",
 		"TEMP=/tmp",
@@ -21,7 +22,7 @@ func TestBootstrapEnvironmentUsesStrictAllowlist(t *testing.T) {
 		"NO_PROXY=ambient.example",
 		"GIT_CONFIG_GLOBAL=/ambient/gitconfig",
 		"GIT_ASKPASS=/ambient/askpass",
-		"KWT_HOME=/ambient/kwt",
+		"KWT_HOME=" + callerKwtHome,
 		"KWT_GITHUB_TOKEN=github-secret",
 		"CUSTOM_FLEET_TOKEN=fleet-secret",
 		"GOAUTH=netrc",
@@ -50,7 +51,7 @@ func TestBootstrapEnvironmentUsesStrictAllowlist(t *testing.T) {
 		"GIT_TERMINAL_PROMPT":    "0",
 		"KWT_HOME":               filepath.Join(scratch, "kwt"),
 		"KWT_TEST_BOOTSTRAP":     "1",
-		callerKwtHomeEnvironment: "/ambient/kwt",
+		callerKwtHomeEnvironment: callerKwtHome,
 	} {
 		if gotValue := values[key]; gotValue != want {
 			t.Errorf("%s = %q, want %q", key, gotValue, want)


### PR DESCRIPTION
The `v0.5.0` tag stopped before GitHub could publish release artifacts. Windows interpreted a Unix-only fixture path as relative, while hosted Linux runners exposed unrelated processes to removal tests and triggered kwt's intentional fail-closed guard.

This makes the release suite portable without weakening the CLI's removal behavior:

- the test harness gives Linux fixtures an empty process table;
- removal tests supply the process policy they intend to exercise, while the live-process tests still inspect the real host table;
- the Windows bootstrap fixture now uses a native absolute path; and
- askpass subprocess failures now report enough evidence to diagnose a recurrence.

`RemovalServiceOptions.ProcessGuard` also gives embedders the same explicit policy seam. The default remains kwt's existing live-process guard, and `Force` remains the deliberate override.

The changelog records `v0.5.1` as the publishable 0.5 build because the existing `v0.5.0` tag will not be moved.
