### PR TITLE
test: validate imported merge conflicts against kit #77

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ instructions.
 
 Requirements:
 
-- Git 2.20 or newer. `kwt doctor`, `kwt prune --expired`, and
-  `kwt prune --merged` require Git 2.31 or newer.
+- Git 2.20 or newer. `kwt pr import` requires Git 2.42.0 or newer on macOS
+  and Linux, or Git for Windows 2.53.0.windows.3 or newer. `kwt doctor`,
+  `kwt prune --expired`, and `kwt prune --merged` require Git 2.31 or newer.
 - tmux 2.1 or newer for workspace launch and `kwt tmux`.
 - Go 1.27 or newer when installing or building from source.
 - macOS 13 or newer, Linux, or Windows.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ description: Release history for kwt
 
 ## Unreleased
 
+- Imported pull-request worktrees now preserve both sides and diff3 markers
+  when a later merge encounters a text conflict. PR import now requires Git
+  2.42.0 or newer on macOS and Linux, or Git for Windows 2.53.0.windows.3 or
+  newer.
 - Recognize bare-container repositories where a `.bare/` control directory
   manages a checked-out `main/` worktree and flat sibling worktrees.
   `kwt projects add` accepts the container or any of its worktrees, `.bare/`

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -4,6 +4,8 @@ Choose a Go install, a release archive, or a source build. kwt supports:
 
 - macOS 13 or newer, Linux, and Windows;
 - Git 2.20 or newer;
+- Git 2.42.0 or newer on macOS and Linux, or Git for Windows 2.53.0.windows.3
+  or newer, for `kwt pr import`;
 - Git 2.31 or newer for `kwt doctor`, `kwt prune --expired`, and
   `kwt prune --merged`;
 - tmux 2.1 or newer for workspace launch and `kwt tmux`; and

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -5,6 +5,11 @@
 [Install kwt](install.md), then confirm that `kwt`, Git, and tmux are available
 in your terminal. You do not need to edit configuration before the first run.
 
+Kwt commands require Git 2.20 or newer. `kwt pr import` additionally requires
+Git 2.42.0 or newer on macOS and Linux, or Git for Windows 2.53.0.windows.3 or
+newer. `kwt doctor` and the `kwt prune --expired` or `--merged` policies require
+Git 2.31 or newer.
+
 Start from a Git repository that you want kwt to manage:
 
 ```sh

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,9 +12,11 @@ CLI, tmux, and SSH boundaries should start with
 [Embed and connect kwt](../integrations/embedding.md). Pull-request imports have
 their own [protected automation contract](pull-requests.md).
 
-Kwt requires Git 2.20 or newer. `kwt doctor` and the `kwt prune --expired` or
-`--merged` policies require Git 2.31 or newer: maintenance inventory relies on
-`git worktree list --expire`, and structural repair uses `git worktree repair`.
+Kwt requires Git 2.20 or newer. `kwt pr import` requires Git 2.42.0 or newer on
+macOS and Linux, or Git for Windows 2.53.0.windows.3 or newer. `kwt doctor` and
+the `kwt prune --expired` or `--merged` policies require Git 2.31 or newer:
+maintenance inventory relies on `git worktree list --expire`, and structural
+repair uses `git worktree repair`.
 Workspace attachment requires tmux 2.1 or newer. Kwt identifies the current
 client's server with tmux's `#{pid}` format; it does not run a separate version
 preflight. A non-numeric PID response blocks attachment with tmux 2.1 guidance.

--- a/docs/reference/pull-requests.md
+++ b/docs/reference/pull-requests.md
@@ -256,9 +256,11 @@ files from disk.
 Kwt requires Git 2.20 or newer. PR import uses per-worktree Git configuration
 to make plain `git push` target the PR head without changing push behavior in
 the main checkout, and checks that capability before it fetches refs, adds
-remotes, or creates a worktree. The `kwt doctor` command and explicit
-`kwt prune` policies require Git 2.31 or newer for their worktree inventory and
-repair operations.
+remotes, or creates a worktree. PR import also requires Git 2.42.0 or newer on
+macOS and Linux, or Git for Windows 2.53.0.windows.3 or newer, for its safe
+merge-driver behavior. The `kwt doctor` command and explicit `kwt prune`
+policies require Git 2.31 or newer for their worktree inventory and repair
+operations.
 
 ## Listing contract
 

--- a/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
+++ b/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
@@ -10,8 +10,8 @@
 
 ## Global Constraints
 
-- Validate first with go.kenn.io/kit pseudo-version v0.22.1-0.20260831205235-baf69924c6cb, resolved from kit PR #77 tip baf69924c6cb25d6235e59fe98e6c46780cd387d.
-- Before the kwt PR merges, replace that pseudo-version with released kit tag v0.23.0 and rerun the focused and full checks.
+- Kit PR #77 was merged at 6bef84f5bf0b2400a04f37c8f1284a6eef12b2a8 and released as go.kenn.io/kit v0.23.0.
+- Keep kwt on the released kit tag and rerun the focused and full checks before the kwt PR merges.
 - Preserve kwt's general Git 2.20 floor and its Git 2.31 floor for kwt doctor and prune policies.
 - Document the separate pull-request import floor: Git 2.42.0 or newer on macOS/Linux, or Git for Windows 2.53.0.windows.3 or newer.
 - Do not duplicate kit's merge-driver implementation or add a compatibility path for older Git versions.
@@ -150,18 +150,18 @@ backend so the missing conflict contents fail before the kit repair is used.
 
 **Interfaces:**
 - Consumes: the failing integration test from Task 1.
-- Produces: kwt builds against kit pseudo-version v0.22.1-0.20260831205235-baf69924c6cb, with the same test passing through the real kit lifecycle.
+- Produces: kwt builds against released kit v0.23.0, with the same test passing through the real kit lifecycle.
 
 - [ ] **Step 1: Update the Go module using Go tooling.**
 
 Run:
 
 ~~~sh
-go get go.kenn.io/kit@baf69924c6cb25d6235e59fe98e6c46780cd387d
+go get go.kenn.io/kit@v0.23.0
 go mod verify
 ~~~
 
-Confirm go.mod records exactly go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb and go.sum contains the matching module checksums. Do not hand-edit either file or run a broad dependency upgrade.
+Confirm go.mod records exactly go.kenn.io/kit v0.23.0 and go.sum contains only the matching current module checksum. Do not hand-edit either file or run a broad dependency upgrade.
 
 - [ ] **Step 2: Run the focused test and verify GREEN.**
 
@@ -180,9 +180,9 @@ Review the module diff and staged checks, then commit go.mod and go.sum with thi
 ~~~text
 fix: validate imported merge conflicts with kit tip
 
-Use the unreleased kit merge-driver repair while kwt#112 is validated. The
-pull-request backend now exercises the behavior that preserves both sides of
-an imported worktree conflict before kit is released.
+Use released kit v0.23.0 after validating its merge-driver repair. The
+pull-request backend exercises the behavior that preserves both sides of an
+imported worktree conflict before kwt is released.
 ~~~
 
 ### Task 3: Publish the new pull-request import requirement
@@ -259,8 +259,8 @@ the requirement.
 - Static checks: make vet and make lint
 
 **Interfaces:**
-- Consumes: the three implementation commits and the current kit pseudo-version.
-- Produces: fresh evidence for the regression, full test suite, build, static checks, and docs site.
+- Consumes: the three implementation commits and released kit v0.23.0.
+- Produces: fresh evidence for the regression, full test suite, build, static checks, and docs site against released kit v0.23.0.
 
 - [ ] **Step 1: Run the focused regression once more.**
 
@@ -307,7 +307,7 @@ Run the public-artifact scrub over all changed tests, docs, module files, and co
 
 - [ ] **Step 6: Record the release handoff.**
 
-Leave the branch on the kit PR pseudo-version while kit PR #77 is unreleased. After kit is released as v0.23.0, run:
+Kit PR #77 is released as v0.23.0. Keep the branch on that tag and run:
 
 ~~~sh
 go get go.kenn.io/kit@v0.23.0
@@ -320,7 +320,7 @@ make lint
 make docs-check
 ~~~
 
-Review go.mod and go.sum to confirm the pseudo-version is gone before the kwt PR merges. Do not merge kit or publish either PR as part of this task.
+Review go.mod and go.sum to confirm the pseudo-version is gone before the kwt PR merges. Do not merge kwt or publish its release as part of this task.
 
 - [ ] **Step 7: Check commit state.**
 

--- a/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
+++ b/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
@@ -75,6 +75,7 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 		0o644,
 	))
 	runGit(t, projectRepo, "commit", "-am", "main change")
+	mainSHA := runGit(t, projectRepo, "rev-parse", "main")
 
 	runGit(t, projectRepo, "remote", "set-url", "origin", projectRepo)
 	runGit(t, projectRepo, "remote", "set-url", "--push", "origin", canonicalURL)
@@ -91,13 +92,13 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 		_ = backend.Rollback(t.Context(), workspace)
 	})
 
-	merge := exec.Command("git", "merge", "--no-edit", "main")
+	merge := exec.Command("git", "merge", "--no-edit", mainSHA)
 	merge.Dir = workspace.Path
 	merge.Env = append(os.Environ(),
 		"GIT_CONFIG_NOSYSTEM=1",
 	)
-	_, err = merge.CombinedOutput()
-	require.Error(t, err, "the merge must report the overlapping change")
+	mergeOutput, err := merge.CombinedOutput()
+	require.Error(t, err, "the merge must report the overlapping change: %s", mergeOutput)
 
 	assert.Equal(t, "UU conflict.txt",
 		runGit(t, workspace.Path, "status", "--short"))

--- a/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
+++ b/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
@@ -1,0 +1,326 @@
+# Imported Worktree Merge-Driver Validation Implementation Plan
+
+> For agentic workers: REQUIRED SUB-SKILL: Use superpowers:executing-plans (or superpowers:subagent-driven-development) to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Prove kwt preserves both sides of a merge conflict in an imported pull-request worktree while consuming kit PR #77, then publish the matching Git-version requirements.
+
+**Architecture:** Keep the merge-driver implementation in kit. Add one kwt integration regression test that calls GitBackend.ImportPullRequest without replacing its createMergeRequestWorktree seam, then runs a real conflicting Git merge in the returned worktree. Use a repository-local URL rewrite so the fixture retains the canonical GitHub identity required by kwt and kit while all Git objects remain in temporary local repositories.
+
+**Tech Stack:** Go 1.27, Go modules, Git temporary repositories, testify, Cobra help text, Markdown/Zensical documentation, and the repository make targets.
+
+## Global Constraints
+
+- Validate first with go.kenn.io/kit pseudo-version v0.22.1-0.20260831205235-baf69924c6cb, resolved from kit PR #77 tip baf69924c6cb25d6235e59fe98e6c46780cd387d.
+- Before the kwt PR merges, replace that pseudo-version with released kit tag v0.23.0 and rerun the focused and full checks.
+- Preserve kwt's general Git 2.20 floor and its Git 2.31 floor for kwt doctor and prune policies.
+- Document the separate pull-request import floor: Git 2.42.0 or newer on macOS/Linux, or Git for Windows 2.53.0.windows.3 or newer.
+- Do not duplicate kit's merge-driver implementation or add a compatibility path for older Git versions.
+- Keep the integration fixture local, temporary, non-networked, and independent of global Git configuration.
+- Do not add a Windows skip solely for this test; Windows CI does not select the complete internal/pullrequest package.
+
+---
+
+### Task 1: Add the failing kwt integration regression test
+
+**Files:**
+- Modify: internal/pullrequest/backend_test.go
+
+**Interfaces:**
+- Consumes: existing newBackendRepo, runGit, testPR, GitBackend.ImportPullRequest, and the real createMergeRequestWorktree package variable.
+- Produces: a regression test named TestGitBackendImportedWorktreePreservesMergeConflictContents that fails on kit v0.22.0 because the imported conflict file has no markers and lacks one side's content.
+
+- [ ] **Step 1: Write the failing test.**
+
+Add the test after TestGitBackendDelegatesPullRequestLifecycleToKit. It must not override createMergeRequestWorktree:
+
+~~~go
+func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) {
+	canonicalURL := "https://github.com/acme/widget.git"
+	baseContent := "base\n"
+	featureContent := "feature change\n"
+	mainContent := "main change\n"
+
+	gitConfigDir := t.TempDir()
+	globalConfig := filepath.Join(gitConfigDir, "global.gitconfig")
+	require.NoError(t, os.WriteFile(globalConfig, nil, 0o600))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	projectRepo, backend := newBackendRepo(t)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, ".gitattributes"),
+		[]byte("conflict.txt merge=untrusted\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, "conflict.txt"),
+		[]byte(baseContent),
+		0o644,
+	))
+	runGit(t, projectRepo, "add", ".gitattributes", "conflict.txt")
+	runGit(t, projectRepo, "commit", "-m", "add merge-driver fixture")
+	runGit(t, projectRepo, "config", "merge.untrusted.driver",
+		"f() { return 1; }; f")
+
+	runGit(t, projectRepo, "checkout", "-q", "-b", "feature/widgets")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, "conflict.txt"),
+		[]byte(featureContent),
+		0o644,
+	))
+	runGit(t, projectRepo, "commit", "-am", "feature change")
+	headSHA := runGit(t, projectRepo, "rev-parse", "HEAD")
+
+	runGit(t, projectRepo, "checkout", "-q", "main")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, "conflict.txt"),
+		[]byte(mainContent),
+		0o644,
+	))
+	runGit(t, projectRepo, "commit", "-am", "main change")
+
+	runGit(t, projectRepo, "config", "url."+projectRepo+".insteadOf",
+		canonicalURL)
+
+	pr := testPR(17, false)
+	pr.HeadSHA = headSHA
+	pr.Source.Repository.CloneURL = canonicalURL
+
+	workspace, err := backend.ImportPullRequest(
+		t.Context(), pr, "pr-17-feature-widgets",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = backend.Rollback(t.Context(), workspace)
+	})
+
+	merge := exec.Command("git", "merge", "--no-edit", "main")
+	merge.Dir = workspace.Path
+	merge.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL="+globalConfig,
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	_, err = merge.CombinedOutput()
+	require.Error(t, err, "the merge must report the overlapping change")
+
+	assert.Equal(t, "UU conflict.txt",
+		runGit(t, workspace.Path, "status", "--short"))
+	contents, err := os.ReadFile(filepath.Join(workspace.Path, "conflict.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), "<<<<<<< current")
+	assert.Contains(t, string(contents), "||||||| base")
+	assert.Contains(t, string(contents), "=======")
+	assert.Contains(t, string(contents), ">>>>>>> other")
+	assert.Contains(t, string(contents), featureContent)
+	assert.Contains(t, string(contents), mainContent)
+}
+~~~
+
+Keep Project.Identity and the pull-request metadata canonical as github.com/acme/widget. The repository-local URL rewrite redirects that canonical fetch to the temporary repository. This exercises kit's same-repository identity comparison and kwt's post-import push validation without GitHub access.
+
+- [ ] **Step 2: Run the focused test and verify RED.**
+
+Run:
+
+~~~sh
+make test TEST_PACKAGES=./internal/pullrequest
+~~~
+
+Expected result with go.kenn.io/kit v0.22.0: the new test reaches the merge, Git reports UU conflict.txt, and an assertion fails because the old replacement driver leaves missing conflict contents. The failure must not be a missing executable, Git-version rejection, network request, or fixture identity error. If it fails earlier, fix only the fixture until the old kit behavior is reproduced.
+
+- [ ] **Step 3: Commit the red regression test.**
+
+Review git status --short, git diff --stat, and git diff --cached --check. Stage only internal/pullrequest/backend_test.go and commit with this message, followed by the required Codex attribution block:
+
+~~~text
+test: reproduce unmarked imported merge conflicts
+
+Imported pull-request worktrees previously reported an unmerged path while
+leaving only the current side in the working file. Exercise the real kwt
+backend so the missing conflict contents fail before the kit repair is used.
+~~~
+
+### Task 2: Consume kit PR #77 and turn the regression green
+
+**Files:**
+- Modify: go.mod
+- Modify: go.sum
+- Test: internal/pullrequest/backend_test.go
+
+**Interfaces:**
+- Consumes: the failing integration test from Task 1.
+- Produces: kwt builds against kit pseudo-version v0.22.1-0.20260831205235-baf69924c6cb, with the same test passing through the real kit lifecycle.
+
+- [ ] **Step 1: Update the Go module using Go tooling.**
+
+Run:
+
+~~~sh
+go get go.kenn.io/kit@baf69924c6cb25d6235e59fe98e6c46780cd387d
+go mod verify
+~~~
+
+Confirm go.mod records exactly go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb and go.sum contains the matching module checksums. Do not hand-edit either file or run a broad dependency upgrade.
+
+- [ ] **Step 2: Run the focused test and verify GREEN.**
+
+Run:
+
+~~~sh
+make test TEST_PACKAGES=./internal/pullrequest
+~~~
+
+Expected result: the imported worktree merge reports UU conflict.txt, and the working file contains current, base, and other diff3 sections plus both branch changes. The test must use the real kit function because no test override is installed.
+
+- [ ] **Step 3: Commit the dependency handoff.**
+
+Review the module diff and staged checks, then commit go.mod and go.sum with this message, followed by the required Codex attribution block:
+
+~~~text
+fix: validate imported merge conflicts with kit tip
+
+Use the unreleased kit merge-driver repair while kwt#112 is validated. The
+pull-request backend now exercises the behavior that preserves both sides of
+an imported worktree conflict before kit is released.
+~~~
+
+### Task 3: Publish the new pull-request import requirement
+
+**Files:**
+- Modify: README.md
+- Modify: docs/get-started/install.md
+- Modify: docs/get-started/quickstart.md
+- Modify: docs/reference/cli.md
+- Modify: docs/reference/pull-requests.md
+- Modify: docs/changelog.md
+- Modify: internal/cmd/pr.go
+
+**Interfaces:**
+- Consumes: kit PR #77's documented platform floors and kwt's existing Git 2.20/2.31 statements.
+- Produces: consistent user-facing requirements in all named Markdown surfaces and kwt pr import --help.
+
+- [ ] **Step 1: Update README requirements.**
+
+Change the requirements paragraph to state that Git 2.20 remains the general floor, doctor and both prune policies require Git 2.31, and kwt pr import additionally requires Git 2.42.0 or newer on macOS/Linux or Git for Windows 2.53.0.windows.3 or newer.
+
+- [ ] **Step 2: Update installation and quickstart guidance.**
+
+In docs/get-started/install.md, add the pull-request import exception as its own Git requirement bullet. In docs/get-started/quickstart.md, add the same requirement under “Before you start” so a user following the PR workflow sees it before importing.
+
+- [ ] **Step 3: Update the CLI reference and command help.**
+
+In the opening requirements paragraph of docs/reference/cli.md, add the third exception without changing the general and maintenance floors. Add a Long field to prImportCmd in internal/cmd/pr.go:
+
+~~~go
+Long: "Pull-request import requires Git 2.42.0 or newer on macOS and Linux, " +
+	"or Git for Windows 2.53.0.windows.3 or newer.",
+~~~
+
+Keep the list and attach commands free of the import-only requirement.
+
+- [ ] **Step 4: Correct the pull-request contract paragraph.**
+
+In docs/reference/pull-requests.md, keep the existing Git 2.20 and Git 2.31 statements, then explicitly say that PR import's per-worktree configuration and safe merge-driver behavior require Git 2.42.0 or newer on macOS/Linux or Git for Windows 2.53.0.windows.3 or newer.
+
+- [ ] **Step 5: Add the Unreleased changelog entry.**
+
+Under ## Unreleased in docs/changelog.md, add a user-outcome bullet explaining that imported pull-request worktrees now preserve both sides and diff3 markers for text conflicts, and name the new platform-specific Git floor.
+
+- [ ] **Step 6: Review every version claim.**
+
+Run:
+
+~~~sh
+rg -n -C 1 'Git 2\.20|Git 2\.31|Git 2\.42|2\.53\.0\.windows\.3' README.md docs/get-started/install.md docs/get-started/quickstart.md docs/reference/cli.md docs/reference/pull-requests.md docs/changelog.md internal/cmd/pr.go
+~~~
+
+Confirm every named file contains the intended exception and no pull-request-specific paragraph still implies that Git 2.20 is sufficient for import.
+
+- [ ] **Step 7: Commit the documentation and help changes.**
+
+Run git diff --check, stage only the seven listed files, and commit with this message, followed by the required Codex attribution block:
+
+~~~text
+docs: document pull-request Git version floor
+
+Imported pull-request worktrees now use Git's safe three-way merge behavior,
+which requires newer Git versions outside Windows. State the higher floor where
+users install, start, inspect, and import pull requests so upgrades do not hide
+the requirement.
+~~~
+
+### Task 4: Verify the complete kwt-side change
+
+**Files:**
+- Test: all repository packages through make test
+- Build: make build
+- Docs: make docs-check
+- Static checks: make vet and make lint
+
+**Interfaces:**
+- Consumes: the three implementation commits and the current kit pseudo-version.
+- Produces: fresh evidence for the regression, full test suite, build, static checks, and docs site.
+
+- [ ] **Step 1: Run the focused regression once more.**
+
+~~~sh
+make test TEST_PACKAGES=./internal/pullrequest
+~~~
+
+- [ ] **Step 2: Run the full repository test suite.**
+
+~~~sh
+make test
+~~~
+
+- [ ] **Step 3: Run build and static checks.**
+
+~~~sh
+make build
+make vet
+make lint
+~~~
+
+If golangci-lint is absent, report that as an environment limitation instead of treating the Makefile's informational message as a lint pass.
+
+- [ ] **Step 4: Build the documentation site.**
+
+~~~sh
+make docs-check
+~~~
+
+This proves the site builds. It does not validate the truth of the version claims, so manually recheck the rg output from Task 3.
+
+- [ ] **Step 5: Review the final diff and public surfaces.**
+
+Inspect:
+
+~~~sh
+git status --short
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD --check
+git diff origin/main...HEAD -- go.mod go.sum internal/pullrequest/backend_test.go README.md docs/get-started/install.md docs/get-started/quickstart.md docs/reference/cli.md docs/reference/pull-requests.md docs/changelog.md internal/cmd/pr.go
+~~~
+
+Run the public-artifact scrub over all changed tests, docs, module files, and commit text before any push or PR creation. Ensure no global Git path, home path, credential, private hostname, or developer email entered the fixture or documentation.
+
+- [ ] **Step 6: Record the release handoff.**
+
+Leave the branch on the kit PR pseudo-version while kit PR #77 is unreleased. After kit is released as v0.23.0, run:
+
+~~~sh
+go get go.kenn.io/kit@v0.23.0
+go mod verify
+make test TEST_PACKAGES=./internal/pullrequest
+make test
+make build
+make vet
+make lint
+make docs-check
+~~~
+
+Review go.mod and go.sum to confirm the pseudo-version is gone before the kwt PR merges. Do not merge kit or publish either PR as part of this task.
+
+- [ ] **Step 7: Check commit state.**
+
+Run git status --short --branch and git log --oneline origin/main..HEAD. The accepted kwt changes must be committed, with no untracked test binaries or uncommitted source/docs changes.

--- a/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
+++ b/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
@@ -95,6 +95,10 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 	merge := exec.Command("git", "merge", "--no-edit", mainSHA)
 	merge.Dir = workspace.Path
 	merge.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test User",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test User",
+		"GIT_COMMITTER_EMAIL=test@example.com",
 		"GIT_CONFIG_NOSYSTEM=1",
 	)
 	mergeOutput, err := merge.CombinedOutput()

--- a/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
+++ b/docs/superpowers/plans/2026-08-31-merge-driver-kwt-validation.md
@@ -40,10 +40,7 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 	featureContent := "feature change\n"
 	mainContent := "main change\n"
 
-	gitConfigDir := t.TempDir()
-	globalConfig := filepath.Join(gitConfigDir, "global.gitconfig")
-	require.NoError(t, os.WriteFile(globalConfig, nil, 0o600))
-	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 	projectRepo, backend := newBackendRepo(t)
 
@@ -79,8 +76,8 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 	))
 	runGit(t, projectRepo, "commit", "-am", "main change")
 
-	runGit(t, projectRepo, "config", "url."+projectRepo+".insteadOf",
-		canonicalURL)
+	runGit(t, projectRepo, "remote", "set-url", "origin", projectRepo)
+	runGit(t, projectRepo, "remote", "set-url", "--push", "origin", canonicalURL)
 
 	pr := testPR(17, false)
 	pr.HeadSHA = headSHA
@@ -97,7 +94,6 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 	merge := exec.Command("git", "merge", "--no-edit", "main")
 	merge.Dir = workspace.Path
 	merge.Env = append(os.Environ(),
-		"GIT_CONFIG_GLOBAL="+globalConfig,
 		"GIT_CONFIG_NOSYSTEM=1",
 	)
 	_, err = merge.CombinedOutput()
@@ -116,7 +112,7 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 }
 ~~~
 
-Keep Project.Identity and the pull-request metadata canonical as github.com/acme/widget. The repository-local URL rewrite redirects that canonical fetch to the temporary repository. This exercises kit's same-repository identity comparison and kwt's post-import push validation without GitHub access.
+Keep Project.Identity and the pull-request metadata canonical as github.com/acme/widget. Point the trusted project's fetch origin at the temporary local repository and set its pushurl to the canonical GitHub URL. This exercises kit's same-repository identity comparison and kwt's post-import push validation without GitHub access.
 
 - [ ] **Step 2: Run the focused test and verify RED.**
 

--- a/docs/superpowers/specs/2026-08-31-merge-driver-kwt-validation-design.md
+++ b/docs/superpowers/specs/2026-08-31-merge-driver-kwt-validation-design.md
@@ -1,0 +1,59 @@
+# Validate Imported Worktree Merge Conflicts Against Kit PR 77
+
+## Goal
+
+Ensure kwt consumes the kit change for kwt#112 before kit is released, and
+prove that a merge or rebase in an imported worktree preserves conflict
+information instead of leaving a current-side-only file marked `UU`.
+
+## Scope
+
+The merge-driver implementation belongs to kit PR #77. The kwt change will
+consume that unreleased kit tip, exercise it through kwt's real pull-request
+backend, and document the resulting Git version requirement. No duplicate
+merge-driver implementation will be added to kwt.
+
+## Design
+
+Update `go.kenn.io/kit` to the pseudo-version for kit PR #77 tip
+`baf69924c6cb25d6235e59fe98e6c46780cd387d`. Add an integration regression test
+in the pull-request backend test package. The test will use temporary local Git
+repositories for the trusted project and pull-request source, configure a
+tracked file to select a custom merge driver that returns failure, and invoke
+`GitBackend.ImportPullRequest` with the real kit lifecycle function. It will
+then perform a conflicting merge in the imported worktree and inspect the
+actual Git status and file contents.
+
+The test must observe all of the issue's important user-visible behavior:
+
+- the imported worktree is created through kwt's production backend wiring;
+- the conflicting path remains unmerged (`UU`);
+- the working file contains diff3 conflict markers; and
+- both current and other changes remain visible in that file.
+
+The test fixture will isolate Git configuration and use only temporary local
+repositories. It will not contact GitHub or depend on the developer's global
+Git configuration. Existing test helpers and the repository test harness will
+remain the source of process and environment isolation.
+
+Update the user-facing requirements so the general Git 2.20 floor remains,
+Git 2.31 remains required for doctor and prune policies, and pull-request
+imports are called out separately as requiring Git 2.42.0 or newer on macOS and
+Linux. The Git for Windows floor from kit's contract will be documented with
+the pull-request import requirement. Add an Unreleased changelog entry that
+describes preserved conflict contents and the higher import floor.
+
+## Verification
+
+Use the focused backend test during development, with the failing test run
+before implementation or dependency wiring is complete. Then run the full
+repository test suite through `make test`, the repository build, lint, and the
+documentation checks that cover the changed requirements. Review the final
+diff and staged contents before committing.
+
+## Non-goals
+
+- Do not reimplement kit's safe merge-driver command in kwt.
+- Do not add a compatibility fallback for Git versions below the new
+  pull-request import floor.
+- Do not merge kit PR #77, tag kit, push branches, or post GitHub comments.

--- a/docs/superpowers/specs/2026-08-31-merge-driver-kwt-validation-design.md
+++ b/docs/superpowers/specs/2026-08-31-merge-driver-kwt-validation-design.md
@@ -15,14 +15,30 @@ merge-driver implementation will be added to kwt.
 
 ## Design
 
-Update `go.kenn.io/kit` to the pseudo-version for kit PR #77 tip
-`baf69924c6cb25d6235e59fe98e6c46780cd387d`. Add an integration regression test
-in the pull-request backend test package. The test will use temporary local Git
-repositories for the trusted project and pull-request source, configure a
-tracked file to select a custom merge driver that returns failure, and invoke
-`GitBackend.ImportPullRequest` with the real kit lifecycle function. It will
-then perform a conflicting merge in the imported worktree and inspect the
-actual Git status and file contents.
+Update `go.kenn.io/kit` temporarily to the pseudo-version for kit PR #77 tip
+`baf69924c6cb25d6235e59fe98e6c46780cd387d`:
+`v0.22.1-0.20260831205235-baf69924c6cb`. This pseudo-version is for pre-release
+validation only. Because the PR will likely be squash-merged, its tip may not
+remain reachable from kit's main history. After kit is merged and released as
+`v0.23.0`, replace the pseudo-version with that released tag before the kwt PR
+merges, and rerun the focused and full checks.
+
+Add an integration regression test in the pull-request backend test package.
+The test will use temporary local Git repositories for the trusted project and
+pull-request source, configure a tracked file to select a custom merge driver
+that returns failure, and invoke `GitBackend.ImportPullRequest` with the real
+kit lifecycle function. It will then perform a conflicting merge in the
+imported worktree and inspect the actual Git status and file contents.
+
+The fixture will keep the public GitHub identity used by `Project.Identity` and
+the pull-request metadata so kwt's post-import push validation still runs. Its
+trusted project's `origin` will retain the canonical GitHub-shaped URL, while
+a repository-local `url.<temporary-repository>.insteadOf` rule redirects Git's
+fetches to the temporary local repository. The pull-request head clone URL will
+use that same canonical URL, so kit's same-repository identity comparison and
+kwt's normal tracking setup are exercised without a network request. The
+complete `internal/pullrequest` package is exercised in Linux CI; Windows CI
+does not select it, so no platform-specific skip is needed for this test.
 
 The test must observe all of the issue's important user-visible behavior:
 
@@ -36,20 +52,34 @@ repositories. It will not contact GitHub or depend on the developer's global
 Git configuration. Existing test helpers and the repository test harness will
 remain the source of process and environment isolation.
 
-Update the user-facing requirements so the general Git 2.20 floor remains,
-Git 2.31 remains required for doctor and prune policies, and pull-request
-imports are called out separately as requiring Git 2.42.0 or newer on macOS and
-Linux. The Git for Windows floor from kit's contract will be documented with
-the pull-request import requirement. Add an Unreleased changelog entry that
-describes preserved conflict contents and the higher import floor.
+Update the user-facing requirements in exactly these files: `README.md`,
+`docs/get-started/install.md`, `docs/get-started/quickstart.md`,
+`docs/reference/cli.md`, `docs/reference/pull-requests.md`, and
+`docs/changelog.md`. Keep the general Git 2.20 floor and the Git 2.31 floor for
+doctor and prune policies, and add a third exception for pull-request imports:
+Git 2.42.0 or newer on macOS and Linux, or Git for Windows
+2.53.0.windows.3 or newer. The pull-request reference must state this beside
+the per-worktree configuration explanation, since that paragraph otherwise
+promises support for the affected feature on Git 2.20. Add the same import
+floor to the `kwt pr`/`kwt pr import` help text in `internal/cmd/pr.go`, and add
+an Unreleased changelog entry describing preserved conflict contents and the
+higher import floor.
+
+The regression test will use a conflicting `git merge`, rather than a rebase.
+Both operations invoke Git's configured merge driver for the conflicted path;
+the merge gives the test a direct, deterministic assertion of the same
+current-side-only failure that the issue reports during rebase.
 
 ## Verification
 
 Use the focused backend test during development, with the failing test run
-before implementation or dependency wiring is complete. Then run the full
-repository test suite through `make test`, the repository build, lint, and the
-documentation checks that cover the changed requirements. Review the final
-diff and staged contents before committing.
+against kit v0.22.0 before dependency wiring is complete. Then update to the
+kit PR pseudo-version and verify that the same test passes. Before the kwt PR
+merges, replace that pseudo-version with kit v0.23.0 and rerun the focused test,
+`make test`, the repository build, lint, and `make docs-check`. `make docs-check`
+only proves that the documentation site builds; manually review every named
+version statement to catch a missed or inaccurate requirement. Review the
+final diff and staged contents before committing.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-08-31-merge-driver-kwt-validation-design.md
+++ b/docs/superpowers/specs/2026-08-31-merge-driver-kwt-validation-design.md
@@ -32,13 +32,14 @@ imported worktree and inspect the actual Git status and file contents.
 
 The fixture will keep the public GitHub identity used by `Project.Identity` and
 the pull-request metadata so kwt's post-import push validation still runs. Its
-trusted project's `origin` will retain the canonical GitHub-shaped URL, while
-a repository-local `url.<temporary-repository>.insteadOf` rule redirects Git's
-fetches to the temporary local repository. The pull-request head clone URL will
-use that same canonical URL, so kit's same-repository identity comparison and
-kwt's normal tracking setup are exercised without a network request. The
-complete `internal/pullrequest` package is exercised in Linux CI; Windows CI
-does not select it, so no platform-specific skip is needed for this test.
+trusted project's `origin` will point to the temporary local repository for the
+same-repository fetch, while an explicit canonical GitHub-shaped `pushurl`
+keeps kwt's push validation on the trusted identity. The pull-request head
+clone URL will use that canonical URL, so kit's same-repository identity
+comparison and kwt's normal tracking setup are exercised without a network
+request. The complete `internal/pullrequest` package is exercised in Linux CI;
+Windows CI does not select it, so no platform-specific skip is needed for this
+test.
 
 The test must observe all of the issue's important user-visible behavior:
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
-	go.kenn.io/kit v0.22.0
+	go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb
 	golang.org/x/mod v0.40.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
-	go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb
+	go.kenn.io/kit v0.23.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.kenn.io/kit v0.22.0 h1:F0tRgXL9Ni4B1EP999DuRlbL2yWiTFnxLRWNOqPosFM=
 go.kenn.io/kit v0.22.0/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
+go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb h1:AoIm3t5w6yds+EeXWiy9z9rygwLqWuU617XIJhX1XtU=
+go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/go.sum
+++ b/go.sum
@@ -129,10 +129,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.kenn.io/kit v0.22.0 h1:F0tRgXL9Ni4B1EP999DuRlbL2yWiTFnxLRWNOqPosFM=
-go.kenn.io/kit v0.22.0/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
-go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb h1:AoIm3t5w6yds+EeXWiy9z9rygwLqWuU617XIJhX1XtU=
-go.kenn.io/kit v0.22.1-0.20260831205235-baf69924c6cb/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
+go.kenn.io/kit v0.23.0 h1:BkpnhPWFyn8ZrsAuqVv3l5u34o2R6hxKV6xO+AsOzh4=
+go.kenn.io/kit v0.23.0/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -101,8 +101,10 @@ var prListCmd = &cobra.Command{
 var prImportCmd = &cobra.Command{
 	Use:   "import <pull-request>",
 	Short: "Import a pull request as a configured kwt workspace",
-	Args:  prExactArgs(1),
-	RunE:  withGracefulSignals(runPRImport),
+	Long: "Pull-request import requires Git 2.42.0 or newer on macOS and Linux, " +
+		"or Git for Windows 2.53.0.windows.3 or newer.",
+	Args: prExactArgs(1),
+	RunE: withGracefulSignals(runPRImport),
 }
 
 var prAttachCmd = &cobra.Command{

--- a/internal/pullrequest/backend_test.go
+++ b/internal/pullrequest/backend_test.go
@@ -230,6 +230,10 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 	merge := exec.Command("git", "merge", "--no-edit", mainSHA)
 	merge.Dir = workspace.Path
 	merge.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test User",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test User",
+		"GIT_COMMITTER_EMAIL=test@example.com",
 		"GIT_CONFIG_NOSYSTEM=1",
 	)
 	mergeOutput, err := merge.CombinedOutput()

--- a/internal/pullrequest/backend_test.go
+++ b/internal/pullrequest/backend_test.go
@@ -210,6 +210,7 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 		0o644,
 	))
 	runGit(t, projectRepo, "commit", "-am", "main change")
+	mainSHA := runGit(t, projectRepo, "rev-parse", "main")
 
 	runGit(t, projectRepo, "remote", "set-url", "origin", projectRepo)
 	runGit(t, projectRepo, "remote", "set-url", "--push", "origin", canonicalURL)
@@ -226,13 +227,13 @@ func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) 
 		_ = backend.Rollback(t.Context(), workspace)
 	})
 
-	merge := exec.Command("git", "merge", "--no-edit", "main")
+	merge := exec.Command("git", "merge", "--no-edit", mainSHA)
 	merge.Dir = workspace.Path
 	merge.Env = append(os.Environ(),
 		"GIT_CONFIG_NOSYSTEM=1",
 	)
-	_, err = merge.CombinedOutput()
-	require.Error(t, err, "the merge must report the overlapping change")
+	mergeOutput, err := merge.CombinedOutput()
+	require.Error(t, err, "the merge must report the overlapping change: %s", mergeOutput)
 
 	assert.Equal(t, "UU conflict.txt",
 		runGit(t, workspace.Path, "status", "--short"))

--- a/internal/pullrequest/backend_test.go
+++ b/internal/pullrequest/backend_test.go
@@ -169,6 +169,83 @@ func TestGitBackendDelegatesPullRequestLifecycleToKit(t *testing.T) {
 	assert.NotEmpty(t, workspace.SessionName)
 }
 
+func TestGitBackendImportedWorktreePreservesMergeConflictContents(t *testing.T) {
+	canonicalURL := "https://github.com/acme/widget.git"
+	baseContent := "base\n"
+	featureContent := "feature change\n"
+	mainContent := "main change\n"
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	projectRepo, backend := newBackendRepo(t)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, ".gitattributes"),
+		[]byte("conflict.txt merge=untrusted\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, "conflict.txt"),
+		[]byte(baseContent),
+		0o644,
+	))
+	runGit(t, projectRepo, "add", ".gitattributes", "conflict.txt")
+	runGit(t, projectRepo, "commit", "-m", "add merge-driver fixture")
+	runGit(t, projectRepo, "config", "merge.untrusted.driver",
+		"f() { return 1; }; f")
+
+	runGit(t, projectRepo, "checkout", "-q", "-b", "feature/widgets")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, "conflict.txt"),
+		[]byte(featureContent),
+		0o644,
+	))
+	runGit(t, projectRepo, "commit", "-am", "feature change")
+	headSHA := runGit(t, projectRepo, "rev-parse", "HEAD")
+
+	runGit(t, projectRepo, "checkout", "-q", "main")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRepo, "conflict.txt"),
+		[]byte(mainContent),
+		0o644,
+	))
+	runGit(t, projectRepo, "commit", "-am", "main change")
+
+	runGit(t, projectRepo, "remote", "set-url", "origin", projectRepo)
+	runGit(t, projectRepo, "remote", "set-url", "--push", "origin", canonicalURL)
+
+	pr := testPR(17, false)
+	pr.HeadSHA = headSHA
+	pr.Source.Repository.CloneURL = canonicalURL
+
+	workspace, err := backend.ImportPullRequest(
+		t.Context(), pr, "pr-17-feature-widgets",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = backend.Rollback(t.Context(), workspace)
+	})
+
+	merge := exec.Command("git", "merge", "--no-edit", "main")
+	merge.Dir = workspace.Path
+	merge.Env = append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	_, err = merge.CombinedOutput()
+	require.Error(t, err, "the merge must report the overlapping change")
+
+	assert.Equal(t, "UU conflict.txt",
+		runGit(t, workspace.Path, "status", "--short"))
+	contents, err := os.ReadFile(filepath.Join(workspace.Path, "conflict.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), "<<<<<<< current")
+	assert.Contains(t, string(contents), "||||||| base")
+	assert.Contains(t, string(contents), "=======")
+	assert.Contains(t, string(contents), ">>>>>>> other")
+	assert.Contains(t, string(contents), featureContent)
+	assert.Contains(t, string(contents), mainContent)
+}
+
 func TestGitBackendMakesCredentialHelpersAvailableToLifecycle(t *testing.T) {
 	configDir := t.TempDir()
 	helper := filepath.Join(configDir, "credential-helper")


### PR DESCRIPTION
This PR proves that kwt preserves both sides of a merge conflict in an imported pull-request worktree. Before the kit repair, a custom merge driver could report a conflict while leaving only the current side in the file; staging that file could lose the incoming change.

## What this changes

- Adds a regression test through `GitBackend.ImportPullRequest` that performs a real conflicting merge and checks `UU` status, diff3 markers, and both sides' content.
- Uses released `go.kenn.io/kit v0.23.0`, which contains kit PR #77's safe merge-driver repair.
- Documents the higher Git floor for pull-request import in the installation guides, CLI reference, pull-request contract, command help, and changelog.

## Landing order

1. Run the focused and full checks with `go.kenn.io/kit v0.23.0`.
2. Merge this kwt PR.
3. Release kwt from the merged, tagged dependency.

Related: #112
Related kit change: kenn-io/kit#77

## Verification note

The focused pull-request suite and full `make test` pass against released kit v0.23.0. `make build`, `make vet`, `make lint`, and `make docs-check` also pass. The full suite previously hit an unrelated 2-second SSH resolver timing bound once; the rerun completed successfully.
