### PR TITLE
Show SSH host-key questions as trust reviews

### DIFF
--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -125,14 +125,14 @@ stdout back to the waiting OpenSSH process; they are not placed in arguments,
 environment values, daemon events, logs, or persistent state. Deliberate empty
 responses remain distinct from rejection. Kwt creates no channel state unless
 the selected system OpenSSH satisfies the 8.4 forced-askpass floor.
-OpenSSH's own askpass confirmation hint distinguishes host-key confirmation
-from credential input before kwt parses the confirmation text into a reviewed
-host, algorithm, and fingerprint for native clients. Every unhinted prompt
-remains sensitive authentication input, even when its text matches OpenSSH's
-standard host-key question; server-controlled prose is not trusted provenance.
-Confirmation requests outside the complete unknown-host shape also remain
-sensitive authentication input, so they reach the client without claiming a
-host-key identity or enabling echoed input.
+OpenSSH's standard unknown-host question does not carry its askpass
+`confirm` hint. Kwt recognizes the complete structured question and extracts
+the host, algorithm, and fingerprint for native review, with or without that
+hint. This classification describes the prompt's shape, not proof of its
+origin: a server can also supply authentication text. Clients should offer
+trust or cancel for host-key review, not ask for a password in that view.
+Prompts outside the complete unknown-host shape remain sensitive
+authentication input without a claimed host-key identity.
 Published prompt details contain only that host-key review identity, the
 already reviewed route targets, and hop position; they contain no credentials
 or environment values.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -221,8 +221,8 @@ include a `host_key` object containing the reviewed `host`, `algorithm`, and
 `fingerprint`, so native clients do not parse OpenSSH prose. The prompt message
 remains OpenSSH's original text. Other OpenSSH confirmation shapes are
 preserved as sensitive `ssh_authentication` prompts without a claimed host-key
-identity. Unhinted prompts are always handled this way, even when their prose
-resembles a host-key question. The process keeps the lease alive
+identity. The complete standard host-key question is recognized even without
+an askpass hint, as OpenSSH sends that question without one. The process keeps the lease alive
 while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -65,8 +65,8 @@ func newRunner(
 			Executable:  options.Executable,
 			Environment: environment,
 			Prompt:      request.Prompt,
-			Describe: func(message, hint string) (service.OperationPrompt, error) {
-				prompt := describeSSHPrompt(message, hint)
+			Describe: func(message, _ string) (service.OperationPrompt, error) {
+				prompt := service.OperationPrompt{Kind: "ssh_authentication", Sensitive: true}
 				hopCount := request.promptTargetCount
 				if hopCount == 0 {
 					hopCount = 1
@@ -78,17 +78,12 @@ func newRunner(
 					"hop_index":        request.promptTargetIndex,
 					"hop_count":        hopCount,
 				}
-				var hostKey *hostKeyPromptDetails
-				if prompt.Kind == "ssh_host_key" {
-					parsed, err := parseHostKeyPrompt(message)
-					if err != nil {
-						prompt.Kind = "ssh_authentication"
-						prompt.Sensitive = true
-					} else {
-						hostKey = &parsed
-					}
-				}
-				if hostKey != nil {
+				// OpenSSH's host-key confirmation uses RP_ECHO, not the
+				// permission prompt that sets SSH_ASKPASS_PROMPT=confirm.
+				// Require the complete structured question regardless of hint.
+				if hostKey, err := parseHostKeyPrompt(message); err == nil {
+					prompt.Kind = "ssh_host_key"
+					prompt.Sensitive = false
 					details["host_key"] = map[string]any{
 						"host":        hostKey.Host,
 						"algorithm":   hostKey.Algorithm,

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -178,43 +178,44 @@ func TestRunnerCarriesPromptThroughAskpassHelperProcess(t *testing.T) {
 }
 
 func TestRunnerClassifiesVisualHostKeyConfirmationAndAttributesProxyHop(t *testing.T) {
-	t.Run("explicit confirmation hint", func(t *testing.T) {
-		var captured service.OperationPrompt
-		request := LeaseRequest{
-			WorkingDirectory: t.TempDir(),
-			Environment:      []string{"PATH=" + os.Getenv("PATH")},
-			Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
-				captured = prompt
-				return "yes", nil
-			},
-			promptTargetIndex: 0,
-			promptTargetCount: 2,
-		}
-		target := ResolvedTarget{
-			LogicalTarget:         Target{Hostname: "relay"},
-			EffectiveTarget:       Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
-			DisplayTarget:         "relay.example.test",
-			StrictHostKeyChecking: "ask",
-			Projection: ExecutionProjection{
-				Arguments: []string{"-F", os.DevNull},
-			},
-		}
-		runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
-			Version: supportedAskpassVersion(),
-			Run: func(
-				_ context.Context,
-				_ []string,
-				_ string,
-				environment []string,
-			) (int, error) {
-				var output bytes.Buffer
-				promptEnvironment := append([]string(nil), environment...)
-				promptEnvironment = append(
-					promptEnvironment,
-					"SSH_ASKPASS_PROMPT=confirm",
-				)
-				exitCode, handled := RunAskpassHelper(
-					[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
+	for _, hint := range []string{"confirm", ""} {
+		t.Run("hint="+hint, func(t *testing.T) {
+			var captured service.OperationPrompt
+			request := LeaseRequest{
+				WorkingDirectory: t.TempDir(),
+				Environment:      []string{"PATH=" + os.Getenv("PATH")},
+				Prompt: func(_ context.Context, prompt service.OperationPrompt) (string, error) {
+					captured = prompt
+					return "yes", nil
+				},
+				promptTargetIndex: 0,
+				promptTargetCount: 2,
+			}
+			target := ResolvedTarget{
+				LogicalTarget:         Target{Hostname: "relay"},
+				EffectiveTarget:       Target{Hostname: "100.64.0.7", User: "jump", Port: 2201},
+				DisplayTarget:         "relay.example.test",
+				StrictHostKeyChecking: "ask",
+				Projection: ExecutionProjection{
+					Arguments: []string{"-F", os.DevNull},
+				},
+			}
+			runner, err := newRunner(t.TempDir(), request, target, runnerOptions{
+				Version: supportedAskpassVersion(),
+				Run: func(
+					_ context.Context,
+					_ []string,
+					_ string,
+					environment []string,
+				) (int, error) {
+					var output bytes.Buffer
+					promptEnvironment := append([]string(nil), environment...)
+					promptEnvironment = append(
+						promptEnvironment,
+						"SSH_ASKPASS_PROMPT="+hint,
+					)
+					exitCode, handled := RunAskpassHelper(
+						[]string{"kwt", `The authenticity of host 'relay.example.test (100.64.0.7)' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
 +--[ED25519 256]--+
 |      .          |
@@ -229,40 +230,41 @@ ED25519 key fingerprint is SHA256:fixture.
 +----[SHA256]-----+
 Matching host key fingerprint found in DNS.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `},
-					promptEnvironment,
-					&output,
-				)
-				require.True(t, handled)
-				assert.Equal(t, "yes\n", output.String())
-				return exitCode, nil
-			},
+						promptEnvironment,
+						&output,
+					)
+					require.True(t, handled)
+					assert.Equal(t, "yes\n", output.String())
+					return exitCode, nil
+				},
+			})
+			require.NoError(t, err)
+
+			exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
+
+			require.NoError(t, err)
+			assert.Equal(t, 0, exitCode)
+			assert.Equal(t, "ssh_host_key", captured.Kind)
+			assert.False(t, captured.Sensitive)
+			assert.Contains(t, captured.Message, "The authenticity of host")
+			assert.Equal(t, map[string]any{
+				"hostname": target.LogicalTarget.Hostname,
+			}, captured.Details["logical_target"])
+			assert.Equal(t, map[string]any{
+				"hostname": target.EffectiveTarget.Hostname,
+				"user":     target.EffectiveTarget.User,
+				"port":     target.EffectiveTarget.Port,
+			}, captured.Details["effective_target"])
+			assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
+			assert.Equal(t, 0, captured.Details["hop_index"])
+			assert.Equal(t, 2, captured.Details["hop_count"])
+			assert.Equal(t, map[string]any{
+				"host":        "relay.example.test (100.64.0.7)",
+				"algorithm":   "ED25519",
+				"fingerprint": "SHA256:fixture",
+			}, captured.Details["host_key"])
 		})
-		require.NoError(t, err)
-
-		exitCode, err := runner(context.Background(), []string{"-MNf", "--", "jump@100.64.0.7"})
-
-		require.NoError(t, err)
-		assert.Equal(t, 0, exitCode)
-		assert.Equal(t, "ssh_host_key", captured.Kind)
-		assert.False(t, captured.Sensitive)
-		assert.Contains(t, captured.Message, "The authenticity of host")
-		assert.Equal(t, map[string]any{
-			"hostname": target.LogicalTarget.Hostname,
-		}, captured.Details["logical_target"])
-		assert.Equal(t, map[string]any{
-			"hostname": target.EffectiveTarget.Hostname,
-			"user":     target.EffectiveTarget.User,
-			"port":     target.EffectiveTarget.Port,
-		}, captured.Details["effective_target"])
-		assert.Equal(t, target.DisplayTarget, captured.Details["display_target"])
-		assert.Equal(t, 0, captured.Details["hop_index"])
-		assert.Equal(t, 2, captured.Details["hop_count"])
-		assert.Equal(t, map[string]any{
-			"host":        "relay.example.test (100.64.0.7)",
-			"algorithm":   "ED25519",
-			"fingerprint": "SHA256:fixture",
-		}, captured.Details["host_key"])
-	})
+	}
 }
 
 func TestRunnerKeepsUntrustedConfirmationSensitive(t *testing.T) {
@@ -279,12 +281,6 @@ func TestRunnerKeepsUntrustedConfirmationSensitive(t *testing.T) {
 		{
 			name: "unhinted server-controlled spoof",
 			message: `Password for The authenticity of host 'build.example.test' can't be established.
-ED25519 key fingerprint is SHA256:fixture.
-Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
-		},
-		{
-			name: "unhinted standard host-key text",
-			message: `The authenticity of host 'build.example.test' can't be established.
 ED25519 key fingerprint is SHA256:fixture.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? `,
 		},


### PR DESCRIPTION
- Show standard SSH host-key questions as trust reviews in native clients instead of password prompts. Recognize the complete question even without an askpass hint.
- Reproduced with macOS OpenSSH 10.3p1 against an isolated local sshd: its host-key question arrives without `SSH_ASKPASS_PROMPT=confirm`. OpenSSH uses `RP_ECHO` for this question; the hint belongs to a different permission path.
- Keep other prompt shapes as sensitive authentication input. Document that matching the question describes its presentation, not proof of its origin.
- Cover both hinted and unhinted questions at the askpass/runner boundary. The SSH suite, full test suite, and build pass.
