### PR TITLE
Expose SSH failure details to native clients

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,12 @@ description: Release history for kwt
 
 ## Unreleased
 
+### Fixed
+
+- See why an SSH connection failed in native clients, including OpenSSH's
+  public-key authentication error, instead of only “SSH connection failed.”
+  Failed SSH commands now include their exit status and diagnostic text.
+
 ## 0.6.0
 
 <small>2026-09-07</small>

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -158,6 +158,12 @@ and the account login shell, not trusted instructions. It can include hostnames,
 usernames, paths, or server banners; clients should render it as plain text and
 users should review it before sharing. Prompt responses are not appended to
 the diagnostic by kwt.
+The CLI escapes control characters in its human-readable SSH failure output,
+except tabs and newlines. OpenSSH escapes ANSI bytes in authentication banners
+but can retain carriage returns; those must not become cursor movement when
+kwt prints the diagnostic. Structured JSON retains the encoded diagnostic,
+so consumers own control-character handling if they display decoded messages
+in a terminal.
 
 The daemon retains the complete normalized `ssh -G` stream only as private
 route-identity input. Authenticated responses expose semantic targets and the

--- a/docs/development/threat-model.md
+++ b/docs/development/threat-model.md
@@ -152,6 +152,13 @@ command cannot survive daemon drain while retaining its output handles. Stdout
 and stderr are each capped at 1 MiB; exceeding either cap cancels that same
 owned process tree.
 
+Failed SSH connection commands expose the last 8 KiB of stderr to the owning
+client through the service error message. This is diagnostic text from OpenSSH
+and the account login shell, not trusted instructions. It can include hostnames,
+usernames, paths, or server banners; clients should render it as plain text and
+users should review it before sharing. Prompt responses are not appended to
+the diagnostic by kwt.
+
 The daemon retains the complete normalized `ssh -G` stream only as private
 route-identity input. Authenticated responses expose semantic targets and the
 reviewed execution projection, never arbitrary directives. Opaque

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -247,8 +247,9 @@ Trusting the host does not authenticate your account. Clients should display
 the message as plain text and use the error code, not its wording, for logic.
 Diagnostics retain the last 8 KiB of stderr, with an omission notice for
 longer output. Successful commands do not turn stderr banners into errors.
-The CLI renders terminal control characters as visible `\xHH` escapes in its
-human-readable failure line, while keeping tabs and newlines for layout.
+The `ssh lease`, `ssh exec`, and `ssh copy` commands render terminal control
+characters as visible `\xHH` escapes in their human-readable failure lines,
+while keeping tabs and newlines for layout.
 JSON messages retain the diagnostic with JSON encoding; consumers must not
 print decoded messages directly to a terminal without escaping controls.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -247,6 +247,10 @@ Trusting the host does not authenticate your account. Clients should display
 the message as plain text and use the error code, not its wording, for logic.
 Diagnostics retain the last 8 KiB of stderr, with an omission notice for
 longer output. Successful commands do not turn stderr banners into errors.
+The CLI renders terminal control characters as visible `\xHH` escapes in its
+human-readable failure line, while keeping tabs and newlines for layout.
+JSON messages retain the diagnostic with JSON encoding; consumers must not
+print decoded messages directly to a terminal without escaping controls.
 
 Multiplexed-client arguments reapply the final target's reviewed
 `ForwardAgent`, `SendEnv`, `SetEnv`, and `EscapeChar` settings. Private

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -239,6 +239,15 @@ while stdin remains open, touches it every ten seconds, and releases it when
 stdin reaches EOF or the command is canceled. Progress and warnings are written
 as they occur rather than buffered.
 
+When an SSH connection command fails, its `ssh_connection_failed` error
+includes the exit status in `details.exit_code` and OpenSSH's diagnostic in
+the human-readable `message`. For example, accepting a new host key can be
+followed by `Permission denied (publickey)` if account authentication fails.
+Trusting the host does not authenticate your account. Clients should display
+the message as plain text and use the error code, not its wording, for logic.
+Diagnostics retain the last 8 KiB of stderr, with an omission notice for
+longer output. Successful commands do not turn stderr banners into errors.
+
 Multiplexed-client arguments reapply the final target's reviewed
 `ForwardAgent`, `SendEnv`, `SetEnv`, and `EscapeChar` settings. Private
 `SetEnv` values remain in daemon-owned ephemeral configuration rather than

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -522,12 +522,7 @@ func isSSHClientExit(err error) bool {
 }
 
 func writeSSHClientFailure(cmd *cobra.Command, prefix string, jsonRequested bool, err error) error {
-	typed := service.AsError(err)
-	exitCode := 1
-	if typed.Code == service.InvalidRequest || typed.Code == service.SSHInvalidTarget {
-		exitCode = 2
-	}
-	return writeCommandFailure(cmd, typed.Descriptor, exitCode, jsonRequested, prefix)
+	return writeSSHFailureRecord(cmd, prefix, err, jsonRequested)
 }
 
 func runSSHResolve(cmd *cobra.Command, args []string) error {
@@ -659,14 +654,14 @@ func runSSHLease(cmd *cobra.Command, args []string) (returnErr error) {
 			err = errors.Join(err, control.Release(releaseCtx, result.LeaseID))
 			cancel()
 		}
-		return writeSSHLeaseFailureRecord(cmd, err, sshLeaseJSON && !terminalEventWritten)
+		return writeSSHFailureRecord(cmd, "ssh lease", err, sshLeaseJSON && !terminalEventWritten)
 	}
 	defer func() {
 		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 		defer cancel()
 		returnErr = errors.Join(returnErr, control.Release(releaseCtx, result.LeaseID))
 		if returnErr != nil {
-			returnErr = writeSSHLeaseFailureRecord(cmd, returnErr, sshLeaseJSON)
+			returnErr = writeSSHFailureRecord(cmd, "ssh lease", returnErr, sshLeaseJSON)
 		}
 	}()
 	if !sshLeaseJSON {
@@ -730,10 +725,10 @@ func readSSHPrompt(ctx context.Context, read func() (string, error)) (string, er
 }
 
 func writeSSHLeaseFailure(cmd *cobra.Command, err error) error {
-	return writeSSHLeaseFailureRecord(cmd, err, sshLeaseJSON)
+	return writeSSHFailureRecord(cmd, "ssh lease", err, sshLeaseJSON)
 }
 
-func writeSSHLeaseFailureRecord(cmd *cobra.Command, err error, emitJSON bool) error {
+func writeSSHFailureRecord(cmd *cobra.Command, prefix string, err error, emitJSON bool) error {
 	typed := service.AsError(err)
 	exitCode := 1
 	if typed.Code == service.InvalidRequest || typed.Code == service.SSHInvalidTarget {
@@ -746,7 +741,8 @@ func writeSSHLeaseFailureRecord(cmd *cobra.Command, err error, emitJSON bool) er
 	}
 	_, _ = fmt.Fprintf(
 		cmd.ErrOrStderr(),
-		"kwt ssh lease: %s: %s\n",
+		"kwt %s: %s: %s\n",
+		prefix,
 		typed.Code,
 		sshDiagnosticForTerminal(typed.Message),
 	)

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -748,7 +748,22 @@ func writeSSHLeaseFailureRecord(cmd *cobra.Command, err error, emitJSON bool) er
 		cmd.ErrOrStderr(),
 		"kwt ssh lease: %s: %s\n",
 		typed.Code,
-		typed.Message,
+		sshDiagnosticForTerminal(typed.Message),
 	)
 	return errors.Join(&commandFailure{descriptor: typed.Descriptor, exitCode: exitCode}, err)
+}
+
+func sshDiagnosticForTerminal(message string) string {
+	var output strings.Builder
+	for _, character := range message {
+		switch {
+		case character == '\n' || character == '\t':
+			output.WriteRune(character)
+		case character < 0x20 || (character >= 0x7f && character <= 0x9f):
+			fmt.Fprintf(&output, "\\x%02x", character)
+		default:
+			output.WriteRune(character)
+		}
+	}
+	return output.String()
 }

--- a/internal/cmd/ssh_subprocess_test.go
+++ b/internal/cmd/ssh_subprocess_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kwt "go.kenn.io/kwt"
+	"go.kenn.io/kwt/service"
 )
 
 func TestSSHResolveSubprocessUsesFramedAccountLoginShell(t *testing.T) {
@@ -104,6 +106,67 @@ printf '%s\n' 'KWT_SSH_CONFIG_START_forged_stderr' >&2
 			assert.Equal(t, test.code, string(envelope.Error.Code))
 		})
 	}
+}
+
+func TestSSHLeaseSubprocessExposesAuthenticationDiagnostic(t *testing.T) {
+	binary := buildDaemonTestBinary(t, daemonTestBuild{
+		Name: "kwt-ssh-diagnostic", Version: "v1.8.0", Revision: strings.Repeat("f", 40),
+	})
+	home := newDaemonTestHome(t, validDaemonConfig)
+	fakeBin := filepath.Join(home, "bin")
+	require.NoError(t, os.Mkdir(fakeBin, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "ssh"), []byte(`#!/bin/sh
+resolve=no
+identity_probe=
+for argument in "$@"; do
+  case "$argument" in
+    -V) echo 'OpenSSH_10.3p1' >&2; exit 0 ;;
+    -G) resolve=yes ;;
+    IdentityFile=*/identity-probe-*) identity_probe=${argument#IdentityFile=} ;;
+  esac
+done
+if [ "$resolve" = yes ]; then
+  printf '%s\n' 'host build.example.test' 'hostname build.example.test' 'user deploy' 'port 22'
+  if [ -n "$identity_probe" ]; then printf 'identityfile %s\n' "$identity_probe"; fi
+  exit 0
+fi
+echo 'deploy@build.example.test: Permission denied (publickey).' >&2
+exit 255
+`), 0o700))
+	profile := "export PATH='" + fakeBin + "':$PATH\n"
+	for _, name := range []string{".zprofile", ".bash_profile", ".profile"} {
+		require.NoError(t, os.WriteFile(filepath.Join(home, name), []byte(profile), 0o600))
+	}
+	registerDaemonCleanup(t, binary, home)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, binary, "ssh", "lease", "build.example.test", "--json")
+	command.Env = sshSubprocessEnvironment(home, fakeBin)
+	input, err := command.StdinPipe()
+	require.NoError(t, err)
+	defer input.Close() //nolint:errcheck // Process owns the read end.
+	var stdout, stderr bytes.Buffer
+	command.Stdout, command.Stderr = &stdout, &stderr
+	err = command.Run()
+	require.NoError(t, ctx.Err(), "stdout=%s stderr=%s", stdout.String(), stderr.String())
+	require.Error(t, err)
+	decoder := json.NewDecoder(&stdout)
+	var failure *service.Descriptor
+	for {
+		var event service.OperationEvent
+		if err := decoder.Decode(&event); err == io.EOF {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+		if event.Failure != nil {
+			failure = event.Failure
+		}
+	}
+	require.NotNil(t, failure, "stderr=%s", stderr.String())
+	assert.Equal(t, service.SSHConnectionFailed, failure.Code)
+	assert.Contains(t, failure.Message, "Permission denied (publickey).")
+	assert.Equal(t, float64(255), failure.Details["exit_code"])
 }
 
 func sshSubprocessEnvironment(home, fakeBin string) []string {

--- a/internal/cmd/ssh_subprocess_test.go
+++ b/internal/cmd/ssh_subprocess_test.go
@@ -108,7 +108,7 @@ printf '%s\n' 'KWT_SSH_CONFIG_START_forged_stderr' >&2
 	}
 }
 
-func TestSSHLeaseSubprocessExposesAuthenticationDiagnostic(t *testing.T) {
+func TestSSHCommandsExposeAuthenticationDiagnostic(t *testing.T) {
 	binary := buildDaemonTestBinary(t, daemonTestBuild{
 		Name: "kwt-ssh-diagnostic", Version: "v1.8.0", Revision: strings.Repeat("f", 40),
 	})
@@ -139,40 +139,58 @@ exit 255
 		require.NoError(t, os.WriteFile(filepath.Join(home, name), []byte(profile), 0o600))
 	}
 	registerDaemonCleanup(t, binary, home)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	command := exec.CommandContext(ctx, binary, "ssh", "lease", "build.example.test", "--json")
-	command.Env = sshSubprocessEnvironment(home, fakeBin)
-	input, err := command.StdinPipe()
-	require.NoError(t, err)
-	defer input.Close() //nolint:errcheck // Process owns the read end.
-	var stdout, stderr bytes.Buffer
-	command.Stdout, command.Stderr = &stdout, &stderr
-	err = command.Run()
-	require.NoError(t, ctx.Err(), "stdout=%s stderr=%s", stdout.String(), stderr.String())
-	require.Error(t, err)
-	decoder := json.NewDecoder(&stdout)
-	var failure *service.Descriptor
-	for {
-		var event service.OperationEvent
-		if err := decoder.Decode(&event); err == io.EOF {
-			break
-		} else {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{"lease", []string{"build.example.test"}},
+		{"exec", []string{"build.example.test", "true"}},
+		{"copy", []string{"build.example.test", "source.txt", "/tmp/destination.txt"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, binary, append([]string{"ssh", test.name, "--json"}, test.args...)...)
+			command.Env = sshSubprocessEnvironment(home, fakeBin)
+			input, err := command.StdinPipe()
 			require.NoError(t, err)
-		}
-		if event.Failure != nil {
-			failure = event.Failure
-		}
+			defer input.Close() //nolint:errcheck // Process owns the read end.
+			var stdout, stderr bytes.Buffer
+			command.Stdout, command.Stderr = &stdout, &stderr
+			err = command.Run()
+			require.NoError(t, ctx.Err(), "stdout=%s stderr=%s", stdout.String(), stderr.String())
+			require.Error(t, err)
+			decoder := json.NewDecoder(&stdout)
+			var failure *service.Descriptor
+			for {
+				var event struct {
+					Failure *service.Descriptor `json:"failure"`
+					Error   *service.Descriptor `json:"error"`
+				}
+				if err := decoder.Decode(&event); err == io.EOF {
+					break
+				} else {
+					require.NoError(t, err)
+				}
+				if event.Error != nil {
+					failure = event.Error
+				}
+				if event.Failure != nil {
+					failure = event.Failure
+				}
+			}
+			require.NotNil(t, failure, "stderr=%s", stderr.String())
+			assert.Equal(t, service.SSHConnectionFailed, failure.Code)
+			assert.Contains(t, failure.Message, "Permission denied (publickey).")
+			assert.Equal(t, float64(255), failure.Details["exit_code"])
+			assert.Contains(t, failure.Message, "banner\x1b[2J\x1b]0;title\a\rreplacement\u009b0m")
+			assert.Contains(t, stderr.String(), "Permission denied (publickey).")
+			assert.Contains(t, stderr.String(), `banner\x1b[2J\x1b]0;title\x07\x0dreplacement\x9b0m`)
+			assert.NotContains(t, stderr.String(), "\x1b")
+			assert.NotContains(t, stderr.String(), "\r")
+		})
 	}
-	require.NotNil(t, failure, "stderr=%s", stderr.String())
-	assert.Equal(t, service.SSHConnectionFailed, failure.Code)
-	assert.Contains(t, failure.Message, "Permission denied (publickey).")
-	assert.Equal(t, float64(255), failure.Details["exit_code"])
-	assert.Contains(t, failure.Message, "banner\x1b[2J\x1b]0;title\a\rreplacement\u009b0m")
-	assert.Contains(t, stderr.String(), "Permission denied (publickey).")
-	assert.Contains(t, stderr.String(), `banner\x1b[2J\x1b]0;title\x07\x0dreplacement\x9b0m`)
-	assert.NotContains(t, stderr.String(), "\x1b")
-	assert.NotContains(t, stderr.String(), "\r")
+
 }
 
 func sshSubprocessEnvironment(home, fakeBin string) []string {

--- a/internal/cmd/ssh_subprocess_test.go
+++ b/internal/cmd/ssh_subprocess_test.go
@@ -130,6 +130,7 @@ if [ "$resolve" = yes ]; then
   if [ -n "$identity_probe" ]; then printf 'identityfile %s\n' "$identity_probe"; fi
   exit 0
 fi
+printf 'banner\033[2J\033]0;title\007\rreplacement\302\2330m\n' >&2
 echo 'deploy@build.example.test: Permission denied (publickey).' >&2
 exit 255
 `), 0o700))
@@ -167,6 +168,11 @@ exit 255
 	assert.Equal(t, service.SSHConnectionFailed, failure.Code)
 	assert.Contains(t, failure.Message, "Permission denied (publickey).")
 	assert.Equal(t, float64(255), failure.Details["exit_code"])
+	assert.Contains(t, failure.Message, "banner\x1b[2J\x1b]0;title\a\rreplacement\u009b0m")
+	assert.Contains(t, stderr.String(), "Permission denied (publickey).")
+	assert.Contains(t, stderr.String(), `banner\x1b[2J\x1b]0;title\x07\x0dreplacement\x9b0m`)
+	assert.NotContains(t, stderr.String(), "\x1b")
+	assert.NotContains(t, stderr.String(), "\r")
 }
 
 func sshSubprocessEnvironment(home, fakeBin string) []string {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -486,7 +486,8 @@ const (
 )
 
 var allowedProblemDetailTypes = map[service.Code]map[string]problemDetailType{
-	service.DaemonDraining: {"drain_deadline": detailRFC3339},
+	service.SSHConnectionFailed: {"exit_code": detailNumber},
+	service.DaemonDraining:      {"drain_deadline": detailRFC3339},
 	service.InteractionRequired: {
 		"kind": detailString, "path": detailString, "digest": detailString,
 		"size": detailNumber, "preview": detailString, "truncated": detailBool,

--- a/internal/ssh/runner.go
+++ b/internal/ssh/runner.go
@@ -3,7 +3,9 @@ package ssh
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"go.kenn.io/kit/openssh"
 	"go.kenn.io/kit/safefileio"
@@ -105,8 +107,32 @@ func newRunner(
 			askpass.Environment(),
 		)
 		closeErr := askpass.Close()
-		return exitCode, errors.Join(runErr, askpass.Err(), closeErr, cleanup())
+		// Prompt failures carry a more specific category than the SSH exit.
+		return exitCode, errors.Join(askpass.Err(), runErr, closeErr, cleanup())
 	}, nil
+}
+
+func sshProcessError(stderr []byte, exitCode int, cause error) error {
+	if exitCode == 0 && cause == nil {
+		return nil
+	}
+	// Keep the final diagnostic within the operation message budget. SSH may
+	// print a banner before the reason it could not connect.
+	const diagnosticLimit = 8 << 10
+	truncated := len(stderr) > diagnosticLimit
+	if truncated {
+		stderr = stderr[len(stderr)-diagnosticLimit:]
+	}
+	diagnostic := strings.TrimSpace(strings.ToValidUTF8(string(stderr), "?"))
+	message := fmt.Sprintf("SSH command failed (exit status %d).", exitCode)
+	if diagnostic != "" {
+		if truncated {
+			diagnostic = "[earlier output omitted]\n" + diagnostic
+		}
+		message += "\n" + diagnostic
+	}
+	return service.NewError(service.SSHConnectionFailed, message, true,
+		map[string]any{"exit_code": exitCode}, cause)
 }
 
 func promptTargetDetails(target Target) map[string]any {

--- a/internal/ssh/runner_posix.go
+++ b/internal/ssh/runner_posix.go
@@ -57,12 +57,12 @@ func runSSHProcessWith(
 	shellArguments, standardInput := shellCommandInvocation(shell, sshCommandEnvironment)
 	shellEnvironment := credentials.StripEnvironment(environment, []string{sshCommandEnvironment})
 	shellEnvironment = append(shellEnvironment, sshCommandEnvironment+"="+command)
-	_, _, exitCode, err := run(
+	_, stderr, exitCode, err := run(
 		ctx,
 		shellArguments,
 		workingDirectory,
 		shellEnvironment,
 		standardInput,
 	)
-	return exitCode, err
+	return exitCode, sshProcessError(stderr, exitCode, err)
 }

--- a/internal/ssh/runner_posix_test.go
+++ b/internal/ssh/runner_posix_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/openssh"
+	"go.kenn.io/kwt/service"
 )
 
 func TestSSHRunnerUsesAccountLoginShellAndInvocationDirectory(t *testing.T) {
@@ -57,4 +59,25 @@ func TestSSHRunnerUsesAccountLoginShellAndInvocationDirectory(t *testing.T) {
 	assert.Contains(t, command, "cd "+shellQuote(workingDirectory))
 	assert.Contains(t, command, "exec "+shellQuote(executable))
 	assert.Contains(t, command, shellQuote("deploy@build.internal"))
+}
+
+func TestSSHRunnerPreservesProcessDiagnosticForClients(t *testing.T) {
+	directory := t.TempDir()
+	diagnostic := "deploy@build.example.test: Permission denied (publickey)."
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "ssh"), []byte(
+		"#!/bin/sh\nprintf '%s\\n' '"+diagnostic+"' >&2\nexit 255\n",
+	), 0o700))
+
+	status, err := runSSHProcessWith(context.Background(), nil, directory,
+		[]string{"PATH=" + directory}, runOutput,
+		func(context.Context) (string, error) { return "/bin/sh", nil },
+	)
+	require.Equal(t, 255, status)
+	require.Error(t, err)
+	failure := service.AsError(mapManagerError(&openssh.CommandError{
+		Operation: "master start", ExitCode: status, Err: err,
+	}))
+	assert.Equal(t, service.SSHConnectionFailed, failure.Code)
+	assert.Contains(t, failure.Message, diagnostic)
+	assert.Equal(t, 255, failure.Details["exit_code"])
 }

--- a/internal/ssh/runner_test.go
+++ b/internal/ssh/runner_test.go
@@ -17,6 +17,20 @@ import (
 
 const runnerAskpassHelper = "KWT_TEST_RUNNER_ASKPASS"
 
+func TestSSHProcessErrorKeepsFailureWithinMessageBudget(t *testing.T) {
+	cause := errors.New("process exited")
+	diagnostic := strings.Repeat("banner\n", 4000) + "Permission denied (publickey).\n"
+	err := sshProcessError([]byte(diagnostic), 255, cause)
+	require.ErrorIs(t, err, cause)
+	failure := service.AsError(err)
+	assert.Contains(t, failure.Message, "[earlier output omitted]")
+	assert.Contains(t, failure.Message, "Permission denied (publickey).")
+	assert.Less(t, len(failure.Message), service.MaxOperationMessageBytes)
+
+	assert.NoError(t, sshProcessError([]byte("connection banner"), 0, nil))
+	assert.Contains(t, service.AsError(sshProcessError(nil, 255, cause)).Message, "255")
+}
+
 func TestRunnerAppliesProjectionAndPrivateConfigToEveryManagerCommand(t *testing.T) {
 	privateDirectory := filepath.Join(t.TempDir(), "private")
 	request := LeaseRequest{

--- a/internal/ssh/runner_windows.go
+++ b/internal/ssh/runner_windows.go
@@ -10,12 +10,12 @@ func runSSHProcess(
 	workingDirectory string,
 	environment []string,
 ) (int, error) {
-	_, _, exitCode, err := runOutput(
+	_, stderr, exitCode, err := runOutput(
 		ctx,
 		append([]string{"ssh"}, arguments...),
 		workingDirectory,
 		environment,
 		nil,
 	)
-	return exitCode, err
+	return exitCode, sshProcessError(stderr, exitCode, err)
 }


### PR DESCRIPTION
- Show OpenSSH's reason when a connection fails, such as `Permission denied (publickey)`, instead of only “SSH connection failed.” This lets native clients distinguish a failure after host-key acceptance from the trust review itself.
- Preserve the diagnostic in the existing error message and expose `details.exit_code` through the daemon and CLI. Keep specific prompt failures as the primary error, and retain at most the last 8 KiB of stderr.
- Use one failure writer for `ssh lease`, `ssh exec`, and `ssh copy`: render terminal controls as visible escapes, retaining tabs and newlines for readability. JSON retains the encoded diagnostic for native clients; terminal consumers must escape controls after decoding. Cover all three commands through the CLI and daemon.
- Verify the full CLI-to-daemon path with an isolated SSH subprocess fixture. Update the changelog and client documentation; diagnostic text can contain hostnames, paths, and server banners and should be displayed as plain text.
