### PR TITLE
Keep CLI errors concise and cover tmux cold starts

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,6 +4,9 @@ Use this page for stable command behavior, JSON fields, exit status, and guarded
 automation contracts. Run `kwt <command> --help` for the complete flags on the
 installed version.
 
+Command failures print the error without appending the full usage text. Use
+`kwt <command> --help` to see usage and flags.
+
 For task-first guidance, start with the [quickstart](../get-started/quickstart.md)
 or [worktree lifecycle](../workflows/worktree-maintenance.md). Agent and terminal
 clients should read [Agent workspaces](../workflows/agent-workspaces.md) before

--- a/docs/workflows/directory-workspaces.md
+++ b/docs/workflows/directory-workspaces.md
@@ -57,6 +57,10 @@ JSON returns each workspace's `name`, canonical absolute `path`, effective
 `session_name`, `session_live`, `tmux_socket_name`, and `tmux_attach_mode`. An
 empty registry returns `[]`.
 
+You do not need to start tmux first. When no tmux server is running, workspace
+listing reports `session_live: false`, and `open --start-session` starts the
+server and creates the workspace session automatically.
+
 Another tmux client can ask kwt to establish the workspace without attaching:
 
 ```sh

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -47,8 +47,9 @@ var rootCmd = &cobra.Command{
 Like how 'ghq' manages repository clones, kwt provides intuitive 
 operations for creating, switching, and deleting worktrees using 
 a fuzzy finder interface.`,
-	Version: getVersionString(),
-	Args:    cobra.NoArgs,
+	Version:      getVersionString(),
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := requireConfigInitialization(); err != nil {
 			return err

--- a/internal/cmd/root_error_test.go
+++ b/internal/cmd/root_error_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIErrorOutputKeepsDiagnosticsWithoutUsage(t *testing.T) {
+	binary := buildDaemonTestBinary(t, daemonTestBuild{Name: "kwt"})
+	t.Chdir(t.TempDir())
+	for _, test := range []struct {
+		name   string
+		config string
+		args   []string
+		want   string
+	}{
+		{
+			name: "missing workspace directory",
+			args: []string{"workspace", "add", filepath.Join(t.TempDir(), "missing")},
+			want: "missing",
+		},
+		{
+			name:   "invalid configuration",
+			config: "[invalid",
+			args:   []string{"workspace", "list"},
+			want:   "config",
+		},
+		{
+			name: "unknown flag",
+			args: []string{"open", "--unknown-flag"},
+			want: "unknown flag: --unknown-flag",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := newDaemonTestHome(t, test.config)
+			stdout, stderr, err := runDaemonCommand(t, binary, home, test.args...)
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			assert.Equal(t, 1, exitErr.ExitCode())
+			assert.Empty(t, stdout)
+			assert.Contains(t, string(stderr), "Error:")
+			assert.Contains(t, string(stderr), test.want)
+			assert.NotContains(t, string(stderr), "Usage:")
+		})
+	}
+
+	stdout, stderr, err := runDaemonCommand(
+		t, binary, newDaemonTestHome(t, ""), "open", "--help",
+	)
+	require.NoError(t, err, string(stderr))
+	assert.Contains(t, string(stdout), "Usage:")
+	assert.Contains(t, string(stdout), "--start-session")
+}

--- a/internal/tmux/list_sessions_test.go
+++ b/internal/tmux/list_sessions_test.go
@@ -1,0 +1,50 @@
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListSessionsTreatsOnlyAbsentServerAsEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is unavailable on Windows")
+	}
+	fixture := filepath.Join(t.TempDir(), "tmux-fixture")
+	require.NoError(t, os.WriteFile(fixture, []byte(`#!/bin/sh
+printf '%s\n' "$KWT_TEST_TMUX_STDERR" >&2
+exit "$KWT_TEST_TMUX_EXIT"
+`), 0o700))
+	for _, test := range []struct {
+		name      string
+		stderr    string
+		exit      string
+		wantError bool
+	}{
+		{name: "no server", stderr: "no server running on /tmp/tmux/socket", exit: "1"},
+		{name: "missing socket", stderr: "error connecting to /tmp/tmux/socket (No such file or directory)", exit: "1"},
+		{name: "permission denied", stderr: "error connecting to /tmp/tmux/socket (Permission denied)", exit: "1", wantError: true},
+		{name: "unexpected error", stderr: "server rejected request", exit: "1", wantError: true},
+		{name: "unexpected exit", stderr: "no server running on /tmp/tmux/socket", exit: "2", wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("KWT_TEST_TMUX_STDERR", test.stderr)
+			t.Setenv("KWT_TEST_TMUX_EXIT", test.exit)
+			command := NewTmuxCommand(fixture)
+			names, namesErr := command.ListSessions()
+			details, detailsErr := command.ListSessionsDetailed()
+			if test.wantError {
+				require.ErrorContains(t, namesErr, test.stderr)
+				require.ErrorContains(t, detailsErr, test.stderr)
+			} else {
+				require.NoError(t, namesErr)
+				require.NoError(t, detailsErr)
+				require.Empty(t, names)
+				require.Empty(t, details)
+			}
+		})
+	}
+}

--- a/internal/tmux/workspace_sessions_integration_test.go
+++ b/internal/tmux/workspace_sessions_integration_test.go
@@ -99,6 +99,47 @@ func TestWorkspaceSessionsCreateOnlyOnKWTServer(t *testing.T) {
 	assert.False(t, fixture.servers.defaultServer().HasSession(fixture.session))
 }
 
+func TestDirectoryWorkspaceColdStart(t *testing.T) {
+	fixture := newRealWorkspaceSessionsFixture(t)
+	fixture.session = DirWorkspaceSessionName("notes", fixture.workspace)
+	fixture.generation = ""
+	requests := []WorkspaceEndpointRequest{fixture.request()}
+
+	// Neither socket exists yet: inventory must report a stopped workspace
+	// without requiring a throwaway session to bootstrap the server.
+	before, err := fixture.sessions.ResolveAll(fixture.ctx, requests)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	assert.False(t, before[0].Live)
+	for _, command := range []*TmuxCommand{
+		fixture.servers.kwtServer(), fixture.servers.defaultServer(),
+	} {
+		details, err := command.ListSessionsDetailed()
+		require.NoError(t, err)
+		assert.Empty(t, details)
+	}
+
+	endpoint, err := fixture.sessions.Establish(
+		fixture.ctx, fixture.session, fixture.workspace, BlankLayout(),
+	)
+	require.NoError(t, err)
+	after, err := fixture.sessions.ResolveAll(fixture.ctx, requests)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.True(t, after[0].Live)
+	assert.Equal(t, endpoint, after[0].Endpoint)
+
+	// Opening again reuses the established session.
+	again, err := fixture.sessions.Establish(
+		fixture.ctx, fixture.session, fixture.workspace, BlankLayout(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, endpoint, again)
+	names, err := fixture.servers.kwtServer().ListSessions()
+	require.NoError(t, err)
+	assert.Equal(t, []string{fixture.session}, names)
+}
+
 func TestWorkspaceSessionsKillSucceedsWhenCapturedSessionAlreadyExited(t *testing.T) {
 	fixture := newRealWorkspaceSessionsFixture(t)
 	fixture.createMatching(t, fixture.servers.kwtServer())


### PR DESCRIPTION
Command failures now keep the error visible without appending a full usage dump. This applies to operational errors and invalid arguments; explicit `--help` still prints usage.

The missing-server handling reported in #131 is already on `main` from #94. This PR adds coverage for both session-list APIs, including the reported missing-socket diagnostic, and a real-tmux test that lists a stopped directory workspace, starts it on a fresh socket, observes it live, and reopens it without creating a second session. Permission and unexpected tmux failures remain errors. The docs explain that users do not need to bootstrap tmux themselves.

Full lint reports four existing findings in `internal/daemon/process_identity_legacy_linux.go`; lint for this branch's changes passes.

Closes #131.
