### PR TITLE
Identify outdated CLIs when daemon inventory contracts differ

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -89,6 +89,7 @@ The daemon and inventory paths currently emit these stable codes:
 | `daemon_start_failed`                     | The daemon could not launch or become ready.                      |
 | `daemon_unresponsive`                     | A verified owner exists but cannot safely be reused or replaced.  |
 | `daemon_incompatible`                     | The owner lacks the required API major or capability.             |
+| `client_outdated`                         | Inventory contracts differ and the invoking CLI is older than the daemon. |
 | `daemon_downgrade_refused`                | An older client attempted replacement.                            |
 | `daemon_build_order_unknown`              | Replacement order cannot be proved.                               |
 | `daemon_draining`                         | The owner is draining; retry according to its deadline.           |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -134,6 +134,15 @@ such as `registration_changed` retain the same envelope. Kwt does not
 normalize unrelated commands' exit behavior. Exit `255` remains unused so an
 SSH caller can distinguish a remote-shell transport failure.
 
+If the daemon lacks the inventory contract required by the CLI and build
+comparison identifies the CLI as older, inventory commands return
+non-retryable `client_outdated`. The message identifies both versions and
+their source revision times when available. Upgrade the CLI or run the
+daemon's own binary. Restarting with the older CLI refuses the downgrade.
+If the CLI is not known to be older, a missing inventory contract returns
+`daemon_incompatible`. A newer daemon that still provides the required
+contract remains usable.
+
 Daemon ownership must not buffer human-facing operation progress. Removal
 continues to print each selected worktree's result as soon as that target
 finishes. SSH lifecycle uses the bounded `operation.stream.v1` transport for

--- a/internal/cmd/daemon_client.go
+++ b/internal/cmd/daemon_client.go
@@ -388,9 +388,35 @@ func inventoryDrainDeadline(err error) (*time.Time, bool) {
 
 func requireInventoryCapability(observation kwtdaemon.Observation) error {
 	if observation.Client == nil || !slices.Contains(observation.Status.Capabilities, kwtdaemon.CapabilityInventory) {
+		build := currentBuildInfo()
+		invoking := kwtdaemon.Build{
+			Version: build.Version, Revision: build.Revision, RevisionTime: build.RevisionTime,
+		}
+		running := kwtdaemon.Build{
+			Version: observation.Status.Version, Revision: observation.Status.Revision,
+			RevisionTime: observation.Status.RevisionTime,
+		}
+		_, advertisedTime := observation.Record.Metadata["revision_time"]
+		if kwtdaemon.CompareBuilds(invoking, running, advertisedTime) == kwtdaemon.BuildOlder {
+			clientLabel, daemonLabel := invoking.Version, running.Version
+			if invoking.RevisionTime != "" {
+				clientLabel += ", " + invoking.RevisionTime
+			}
+			if running.RevisionTime != "" {
+				daemonLabel += ", " + running.RevisionTime
+			}
+			return service.NewError(
+				service.ClientOutdated,
+				fmt.Sprintf(
+					"this kwt (%s) is older than the running daemon (%s); upgrade the CLI or run the daemon's own binary",
+					clientLabel, daemonLabel,
+				),
+				false, nil, nil,
+			)
+		}
 		return service.NewError(
 			service.DaemonIncompatible,
-			"the running kwt daemon does not provide worktree inventory",
+			"the running kwt daemon does not provide the worktree inventory contract required by this CLI",
 			false,
 			nil,
 			nil,

--- a/internal/cmd/daemon_client_test.go
+++ b/internal/cmd/daemon_client_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -282,4 +283,72 @@ func TestInventoryRejectsVersionOneDaemonBeforeRequest(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, service.IsCode(err, service.DaemonIncompatible))
+}
+
+func TestInventoryCapabilityMismatchReportsBuildOrder(t *testing.T) {
+	oldVersion, oldCommit, oldTime, oldRead := version, commit, revisionTime, readBuildInfo
+	t.Cleanup(func() {
+		version, commit, revisionTime, readBuildInfo = oldVersion, oldCommit, oldTime, oldRead
+	})
+	version, commit, revisionTime = "sha-client", "client-revision", "2026-08-01T12:00:00Z"
+	readBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
+
+	for _, test := range []struct {
+		name         string
+		daemonTime   string
+		capabilities []string
+		code         service.Code
+		message      string
+	}{
+		{
+			name: "newer daemon", daemonTime: "2026-09-01T12:00:00Z",
+			capabilities: []string{"worktree.inventory.v3"},
+			code:         service.ClientOutdated, message: "upgrade the CLI or run the daemon's own binary",
+		},
+		{
+			name: "older daemon", daemonTime: "2026-07-01T12:00:00Z",
+			code:    service.DaemonIncompatible,
+			message: "does not provide the worktree inventory contract required by this CLI",
+		},
+		{
+			name: "unknown order", daemonTime: "",
+			code:    service.DaemonIncompatible,
+			message: "does not provide the worktree inventory contract required by this CLI",
+		},
+		{
+			name: "equal time", daemonTime: revisionTime,
+			code:    service.DaemonIncompatible,
+			message: "does not provide the worktree inventory contract required by this CLI",
+		},
+		{
+			name: "compatible newer daemon", daemonTime: "2026-09-01T12:00:00Z",
+			capabilities: []string{kwtdaemon.CapabilityInventory},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			observation := kwtdaemon.Observation{
+				Client: &kwtdaemon.Client{},
+				Status: kwtdaemon.Status{
+					Version: "sha-daemon", Revision: "daemon-revision",
+					RevisionTime: test.daemonTime, Capabilities: test.capabilities,
+				},
+			}
+			observation.Record.Metadata = map[string]string{"revision_time": test.daemonTime}
+			err := requireInventoryCapability(observation)
+			if test.code == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, service.IsCode(err, test.code), "%v", err)
+			assert.Contains(t, err.Error(), test.message)
+			assert.False(t, service.AsError(err).Retryable)
+			if test.code == service.ClientOutdated {
+				assert.Contains(t, err.Error(), version)
+				assert.Contains(t, err.Error(), revisionTime)
+				assert.Contains(t, err.Error(), "sha-daemon")
+				assert.Contains(t, err.Error(), test.daemonTime)
+			}
+		})
+	}
 }

--- a/internal/cmd/daemon_subprocess_test.go
+++ b/internal/cmd/daemon_subprocess_test.go
@@ -376,6 +376,7 @@ func TestDaemonSubprocessSHARevisionOrderingAndEqualTimeOverride(t *testing.T) {
 	_, stderr, err := runDaemonCommand(t, older, orderedHome, "daemon", "restart")
 	require.Error(t, err)
 	assert.Contains(t, string(stderr), "older kwt cannot replace")
+	assert.NotContains(t, string(stderr), "Usage:")
 	assert.Equal(t, newStatus.PID, daemonStatus(t, newer, orderedHome).PID)
 
 	equalHome := newDaemonTestHome(t, validDaemonConfig)

--- a/internal/cmd/inventory_subprocess_test.go
+++ b/internal/cmd/inventory_subprocess_test.go
@@ -233,3 +233,36 @@ func TestInventorySubprocessDaemonFailuresNeverUseSSHExit255(t *testing.T) {
 		})
 	}
 }
+
+func TestInventorySubprocessOutdatedClientDiagnostic(t *testing.T) {
+	binary := buildDaemonTestBinary(t, daemonTestBuild{
+		Name: "kwt-older", Version: "sha-client", Revision: strings.Repeat("a", 40),
+		RevisionTime: "2026-08-01T12:00:00Z",
+	})
+	fixture := buildDaemonFixture(t)
+	home := newDaemonTestHome(t, validDaemonConfig)
+	startDaemonFixture(t, fixture, home, "future_inventory")
+	directory := t.TempDir()
+	for _, jsonOutput := range []bool{false, true} {
+		args := []string{"list", "--global"}
+		if jsonOutput {
+			args = append(args, "--json")
+		}
+		stdout, stderr, err := runInventoryCommand(t, binary, home, directory, args...)
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr, "stderr=%s", stderr)
+		assert.Equal(t, 1, exitErr.ExitCode())
+		assert.Contains(t, string(stderr), "this kwt (sha-client, 2026-08-01T12:00:00Z) is older than the running daemon (sha-daemon, 2026-09-01T12:00:00Z)")
+		assert.Contains(t, string(stderr), "upgrade the CLI or run the daemon's own binary")
+		assert.NotContains(t, string(stderr), "Usage:")
+		if jsonOutput {
+			var envelope jsonErrorEnvelope
+			require.NoError(t, json.Unmarshal(stdout, &envelope))
+			assert.Equal(t, service.Code("client_outdated"), envelope.Error.Code)
+			assert.False(t, envelope.Error.Retryable)
+			assert.Contains(t, string(stderr), envelope.Error.Message)
+		} else {
+			assert.Empty(t, stdout)
+		}
+	}
+}

--- a/internal/cmd/testdata/daemonfixture/main.go
+++ b/internal/cmd/testdata/daemonfixture/main.go
@@ -57,13 +57,23 @@ func main() {
 		log.Fatal(err)
 	}
 	build := kwtdaemon.Build{Version: "v1.0.0", Revision: strings.Repeat("a", 40)}
+	if *mode == "future_inventory" {
+		build = kwtdaemon.Build{
+			Version: "sha-daemon", Revision: strings.Repeat("b", 40),
+			RevisionTime: "2026-09-01T12:00:00Z",
+		}
+	}
 	record, token, err := kwtdaemon.NewRuntimeRecord(*home, build, endpoint)
 	if err != nil {
 		log.Fatal(err)
 	}
 	schemaMajor := kwtdaemon.APISchemaMajor
 	schemaVersion := kwtdaemon.APISchemaVersion
-	if *mode == "incompatible" {
+	if *mode == "future_inventory" {
+		record.Metadata["capabilities"] = strings.ReplaceAll(
+			record.Metadata["capabilities"], kwtdaemon.CapabilityInventory, "worktree.inventory.v3",
+		)
+	} else if *mode == "incompatible" {
 		schemaMajor = 2
 		schemaVersion = "2.0.0"
 		record.Metadata["schema_major"] = strconv.Itoa(schemaMajor)
@@ -113,7 +123,8 @@ func main() {
 		Service: kwtdaemon.ServiceName, State: kwtdaemon.StateReady,
 		Home: *home, Endpoint: listener.Addr().String(), PID: os.Getpid(),
 		Version: build.Version, Revision: build.Revision,
-		SchemaMajor: schemaMajor, SchemaVersion: schemaVersion,
+		RevisionTime: build.RevisionTime,
+		SchemaMajor:  schemaMajor, SchemaVersion: schemaVersion,
 		Capabilities: capabilities, StartedAt: started,
 	}
 	if *mode == "draining" {

--- a/service/error.go
+++ b/service/error.go
@@ -19,6 +19,7 @@ const (
 	DaemonStartFailed                    Code = "daemon_start_failed"
 	DaemonUnresponsive                   Code = "daemon_unresponsive"
 	DaemonIncompatible                   Code = "daemon_incompatible"
+	ClientOutdated                       Code = "client_outdated"
 	DaemonDowngradeRefused               Code = "daemon_downgrade_refused"
 	DaemonBuildOrderUnknown              Code = "daemon_build_order_unknown"
 	DaemonDraining                       Code = "daemon_draining"


### PR DESCRIPTION
When an older CLI encounters a newer daemon's inventory contract, report non-retryable `client_outdated` with both versions, available source revision times, and an instruction to upgrade the CLI or run the daemon's binary. Previously, `kwt list` blamed the daemon for missing inventory and led users toward a restart that would refuse the downgrade.

Reuse the existing build comparison. Keep `daemon_incompatible` when the CLI is not known to be older, and continue accepting newer daemons that provide the required contract. Regression tests exercise text and JSON output against a daemon fixture.

The restart refusal already omits usage after #139; this adds subprocess coverage for that behavior.

Fixes #142.
